### PR TITLE
Hub Prep: Remove empty keys from specs

### DIFF
--- a/advanced_regex/plugin.spec.yaml
+++ b/advanced_regex/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/advanced_regex
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - data manipulation
 - utility

--- a/base64/plugin.spec.yaml
+++ b/base64/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/base64
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - base64
 - encoder

--- a/basename/plugin.spec.yaml
+++ b/basename/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/basename
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - basename
 - utilities

--- a/bhr/plugin.spec.yaml
+++ b/bhr/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 1.0.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/bhr
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - block
 - ips

--- a/cef/plugin.spec.yaml
+++ b/cef/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 1.0.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/cef
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - cef
 - arcsight

--- a/chaosreader/plugin.spec.yaml
+++ b/chaosreader/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 1.0.2
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/chaosreader
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - chaosreader
 - pcap

--- a/chardet/plugin.spec.yaml
+++ b/chardet/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/chardet
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - base64
 - encoder

--- a/checkdmarc/plugin.spec.yaml
+++ b/checkdmarc/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/checkdmarc
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - checkdmarc
 - SPF

--- a/checkpoint_sand_blast/plugin.spec.yaml
+++ b/checkpoint_sand_blast/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/checkpoint_sand_blast
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - threat intelligence
 - breach prevention

--- a/cif/plugin.spec.yaml
+++ b/cif/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 2.0.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/cif
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - cif
 - intel

--- a/compression/plugin.spec.yaml
+++ b/compression/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/compression
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - compress
 - decompress

--- a/csv/plugin.spec.yaml
+++ b/csv/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/csv
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - csv
 - utilities

--- a/cymon/plugin.spec.yaml
+++ b/cymon/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: [obsolete]
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/cymon
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - cymon
 - intel

--- a/cymon_v2/plugin.spec.yaml
+++ b/cymon_v2/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: [obsolete]
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/cymon_v2
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - cymon
 - intel

--- a/datetime/plugin.spec.yaml
+++ b/datetime/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/datetime
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - datetime
 - utilities

--- a/diff/plugin.spec.yaml
+++ b/diff/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 1.0.2
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/diff
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - diff
 - utilities

--- a/dig/plugin.spec.yaml
+++ b/dig/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/dig
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - dig
 - dns

--- a/dirname/plugin.spec.yaml
+++ b/dirname/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/dirname
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - dirname
 - utilities

--- a/dumbno/plugin.spec.yaml
+++ b/dumbno/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 1.0.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/dumbno
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - dumbno
 - blocking

--- a/eml/plugin.spec.yaml
+++ b/eml/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/eml
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url: 
 tags:
 - eml
 - mail

--- a/finger/plugin.spec.yaml
+++ b/finger/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/finger
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url: 
 tags:
 - finger
 - users

--- a/ftp/plugin.spec.yaml
+++ b/ftp/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 2.0.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/ftp
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - ftp
 - authentication

--- a/get_url/plugin.spec.yaml
+++ b/get_url/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/get_url
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - url
 - file

--- a/grep/plugin.spec.yaml
+++ b/grep/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/grep
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - grep
 - regex

--- a/hashit/plugin.spec.yaml
+++ b/hashit/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 2.0.2
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/hashit
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - hashes
 - crypto

--- a/html/plugin.spec.yaml
+++ b/html/plugin.spec.yaml
@@ -12,7 +12,6 @@ version: 1.2.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/html
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - markdown
 - html

--- a/jq/plugin.spec.yaml
+++ b/jq/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/jq
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - jq
 - JSON

--- a/markdown/plugin.spec.yaml
+++ b/markdown/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/markdown
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - markdown
 - html

--- a/math/plugin.spec.yaml
+++ b/math/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/math
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - math
 - computation

--- a/netmiko/plugin.spec.yaml
+++ b/netmiko/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/netmiko
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - netmiko
 - SSH

--- a/p0f/plugin.spec.yaml
+++ b/p0f/plugin.spec.yaml
@@ -11,7 +11,6 @@ version: 1.0.2
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/p0f
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - p0f
 - pcap

--- a/pdf_generator/plugin.spec.yaml
+++ b/pdf_generator/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/pdf_generator
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - pdf
 - document

--- a/pdf_reader/plugin.spec.yaml
+++ b/pdf_reader/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/pdf_reader
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - PDF
 - Reader

--- a/ping/plugin.spec.yaml
+++ b/ping/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/ping
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - ping
 - network diagnostics

--- a/python_2_script/plugin.spec.yaml
+++ b/python_2_script/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: [deprecated]
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/python_2_script
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url: 
 tags:
 - python
 - python2

--- a/python_3_script/plugin.spec.yaml
+++ b/python_3_script/plugin.spec.yaml
@@ -12,7 +12,6 @@ enable_cache: true
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/python_3_script
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
  - python
  - python3

--- a/rest/plugin.spec.yaml
+++ b/rest/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/rest
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - rest
 - http

--- a/rpm/plugin.spec.yaml
+++ b/rpm/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/rpm
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - rpm
 - package

--- a/rss/plugin.spec.yaml
+++ b/rss/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/rss
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - rss
 - atom

--- a/sed/plugin.spec.yaml
+++ b/sed/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/sed
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - sed
 - edit

--- a/sleep/plugin.spec.yaml
+++ b/sleep/plugin.spec.yaml
@@ -12,7 +12,6 @@ version: 1.0.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/sleep
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - sleep
 - delay

--- a/smtp/plugin.spec.yaml
+++ b/smtp/plugin.spec.yaml
@@ -13,7 +13,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/smtp
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - smtp
 - email

--- a/sqlmap/plugin.spec.yaml
+++ b/sqlmap/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/sqlmap
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - vulnerability
 - exploit

--- a/ssh/plugin.spec.yaml
+++ b/ssh/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/ssh
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - ssh
 - remote

--- a/statsd/plugin.spec.yaml
+++ b/statsd/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/statsd
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - stats
 - statsd

--- a/storage/plugin.spec.yaml
+++ b/storage/plugin.spec.yaml
@@ -12,7 +12,6 @@ enable_cache: true
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/storage
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - utilities
 - variables

--- a/string/plugin.spec.yaml
+++ b/string/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/string
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - utilities
 - string

--- a/subnet/plugin.spec.yaml
+++ b/subnet/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/subnet
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - subnet
 - ip

--- a/syslog_forwarder/plugin.spec.yaml
+++ b/syslog_forwarder/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/syslog_forwarder
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - syslog
 - logs

--- a/tr/plugin.spec.yaml
+++ b/tr/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/tr
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - tr
 - translate

--- a/traceroute/plugin.spec.yaml
+++ b/traceroute/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/traceroute
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - Tracerout
 - network diagnostics

--- a/trufflehog/plugin.spec.yaml
+++ b/trufflehog/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/trufflehog
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - entropy
 - secret

--- a/tsv/plugin.spec.yaml
+++ b/tsv/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/tsv
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - tsv
 - utilities

--- a/typo_squatter/plugin.spec.yaml
+++ b/typo_squatter/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/typo_squatter
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - dns
 - typo

--- a/uniq/plugin.spec.yaml
+++ b/uniq/plugin.spec.yaml
@@ -12,7 +12,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/uniq
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - uniq
 - unique

--- a/viper/plugin.spec.yaml
+++ b/viper/plugin.spec.yaml
@@ -16,7 +16,6 @@ hub_tags:
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/viper
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 
 types:
   Archive:

--- a/whois/plugin.spec.yaml
+++ b/whois/plugin.spec.yaml
@@ -11,7 +11,6 @@ status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/whois
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
-  vendor_url:
 tags:
 - whois
 - ip lookup


### PR DESCRIPTION
## Proposed Changes

Describe the proposed changes:

  -  Remove empty Hub keys from spec for cleanup e.g. `resources`, `source_url`, `license_url`, and `vendor_url`. `resources` object is removed if its underlying keys do not contain values.

## Testing

```
$ for i in */plugin.spec.yaml; do js-yaml $i 1>/dev/null || printf "Failure for $i\n"; done && printf "Complete"
Complete
```