### PR TITLE
Hub: Product key is an array, make plural

### DIFF
--- a/abuseipdb/plugin.spec.yaml
+++ b/abuseipdb/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: abuseipdb
 title: AbuseIPDB
 description: This plugin allows you to look up IP reports, provides list and details of blacklisted IPs, or report an abusive IP

--- a/active_directory_ldap/plugin.spec.yaml
+++ b/active_directory_ldap/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: active_directory_ldap
 title: Active Directory LDAP
 description: This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network

--- a/advanced_regex/plugin.spec.yaml
+++ b/advanced_regex/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: advanced_regex
 title: Advanced Regex
 description: This plugin performs advanced regex operations on a string using Python regex

--- a/anomali_threatstream/plugin.spec.yaml
+++ b/anomali_threatstream/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: anomali_threatstream
 title: Anomali ThreatStream
 description: Anomali ThreatStream operationalizes threat intelligence, automating collection

--- a/att_cybersecurity_alienvault_otx/plugin.spec.yaml
+++ b/att_cybersecurity_alienvault_otx/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: att_cybersecurity_alienvault_otx
 title: AT&T Cybersecurity AlienVault Open Threat Exchange
 description: This plugin utilizes AT&T Cybersecurity (AlienVault OTX) to retrieve details about an indicator

--- a/awk/plugin.spec.yaml
+++ b/awk/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: awk
 title: Awk
 description: This plugin manipulates an input string or file with the GNU awk programming language

--- a/aws_securityhub/plugin.spec.yaml
+++ b/aws_securityhub/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: aws_securityhub
 title: "AWS Security Hub"
 description: This plugin utilizes AWS Security Hub to lists and describes security hub-aggregated findings and retrieve SQS messages

--- a/aws_workspaces/plugin.spec.yaml
+++ b/aws_workspaces/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: aws_workspaces
 title: AWS WorkSpaces
 vendor: rapid7

--- a/azure_ad_admin/plugin.spec.yaml
+++ b/azure_ad_admin/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: azure_ad_admin
 title: Azure AD Admin
 description: Preform Administrative tasks in Azure AD

--- a/azure_compute/plugin.spec.yaml
+++ b/azure_compute/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: azure_compute
 title: Azure Compute
 description: Azure Virtual Machines is one of several types of on-demand, scalable computing resources that Azure offers

--- a/barracuda_waf/plugin.spec.yaml
+++ b/barracuda_waf/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: barracuda_waf
 title: Barracuda Web Application Firewall
 description: The Barracuda WAF plugin automates administrative tasks as well as rule creation and modification

--- a/base64/plugin.spec.yaml
+++ b/base64/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: base64
 title: Base64
 description: Encode and decode data using the base64 alphabet

--- a/basename/plugin.spec.yaml
+++ b/basename/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: basename
 title: Basename
 description: This plugin is used to get the last item of a file path or URL using Python's basename utility

--- a/bhr/plugin.spec.yaml
+++ b/bhr/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: bhr
 title: BHR
 vendor: rapid7

--- a/bitbucket/plugin.spec.yaml
+++ b/bitbucket/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: bitbucket
 title: Bitbucket
 vendor: rapid7

--- a/blockade/plugin.spec.yaml
+++ b/blockade/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: blockade
 title: Blockade
 vendor: rapid7

--- a/bluecoat_labs/plugin.spec.yaml
+++ b/bluecoat_labs/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: bluecoat_labs
 title: Bluecoat Labs
 vendor: rapid7

--- a/bmc_remedy_itsm/plugin.spec.yaml
+++ b/bmc_remedy_itsm/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: bmc_remedy_itsm
 title: "BMC Remedy ITSM"
 description: "Create update and close BMC Remedy ITSM Incidents"

--- a/box/plugin.spec.yaml
+++ b/box/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: box
 title: Box
 vendor: rapid7

--- a/carbon_black_defense/plugin.spec.yaml
+++ b/carbon_black_defense/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: carbon_black_defense
 title: Carbon Black Defense
 description: Find events and retrieve details for specific events

--- a/carbon_black_live_response/plugin.spec.yaml
+++ b/carbon_black_live_response/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: carbon_black_live_response
 title: Carbon Black Live Response
 description: Delete malicious files

--- a/carbon_black_protection/plugin.spec.yaml
+++ b/carbon_black_protection/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: carbon_black_protection
 title: Carbon Black Protection
 description: Ban and unban files and as well as manage approval requests

--- a/carbon_black_response/plugin.spec.yaml
+++ b/carbon_black_response/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: carbon_black_response
 title: Cb Response
 vendor: rapid7

--- a/cef/plugin.spec.yaml
+++ b/cef/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cef
 title: CEF
 vendor: rapid7

--- a/chaosreader/plugin.spec.yaml
+++ b/chaosreader/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: chaosreader
 title: Chaosreader
 vendor: rapid7

--- a/chardet/plugin.spec.yaml
+++ b/chardet/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: chardet
 title: Chardet
 description: This plugin is a Python compatible character encoding detector

--- a/checkdmarc/plugin.spec.yaml
+++ b/checkdmarc/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: checkdmarc
 title: Checkdmarc
 description: The checkdmarc plugin is used to parser SPF and DMARC records

--- a/checkmarx_cxsast/plugin.spec.yaml
+++ b/checkmarx_cxsast/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: checkmarx_cxsast
 title: Checkmarx CxSAST
 version: 1.0.1

--- a/checkpoint_sand_blast/plugin.spec.yaml
+++ b/checkpoint_sand_blast/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: checkpoint_sand_blast
 title: Checkpoint Sand Blast
 description: The Checkpoint Sand Blast plugin extends the Sand Blast service and enables report status and suspicious file upload

--- a/cherwell/plugin.spec.yaml
+++ b/cherwell/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cherwell
 title: Cherwell
 description: The Cherwell plugin is used to administrate incidents in Cherwell

--- a/cif/plugin.spec.yaml
+++ b/cif/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cif
 title: Collective Intelligence Framework
 vendor: rapid7

--- a/cisco_cloudlock/plugin.spec.yaml
+++ b/cisco_cloudlock/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_cloudlock
 title: CloudLock
 vendor: rapid7

--- a/cisco_firepower/plugin.spec.yaml
+++ b/cisco_firepower/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_firepower
 title: Cisco Firepower
 vendor: rapid7

--- a/cisco_firepower_management_center/plugin.spec.yaml
+++ b/cisco_firepower_management_center/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_firepower_management_center
 title: Cisco Firepower Management Center
 vendor: rapid7

--- a/cisco_ise/plugin.spec.yaml
+++ b/cisco_ise/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_ise
 title: Cisco ISE
 description: This plugin utilizes Cisco Identity Services Engine to retrieve ANC details, endpoint details and manage Quarantine

--- a/cisco_threatgrid/plugin.spec.yaml
+++ b/cisco_threatgrid/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_threatgrid
 title: Cisco ThreatGrid
 description: This plugin retrieves malware reports, report samples and URLs for analysis to Cisco ThreatGrid server

--- a/cisco_umbrella_enforcement/plugin.spec.yaml
+++ b/cisco_umbrella_enforcement/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_umbrella_enforcement
 title: Cisco Umbrella Enforcement
 vendor: rapid7

--- a/cisco_umbrella_investigate/plugin.spec.yaml
+++ b/cisco_umbrella_investigate/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cisco_umbrella_investigate
 title: Cisco Umbrella Investigate
 vendor: rapid7

--- a/cloudshark/plugin.spec.yaml
+++ b/cloudshark/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cloudshark
 title: Cloud Shark
 vendor: rapid7

--- a/compression/plugin.spec.yaml
+++ b/compression/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: compression
 title: Compression
 description: "The Compression plugin for Rapid7 InsightConnect allows users to compress/decompress files using different

--- a/confluence/plugin.spec.yaml
+++ b/confluence/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: confluence
 title: Confluence
 vendor: rapid7

--- a/cortex/plugin.spec.yaml
+++ b/cortex/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cortex
 title: Cortex
 vendor: rapid7

--- a/cortex_v2/plugin.spec.yaml
+++ b/cortex_v2/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cortex_v2
 title: Cortex v2
 vendor: rapid7

--- a/craigslist/plugin.spec.yaml
+++ b/craigslist/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: craigslist
 title: Craigslist
 vendor: rapid7

--- a/crits/plugin.spec.yaml
+++ b/crits/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: crits
 title: CRITs
 vendor: rapid7

--- a/csv/plugin.spec.yaml
+++ b/csv/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: csv
 title: CSV
 description: "CSV (Comma Separated Values) is a simple data format for storing data. This plugin allows one to

--- a/cuckoo/plugin.spec.yaml
+++ b/cuckoo/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cuckoo
 title: Cuckoo Sandbox
 description: "Cuckoo Sandbox is an open source automated malware analysis system. Using the Cuckoo Sandbox plugin for

--- a/cymon/plugin.spec.yaml
+++ b/cymon/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cymon
 title: Cymon
 description: Cymon Open Threat Intelligence

--- a/cymon_v2/plugin.spec.yaml
+++ b/cymon_v2/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: cymon_v2
 title: Cymon v2
 description: Cymon is the largest tracker of open-source security reports about phishing,

--- a/datadog/plugin.spec.yaml
+++ b/datadog/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: datadog
 title: "Datadog"
 description: "Datadog is a monitoring service for cloud-scale applications, providing monitoring of servers,

--- a/datetime/plugin.spec.yaml
+++ b/datetime/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: datetime
 title: Datetime
 description: This plugin manipulates timestamps using Python's maya library

--- a/diff/plugin.spec.yaml
+++ b/diff/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: diff
 title: Diff
 vendor: rapid7

--- a/dig/plugin.spec.yaml
+++ b/dig/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: dig
 title: Dig
 description: Dig is used for forward and reverse DNS lookups

--- a/digitalocean/plugin.spec.yaml
+++ b/digitalocean/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: digitalocean
 title: Digital Ocean
 vendor: rapid7

--- a/dirname/plugin.spec.yaml
+++ b/dirname/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: dirname
 title: Dirname
 description: This plugin gets the directory name of a file path or protocol and domain of a URL

--- a/docker_engine/plugin.spec.yaml
+++ b/docker_engine/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: docker_engine
 title: Docker Engine
 vendor: rapid7

--- a/domaintools/plugin.spec.yaml
+++ b/domaintools/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: domaintools
 title: DomainTools
 vendor: rapid7

--- a/dumbno/plugin.spec.yaml
+++ b/dumbno/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: dumbno
 title: Dumbno
 vendor: rapid7

--- a/duo_admin/plugin.spec.yaml
+++ b/duo_admin/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: duo_admin
 title: Duo Admin API
 vendor: rapid7

--- a/duo_auth/plugin.spec.yaml
+++ b/duo_auth/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: duo_auth
 title: Duo Auth API
 vendor: rapid7

--- a/dynamodb/plugin.spec.yaml
+++ b/dynamodb/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: dynamodb
 title: Dynamo DB
 vendor: rapid7

--- a/ec2_investigations/plugin.spec.yaml
+++ b/ec2_investigations/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ec2_investigations
 title: EC2 Investigations
 vendor: rapid7

--- a/echotrail/plugin.spec.yaml
+++ b/echotrail/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: echotrail
 title: "EchoTrail Insights"
 description: "EchoTrail Insights is a database of executable behavioral analytics, searchable by filename or

--- a/elastalert/plugin.spec.yaml
+++ b/elastalert/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: elastalert
 title: ElastAlert
 description: "ElastAlert provides easy & flexible alerting with Elasticsearch. Users of the ElastAlert plugin can

--- a/elasticsearch/plugin.spec.yaml
+++ b/elasticsearch/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: elasticsearch
 title: Elasticsearch
 description: Distributed Real-Time Search and Analytics Engine

--- a/eml/plugin.spec.yaml
+++ b/eml/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: eml
 title: EML
 description: The EML plugins will parse and extract data from an EML file

--- a/facebook_threat_exchange/plugin.spec.yaml
+++ b/facebook_threat_exchange/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: facebook_threat_exchange
 title: Facebook Threat Exchange
 vendor: rapid7

--- a/finger/plugin.spec.yaml
+++ b/finger/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: finger
 title: Finger
 description: Query the Finger Service

--- a/fireeye_hx/plugin.spec.yaml
+++ b/fireeye_hx/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: fireeye_hx
 title: "FireEye HX"
 description: The FireEye plugin will allow you to get alerts from a given host

--- a/foremost/plugin.spec.yaml
+++ b/foremost/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: foremost
 title: Foremost
 description: The Foremost plugin will take a disk image and attempt to recover files from it

--- a/freegeoip/plugin.spec.yaml
+++ b/freegeoip/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: freegeoip
 title: FreeGeoIP
 description: This plugin lookup GeoIP information for a specified host

--- a/freeipa/plugin.spec.yaml
+++ b/freeipa/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: freeipa
 title: FreeIPA
 description: This plugin can retrieve user details and statuses and delete users from FreeIPA servers

--- a/ftp/plugin.spec.yaml
+++ b/ftp/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ftp
 title: FTP
 vendor: rapid7

--- a/geoip2precision/plugin.spec.yaml
+++ b/geoip2precision/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: geoip2precision
 title: GeoIP2 Precision
 vendor: rapid7

--- a/get_url/plugin.spec.yaml
+++ b/get_url/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: get_url
 title: Get URL
 description: Get URL plugin downloads files by URL using HTTP, HTTPS, or FTP

--- a/git/plugin.spec.yaml
+++ b/git/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: git
 title: Git
 description: Git plugin allows you to add, remove and commit files to Git repository

--- a/github/plugin.spec.yaml
+++ b/github/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: github
 title: GitHub
 vendor: rapid7

--- a/github_enterprise/plugin.spec.yaml
+++ b/github_enterprise/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: github_enterprise
 title: GitHub Enterprise
 vendor: rapid7

--- a/gitlab/plugin.spec.yaml
+++ b/gitlab/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: gitlab
 title: GitLab
 vendor: rapid7

--- a/google_admin/plugin.spec.yaml
+++ b/google_admin/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_admin
 title: Google Apps Admin
 description: Get and suspend users with the Google admin plugin

--- a/google_cloud_compute/plugin.spec.yaml
+++ b/google_cloud_compute/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_cloud_compute
 title: Google Cloud Compute
 vendor: rapid7

--- a/google_cloud_pub_sub/plugin.spec.yaml
+++ b/google_cloud_pub_sub/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_cloud_pub_sub
 title: Google Cloud Pub Sub
 description: A fully-managed real-time messaging service that allows you to send and

--- a/google_directory/plugin.spec.yaml
+++ b/google_directory/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_directory
 title: Google Directory
 description: Uses the Google Directory plugin to manage members, users, and user aliases

--- a/google_docs/plugin.spec.yaml
+++ b/google_docs/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_docs
 title: Google Docs
 description: Create and retrieve Google documents

--- a/google_drive/plugin.spec.yaml
+++ b/google_drive/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_drive
 title: Google Drive
 description: Upload and retrieve files from Google drive

--- a/google_safe_browsing/plugin.spec.yaml
+++ b/google_safe_browsing/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_safe_browsing
 title: Google Safe Browsing
 description: Check URLs against the Google Safe Browsing service

--- a/google_search/plugin.spec.yaml
+++ b/google_search/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_search
 title: Google Search
 description: Search the worlds information, including webpages, images, videos and

--- a/google_sheets/plugin.spec.yaml
+++ b/google_sheets/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_sheets
 title: Google Sheets
 description: Create, edit and collaborate with others on spreadsheets

--- a/google_web_risk/plugin.spec.yaml
+++ b/google_web_risk/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: google_web_risk
 title: Google Web Risk
 description: Check URLs against the Google Web Risk service

--- a/grafana/plugin.spec.yaml
+++ b/grafana/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: grafana
 title: Grafana
 vendor: rapid7

--- a/graphite/plugin.spec.yaml
+++ b/graphite/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: graphite
 title: Graphite
 vendor: rapid7

--- a/grep/plugin.spec.yaml
+++ b/grep/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: grep
 title: Grep
 description: This plugin searches for a specified pattern in a string or a file

--- a/grr/plugin.spec.yaml
+++ b/grr/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: grr
 title: Google Rapid Response
 description: The GRR plugin allows you to organize and start hunts using GRR

--- a/hashit/plugin.spec.yaml
+++ b/hashit/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: hashit
 title: HashIt
 vendor: rapid7

--- a/haveibeenpwned/plugin.spec.yaml
+++ b/haveibeenpwned/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: haveibeenpwned
 title: HaveIBeenPwned
 vendor: rapid7

--- a/hipchat/plugin.spec.yaml
+++ b/hipchat/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: hipchat
 title: HipChat
 description: The HipChat plugin can send and receive messages along with managing users

--- a/hippocampe/plugin.spec.yaml
+++ b/hippocampe/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: hippocampe
 title: Hippocampe
 description: The Hippocampe plugin allows for advanced queries and management of your Hippocampe feeds

--- a/html/plugin.spec.yaml
+++ b/html/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: html
 title: HTML
 vendor: rapid7

--- a/hybrid_analysis/plugin.spec.yaml
+++ b/hybrid_analysis/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: hybrid_analysis
 title: Hybrid Analysis
 vendor: rapid7

--- a/ibm_resilient_incident/plugin.spec.yaml
+++ b/ibm_resilient_incident/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ibm_resilient_incident
 title: IBM Resilient Incident
 vendor: rapid7

--- a/ifconfig_co/plugin.spec.yaml
+++ b/ifconfig_co/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ifconfig_co
 title: ifconfig.co
 vendor: rapid7

--- a/imperva_securesphere/plugin.spec.yaml
+++ b/imperva_securesphere/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: imperva_securesphere
 title: Imperva SecureSphere
 vendor: rapid7

--- a/influxdb/plugin.spec.yaml
+++ b/influxdb/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: influxdb
 title: InfluxDB
 vendor: rapid7

--- a/infoblox/plugin.spec.yaml
+++ b/infoblox/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: infoblox
 title: Infoblox
 description: Infoblox helps with managing and identifying devices connected to networks

--- a/ipify/plugin.spec.yaml
+++ b/ipify/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ipify
 title: IPify
 vendor: rapid7

--- a/ipinfo/plugin.spec.yaml
+++ b/ipinfo/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ipinfo
 title: IPinfo
 vendor: rapid7

--- a/ipintel/plugin.spec.yaml
+++ b/ipintel/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ipintel
 title: IPIntel
 vendor: rapid7

--- a/ipstack/plugin.spec.yaml
+++ b/ipstack/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ipstack
 title: IPStack
 description: Lookup geographical information for a host

--- a/jamf/plugin.spec.yaml
+++ b/jamf/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: jamf
 title: Jamf
 description: Jamf is a popular product for managing iPads, iPhones, Macs, and Apple TVs for schools and businesses

--- a/jenkins/plugin.spec.yaml
+++ b/jenkins/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: jenkins
 title: Jenkins
 description: Reliably build, test, and deploy their software

--- a/jira/plugin.spec.yaml
+++ b/jira/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: jira
 title: Jira
 vendor: rapid7

--- a/joe_sandbox/plugin.spec.yaml
+++ b/joe_sandbox/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: joe_sandbox
 title: Joe Sandbox
 description: Joe Sandbox Cloud executes files and URLs fully automated in a controlled

--- a/jq/plugin.spec.yaml
+++ b/jq/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: jq
 title: jq
 description: Send JSON data through jq

--- a/json_edit/plugin.spec.yaml
+++ b/json_edit/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: json_edit
 title: JSON Edit
 description: Provides the ability to edit JSON data

--- a/kintone/plugin.spec.yaml
+++ b/kintone/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: kintone
 title: Kintone
 description: Custom workflows and data management for businesses and non-profits in one place

--- a/kolide/plugin.spec.yaml
+++ b/kolide/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: kolide
 title: Kolide
 vendor: rapid7

--- a/komand/plugin.spec.yaml
+++ b/komand/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: komand
 title: Komand
 description: Komand Meta-Actions

--- a/lastpass_enterprise/plugin.spec.yaml
+++ b/lastpass_enterprise/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: lastpass_enterprise
 title: LastPass Enterprise
 vendor: rapid7

--- a/logstash/plugin.spec.yaml
+++ b/logstash/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: logstash
 title: Logstash
 vendor: rapid7

--- a/malwareconfig/plugin.spec.yaml
+++ b/malwareconfig/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: malwareconfig
 title: MalwareConfig
 vendor: rapid7

--- a/markdown/plugin.spec.yaml
+++ b/markdown/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: markdown
 title: Markdown
 description: Convert markdown to and from various popular formats

--- a/math/plugin.spec.yaml
+++ b/math/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: math
 title: Math
 description: Basic mathematical operations

--- a/matplotlib/plugin.spec.yaml
+++ b/matplotlib/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: matplotlib
 title: Matplotlib
 description: Provides graphing capability of base64 encoded CSV data using Matplotlib,

--- a/mcafee_epo/plugin.spec.yaml
+++ b/mcafee_epo/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: mcafee_epo
 title: McAfee ePO
 vendor: rapid7

--- a/mcafee_esm/plugin.spec.yaml
+++ b/mcafee_esm/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: mcafee_esm
 title: McAfee ESM
 description: McAfee Enterprise Security Manager is a security information and event

--- a/microsoft_atp/plugin.spec.yaml
+++ b/microsoft_atp/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: microsoft_atp
 title: Microsoft Windows Defender ATP
 description: Windows Defender Advanced Threat Protection (ATP) is a unified platform

--- a/microsoft_atp_safe_links/plugin.spec.yaml
+++ b/microsoft_atp_safe_links/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: microsoft_atp_safe_links
 title: Microsoft Office 365 ATP Safe Links
 description: Helps protect your organization by providing time-of-click verification

--- a/microsoft_teams/plugin.spec.yaml
+++ b/microsoft_teams/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
 description: Microsoft Teams actions and triggers

--- a/mimecast/plugin.spec.yaml
+++ b/mimecast/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage

--- a/minfraud/plugin.spec.yaml
+++ b/minfraud/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: minfraud
 title: minFraud
 vendor: rapid7

--- a/misp/plugin.spec.yaml
+++ b/misp/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: misp
 title: MISP
 description: MISP is an open source threat sharing platform

--- a/mxtoolbox_dns/plugin.spec.yaml
+++ b/mxtoolbox_dns/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: mxtoolbox_dns
 title: MxToolBox DNS
 vendor: rapid7

--- a/netmiko/plugin.spec.yaml
+++ b/netmiko/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: netmiko
 title: Netmiko
 description: Netmiko is used to access network devices over SSH

--- a/networktotal/plugin.spec.yaml
+++ b/networktotal/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: networktotal
 title: Network Total
 description: Networktotal is used to upload a PCAP for analysis

--- a/newrelic/plugin.spec.yaml
+++ b/newrelic/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: newrelic
 title: New Relic
 description: Monitors the performance of applications and infrastructure

--- a/nmap/plugin.spec.yaml
+++ b/nmap/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: nmap
 title: Nmap
 description: Nmap is used to launch scan against a networt to discover and audit

--- a/office365_admin/plugin.spec.yaml
+++ b/office365_admin/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: office365_admin
 title: Office365 Admin
 description: The Office 365 Admin plugin allows you to manage users in Office 365

--- a/okta/plugin.spec.yaml
+++ b/okta/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: okta
 title: Okta
 vendor: rapid7

--- a/opendxl/plugin.spec.yaml
+++ b/opendxl/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: opendxl
 title: OpenDXL
 description: Communicate and share information for real-time, accurate security

--- a/openphish/plugin.spec.yaml
+++ b/openphish/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: openphish
 title: "OpenPhish"
 description: "OpenPhish is a fully automated self-contained platform for phishing intelligence. Use the OpenPhish plugin to identify zero-day phishing sites and provide real-time threat intelligence"

--- a/openvas/plugin.spec.yaml
+++ b/openvas/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: openvas
 title: OpenVAS
 description: "Allows users to perform common tasks such as

--- a/ossec/plugin.spec.yaml
+++ b/ossec/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ossec
 title: OSSEC
 description: OSSEC is a free, open-source host-based intrusion detection system. Using the OSSEC plugin for InsightConnect, users can parse OSSEC alerts into JSON format

--- a/otrs/plugin.spec.yaml
+++ b/otrs/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: otrs
 title: OTRS
 description: Create and manage OTRS tickets

--- a/p0f/plugin.spec.yaml
+++ b/p0f/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: p0f
 title: p0f
 vendor: rapid7

--- a/pagerduty/plugin.spec.yaml
+++ b/pagerduty/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: pagerduty
 title: PagerDuty
 description: PagerDuty provides enterprise-grade incident management. Leverage PagerDuty for incident management and response with the PagerDuty plugin for InsightConnect

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto PAN-OS
 description: Manage Palo Alto Networks devices via PAN-OS

--- a/paloalto_wildfire/plugin.spec.yaml
+++ b/paloalto_wildfire/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: paloalto_wildfire
 title: Palo Alto Wildfire
 vendor: rapid7

--- a/passivetotal/plugin.spec.yaml
+++ b/passivetotal/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: passivetotal
 title: PassiveTotal
 description: PassiveTotal

--- a/pastebin/plugin.spec.yaml
+++ b/pastebin/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: pastebin
 title: Pastebin
 description: The Pastebin plugin allows you to send text to and check posts on Pastebin

--- a/pdf_generator/plugin.spec.yaml
+++ b/pdf_generator/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: pdf_generator
 title: PDF Generator
 description: The PDF plugin allows the user to create PDF reports from workflow data

--- a/pdf_reader/plugin.spec.yaml
+++ b/pdf_reader/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: pdf_reader
 title: PDF Reader
 description: Tools for extracting text from a PDF

--- a/phabricator/plugin.spec.yaml
+++ b/phabricator/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: phabricator
 title: Phabricator
 vendor: rapid7

--- a/phishtank/plugin.spec.yaml
+++ b/phishtank/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: phishtank
 title: PhishTank
 description: The Phishtank plugin allows you to submit URLs for analysis by the PhishTank community

--- a/ping/plugin.spec.yaml
+++ b/ping/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ping
 title: Ping
 description: The Ping plugin is used to check for network connectivity and response times

--- a/port_knocking/plugin.spec.yaml
+++ b/port_knocking/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: port_knocking
 title: Port Knocking
 vendor: rapid7

--- a/powershell/plugin.spec.yaml
+++ b/powershell/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: powershell
 title: PowerShell
 description: The PowerShell plugin runs a PowerShell script on a remote host or locally on the InsightConnect Orchestrator

--- a/presto/plugin.spec.yaml
+++ b/presto/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: presto
 title: Presto
 vendor: rapid7

--- a/proofpoint_tap/plugin.spec.yaml
+++ b/proofpoint_tap/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: A plugin for Proofpoint Targeted Attack Protection (TAP) alerts

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: proofpoint_url_defense
 title: Proofpoint URL Defense
 vendor: rapid7

--- a/pushover/plugin.spec.yaml
+++ b/pushover/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: pushover
 title: Pushover.net
 description: The Pushover plugin allows you to send Pushover notifications

--- a/python_2_script/plugin.spec.yaml
+++ b/python_2_script/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: python_2_script
 title: Python 2 Script
 description: The Python 2 plugin allows you to run a Python 2 script

--- a/python_3_script/plugin.spec.yaml
+++ b/python_3_script/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: python_3_script
 title: Python 3 Script
 vendor: rapid7

--- a/qradar/plugin.spec.yaml
+++ b/qradar/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: qradar
 title: QRadar Security Intelligence Platform
 description: The QRadar plugin allows you to run Ariel queries and retrieve policy offense data

--- a/qualys_ssl/plugin.spec.yaml
+++ b/qualys_ssl/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: qualys_ssl
 title: Qualys SSL Labs
 description: The Qualys SSL plugin allows the user to get information and test SSL servers

--- a/rapid7_insightappsec/plugin.spec.yaml
+++ b/rapid7_insightappsec/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_insightappsec
 title: Rapid7 InsightAppSec
 description: This plugin allows for the creation, configuration, and starting of scans. The plugin can also retrieve scan results and logging related to the execution of the scan

--- a/rapid7_insightidr/plugin.spec.yaml
+++ b/rapid7_insightidr/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"

--- a/rapid7_insightops/plugin.spec.yaml
+++ b/rapid7_insightops/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_insightops
 title: Rapid7 InsightOps
 vendor: rapid7

--- a/rapid7_insightvm/plugin.spec.yaml
+++ b/rapid7_insightvm/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_insightvm
 title: Rapid7 InsightVM
 description: InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin can get top remediations, scan results and start scans

--- a/rapid7_metasploit/plugin.spec.yaml
+++ b/rapid7_metasploit/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_metasploit
 title: Rapid7 Metasploit
 description: This plugin allows you to search for and execute exploits in Metasploit

--- a/rapid7_tcell/plugin.spec.yaml
+++ b/rapid7_tcell/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_tcell
 title: Rapid7 tCell
 description: Rapid7 tCell is a Next-Gen Cloud WAF that enables web applications to

--- a/rapid7_vulndb/plugin.spec.yaml
+++ b/rapid7_vulndb/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rapid7_vulndb
 title: Rapid7 Vulnerability & Exploit Database
 description: The Vulnerability & Exploit Database plugin allows you to search and compare potential threats with a curated repository of vetted computer software exploits and exploitable vulnerabilities

--- a/recorded_future/plugin.spec.yaml
+++ b/recorded_future/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: recorded_future
 title: Recorded Future
 vendor: rapid7

--- a/red_canary/plugin.spec.yaml
+++ b/red_canary/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: red_canary
 title: Red Canary
 description: The RedCanary plugin allows you to manage endpoint detection and respond to threats

--- a/redhat_advisory/plugin.spec.yaml
+++ b/redhat_advisory/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: redhat_advisory
 title: Redhat Security Advisories
 vendor: rapid7

--- a/redis/plugin.spec.yaml
+++ b/redis/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: redis
 title: Redis
 description: The Redis plugin allows you to add, update, and manage data in a Redis database

--- a/request_tracker/plugin.spec.yaml
+++ b/request_tracker/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: request_tracker
 title: Request Tracker
 description: The Request Tracker plugin allows you to create and manage tickets in Request Tracker

--- a/rest/plugin.spec.yaml
+++ b/rest/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rest
 title: REST
 description: The REST plugin to make it easy to integrate with RESTful services

--- a/rpm/plugin.spec.yaml
+++ b/rpm/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rpm
 title: RPM
 description: The RPM plugin allows you to download and analyze an RPM pacakge

--- a/rss/plugin.spec.yaml
+++ b/rss/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: rss
 title: RSS
 description: The RSS plugin allows you to monitor an RSS feed

--- a/salesforce/plugin.spec.yaml
+++ b/salesforce/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: salesforce
 title: Salesforce
 description: The Salesforce plugin allows you to search, update, and manage salesforce records

--- a/samanage/plugin.spec.yaml
+++ b/samanage/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: samanage
 title: Samanage
 description: The Samanage plugin allows you to start workflows on new incidents, manage incidents, and manage users

--- a/screenshot_machine/plugin.spec.yaml
+++ b/screenshot_machine/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: screenshot_machine
 title: Screenshot Machine
 description: The Screenshot Machine plugin allows you to capture screenshots

--- a/sed/plugin.spec.yaml
+++ b/sed/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sed
 title: Sed
 description: The Sed plugin allows you to run the GNU stream editor on strings and files

--- a/sentinelone/plugin.spec.yaml
+++ b/sentinelone/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sentinelone
 title: SentinelOne
 description: The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne

--- a/sentry/plugin.spec.yaml
+++ b/sentry/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sentry
 title: Sentry
 description: "Sentry is an open source error tracking tool that helps developers monitor and fix crashes in real time.

--- a/shattered/plugin.spec.yaml
+++ b/shattered/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: shattered
 title: SHAttered
 description: "SHAttered is a free service for checking SHA-1 hash collisions. Using the SHAttered plugin for

--- a/shodan/plugin.spec.yaml
+++ b/shodan/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: shodan
 title: Shodan
 description: "Shodan is a search engine for internet-connected devices. Using the Shodan plugin for Rapid7 InsightConnect,

--- a/sketchify/plugin.spec.yaml
+++ b/sketchify/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sketchify
 title: Sketchify
 description: "Sketchify is a service used to turn any link into one that appears suspicious. With the Sketchify plugin

--- a/sleep/plugin.spec.yaml
+++ b/sleep/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sleep
 title: Sleep
 vendor: rapid7

--- a/smb/plugin.spec.yaml
+++ b/smb/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: smb
 title: SMB
 description: "Server Message Block (SMB) is a protocol used for interacting with files on an SMB server. Using this

--- a/smtp/plugin.spec.yaml
+++ b/smtp/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: smtp
 title: SMTP
 description: "Simple Mail Transfer Protocol (SMTP) is an Internet standard for electronic

--- a/snortlabslist/plugin.spec.yaml
+++ b/snortlabslist/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: snortlabslist
 title: Snort Labs IP Reputation
 description: "Snort Labs List is an IP blacklist service provided by Snort. Users of this plugin can query with

--- a/sophos_xg_firewall/plugin.spec.yaml
+++ b/sophos_xg_firewall/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sophos_xg_firewall
 title: Sophos XG Firewall
 description: The Sophos XG Firewall plugin allows you to manage your Sophos XG Firewall through policies

--- a/splunk/plugin.spec.yaml
+++ b/splunk/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: splunk
 title: Splunk
 description: The Splunk plugin allows you to search, monitor, analyze and analyze machine data

--- a/sql/plugin.spec.yaml
+++ b/sql/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sql
 title: SQL
 description: The SQL plugin allows you to run SQL queries

--- a/sqlmap/plugin.spec.yaml
+++ b/sqlmap/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sqlmap
 title: SQLMap
 description: The SQLMap plugin allows you to scan targets and analyze the results

--- a/ssh/plugin.spec.yaml
+++ b/ssh/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: ssh
 title: SSH
 description: The SSH protocol is a method for secure remote login from one computer

--- a/statsd/plugin.spec.yaml
+++ b/statsd/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: statsd
 title: Statsd
 description: The Statsd plugin will allow you to create metrics from your workflow

--- a/storage/plugin.spec.yaml
+++ b/storage/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: storage
 title: Storage
 description: The Storage plugin is a utility that stores information across loops and workflows

--- a/string/plugin.spec.yaml
+++ b/string/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: string
 title: String Operations
 description: The String plugin provides common programmatic string operations

--- a/subnet/plugin.spec.yaml
+++ b/subnet/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: subnet
 title: Subnet
 description: The Subnet plugin takes input as a network in CIDR notation and returns useful information, such as the number of hosts, the ID, host address range, and broadcast address

--- a/sumologic/plugin.spec.yaml
+++ b/sumologic/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: sumologic
 title: Sumo Logic
 description: The Sumo Logic plugin allows you to run a Sumo Logic query and view the results

--- a/symantec_bcs/plugin.spec.yaml
+++ b/symantec_bcs/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: symantec_bcs
 title: Symantec Business Critical Services
 description: The Symantec Business Critical Services plugin allows you to submit a file to Symantec Security Response

--- a/syslog_forwarder/plugin.spec.yaml
+++ b/syslog_forwarder/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: syslog_forwarder
 title: Syslog Forwarder
 description: The Syslog Forwarder plugin will forward messages to a syslog server

--- a/tcpdump/plugin.spec.yaml
+++ b/tcpdump/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tcpdump
 title: Tcpdump
 description: The Tcpdump plugin is used to read contents of a PCAP

--- a/tcpxtract/plugin.spec.yaml
+++ b/tcpxtract/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tcpxtract
 title: Tcpxtract
 description: The Tcpxtract plugin is a tool for extracting files from network traffic

--- a/tenable_io/plugin.spec.yaml
+++ b/tenable_io/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tenable_io
 title: TenableIO
 vendor: rapid7

--- a/tenable_nessus/plugin.spec.yaml
+++ b/tenable_nessus/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tenable_nessus
 title: Tenable Nessus
 vendor: rapid7

--- a/thehive/plugin.spec.yaml
+++ b/thehive/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: thehive
 title: TheHive
 description: "TheHive is a scalable, open source security incident response solution designed for

--- a/threat_connect/plugin.spec.yaml
+++ b/threat_connect/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: threat_connect
 title: ThreatConnect
 description: "ThreatConnect is a Threat Intelligence Platform (TIP) that empowers large

--- a/threatminer/plugin.spec.yaml
+++ b/threatminer/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: threatminer
 title: Threat Miner
 description: "Threat Miner is an open source search engine for fast threat intelligence research and pivoting with

--- a/threatq/plugin.spec.yaml
+++ b/threatq/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: threatq
 title: Threat Quotient
 vendor: rapid7

--- a/threatstack/plugin.spec.yaml
+++ b/threatstack/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: threatstack
 title: Threat Stack
 description: The Threat Stack plugin is used to get information about alerts, assets, and policies

--- a/tr/plugin.spec.yaml
+++ b/tr/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tr
 title: Translate
 description: Translate or replace characters from text using the tr command line utility

--- a/traceroute/plugin.spec.yaml
+++ b/traceroute/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: traceroute
 title: Traceroute
 description: The traceroute plugin will trace a network route to a host

--- a/trello/plugin.spec.yaml
+++ b/trello/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: trello
 title: Trello
 description: Boards, lists, and cards enable you to organize and prioritize your projects in a fun, flexible and rewarding way

--- a/trufflehog/plugin.spec.yaml
+++ b/trufflehog/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: trufflehog
 title: TruffleHog
 description: The TruffleHog plugin searches through git repositories for high entropy strings and secrets digging deep into commit history

--- a/try_bro/plugin.spec.yaml
+++ b/try_bro/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: try_bro
 title: Try Bro
 description: "With the Try Bro plugin for Rapid7 InsightConnect, users can use a free instance of Bro Network Security

--- a/tshark/plugin.spec.yaml
+++ b/tshark/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tshark
 title: TShark
 description: "TShark is a tool for dumping and analyzing network traffic. With the TShark plugin for

--- a/tsv/plugin.spec.yaml
+++ b/tsv/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: tsv
 title: TSV
 description: "TSV (Tab Separated Values) is a simple data format for storing data. This plugin allows one to

--- a/twilio/plugin.spec.yaml
+++ b/twilio/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: twilio
 title: Twilio
 description: "Twilio is a cloud communications platform for building SMS, Voice & Messaging applications

--- a/twitter/plugin.spec.yaml
+++ b/twitter/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: twitter
 title: Twitter
 vendor: rapid7

--- a/typo_squatter/plugin.spec.yaml
+++ b/typo_squatter/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: typo_squatter
 title: Typo Squatter
 description: "Typo Squatter detects cybersquatting of domains and allows for domain scoring. This plugin can be used

--- a/uniq/plugin.spec.yaml
+++ b/uniq/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: uniq
 title: Uniq
 description: "Uniq removes redundant lines or items from data. Using the Uniq plugin can allow users to deduplicate

--- a/unshorten/plugin.spec.yaml
+++ b/unshorten/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: unshorten
 title: Unshorten.me
 description: "Unshorten.me provides an easy method to unshorten a wide range of shortened URLs. The Unshorten.me plugin

--- a/url_expander/plugin.spec.yaml
+++ b/url_expander/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: url_expander
 title: URL Expander
 description: Expands a shortened URL

--- a/urlscan/plugin.spec.yaml
+++ b/urlscan/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: urlscan
 title: urlscan.io
 vendor: rapid7

--- a/viper/plugin.spec.yaml
+++ b/viper/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: viper
 title: "Viper"
 description: "The Viper plugins allows you to use Viper's platform to store, search, and analyze files"

--- a/virustotal_yara/plugin.spec.yaml
+++ b/virustotal_yara/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: virustotal_yara
 title: VirusTotal Yara
 description: The VirusTotal Yara plugin allows the user to analyze files with the Yara Python libarary

--- a/vmray/plugin.spec.yaml
+++ b/vmray/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: vmray
 title: VMRay Sandbox
 description: The VMRay plugin allows you to analyze and detect malware before it lands

--- a/vxstream_sandbox/plugin.spec.yaml
+++ b/vxstream_sandbox/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: vxstream_sandbox
 title: VxStream Sandbox
 vendor: rapid7

--- a/wazuh_ossec/plugin.spec.yaml
+++ b/wazuh_ossec/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: wazuh_ossec
 title: Wazuh OSSEC
 description: Provides security visibility, compliance and infrastructure monitoring

--- a/whois/plugin.spec.yaml
+++ b/whois/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: whois
 title: WHOIS
 description: The WHOIS plugin enables address and domain lookups in the WHOIS databases

--- a/wigle/plugin.spec.yaml
+++ b/wigle/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: wigle
 title: WiGLE
 description: The WiGLE (Wireless Geographic Logging Engine) plugin will get and send information about wireless networks

--- a/wordpress/plugin.spec.yaml
+++ b/wordpress/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: wordpress
 title: WordPress
 description: The WordPress plugin allows for user management on the WordPress platform

--- a/zendesk/plugin.spec.yaml
+++ b/zendesk/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: zendesk
 title: Zendesk
 description: The Zendesk plugin helps manage communication with customers. This plugin allows you to manage tickets and users in Zendesk

--- a/zenhub/plugin.spec.yaml
+++ b/zenhub/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: zenhub
 title: ZenHub
 description: The ZenHub plugin allows for agile project management in GitHub

--- a/zeus_tracker/plugin.spec.yaml
+++ b/zeus_tracker/plugin.spec.yaml
@@ -1,6 +1,6 @@
 plugin_spec_version: v2
 extension: plugin
-product: [insightconnect]
+products: [insightconnect]
 name: zeus_tracker
 title: ZeuS Tracker
 description: The ZeuS Command&Control Server Tracking plugin


### PR DESCRIPTION
## Proposed Changes

Describe the proposed changes:

  - Make `product` key plural because it's an array

## Testing

```
$ for i in */plugin.spec.yaml; do js-yaml $i 1>/dev/null || printf "Failure for $i\n"; done && printf "Complete"
Complete
```