### PR TITLE
Makefiles: Remove outdated Makefile helpers

### DIFF
--- a/tools/Makefiles/Helpers.mk
+++ b/tools/Makefiles/Helpers.mk
@@ -1,14 +1,14 @@
 menu:
 	$(Q)echo ""
 	$(Q)echo "$(BOLD)Plugin main targets:$(NORMAL)"
-	$(Q)echo " $(RED)default$(NORMAL)    - Builds the plugin and creates a tarball (image + tarball targets)"
-	$(Q)echo " $(RED)image$(NORMAL)      - Build a Docker image of the current plugin directory"
-	$(Q)echo " $(RED)tarball$(NORMAL)    - Create a plugin tarball of the current directory"
-	$(Q)echo " $(RED)regenerate$(NORMAL) - Regenerate the plugin schema from plugin.spec.yaml"
+	$(Q)echo " $(RED)default$(NORMAL)      - Builds the plugin and creates a tarball (image + tarball targets)"
+	$(Q)echo " $(RED)image$(NORMAL)        - Build a Docker image of the current plugin directory"
+	$(Q)echo " $(RED)tarball$(NORMAL)      - Create a plugin tarball of the current directory"
+	$(Q)echo " $(RED)regenerate$(NORMAL)   - Regenerate the plugin schema from plugin.spec.yaml"
 	$(Q)echo "$(BOLD)Plugin helper targets:$(NORMAL) (depends on installed tools: ../tools/)"
-	$(Q)echo " $(RED)menu$(NORMAL)       - This menu"
-	$(Q)echo " $(RED)validate$(NORMAL)   - Runs the plugin's files through installed validators"
-	$(Q)echo " $(RED)update-tools$(NORMAL)   - Automatically updates all your plugin tooling"
+	$(Q)echo " $(RED)menu$(NORMAL)         - This menu"
+	$(Q)echo " $(RED)validate$(NORMAL)     - Runs the plugin's files through installed validators"
+	$(Q)echo " $(RED)update-tools$(NORMAL) - Automatically updates all your plugin tooling"
 
 validate:
 	$(info [$(YELLOW)*$(NORMAL)] Running validators)

--- a/tools/Makefiles/Helpers.mk
+++ b/tools/Makefiles/Helpers.mk
@@ -7,20 +7,8 @@ menu:
 	$(Q)echo " $(RED)regenerate$(NORMAL) - Regenerate the plugin schema from plugin.spec.yaml"
 	$(Q)echo "$(BOLD)Plugin helper targets:$(NORMAL) (depends on installed tools: ../tools/)"
 	$(Q)echo " $(RED)menu$(NORMAL)       - This menu"
-	$(Q)echo " $(RED)help$(NORMAL)       - Generates a help documentation template from plugin.spec.yaml"
-	$(Q)echo " $(RED)runner$(NORMAL)     - Creates run.sh, the best way to run and test plugins"
 	$(Q)echo " $(RED)validate$(NORMAL)   - Runs the plugin's files through installed validators"
-
-runner:	run.sh
-
-run.sh:
-	$(info [$(YELLOW)*$(NORMAL)] Creating link to run.sh $(YELLOW)|$(NORMAL))
-	@ln -f -s ../tools/run.sh run.sh
-
-help:
-	$(info [$(YELLOW)*$(NORMAL)] Generating help template from plugin.spec.yaml)
-	$(info [$(YELLOW)*$(NORMAL)] Edit and place Markdown output in help.md)
-	@test -x ../tools/help.py && ../tools/help.py ./plugin.spec.yaml || true
+	$(Q)echo " $(RED)update-tools$(NORMAL)   - Automatically updates all your plugin tooling"
 
 validate:
 	$(info [$(YELLOW)*$(NORMAL)] Running validators)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Remove `runner` targets from Helpers Makefile, `icon-plugin` should be used instead
  - Remove `help` target from Helpers Makefile, it's outdated and `icon-plugin generate help` should be used instead
  - Add `update-tools` target to menu
  - Keep scripts around in `tools/` directory for now in case they become necessary for use in edge cases or bugs in the main tool.

### Testing

`make` validation:

```
$ make -n -f tools/Makefiles/Helpers.mk
echo ""
echo "Plugin main targets:"
echo " default    - Builds the plugin and creates a tarball (image + tarball targets)"
echo " image      - Build a Docker image of the current plugin directory"
echo " tarball    - Create a plugin tarball of the current directory"
echo " regenerate - Regenerate the plugin schema from plugin.spec.yaml"
echo "Plugin helper targets: (depends on installed tools: ../tools/)"
echo " menu       - This menu"
echo " validate   - Runs the plugin's files through installed validators"
echo " update-tools   - Automatically updates all your plugin tooling"
```

```
$ cd sentinelone
$ make validate
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Colors.mk ../tools/Makefiles/Helpers.mk
--
[*] Running validators
```

```
$ cd dirname
$ make update-tools
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Colors.mk ../tools/Makefiles/Helpers.mk
--
../tools/update-tools.sh
[*] Executing update/installation for MacOS!
[*] Installing/updating icon-plugin via homebrew...
```

Reformat `make menu` to align the columns:

```
$ make menu
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Colors.mk ../tools/Makefiles/Helpers.mk
--

Plugin main targets:
 default      - Builds the plugin and creates a tarball (image + tarball targets)
 image        - Build a Docker image of the current plugin directory
 tarball      - Create a plugin tarball of the current directory
 regenerate   - Regenerate the plugin schema from plugin.spec.yaml
Plugin helper targets: (depends on installed tools: ../tools/)
 menu         - This menu
 validate     - Runs the plugin's files through installed validators
 update-tools - Automatically updates all your plugin tooling
```