### PR TITLE
Added new value to return output of proofpoint TAP plugin

### DIFF
--- a/proofpoint_tap/.CHECKSUM
+++ b/proofpoint_tap/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "c41462918556349584c234982d498e1e",
-	"manifest": "8941ee75799d3b6ce10d191ffce4782d",
-	"setup": "30be6812ef9c468182d1237ae45b9d6f",
+	"spec": "6dfd82ee0348f6d9789182edc4f1ac03",
+	"manifest": "8dd7a4399d49eccf2d8532f17996dfb7",
+	"setup": "ea5034fba757de42e4c0673ce9cd5125",
 	"schemas": [
 		{
 			"identifier": "parse_tap_alert/schema.py",
-			"hash": "db32bf7a8c6db62b2745ac84de1f3358"
+			"hash": "05a4a220b3b0b3cb22f4faa8b26471b2"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from komand_proofpoint_tap import connection, actions, triggers
 
 Name = 'Proofpoint TAP'
 Vendor = 'rapid7'
-Version = '1.0.4'
+Version = '1.0.5'
 Description = 'A plugin for Proofpoint Targeted Attack Protection (TAP) alerts'
 
 

--- a/proofpoint_tap/help.md
+++ b/proofpoint_tap/help.md
@@ -43,16 +43,17 @@ Example output:
   "threat": {
     "attachment_sha256": "f2ca1bb6c7e907d06dafe4687e579fce76b37e4e93b7605022da52e6ccc26fd2",
     "category": "Malware",
-    "condemnation_time": "2019-01-10T12:34:05Z"
+    "condemnation_time": "2019-01-10T12:34:05Z",
+    "threat_details_url": "https://threatinsight.proofpoint.com/d7924670-a2ec-a214-9b2a-acd68a33dba2/threat/email/6789c46ac78950da6c243c52dc9312cab77877c6b0e1dbd5d66f9870e96d30bf?linkOrigin=notif"
   },
   "message": {
     "time_delivered": "2019-01-10T12:10:21Z",
-    "recipients": "alice@example.com",
+    "recipients": "user@example.com",
     "subject": "January Invoice",
-    "sender": "bob@example.com",
+    "sender": "user@example.com",
     "header_from": "Bob",
-    "header_replyto": "bob@example.com",
-    "message_id": " 1111111111.22222222.3333333333333@mail.yahoo.com",
+    "header_replyto": "user@example.com",
+    "message_id": "user@example.com",
     "sender_ip": "1.2.3.4",
     "message_size": "152 KB"
   },
@@ -78,6 +79,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 1.0.5 - Parsing out the View Threat Details link from emails to its own value
 * 1.0.4 - New spec and help.md format for the Hub
 * 1.0.3 - Fixed issue where headers were occasionally parsed improperly
 * 1.0.2 - Sanitize example output in Parse Alert action documentation

--- a/proofpoint_tap/komand_proofpoint_tap/actions/parse_tap_alert/action.py
+++ b/proofpoint_tap/komand_proofpoint_tap/actions/parse_tap_alert/action.py
@@ -3,6 +3,7 @@ from .schema import ParseTapAlertInput, ParseTapAlertOutput, Input, Output
 # Custom imports below
 from html_table_parser import HTMLTableParser
 from komand_proofpoint_tap.util.tap_formatter import TAP
+from urlextract import URLExtract
 
 
 class ParseTapAlert(komand.Action):
@@ -19,5 +20,16 @@ class ParseTapAlert(komand.Action):
         p.feed(params.get(Input.TAP_ALERT))
         data = p.tables
         clean_data = TAP(data).data
+
+        # Get the Threat details URL which is NOT an HTML table element, but instead the <a> link of the
+        #    table element
+        extractor = URLExtract()
+        cleaned_input_for_extractor = params.get(Input.TAP_ALERT)
+        cleaned_input_for_extractor.replace('\n', '')
+        urls_from_input = extractor.find_urls(cleaned_input_for_extractor)
+        threat_details_urls = list(filter(lambda u: r'threat/email' in u and r'threatinsight.proofpoint.com' in u[:40],
+                                     urls_from_input))
+        if threat_details_urls:
+            clean_data['threat']['threat_details_url'] = threat_details_urls[0]
 
         return {Output.RESULTS: clean_data}

--- a/proofpoint_tap/komand_proofpoint_tap/actions/parse_tap_alert/schema.py
+++ b/proofpoint_tap/komand_proofpoint_tap/actions/parse_tap_alert/schema.py
@@ -266,6 +266,12 @@ class ParseTapAlertOutput(komand.Output):
               "description": "Condemnation Time",
               "order": 4
             },
+            "threat_details_url": {
+              "type": "string",
+              "title": "Threat Details URL",
+              "description": "URL for Details of the Threat",
+              "order": 5
+            },
             "url": {
               "type": "string",
               "title": "URL",
@@ -297,6 +303,12 @@ class ParseTapAlertOutput(komand.Output):
           "title": "Condemnation Time",
           "description": "Condemnation Time",
           "order": 4
+        },
+        "threat_details_url": {
+          "type": "string",
+          "title": "Threat Details URL",
+          "description": "URL for Details of the Threat",
+          "order": 5
         },
         "url": {
           "type": "string",

--- a/proofpoint_tap/komand_proofpoint_tap/util/tap_formatter.py
+++ b/proofpoint_tap/komand_proofpoint_tap/util/tap_formatter.py
@@ -14,7 +14,8 @@ class TAP:
                 "attachment_sha256": "",
                 "category": "",
                 "condemnation_time": "",
-                "url": ""
+                "url": "",
+                "threat_details_url": ""
             },
             "message": {
                 "time_delivered": "",

--- a/proofpoint_tap/plugin.spec.yaml
+++ b/proofpoint_tap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: A plugin for Proofpoint Targeted Attack Protection (TAP) alerts
-version: 1.0.4
+version: 1.0.5
 vendor: rapid7
 support: community
 status: []
@@ -40,6 +40,11 @@ types:
     condemnation_time:
       title: Condemnation Time
       description: Condemnation Time
+      type: string
+      required: false
+    threat_details_url:
+      title: Threat Details URL
+      description: URL for Details of the Threat
       type: string
       required: false
   message:

--- a/proofpoint_tap/requirements.txt
+++ b/proofpoint_tap/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 html-table-parser-python3==0.1.5
+urlextract==0.14.0

--- a/proofpoint_tap/setup.py
+++ b/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name='proofpoint_tap-rapid7-plugin',
-      version='1.0.4',
+      version='1.0.5',
       description='A plugin for Proofpoint Targeted Attack Protection (TAP) alerts',
       author='rapid7',
       author_email='',

--- a/proofpoint_tap/tests/parse_tap_alert.json
+++ b/proofpoint_tap/tests/parse_tap_alert.json
@@ -1,12 +1,12 @@
 {
-    "body": {
-        "action": "parse_tap_alert",
-        "connection": null,
-        "input": {
-            "tap_alert": ""
-        },
-        "meta": {}
+  "body": {
+    "action": "parse_tap_alert",
+    "meta": {},
+    "input": {
+      "tap_alert": ""
     },
-    "type": "action_start",
-    "version": "v1"
+    "connection": null
+  },
+  "type": "action_start",
+  "version": "v1"
 }


### PR DESCRIPTION
### Description

- Add a new return key and value to the Proofpoint TAP action.  The Threat Details URL is a link to Proofpoint documentation on the threat in element "threat_details_url"

## Testing

Some fields obfuscated with <removed>

```
run -R tests/parse_tap_alert_attachment.json 
INFO[0000] Running command:  docker run --rm -i rapid7/proofpoint_tap:1.0.5 run < tests/parse_tap_alert_attachment.json 
{"body": {"log": "rapid7/Proofpoint TAP:1.0.5. Step name: parse_tap_alert", "status": "ok", "meta": {}, "output": {"results": {"threat": {"attachment_sha256": "", "category": "phish", "condemnation_time": "2019-08-12T22:03:36Z", "url": "<removed>", "threat_details_url": "https://threatinsight.proofpoint.com/<removed>/threat/email/<removed>"}, "message": {"time_delivered": "2019-08-10T05:18:51Z", "recipients": "<removed>", "subject": "97", "sender": "<removed>", "header_from": "97", "header_replyto": "97", "message_id": "<removed>", "sender_ip": "103.27.74.25", "message_size": "97"}, "browser": {"time": "2019-08-12T14:11:47Z", "source_ip": “<removed>“, "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edge/17.17134"}}}}, "version": "v1", "type": "action_event"}

```


```
icon-plugin run -R tests/parse_tap_alert_attachment_bad_input.json
INFO[0000] Running command:  docker run --rm -i rapid7/proofpoint_tap:1.0.5 run < tests/parse_tap_alert_attachment_bad_input.json 
{"body": {"log": "rapid7/Proofpoint TAP:1.0.5. Step name: parse_tap_alert\n", "status": "ok", "meta": {}, "output": {"results": {"threat": {"attachment_sha256": "", "category": "phish", "condemnation_time": "2019-08-12T22:03:36Z", "url": "hxxp://tags[.]my/htaccess/file/index[.]php?e user@example.com", "threat_details_url": ""}, "message": {"time_delivered": "2019-08-10T05:18:51Z", "recipients": "user@example.com", "subject": "97", "sender": "user@example.com", "header_from": "97", "header_replyto": "97", "message_id": "user@example.com", "sender_ip": "103.27.74.25", "message_size": "97"}, "browser": {"time": "2019-08-12T14:11:47Z", "source_ip": "192.234.69.178", "user_agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) Ap pleWebKit/537.36 (KHTML, like Gecko) Chrome/64.0.3282.140 Safari/537.36 Edg e/17.17134"}}}}, "version": "v1", "type": "action_event"}

```




## Input 

<img width="609" alt="Screen Shot 2019-12-09 at 3 17 31 PM" src="https://user-images.githubusercontent.com/57681561/70469773-afcc3100-1a97-11ea-83bb-097424bcd53d.png">

<img width="916" alt="Screen Shot 2019-12-09 at 3 17 56 PM" src="https://user-images.githubusercontent.com/57681561/70469814-c6728800-1a97-11ea-87b9-382789d6551f.png">


## Output

<img width="889" alt="Screen Shot 2019-12-09 at 3 23 35 PM" src="https://user-images.githubusercontent.com/57681561/70469894-f6ba2680-1a97-11ea-89ad-ab0d8f5c32fc.png">


## Artifacts


<img width="876" alt="Screen Shot 2019-12-09 at 3 24 46 PM" src="https://user-images.githubusercontent.com/57681561/70469975-15b8b880-1a98-11ea-9d4d-86751e3b01b9.png">

