### PR TITLE
Enforce markdown linting in validation

### DIFF
--- a/mimecast/help.md
+++ b/mimecast/help.md
@@ -33,9 +33,6 @@ The connection configuration accepts the following parameters:
 
 ## Technical Details
 
-No notable technical requirements to highlight
-
-
 ### Actions
 
 #### Create Managed URL
@@ -300,7 +297,7 @@ Example output:
 
 ```
 {
-  "success": true 
+  "success": true
 }
 ```
 

--- a/tools/mdl.sh
+++ b/tools/mdl.sh
@@ -24,15 +24,15 @@ main() {
     is_mdl || exit 0
     is_help || exit 0
     printf "\n[${YELLOW}*${NORMAL}] ${BOLD}Validating markdown...${NORMAL}\n"
-    output=$(mdl help.md)
-    # We don't rely on exit code due to the following rules we don't care about
-    if echo "$output" | egrep -v "MD024|MD013|MD029|MD033|MD013|MD024|MD025|MD034|MD036" | fgrep 'help.md:'; then
+    mdl --rules ~MD024,~MD013,~MD029,~MD033,~MD034,~MD013,~MD024,~MD025,~MD034,~MD036 help.md
+    result=$?
+    if [[ $result > 0 ]]; then
       printf "[${RED}FAIL${NORMAL}] Fails markdown linting\n"
     else
       printf "[${YELLOW}SUCCESS${NORMAL}] Passes markdown linting\n"
     fi
 
-    return 0 # Make make happy :)
+    return $result
 }
 
 main


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Enforce markdown linting when `icon-validate` is used by returning `mdl` status code
  - Update any specs to pass linting rules

### Testing

```
$ for i in */help.md; do plugin=$(dirname $i); pushd $plugin 1>/dev/null; ../tools/mdl.sh &>/dev/null || printf "$plugin\n"; popd 1>/dev/null; done && printf "Done"
Done
```