### PR TITLE
Fix spec error in use case elements

### DIFF
--- a/domaintools/plugin.spec.yaml
+++ b/domaintools/plugin.spec.yaml
@@ -20,7 +20,7 @@ tags:
 - domain
 - intel
 hub_tags:
-  use_cases: [threat_detection_and_response, , offensive_security]
+  use_cases: [threat_detection_and_response, offensive_security]
   keywords: [domain, whois, ip, domain, intel]
   features: []
 enable_cache: true


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

* Fix syntax bug in `plugin.spec.yaml` causing error in CI

```
17:13:17 ruamel.yaml.parser.ParserError: while parsing a flow node
17:13:17 expected the node content, but found ','
17:13:17   in "<unicode string>", line 23, column 46:
17:13:17      ... [threat_detection_and_response, , offensive_security]
17:13:17                                          ^ (line: 23)
17:13:17 Build step 'Execute shell' marked build as failure
```