### PR TITLE
#134 abuseipdb amendments - Changed descriptions | Removed code dupli…

### DIFF
--- a/abuseipdb/.CHECKSUM
+++ b/abuseipdb/.CHECKSUM
@@ -1,15 +1,15 @@
 {
-	"spec": "88b0ab7ddf6993a85ded682d0d37a219",
-	"manifest": "64c5e6476bb8d5872e429017776f9e47",
-	"setup": "297ef90b1a5acde3cd7d3c41da73e397",
+	"spec": "88162fcf558358a818ed62b9bb012bef",
+	"manifest": "4f9076499b1d2c05806ff8a6d3236f80",
+	"setup": "f3571028fb9652b24b8bac495124a3b3",
 	"schemas": [
 		{
 			"identifier": "check_cidr/schema.py",
-			"hash": "d914ed5eebc4c63a5506f8ce22b3770d"
+			"hash": "b19f6a4ab1e2f39e8a6aabbabe463d63"
 		},
 		{
 			"identifier": "check_ip/schema.py",
-			"hash": "145cf31842e684859bf9bee318d67663"
+			"hash": "f59063e54846f5676927180c76700e29"
 		},
 		{
 			"identifier": "get_blacklist/schema.py",
@@ -21,7 +21,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "4a9612e474a02b1fce58dd27df826e18"
+			"hash": "e8f7bd175d6ecd76b01cfb6df6970683"
 		}
 	]
 }

--- a/abuseipdb/bin/komand_abuseipdb
+++ b/abuseipdb/bin/komand_abuseipdb
@@ -4,10 +4,10 @@ import komand
 from komand_abuseipdb import connection, actions, triggers
 
 
-Name = 'AbuseIPDB'
-Vendor = 'rapid7'
-Version = '5.0.1'
-Description = 'Enables the look up of IP reports, provides list and details of blacklisted IPs, and submissions of abusive IPs'
+Name = "AbuseIPDB"
+Vendor = "rapid7"
+Version = "5.0.2"
+Description = "Enables the look up of IP reports, provides list and details of blacklisted IPs, and submissions of abusive IPs"
 
 
 class ICONAbuseipdb(komand.Plugin):

--- a/abuseipdb/help.md
+++ b/abuseipdb/help.md
@@ -289,7 +289,7 @@ There's a rate limit on the free API service. The following error messags `429 C
 
 # Version History
 
-* 5.0.2 - Changed descriptions | Removed code duplicated | Changed bare strings in params.get and output to static fields from schema | Added "f" strings
+* 5.0.2 - Changed descriptions | Removed duplicated code | Use output constants | Added "f" strings
 * 5.0.1 - New spec and help.md format for the Hub
 * 5.0.0 - Mark certain outputs as optional as they are not always returned by the AbuseIPDB service | Clean output of null values
 * 4.0.1 - Transform null value of various output properties of Check IP action to false or empty string.

--- a/abuseipdb/help.md
+++ b/abuseipdb/help.md
@@ -22,7 +22,7 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
-|credentials|credential_secret_key|None|True|API key|None|
+|credentials|credential_secret_key|None|True|API key from account|None|
 
 ## Technical Details
 
@@ -76,7 +76,7 @@ This action is used to look up an IP address in the database.
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
-|address|string|None|True|IPv4 or IPv6 address e.g. 8.8.8.8, ::1|None|
+|address|string|None|True|IPv4 or IPv6 address e.g. 8.8.8.8, ::1, must be subscribed to accept bitmask wider than 255.255.255.0 (/24)|None|
 |days|string|30|True|Check for IP reports in the last x days|None|
 |verbose|boolean|True|True|When set, reports will include the comment (if any) and the reporter's user ID number (0 if reported anonymously)|None|
 
@@ -159,12 +159,12 @@ This action is used to look up a CIDR address in the database.
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|addressSpaceDesc|string|False|Address space description|
+|addressSpaceDesc|string|False|Description of address space|
 |found|boolean|True|Whether the CIDR was found in the database|
-|maxAddress|string|False|Maximum address|
-|minAddress|string|False|Minimum address|
-|netmask|string|False|Netmask|
-|networkAddress|string|False|Network address|
+|maxAddress|string|False|Last address in block|
+|minAddress|string|False|First address in block|
+|netmask|string|False|Netmask, ie. 24|
+|networkAddress|string|False|Network address in block|
 |numPossibleHosts|integer|False|Number of possible hosts|
 |reportedAddress|[]reportedIPs|False|List of reported IPs|
 
@@ -289,6 +289,7 @@ There's a rate limit on the free API service. The following error messags `429 C
 
 # Version History
 
+* 5.0.2 - Changed descriptions | Removed code duplicated | Changed bare strings in params.get and output to static fields from schema | Added "f" strings
 * 5.0.1 - New spec and help.md format for the Hub
 * 5.0.0 - Mark certain outputs as optional as they are not always returned by the AbuseIPDB service | Clean output of null values
 * 4.0.1 - Transform null value of various output properties of Check IP action to false or empty string.

--- a/abuseipdb/komand_abuseipdb/actions/check_cidr/schema.py
+++ b/abuseipdb/komand_abuseipdb/actions/check_cidr/schema.py
@@ -63,7 +63,7 @@ class CheckCidrOutput(komand.Output):
     "addressSpaceDesc": {
       "type": "string",
       "title": "Address Space Description",
-      "description": "Address space description",
+      "description": "Description of address space",
       "order": 6
     },
     "found": {
@@ -75,25 +75,25 @@ class CheckCidrOutput(komand.Output):
     "maxAddress": {
       "type": "string",
       "title": "Maximum Address",
-      "description": "Maximum address",
+      "description": "Last address in block",
       "order": 4
     },
     "minAddress": {
       "type": "string",
       "title": "Minimum Address",
-      "description": "Minimum address",
+      "description": "First address in block",
       "order": 3
     },
     "netmask": {
       "type": "string",
       "title": "Netmask",
-      "description": "Netmask",
+      "description": "Netmask, ie. 24",
       "order": 2
     },
     "networkAddress": {
       "type": "string",
       "title": "Network Address",
-      "description": "Network address",
+      "description": "Network address in block",
       "order": 1
     },
     "numPossibleHosts": {

--- a/abuseipdb/komand_abuseipdb/actions/check_ip/schema.py
+++ b/abuseipdb/komand_abuseipdb/actions/check_ip/schema.py
@@ -40,7 +40,7 @@ class CheckIpInput(komand.Input):
     "address": {
       "type": "string",
       "title": "IP Address",
-      "description": "IPv4 or IPv6 address e.g. 8.8.8.8, ::1",
+      "description": "IPv4 or IPv6 address e.g. 8.8.8.8, ::1, must be subscribed to accept bitmask wider than 255.255.255.0 (/24)",
       "order": 1
     },
     "days": {

--- a/abuseipdb/komand_abuseipdb/actions/get_blacklist/action.py
+++ b/abuseipdb/komand_abuseipdb/actions/get_blacklist/action.py
@@ -1,10 +1,11 @@
 import komand
-from .schema import GetBlacklistInput, GetBlacklistOutput, Input
+from .schema import GetBlacklistInput, GetBlacklistOutput, Input, Output
 # Custom imports below
 from komand.exceptions import PluginException
 import json
 import requests
 import logging
+from komand_abuseipdb.util import helper
 logging.getLogger('requests').setLevel(logging.WARNING)
 
 
@@ -32,19 +33,16 @@ class GetBlacklist(komand.Action):
         r = requests.get(url, params=params, headers=self.connection.headers)
 
         try:
-            json_ = r.json()
-            if "errors" in json_:
-                raise PluginException(cause='Received an error response from AbuseIPDB.',
-                                      assistance=json_['errors'][0]["detail"])
+            json_ = helper.get_json(r)
             blacklist = json_["data"]
-            out = {"blacklist": blacklist}
+            out = {Output.BLACKLIST: blacklist}
         except json.decoder.JSONDecodeError:
             raise PluginException(cause='Received an unexpected response from AbuseIPDB.',
-                                  assistance="(non-JSON or no response was received). Response was: %s" % r.text)
+                                  assistance=f"(non-JSON or no response was received). Response was: {r.text}")
 
         if len(out) > 0:
-            out["success"] = True
+            out[Output.SUCCESS] = True
         else:
-            out["success"] = False
+            out[Output.SUCCESS] = False
 
         return out

--- a/abuseipdb/komand_abuseipdb/actions/report_ip/action.py
+++ b/abuseipdb/komand_abuseipdb/actions/report_ip/action.py
@@ -1,10 +1,11 @@
 import komand
-from .schema import ReportIpInput, ReportIpOutput, Input
+from .schema import ReportIpInput, ReportIpOutput, Input, Output
 # Custom imports below
 from komand.exceptions import PluginException
 import json
 import requests
 import logging
+from komand_abuseipdb.util import helper
 logging.getLogger('requests').setLevel(logging.WARNING)
 
 
@@ -31,18 +32,15 @@ class ReportIp(komand.Action):
         r = requests.post(url, params=params, headers=self.connection.headers)
 
         try:
-            json_ = r.json()
-            if "errors" in json_:
-                raise PluginException(cause='Received an error response from AbuseIPDB.',
-                                      assistance=json_['errors'][0]["detail"])
+            json_ = helper.get_json(r)
             out = json_["data"]
         except json.decoder.JSONDecodeError:
             raise PluginException(cause='Received an unexpected response from AbuseIPDB.',
-                                  assistance="(non-JSON or no response was received). Response was: %s" % r.text)
+                                  assistance=f"(non-JSON or no response was received). Response was: {r.text}")
 
         if len(out) > 0:
-            out["success"] = True
+            out[Output.SUCCESS] = True
         else:
-            out["success"] = False
+            out[Output.SUCCESS] = False
 
         return out

--- a/abuseipdb/komand_abuseipdb/connection/connection.py
+++ b/abuseipdb/komand_abuseipdb/connection/connection.py
@@ -10,6 +10,9 @@ class Connection(komand.Connection):
 
     def __init__(self):
         super(self.__class__, self).__init__(input=ConnectionSchema())
+        self.api_key = None
+        self.base = None
+        self.headers = None
 
     def connect(self, params):
         self.api_key = params.get('credentials').get('secretKey')
@@ -18,7 +21,7 @@ class Connection(komand.Connection):
             'Accept': 'application/json',
             'Key': self.api_key
         }
-        self.logger.info('Connect: Connecting to %s...' % self.base)
+        self.logger.info(f'Connect: Connecting to {self.base}...')
 
     def test(self):
         # Use private IP Addresses for testing the API (e.g. 127.0.0.1) from https://www.abuseipdb.com/api
@@ -31,8 +34,8 @@ class Connection(komand.Connection):
             json_ = r.json()
         except json.decoder.JSONDecodeError:
             raise ConnectionTestException(cause='Received an unexpected response from AbuseIPDB.',
-                                          assistance="(non-JSON or no response"
-                                                     " was received). Response was: %s" % r.text)
+                                          assistance=f"(non-JSON or no response"
+                                                     f" was received). Response was: {r.text}")
         except Exception as e:
             self.logger.error(e)
             raise

--- a/abuseipdb/komand_abuseipdb/connection/schema.py
+++ b/abuseipdb/komand_abuseipdb/connection/schema.py
@@ -16,7 +16,7 @@ class ConnectionSchema(komand.Input):
     "credentials": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "API Key",
-      "description": "API key",
+      "description": "API key from account",
       "order": 1
     }
   },

--- a/abuseipdb/komand_abuseipdb/util/helper.py
+++ b/abuseipdb/komand_abuseipdb/util/helper.py
@@ -1,0 +1,14 @@
+from komand.exceptions import PluginException
+
+
+def get_json(response):
+    json_ = response.json()
+    if "errors" in json_:
+        details = ''
+        if len(json_['errors']) > 0 and 'details' in json_['errors'][0]:
+            details = json_['errors'][0]["detail"]
+
+        raise PluginException(cause='Received an error response from AbuseIPDB.',
+                              assistance=details)
+
+    return json_

--- a/abuseipdb/plugin.spec.yaml
+++ b/abuseipdb/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: abuseipdb
 title: AbuseIPDB
 description: Enables the look up of IP reports, provides list and details of blacklisted IPs, and submissions of abusive IPs
-version: 5.0.1
+version: 5.0.2
 vendor: rapid7
 support: community
 status: []
@@ -92,7 +92,7 @@ types:
 connection:
   credentials:
     title: API Key
-    description: API key
+    description: API key from account
     type: credential_secret_key
     required: true
 
@@ -103,7 +103,7 @@ actions:
     input:
       address:
         title: IP Address
-        description: IPv4 or IPv6 address e.g. 8.8.8.8, ::1
+        description: IPv4 or IPv6 address e.g. 8.8.8.8, ::1, must be subscribed to accept bitmask wider than 255.255.255.0 (/24)
         type: string
         required: true
       days:
@@ -214,22 +214,22 @@ actions:
     output:
       networkAddress:
         title: Network Address
-        description: Network address
+        description: Network address in block
         type: string
         required: false
       netmask:
         title: Netmask
-        description: Netmask
+        description: Netmask, ie. 24
         type: string
         required: false
       minAddress:
         title: Minimum Address
-        description: Minimum address
+        description: First address in block
         type: string
         required: false
       maxAddress:
         title: Maximum Address
-        description: Maximum address
+        description: Last address in block
         type: string
         required: false
       numPossibleHosts:
@@ -239,7 +239,7 @@ actions:
         required: false
       addressSpaceDesc:
         title: Address Space Description
-        description: Address space description
+        description: Description of address space
         type: string
         required: false
       reportedAddress:

--- a/abuseipdb/setup.py
+++ b/abuseipdb/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 
-setup(name='abuseipdb-rapid7-plugin',
-      version='5.0.1',
-      description='Enables the look up of IP reports, provides list and details of blacklisted IPs, and submissions of abusive IPs',
-      author='rapid7',
-      author_email='',
-      url='',
+setup(name="abuseipdb-rapid7-plugin",
+      version="5.0.2",
+      description="Enables the look up of IP reports, provides list and details of blacklisted IPs, and submissions of abusive IPs",
+      author="rapid7",
+      author_email="",
+      url="",
       packages=find_packages(),
       install_requires=['komand'],  # Add third-party dependencies to requirements.txt, not here!
       scripts=['bin/komand_abuseipdb']


### PR DESCRIPTION
…cated | Changed bare strings in params.get and output to static fields from schema | Added "f" strings

## Proposed Changes
- Changed descriptions
- Removed code duplicated
- Changed bare strings in params.get and output to static fields from schema
- Added "f" strings

### Description

Describe the proposed changes:
  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [x] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [x] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [x] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)


## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_cidr\n",
    "meta": {},
    "output": {
      "addressSpaceDesc": "Internet",
      "found": true,
      "maxAddress": "51.91.254.145",
      "minAddress": "51.91.254.144",
      "netmask": "255.255.255.254",
      "networkAddress": "51.91.254.144",
      "numPossibleHosts": 2,
      "reportedAddress": []
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/check_cidr.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. ",
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_cidr\nAn error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. \nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 419, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/actions/check_cidr/action.py\", line 34, in run\n    json_ = helper.get_json(r)\n  File \"/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/util/helper.py\", line 12, in get_json\n    assistance=details)\nkomand.exceptions.PluginException: An error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. \n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/check_cidr_error.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_ip\n",
    "meta": {},
    "output": {
      "abuseConfidenceScore": 0,
      "countryCode": "US",
      "countryName": "United States",
      "domain": "google.com",
      "found": true,
      "ipAddress": "8.8.8.8",
      "ipVersion": 4,
      "isPublic": true,
      "isWhitelisted": true,
      "isp": "Google LLC",
      "lastReportedAt": "2019-12-26T23:56:04+00:00",
      "numDistinctUsers": 3,
      "reports": [
        {
          "categories": [
            3,
            15
          ],
          "comment": "look after your forces USA/UK GOV/BBC SCOTLAND near England -ITV NEAR ENGLAND - confused.com of how we work -CLIENTS1.GOOGLE.COM ????-TV MEDIA more powerful than any GOV -AND YOUR RELATIVES IN TV MEDIA USA and uk and AU -ALLOW tv media to rule the networks and sky sats",
          "reportedAt": "2019-12-26T23:56:04+00:00",
          "reporterCountryCode": "GB",
          "reporterCountryName": "United Kingdom",
          "reporterId": 0
        },
        {
          "categories": [
            4,
            5,
            7,
            8,
            10,
            11,
            12,
            13,
            14,
            15,
            16,
            17,
            21,
            23
          ],
          "comment": "Middle man attack",
          "reportedAt": "2019-12-23T09:37:02+00:00",
          "reporterCountryCode": "US",
          "reporterCountryName": "United States",
          "reporterId": 0
        },
        {
          "categories": [
            3,
            4,
            5,
            6,
            7,
            8,
            9,
            10,
            11,
            12,
            13,
            14,
            15,
            16,
            17,
            18,
            19,
            20,
            21,
            22,
            23
          ],
          "comment": "41.207.160.90",
          "reportedAt": "2019-12-21T17:01:55+00:00",
          "reporterCountryCode": "NL",
          "reporterCountryName": "Netherlands",
          "reporterId": 0
        },
        {
          "categories": [
            11
          ],
          "reportedAt": "2019-12-20T15:39:04+00:00",
          "reporterCountryCode": "ID",
          "reporterCountryName": "Indonesia",
          "reporterId": 0
        },
        {
          "categories": [
            14
          ],
          "comment": "ET TROJAN DNS Reply Sinkhole - Anubis - 195.22.26.192/26 - port: 28369 proto: UDP cat: A Network Trojan was Detected",
          "reportedAt": "2019-12-20T12:16:02+00:00",
          "reporterCountryCode": "US",
          "reporterCountryName": "United States",
          "reporterId": 13871
        },
        {
          "categories": [
            15
          ],
          "comment": "bonkers BBC -threat to us -faKE PNN.NET -BUILDER BOB ???8-FAKE BBC",
          "reportedAt": "2019-12-20T00:29:33+00:00",
          "reporterCountryCode": "GB",
          "reporterCountryName": "United Kingdom",
          "reporterId": 0
        },
        {
          "categories": [
            15
          ],
          "comment": "AMAZINg - TWICE - ON tv -donate 1 therein for each amazing - don't know either -social media overtake -don't know 1234-USA teach equal education and religious education akamai RE - Coming to see our New England SOON -let the youngster take over -top tip - can't IE throw bottles at the Rozzers - ANOTHER reality show prompt -for another tv reality show based on social media -enough-AU near Scotland put our the fires - -perimeterx.com -kick out GSTATIC.COM -combination key G.ROOT-SERVERS.NET/INFO/IO ETC ETC BLOODY ETC REPEAT -MAC AND USA same -respectfully -looking after our New England likely a Scots not English -coming to see -holiday -interest in USA -US English are as bad -work differently -observe 1234+fr es etc history es-fr-8.8.8.8 aggressive 8.8.8.8-prefix view/i.root-servers.com and hyphens developer spying on your own waring past",
          "reportedAt": "2019-12-19T00:27:51+00:00",
          "reporterCountryCode": "GB",
          "reporterCountryName": "United Kingdom",
          "reporterId": 0
        },
        {
          "categories": [
            4
          ],
          "reportedAt": "2019-12-17T11:09:21+00:00",
          "reporterCountryCode": "RU",
          "reporterCountryName": "Russian Federation",
          "reporterId": 0
        },
        {
          "categories": [
            14
          ],
          "comment": "ET TROJAN DNS Reply Sinkhole - Anubis - 195.22.26.192/26 - port: 46351 proto: UDP cat: A Network Trojan was Detected",
          "reportedAt": "2019-12-16T18:16:05+00:00",
          "reporterCountryCode": "US",
          "reporterCountryName": "United States",
          "reporterId": 13871
        },
        {
          "categories": [
            15
          ],
          "comment": "Dec 11 15:47:00 h2177944 kernel: \\[8950710.779409\\] \\[UFW BLOCK\\] IN=venet0 OUT= MAC= SRC=8.8.8.8 DST=85.214.117.9 LEN=141 TOS=0x00 PREC=0x00 TTL=122 ID=42779 PROTO=UDP SPT=53 DPT=13147 LEN=121 \nDec 11 15:48:45 h2177944 kernel: \\[8950815.561729\\] \\[UFW BLOCK\\] IN=venet0 OUT= MAC= SRC=8.8.8.8 DST=85.214.117.9 LEN=141 TOS=0x00 PREC=0x00 TTL=122 ID=28135 PROTO=UDP SPT=53 DPT=13147 LEN=121 \nDec 11 16:05:41 h2177944 kernel: \\[8951831.300744\\] \\[UFW BLOCK\\] IN=venet0 OUT= MAC= SRC=8.8.8.8 DST=85.214.117.9 LEN=141 TOS=0x00 PREC=0x00 TTL=104 ID=63232 PROTO=UDP SPT=53 DPT=13147 LEN=121 \nDec 11 16:06:15 h2177944 kernel: \\[8951865.629964\\] \\[UFW BLOCK\\] IN=venet0 OUT= MAC= SRC=8.8.8.8 DST=85.214.117.9 LEN=141 TOS=0x00 PREC=0x00 TTL=104 ID=9204 PROTO=UDP SPT=53 DPT=13147 LEN=121 \nDec 11 16:22:38 h2177944 kernel: \\[8952847.949892\\] \\[UFW BLOCK\\] IN=venet0 OUT= MAC= SRC=8.8.8.8 DST=85.214.117.9 LEN=141 TOS=0x00 PREC=0x00 TTL=122 ID=17185 PROTO=UDP SPT=53 DPT=13147 LEN=121 \n...",
          "reportedAt": "2019-12-11T15:22:39+00:00",
          "reporterCountryCode": "DE",
          "reporterCountryName": "Germany",
          "reporterId": 10537
        },
        {
          "categories": [
            14
          ],
          "comment": "ET TROJAN DNS Reply Sinkhole - Anubis - 195.22.26.192/26 - port: 62343 proto: UDP cat: A Network Trojan was Detected",
          "reportedAt": "2019-12-08T18:16:03+00:00",
          "reporterCountryCode": "US",
          "reporterCountryName": "United States",
          "reporterId": 13871
        },
        {
          "categories": [
            14,
            18
          ],
          "reportedAt": "2019-12-07T05:32:16+00:00",
          "reporterCountryCode": "RU",
          "reporterCountryName": "Russian Federation",
          "reporterId": 0
        },
        {
          "categories": [
            14
          ],
          "reportedAt": "2019-12-06T21:23:45+00:00",
          "reporterCountryCode": "BR",
          "reporterCountryName": "Brazil",
          "reporterId": 0
        },
        {
          "categories": [
            3,
            15
          ],
          "comment": "set aside - check out re-inventing face book versions -by other countries - might want to revenge - 101 is fake police and tv media -bbc mostly mc HALL English educated as is Roberts - -address IT/DEV from other countries duplications - SSL - USUALLY IS IT dev exploiting http://www.google.co.uk -work within google ADT JOHN JOE LENORALD -employing a nation that can exploit - ADT TAMPERED SEDURITY AS WITH G4 near Manchester macdonalds -wake up-represents USA TOP SECURITY - city fm - contract via Geordie -Mac then !!!-8.8.8.8  pedophile",
          "reportedAt": "2019-12-05T00:36:43+00:00",
          "reporterCountryCode": "GB",
          "reporterCountryName": "United Kingdom",
          "reporterId": 0
        },
        {
          "categories": [
            3,
            15
          ],
          "comment": "ex husband/careless comment -re-focus onto our multiple SPC -not fully hacked -which Virgin mediA fake operating in Eaglescliffe -inform your partner of your IT - in jail or out !!! skills learned -using WWW for revenge attacks - careless comments- racheal okay with your perverted interests again -sister Anne -these WWW mobile addicted - recorded by USA - 1234/mental health issues need addressing still - mobile addiction action line by BBC digital footprint -foundations -tree huggers and vegans - nice to see no protests - most USA is us 4-still need to review a remembrance for WW2/vague to us watching - luckily new war become WWW3-ONLINE misuse -not seeing respect to USA participating -didn't have too BBC - odd reporting - who regulates tv media /paps -vultures in the UK -different laws/at least respecting Megs and Harry -let them live their lives -review paps -USA strict procedures for press/TV MEDIA -8.8.8.8 -learned more of a relative Anne -never welcomed via treatment of cancer -careless words",
          "reportedAt": "2019-12-04T23:38:31+00:00",
          "reporterCountryCode": "GB",
          "reporterCountryName": "United Kingdom",
          "reporterId": 0
        },
        {
          "categories": [
            14,
            18,
            20
          ],
          "reportedAt": "2019-12-04T11:05:07+00:00",
          "reporterCountryCode": "RU",
          "reporterCountryName": "Russian Federation",
          "reporterId": 0
        },
        {
          "categories": [
            14,
            20
          ],
          "reportedAt": "2019-12-03T11:15:13+00:00",
          "reporterCountryCode": "RU",
          "reporterCountryName": "Russian Federation",
          "reporterId": 0
        },
        {
          "categories": [
            14,
            18,
            20
          ],
          "reportedAt": "2019-12-02T13:00:39+00:00",
          "reporterCountryCode": "RU",
          "reporterCountryName": "Russian Federation",
          "reporterId": 0
        }
      ],
      "totalReports": 18,
      "usageType": "Data Center/Web Hosting/Transit"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/check_ip.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "('action input JSON was invalid', \u003cValidationError: \"'address' is a required property\"\u003e)",
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\n('action input JSON was invalid', \u003cValidationError: \"'address' is a required property\"\u003e)\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 380, in start_step\n    step.input.validate(params)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/variables.py\", line 24, in validate\n    validate(parameters, self.schema)\n  File \"/usr/local/lib/python3.7/site-packages/jsonschema-2.3.0-py3.7.egg/jsonschema/validators.py\", line 432, in validate\n    cls(schema, *args, **kwargs).validate(instance)\n  File \"/usr/local/lib/python3.7/site-packages/jsonschema-2.3.0-py3.7.egg/jsonschema/validators.py\", line 117, in validate\n    raise error\njsonschema.exceptions.ValidationError: 'address' is a required property\n\nFailed validating 'required' in schema:\n    {'properties': {'address': {'description': 'IPv4 or IPv6 address e.g. '\n                                               '8.8.8.8, ::1, must be '\n                                               'subscribed to accept '\n                                               'bitmask wider than '\n                                               '255.255.255.0 (/24)',\n                                'order': 1,\n                                'title': 'IP Address',\n                                'type': 'string'},\n                    'days': {'default': '30',\n                             'description': 'Check for IP reports in the '\n                                            'last x days',\n                             'order': 2,\n                             'title': 'Days',\n                             'type': 'string'},\n                    'verbose': {'default': True,\n                                'description': 'When set, reports will '\n                                               'include the comment (if '\n                                               \"any) and the reporter's \"\n                                               'user ID number (0 if '\n                                               'reported anonymously)',\n                                'order': 3,\n                                'title': 'Verbose',\n                                'type': 'boolean'}},\n     'required': ['address', 'days', 'verbose'],\n     'title': 'Variables',\n     'type': 'object'}\n\nOn instance:\n    {'days': '30', 'ip': '1.2', 'verbose': True}\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 387, in start_step\n    raise ClientException('{} input JSON was invalid'.format(step_key), e)\nkomand.exceptions.ClientException: ('action input JSON was invalid', \u003cValidationError: \"'address' is a required property\"\u003e)\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/check_ip_error.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. ",
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: get_blacklist\nAn error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. \nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 419, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/actions/get_blacklist/action.py\", line 36, in run\n    json_ = helper.get_json(r)\n  File \"/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/util/helper.py\", line 12, in get_json\n    assistance=details)\nkomand.exceptions.PluginException: An error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. \n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/get_blacklist.json
</summary>
</details>

<details>

```
Connect: Connecting to https://api.abuseipdb.com/api/v2...
rapid7/AbuseIPDB:5.0.0. Step name: report_ip
Starting new HTTPS connection (1): api.abuseipdb.com:443
https://api.abuseipdb.com:443 "POST /api/v2/report?
ip=1.2.3.4&categories=10%2C12&comment=Testing HTTP/1.1" 200 None
{"body": {"log": "Connect: Connecting to
https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.0. Step name: report_ip\n", "status":
"ok", "meta": {}, "output": {"ipAddress": "1.2.3.4", "abuseConfidenceScore": 19, "success": true}},
"version": "v1", "type": "action_event"}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/report_ip.json
</summary>
</details>

<details>

```
Connect: Connecting to https://api.abuseipdb.com/api/v2...
rapid7/AbuseIPDB:5.0.1. Step name: report_ip
Starting new HTTPS connection (1): api.abuseipdb.com:443
https://api.abuseipdb.com:443 "POST /api/v2/report?ip=1.&categories=10%2C12&comment=Testing HTTP/1.1" 422 None
An error occurred during plugin execution!

Received an error response from AbuseIPDB.
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py", line 311, in handle_step
    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py", line 419, in start_step
    output = func(params)
  File "/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/actions/report_ip/action.py", line 35, in run
    json_ = helper.get_json(r)
  File "/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/util/helper.py", line 12, in get_json
    assistance=details)
komand.exceptions.PluginException: An error occurred during plugin execution!

Received an error response from AbuseIPDB.
{"body": {"log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: report_ip\nAn error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. \nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 419, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/actions/report_ip/action.py\", line 35, in run\n    json_ = helper.get_json(r)\n  File \"/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/komand_abuseipdb/util/helper.py\", line 12, in get_json\n    assistance=details)\nkomand.exceptions.PluginException: An error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. \n", "status": "error", "meta": {}, "error": "An error occurred during plugin execution!\n\nReceived an error response from AbuseIPDB. "}, "version": "v1", "type": "action_event"}Traceback (most recent call last):
  File "/usr/local/bin/komand_abuseipdb", line 4, in <module>
    __import__('pkg_resources').run_script('abuseipdb-rapid7-plugin==5.0.1', 'komand_abuseipdb')
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 666, in run_script
    self.require(requires)[0].run_script(script_name, ns)
  File "/usr/local/lib/python3.7/site-packages/pkg_resources/__init__.py", line 1453, in run_script
    exec(script_code, namespace, namespace)
  File "/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/EGG-INFO/scripts/komand_abuseipdb", line 38, in <module>
  File "/usr/local/lib/python3.7/site-packages/abuseipdb_rapid7_plugin-5.0.1-py3.7.egg/EGG-INFO/scripts/komand_abuseipdb", line 34, in main
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 188, in run
    args.func(args)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 138, in run_step
    return self.execute_step(is_test=False, is_debug=args.debug)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 135, in execute_step
    raise exception
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/cli.py", line 126, in execute_step
    output = self.plugin.handle_step(msg, is_test=is_test, is_debug=is_debug)
  File "/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py", line 331, in handle_step
    raise LoggedException(ex, output)
komand.exceptions.LoggedException: An error occurred during plugin execution!

Received an error response from AbuseIPDB.

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug run < tests/report_ip_error.json
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_cidr\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/check_cidr.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_cidr\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/check_cidr_error.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_ip\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/check_ip.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: check_ip\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/check_ip_error.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: get_blacklist\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/get_blacklist.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: report_ip\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/report_ip.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting to https://api.abuseipdb.com/api/v2...\nrapid7/AbuseIPDB:5.0.1. Step name: report_ip\n",
    "meta": {},
    "output": {
      "data": {
        "abuseConfidenceScore": 0,
        "countryCode": "",
        "domain": null,
        "ipAddress": "127.0.0.0",
        "ipVersion": 4,
        "isPublic": false,
        "isWhitelisted": false,
        "isp": null,
        "lastReportedAt": null,
        "numDistinctUsers": 0,
        "totalReports": 0,
        "usageType": null
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/report_ip_error.json
</summary>
</details>

### Make validate
<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator DockerValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 11778.044ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
[SUCCESS] Passes flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.5
Run started:2019-12-30 16:53:17.755652

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 783
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

```

<summary>
docker run --rm -i rapid7/abuseipdb:5.0.1 --debug test < tests/report_ip_error.json
</summary>
</details>