### PR TITLE
#179 redis plugin amendments

### DIFF
--- a/redis/.CHECKSUM
+++ b/redis/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d0b30bfb265d667698015fcfe69b3cae",
-	"manifest": "bbc79cf009aa939c5b68b8451bc78cff",
-	"setup": "ff76a01958969fcc28eee17ba2c723c4",
+	"spec": "c5b20b3ff898b127a42e1fc218c7ebe8",
+	"manifest": "2346e6f97e82b9c3fa460e4484add5c8",
+	"setup": "2b43729e8d7aecf2591cbaa4656430d5",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",
@@ -49,7 +49,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "979eba6adfe726ecd022022e917e5d6d"
+			"hash": "5ac8ae5fec48478726f29a1feb9bcc19"
 		}
 	]
 }

--- a/redis/Dockerfile
+++ b/redis/Dockerfile
@@ -1,11 +1,4 @@
-FROM komand/python-3-plugin:2
-# The three supported python parent images are:
-# - komand/python-2-plugin
-# - komand/python-3-plugin
-# - komand/python-pypy3-plugin
-#
-# Update the tag to a full semver version
-
+FROM komand/python-3-37-slim-plugin:3
 # Add any custom package dependencies here
 # NOTE: Add pip packages to requirements.txt
 

--- a/redis/bin/komand_redis
+++ b/redis/bin/komand_redis
@@ -4,10 +4,10 @@ import komand
 from komand_redis import connection, actions, triggers
 
 
-Name = 'Redis'
-Vendor = 'rapid7'
-Version = '1.0.1'
-Description = 'The Redis plugin allows you to add, update, and manage data in a Redis database'
+Name = "Redis"
+Vendor = "rapid7"
+Version = "1.0.2"
+Description = "The Redis plugin allows you to add, update, and manage data in a Redis database"
 
 
 class ICONRedis(komand.Plugin):

--- a/redis/help.md
+++ b/redis/help.md
@@ -385,7 +385,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size
+* 1.0.2 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Use input and output constants | Changed `Exception` to `PluginException` | Remove test from actions | Removed duplicated code
 * 1.0.1 - New spec and help.md format for the Hub
 * 1.0.0 - Support web server mode | Add actions HMSET, HMGET and HINCRBY
 * 0.1.2 - Update to new plugin architecture, fix action "keys"

--- a/redis/help.md
+++ b/redis/help.md
@@ -20,8 +20,8 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
+|db|integer|0|True|DB to use usually (0-15)|None|
 |host|string|None|True|Host, e.g. 10.4.4.4|None|
-|db|integer|0|True|Db to use usually (0-15)|None|
 |port|integer|6379|True|Port|None|
 
 ## Technical Details
@@ -180,8 +180,8 @@ There is an optional expiration timeout which will auto remove the key when `exp
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
 |expire|integer|None|False|Expiration in seconds|None|
-|values|object|None|True|Object hash field:value to set|None|
 |key|string|None|True|Key|None|
+|values|object|None|True|Object hash field:value to set|None|
 
 ##### Output
 
@@ -290,8 +290,8 @@ If key does not exist, a new key holding a hash is created. If field does not ex
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
-|key|string|None|True|Key to lookup|None|
 |field|string|None|True|Field to increment|None|
+|key|string|None|True|Key to lookup|None|
 |value|integer|0|True|How much to increment by|None|
 
 ##### Output
@@ -318,9 +318,9 @@ This action is used to returns the values associated with the specified fields i
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
-|key|string|None|True|Key to get|None|
 |fields|[]string|None|False|Fields to retrieve values from|None|
 |get_all|boolean|False|True|Get all values|None|
+|key|string|None|True|Key to get|None|
 
 ##### Output
 
@@ -351,9 +351,9 @@ This command overwrites any specified fields already existing in the hash. If ke
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
+|expire|integer|None|False|Expiration in seconds|None|
 |key|string|None|True|Key|None|
 |values|object|None|True|Object hash field:value to set|None|
-|expire|integer|None|False|Expiration in seconds|None|
 
 ##### Output
 
@@ -385,6 +385,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.0.2 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size
 * 1.0.1 - New spec and help.md format for the Hub
 * 1.0.0 - Support web server mode | Add actions HMSET, HMGET and HINCRBY
 * 0.1.2 - Update to new plugin architecture, fix action "keys"

--- a/redis/komand_redis/actions/delete/action.py
+++ b/redis/komand_redis/actions/delete/action.py
@@ -1,6 +1,5 @@
 import komand
-from .schema import DeleteInput, DeleteOutput
-# Custom imports below
+from .schema import DeleteInput, DeleteOutput, Input, Output, Component
 
 
 class Delete(komand.Action):
@@ -8,17 +7,12 @@ class Delete(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='delete',
-            description='Delete',
+            description=Component.DESCRIPTION,
             input=DeleteInput(),
             output=DeleteOutput())
 
     def run(self, params={}):
         """Run action"""
-        count = self.connection.redis.delete(params['key'])
         return {
-            'count': count
+            Output.COUNT: self.connection.redis.delete(params[Input.KEY])
         }
-
-    def test(self):
-        """Test action"""
-        return {}

--- a/redis/komand_redis/actions/get/action.py
+++ b/redis/komand_redis/actions/get/action.py
@@ -1,6 +1,5 @@
 import komand
-from .schema import GetInput, GetOutput
-# Custom imports below
+from .schema import GetInput, GetOutput, Input, Output, Component
 
 
 class Get(komand.Action):
@@ -8,12 +7,12 @@ class Get(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='get',
-            description='Get',
+            description=Component.DESCRIPTION,
             input=GetInput(),
             output=GetOutput())
 
     def run(self, params={}):
-        value = self.connection.redis.get(params['key']) or None
+        value = self.connection.redis.get(params[Input.KEY]) or None
         found = value is not None
         if found:
             value = value.decode("utf-8")
@@ -21,10 +20,6 @@ class Get(komand.Action):
             value = ''
 
         return {
-            'value': value,
-            'found': found
+            Output.VALUE: value,
+            Output.FOUND: found
         }
-
-    def test(self):
-        """TODO: Test action"""
-        return {}

--- a/redis/komand_redis/actions/hash_get/action.py
+++ b/redis/komand_redis/actions/hash_get/action.py
@@ -1,5 +1,5 @@
 import komand
-from .schema import HashGetInput, HashGetOutput
+from .schema import HashGetInput, HashGetOutput, Input, Output, Component
 # Custom imports below
 
 
@@ -8,13 +8,13 @@ class HashGet(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='hash_get',
-            description='Get Hash',
+            description=Component.DESCRIPTION,
             input=HashGetInput(),
             output=HashGetOutput())
 
     def run(self, params={}):
         """Run action"""
-        values = self.connection.redis.hgetall(params['key'])
+        values = self.connection.redis.hgetall(params[Input.KEY])
         found = not not values
         if values:
             v = {}
@@ -23,10 +23,6 @@ class HashGet(komand.Action):
             values = v
 
         return {
-            'values': values or {},
-            'found': found
+            Output.VALUES: values or {},
+            Output.FOUND: found
         }
-
-    def test(self):
-        """TODO: Test action"""
-        return {}

--- a/redis/komand_redis/actions/hash_set/action.py
+++ b/redis/komand_redis/actions/hash_set/action.py
@@ -1,6 +1,7 @@
+from komand_redis.util.helper import Helper
+
 import komand
-from .schema import HashSetInput, HashSetOutput
-# Custom imports below
+from .schema import HashSetInput, HashSetOutput, Input, Output, Component
 
 
 class HashSet(komand.Action):
@@ -8,23 +9,17 @@ class HashSet(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='hash_set',
-            description='Set Hash',
+            description=Component.DESCRIPTION,
             input=HashSetInput(),
             output=HashSetOutput())
 
     def run(self, params={}):
         reply = 'OK'
-        result = self.connection.redis.hmset(params['key'], params['values'] or {})
-
-        if params.get('expire'):
-            self.logger.info("Setting expiration: %s", params['expire'])
-            self.connection.redis.expire(params['key'], params['expire'])
-        if not result:
+        if not self.connection.redis.hmset(params[Input.KEY], params.get(Input.VALUES, {})):
             reply = 'Failed'
-        return {
-            'reply': reply
-        }
 
-    def test(self):
-        """TODO: Test action"""
-        return {}
+        Helper.set_expire(self.logger, self.connection, params.get(Input.KEY), params.get(Input.EXPIRE))
+
+        return {
+            Output.REPLY: reply
+        }

--- a/redis/komand_redis/actions/hincrby/action.py
+++ b/redis/komand_redis/actions/hincrby/action.py
@@ -1,33 +1,29 @@
 import komand
-from .schema import HincrbyInput, HincrbyOutput
-# Custom imports below
+from komand.exceptions import PluginException
+from .schema import HincrbyInput, HincrbyOutput, Input, Output, Component
 
 
 class Hincrby(komand.Action):
 
     def __init__(self):
         super(self.__class__, self).__init__(
-                name='hincrby',
-                description='Increments the number stored at field in the hash stored at key by increment',
-                input=HincrbyInput(),
-                output=HincrbyOutput())
+            name='hincrby',
+            description=Component.DESCRIPTION,
+            input=HincrbyInput(),
+            output=HincrbyOutput())
 
     def run(self, params={}):
-        key = params.get("key")
-        field = params.get("field")
-        value = params.get("value")
+        key = params.get(Input.KEY)
+        field = params.get(Input.FIELD)
+        value = params.get(Input.VALUE)
         try:
             result = self.connection.redis.hincrby(key, field, value)
         except Exception as e:
             self.logger.error("An error occurred while running HINCRBY: ", e)
-            raise
+            raise PluginException(cause='Server error',
+                                  assistance="An error occurred while running HINCRBY",
+                                  data=e)
 
-        return {"result": result}
-
-    def test(self):
-        try:
-            self.connection.redis.config_get()
-        except Exception as e:
-            self.logger.error("An error occurred while testing HMSET: ", e)
-            raise
-        return {"success": True}
+        return {
+            Output.RESULT: result
+        }

--- a/redis/komand_redis/actions/hmget/action.py
+++ b/redis/komand_redis/actions/hmget/action.py
@@ -1,6 +1,6 @@
 import komand
-from .schema import HmgetInput, HmgetOutput
-# Custom imports below
+from .schema import HmgetInput, HmgetOutput, Input, Output, Component
+from komand.exceptions import PluginException
 
 
 class Hmget(komand.Action):
@@ -8,14 +8,14 @@ class Hmget(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
                 name='hmget',
-                description='Returns the values associated with the specified fields in the hash stored at key',
+                description=Component.DESCRIPTION,
                 input=HmgetInput(),
                 output=HmgetOutput())
 
     def run(self, params={}):
-        key = params["key"]
-        fields = params["fields"]
-        get_all = params["get_all"]
+        key = params[Input.KEY]
+        fields = params[Input.FIELDS]
+        get_all = params[Input.GET_ALL]
 
         try:
             if get_all:
@@ -24,7 +24,9 @@ class Hmget(komand.Action):
                 result = self.connection.redis.hmget(key, fields)
         except Exception as e:
             self.logger.error("An error occurred while running HMSET: ", e)
-            raise
+            raise PluginException(cause='Server error',
+                                  assistance="An error occurred while running HMSET",
+                                  data=e)
 
         if result:
             v = {}
@@ -32,12 +34,6 @@ class Hmget(komand.Action):
                 v[key.decode('utf-8')] = val.decode('utf-8')
             result = v
 
-        return {"values": result}
-
-    def test(self):
-        try:
-            self.connection.redis.config_get()
-        except Exception as e:
-            self.logger.error("An error occurred while testing HMSET: ", e)
-            raise
-        return {"success": True}
+        return {
+            Output.VALUES: result
+        }

--- a/redis/komand_redis/actions/keys/action.py
+++ b/redis/komand_redis/actions/keys/action.py
@@ -1,6 +1,5 @@
 import komand
-from .schema import KeysInput, KeysOutput
-# Custom imports below
+from .schema import KeysInput, KeysOutput, Input, Output, Component
 
 
 class Keys(komand.Action):
@@ -8,21 +7,15 @@ class Keys(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='keys',
-            description='Return keys matching pattern',
+            description=Component.DESCRIPTION,
             input=KeysInput(),
             output=KeysOutput())
 
     def run(self, params={}):
-        keys = self.connection.redis.keys(params['pattern'])
+        keys = self.connection.redis.keys(params[Input.PATTERN])
         keys = [key.decode('utf-8') for key in keys]
         count = len(keys or [])
         return {
-            'count': count,
-            'keys': keys
-        }
-
-    def test(self):
-        return {
-            'count': 0,
-            'keys': []
+            Output.COUNT: count,
+            Output.KEYS: keys
         }

--- a/redis/komand_redis/actions/list_get/action.py
+++ b/redis/komand_redis/actions/list_get/action.py
@@ -1,5 +1,5 @@
 import komand
-from .schema import ListGetInput, ListGetOutput
+from .schema import ListGetInput, ListGetOutput, Input, Output, Component
 # Custom imports below
 
 
@@ -8,7 +8,7 @@ class ListGet(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='list_get',
-            description='Get all elements in a list',
+            description=Component.DESCRIPTION,
             input=ListGetInput(),
             output=ListGetOutput())
 
@@ -16,17 +16,13 @@ class ListGet(komand.Action):
         values = []
         found = False
 
-        result = self.connection.redis.lrange(params['key'], 0, params['count'])
+        result = self.connection.redis.lrange(params[Input.KEY], 0, params[Input.COUNT])
         if result:
             for r in result:
                 values.append(r.decode("utf-8"))
             found = True
 
         return {
-            'values': values,
-            'found': found
+            Output.VALUES: values,
+            Output.FOUND: found
         }
-
-    def test(self):
-        """TODO: Test action"""
-        return {}

--- a/redis/komand_redis/actions/list_push/action.py
+++ b/redis/komand_redis/actions/list_push/action.py
@@ -1,6 +1,7 @@
+from komand_redis.util.helper import Helper
+
 import komand
-from .schema import ListPushInput, ListPushOutput
-# Custom imports below
+from .schema import ListPushInput, ListPushOutput, Input, Output, Component
 
 
 class ListPush(komand.Action):
@@ -8,24 +9,17 @@ class ListPush(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='list_push',
-            description='List Push',
+            description=Component.DESCRIPTION,
             input=ListPushInput(),
             output=ListPushOutput())
 
     def run(self, params={}):
         reply = 'OK'
-        result = self.connection.redis.rpush(params['key'], params['value'])
-
-        if params.get('expire'):
-            self.logger.info("Setting expiration: %s", params['expire'])
-            self.connection.redis.expire(params['key'], params['expire'])
-
-        if not result:
+        if not self.connection.redis.rpush(params[Input.KEY], params[Input.VALUE]):
             reply = 'Failed'
-        return {
-            'reply': reply
-        }
 
-    def test(self):
-        """TODO: Test action"""
-        return {}
+        Helper.set_expire(self.logger, self.connection, params.get(Input.KEY), params.get(Input.EXPIRE))
+
+        return {
+            Output.REPLY: reply
+        }

--- a/redis/komand_redis/actions/set/action.py
+++ b/redis/komand_redis/actions/set/action.py
@@ -1,6 +1,6 @@
 import komand
-from .schema import SetInput, SetOutput
-# Custom imports below
+from .schema import SetInput, SetOutput, Input, Output, Component
+from komand_redis.util.helper import Helper
 
 
 class Set(komand.Action):
@@ -8,24 +8,21 @@ class Set(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
             name='set',
-            description='Set',
+            description=Component.DESCRIPTION,
             input=SetInput(),
             output=SetOutput())
 
     def run(self, params={}):
         reply = 'OK'
-        expire = params.get('expire')
+        expire = Helper.clear_expire(params.get(Input.EXPIRE))
         if not expire:
-            result = self.connection.redis.set(params['key'], params['value'])
+            result = self.connection.redis.set(params[Input.KEY], params[Input.VALUE])
         else:
-            result = self.connection.redis.setex(params['key'], expire, params['value'])
+            result = self.connection.redis.setex(params[Input.KEY], expire, params[Input.VALUE])
 
         if not result:
             reply = 'Failed'
-        return {
-            'reply': reply
-        }
 
-    def test(self):
-        """Test action"""
-        return {}
+        return {
+            Output.REPLY: reply
+        }

--- a/redis/komand_redis/connection/connection.py
+++ b/redis/komand_redis/connection/connection.py
@@ -1,5 +1,5 @@
 import komand
-from .schema import ConnectionSchema
+from .schema import ConnectionSchema, Input
 # Custom imports below
 import redis
 
@@ -12,8 +12,5 @@ class Connection(komand.Connection):
 
     def connect(self, params):
         self.logger.info("Connect: Connecting..")
-        db = params['db']
-        host = params['host']
-        port = params['port']
-        self.redis = redis.StrictRedis(host=host, port=port, db=db)
+        self.redis = redis.StrictRedis(host=params[Input.HOST], port=params[Input.PORT], db=params[Input.DB])
         self.redis.get("test")

--- a/redis/komand_redis/connection/schema.py
+++ b/redis/komand_redis/connection/schema.py
@@ -18,7 +18,7 @@ class ConnectionSchema(komand.Input):
     "db": {
       "type": "integer",
       "title": "Db",
-      "description": "Db to use usually (0-15)",
+      "description": "DB to use usually (0-15)",
       "default": 0,
       "order": 3
     },

--- a/redis/komand_redis/util/helper.py
+++ b/redis/komand_redis/util/helper.py
@@ -1,0 +1,19 @@
+from komand.exceptions import PluginException
+
+
+class Helper:
+    @staticmethod
+    def set_expire(logger, connection, key, expire):
+        expire = Helper.clear_expire(expire)
+
+        if expire:
+            logger.info(f"Setting expiration: {key}")
+            connection.redis.expire(key, expire)
+
+    @staticmethod
+    def clear_expire(expire):
+        if expire and int(expire) < 0:
+            raise PluginException(cause='Input error',
+                                  assistance='Expire should be greater than or equal 0')
+
+        return expire

--- a/redis/plugin.spec.yaml
+++ b/redis/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: redis
 title: Redis
 description: The Redis plugin allows you to add, update, and manage data in a Redis database
-version: 1.0.1
+version: 1.0.2
 vendor: rapid7
 support: community
 status: []
@@ -31,7 +31,7 @@ connection:
     required: true
   db:
     type: integer
-    description: Db to use usually (0-15)
+    description: DB to use usually (0-15)
     default: 0
     required: true
 actions:

--- a/redis/setup.py
+++ b/redis/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 
-setup(name='redis-rapid7-plugin',
-      version='1.0.1',
-      description='The Redis plugin allows you to add, update, and manage data in a Redis database',
-      author='rapid7',
-      author_email='',
-      url='',
+setup(name="redis-rapid7-plugin",
+      version="1.0.2",
+      description="The Redis plugin allows you to add, update, and manage data in a Redis database",
+      author="rapid7",
+      author_email="",
+      url="",
       packages=find_packages(),
       install_requires=['komand'],  # Add third-party dependencies to requirements.txt, not here!
       scripts=['bin/komand_redis']


### PR DESCRIPTION
Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Use input and output constants | Changed `Exception` to `PluginException` | Remove test from actions | Removed duplicated code

## Proposed Changes

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: set\n",
    "meta": {},
    "output": {
      "reply": "OK"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/00_set.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_set\nSetting expiration: hashfoo\n",
    "meta": {},
    "output": {
      "reply": "OK"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/01_hash_set.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_get\n",
    "meta": {},
    "output": {
      "found": true,
      "values": {
        "hello": "world "
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/02_hash_get.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hmset\n",
    "meta": {},
    "output": {
      "reply": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/03_hmset.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: list_push\n",
    "meta": {},
    "output": {
      "reply": "OK"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/04_list_push.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hincrby\n",
    "meta": {},
    "output": {
      "result": 16
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/05_hincrby.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hmget\n",
    "meta": {},
    "output": {
      "values": {
        "herp": "lawl",
        "lawl": "derp",
        "lol": "nope"
      }
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/06_hmget.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: keys\n",
    "meta": {},
    "output": {
      "count": 4,
      "keys": [
        "derp",
        "foo",
        "lol",
        "keylist"
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/07_keys.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: list_get\n",
    "meta": {},
    "output": {
      "found": true,
      "values": [
        "foo1",
        "foo1",
        "foo1",
        "foo1"
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/08_list_get.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_get\n",
    "meta": {},
    "output": {
      "found": false,
      "values": {}
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/09_hash_get.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: get\n",
    "meta": {},
    "output": {
      "found": true,
      "value": "bar"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/10_get.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_get\n",
    "meta": {},
    "output": {
      "found": false,
      "values": {}
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/11_hash_get.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: delete\n",
    "meta": {},
    "output": {
      "count": 1
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/12_delete.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nInput error Expire should be greater than or equal 0",
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_set\nAn error occurred during plugin execution!\n\nInput error Expire should be greater than or equal 0\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 419, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.7/site-packages/redis_rapid7_plugin-1.0.2-py3.7.egg/komand_redis/actions/hash_set/action.py\", line 21, in run\n    Helper.set_expire(self.logger, self.connection, params.get(Input.KEY), params.get(Input.EXPIRE))\n  File \"/usr/local/lib/python3.7/site-packages/redis_rapid7_plugin-1.0.2-py3.7.egg/komand_redis/util/helper.py\", line 7, in set_expire\n    expire = Helper.clear_expire(expire)\n  File \"/usr/local/lib/python3.7/site-packages/redis_rapid7_plugin-1.0.2-py3.7.egg/komand_redis/util/helper.py\", line 17, in clear_expire\n    assistance='Expire should be greater than or equal 0')\nkomand.exceptions.PluginException: An error occurred during plugin execution!\n\nInput error Expire should be greater than or equal 0\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug run < tests/13_hash_set_bad.json
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: set\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/00_set.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_set\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/01_hash_set.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_get\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/02_hash_get.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hmset\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/03_hmset.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: list_push\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/04_list_push.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hincrby\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/05_hincrby.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hmget\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/06_hmget.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: keys\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/07_keys.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: list_get\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/08_list_get.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_get\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/09_hash_get.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: get\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/10_get.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_get\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/11_hash_get.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: delete\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/12_delete.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nrapid7/Redis:1.0.2. Step name: hash_set\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/redis:1.0.2 --debug test < tests/13_hash_set_bad.json
</summary>
</details>

Autogenerate with:
<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 434.30400000000003ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
[SUCCESS] Passes flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.6
Run started:2020-02-24 18:30:14.514828

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 967
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

```

<summary>
make validate
</summary>
</details>

Autogenerate with:
<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 23689.129999999997ms

```

<summary>
icon-validate --all .
</summary>
</details>