### PR TITLE
Missing punctuation in help.md files

### DIFF
--- a/ifconfig_co/help.md
+++ b/ifconfig_co/help.md
@@ -9,7 +9,7 @@
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 
@@ -86,7 +86,7 @@ Example output:
 
 ### Triggers
 
-This plugin does not contain any triggers.
+_This plugin does not contain any triggers._
 
 ### Custom Output Types
 

--- a/ipify/help.md
+++ b/ipify/help.md
@@ -8,7 +8,7 @@
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 

--- a/jq/help.md
+++ b/jq/help.md
@@ -8,7 +8,7 @@
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 

--- a/json_edit/help.md
+++ b/json_edit/help.md
@@ -8,7 +8,7 @@ JSON Edit is a data utility that allows for the manipulation of [JSON](https://w
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 

--- a/markdown/help.md
+++ b/markdown/help.md
@@ -10,7 +10,7 @@ This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.p
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 

--- a/math/help.md
+++ b/math/help.md
@@ -9,7 +9,7 @@ This plugin allows basic arithmetic functions to be performed.
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 

--- a/matplotlib/help.md
+++ b/matplotlib/help.md
@@ -12,7 +12,7 @@ NumPy, Pandas, and Seaborn, utilizing the [matplotlib API](https://matplotlib.or
 
 # Requirements
 
-_This plugin does not contain any requirements_
+_This plugin does not contain any requirements._
 
 # Documentation
 

--- a/pushover/help.md
+++ b/pushover/help.md
@@ -57,7 +57,7 @@ This action sends a message to a user or group
 
 ### Triggers
 
-_This plugin does not contain any triggers_
+_This plugin does not contain any triggers._
 
 ### Custom Output Types
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Added missing punctuation on the following lines:

```
_This plugin does not contain any triggers_
_This plugin does not contain any requirements_
```

### Testing

Any testing information goes here.
