### PR TITLE
Add the identifier field for the vuln_db search result.

### DIFF
--- a/rapid7_vulndb/.CHECKSUM
+++ b/rapid7_vulndb/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "ce4ae2a44e83d4a60c2c041866964bd3",
-	"manifest": "8cc93587a14e91cb5557fca9ad9e1628",
-	"setup": "6960583d7691be8f61e8f205d3e3bac3",
+	"spec": "5a9804a7123270b6886f64077db5fe2b",
+	"manifest": "0017e44d3bbed5cd86c08c1acf8a4f03",
+	"setup": "158d7ed0d8be4651f3aafc1a361055fc",
 	"schemas": [
 		{
 			"identifier": "get_content/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "search_db/schema.py",
-			"hash": "c54f81eb89dd4c7a7eaa3a66c3961e19"
+			"hash": "e3df4634a61efd5fe4dc5679509310d4"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/rapid7_vulndb/.CHECKSUM
+++ b/rapid7_vulndb/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "5a9804a7123270b6886f64077db5fe2b",
+	"spec": "a763224ac4c4712cefe0c0267dcb95e5",
 	"manifest": "0017e44d3bbed5cd86c08c1acf8a4f03",
 	"setup": "158d7ed0d8be4651f3aafc1a361055fc",
 	"schemas": [
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "search_db/schema.py",
-			"hash": "e3df4634a61efd5fe4dc5679509310d4"
+			"hash": "690f217e0f218f6b0fa89cd6d75dbabd"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/rapid7_vulndb/bin/komand_rapid7_vulndb
+++ b/rapid7_vulndb/bin/komand_rapid7_vulndb
@@ -6,7 +6,7 @@ from komand_rapid7_vulndb import connection, actions, triggers
 
 Name = "Rapid7 Vulnerability & Exploit Database"
 Vendor = "rapid7"
-Version = "2.0.0"
+Version = "2.0.1"
 Description = "The Vulnerability & Exploit Database plugin allows you to search and compare potential threats with a curated repository of vetted computer software exploits and exploitable vulnerabilities vulnerabilities"
 
 

--- a/rapid7_vulndb/help.md
+++ b/rapid7_vulndb/help.md
@@ -115,7 +115,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - Add identifier field to the search action
+* 2.0.1 - Add identifier field to the Search Database action
 * 2.0.0 - Utilize VulnDB API
 * 1.1.1 - New spec and help.md format for the Hub
 * 1.1.0 - Fix issue where Published Date input in the Search Database action would not always parse correctly | Fix issue with memory leaks

--- a/rapid7_vulndb/help.md
+++ b/rapid7_vulndb/help.md
@@ -115,6 +115,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 2.0.1 - Add identifier field to the search action
 * 2.0.0 - Utilize VulnDB API
 * 1.1.1 - New spec and help.md format for the Hub
 * 1.1.0 - Fix issue where Published Date input in the Search Database action would not always parse correctly | Fix issue with memory leaks

--- a/rapid7_vulndb/komand_rapid7_vulndb/actions/search_db/schema.py
+++ b/rapid7_vulndb/komand_rapid7_vulndb/actions/search_db/schema.py
@@ -83,7 +83,7 @@ class SearchDbOutput(komand.Output):
       "properties": {
         "identifier": {
           "type": "string",
-          "title": "Content identifier",
+          "title": "Content Identifier",
           "description": "Content identifier for module or vulnerability",
           "order": 4
         },

--- a/rapid7_vulndb/komand_rapid7_vulndb/actions/search_db/schema.py
+++ b/rapid7_vulndb/komand_rapid7_vulndb/actions/search_db/schema.py
@@ -81,6 +81,12 @@ class SearchDbOutput(komand.Output):
       "type": "object",
       "title": "search_result",
       "properties": {
+        "identifier": {
+          "type": "string",
+          "title": "Content identifier",
+          "description": "Content identifier for module or vulnerability",
+          "order": 4
+        },
         "link": {
           "type": "string",
           "title": "Link",

--- a/rapid7_vulndb/komand_rapid7_vulndb/util/transform.py
+++ b/rapid7_vulndb/komand_rapid7_vulndb/util/transform.py
@@ -68,7 +68,6 @@ def generate_link_attr(d: Dict):
     d.update({"link": urljoin(
         "https://vdb-kasf1i23nr1kl2j4.rapid7.com/v1/content/",
         d.get("identifier"))})
-    d.pop("identifier")
 
 
 def pop_non_relevant_module_fields(data: Dict):

--- a/rapid7_vulndb/plugin.spec.yaml
+++ b/rapid7_vulndb/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: rapid7_vulndb
 title: Rapid7 Vulnerability & Exploit Database
 description: The Vulnerability & Exploit Database plugin allows you to search and compare potential threats with a curated repository of vetted computer software exploits and exploitable vulnerabilities
   vulnerabilities
-version: 2.0.0
+version: 2.0.1
 vendor: rapid7
 support: rapid7
 status: []
@@ -40,6 +40,11 @@ types:
     published_at:
       title: Published At
       description: Published date of vulnerability
+      type: string
+      required: false
+    identifier:
+      title: Content identifier
+      description: Content identifier for module or vulnerability
       type: string
       required: false
   content:

--- a/rapid7_vulndb/plugin.spec.yaml
+++ b/rapid7_vulndb/plugin.spec.yaml
@@ -43,7 +43,7 @@ types:
       type: string
       required: false
     identifier:
-      title: Content identifier
+      title: Content Identifier
       description: Content identifier for module or vulnerability
       type: string
       required: false

--- a/rapid7_vulndb/setup.py
+++ b/rapid7_vulndb/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_vulndb-rapid7-plugin",
-      version="2.0.0",
+      version="2.0.1",
       description="The Vulnerability & Exploit Database plugin allows you to search and compare potential threats with a curated repository of vetted computer software exploits and exploitable vulnerabilities vulnerabilities",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Add module or vulnerability identifier to the search result

### Description
Currently, search vuln_db action doesn't return identifier of the module or vulnerability , instead it returns the URL,  which makes using the `get_content` action inconvenient as  URL should be parsed and identifier should be extracted manually from the URL.  This PR adds the field so no parsing is required to get the content results for the search_db results. 

Describe the proposed changes:

  - Update schema to include the result
  - Don't pop the identifier from the original API result

### Testing
- checked that search action returns identifier `"identifier": "mozilla-thunderbird-cve-2015-7189"`

```
icon-plugin run -R tests/search_db.json
INFO[0000] Running command:  docker run --rm -i rapid7/rapid7_vulndb:2.0.1 run < tests/search_db.json
Starting new HTTPS connection (1): vdb-kasf1i23nr1kl2j4.rapid7.com:443
https://vdb-kasf1i23nr1kl2j4.rapid7.com:443 "GET /v1/info HTTP/1.1" 200 51
rapid7/Rapid7 Vulnerability & Exploit Database:2.0.1. Step name: search_db
Starting new HTTPS connection (1): vdb-kasf1i23nr1kl2j4.rapid7.com:443
https://vdb-kasf1i23nr1kl2j4.rapid7.com:443 "GET /v1/search?query=cve-123&type=Nexpose HTTP/1.1" 200 3374
Starting new HTTPS connection (1): vdb-kasf1i23nr1kl2j4.rapid7.com:443
https://vdb-kasf1i23nr1kl2j4.rapid7.com:443 "GET /v1/search?query=cve-123&type=Nexpose&page=0 HTTP/1.1" 200 3374
{"body": {"log": "rapid7/Rapid7 Vulnerability & Exploit Database:2.0.1. Step name: search_db\n", "status": "ok", "meta": {}, "output": {"results_found": true, "search_results": [{"identifier": "mozilla-thunderbird-cve-2015-7189", "title": "MFSA2015-123 Thunderbird: Buffer overflow during image interactions in canvas (CVE-2015-7189)", "published_at": "2015-11-05T00:00:00.000Z", "link": "https://vdb-kasf1i23nr1kl2j4.rapid7.com/v1/content/mozilla-thunderbird-cve-2015-7189"}, {"identifier": "mfsa2015-123-cve-2015-7189", "title": "MFSA2015-123 Firefox: Buffer overflow during image interactions in canvas (CVE-2015-7189)", "published_at": "2015-11-03T00:00:00.000Z", "link": "https://vdb-kasf1i23nr1kl2j4.rapid7.com/v1/content/mfsa2015-123-cve-2015-7189"}]}}, "version": "v1", "type": "action_event"}
WARN[0006] ATTENTION: A new version of icon-plugin is available: 4.4.2 (current: 4.4.0)
```
## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR.
4. Add UI screenshot of the workflow used for testing
5. Add UI screenshot of the job output used for testing
6. Add UI screenshot of the artifact (See rules in UI Checklist) used for testing
