### PR TITLE
Dig: Example Input Reference

### DIFF
--- a/dig/.CHECKSUM
+++ b/dig/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "6e0e0a284f7504d37b3974b75e1f29c7",
-	"manifest": "ec56d7a0ae86b42585e46470df9ce446",
-	"setup": "e570d15a2cdbdee5db266d723745c450",
+	"spec": "ef6aa9d62546ea1983ccaed9c7dc45c3",
+	"manifest": "8032f3b68dd9a8951bd46660bebc3976",
+	"setup": "5cad2fe2d96fc300b1df58c0ab33a5f5",
 	"schemas": [
 		{
 			"identifier": "forward/schema.py",

--- a/dig/bin/komand_dig
+++ b/dig/bin/komand_dig
@@ -6,7 +6,7 @@ from komand_dig import connection, actions, triggers
 
 Name = "Dig"
 Vendor = "rapid7"
-Version = "1.0.3"
+Version = "1.0.4"
 Description = "Dig is used for forward and reverse DNS lookups"
 
 

--- a/dig/help.md
+++ b/dig/help.md
@@ -38,11 +38,11 @@ It accepts a domain name of type `string` and one of the following record types:
 * PTR
 * SOA
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|domain|string|None|True|Domain name to resolve|None|
-|query|string|None|True|Query type e.g. ANY, A, MX, NS, etc|['A', 'AAAA', 'ANY', 'CNAME', 'MX', 'NS', 'PTR', 'SOA']|
-|resolver|string|None|False|Resolver. Leave blank to use default resolver for the system|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|domain|string|None|True|Domain name to resolve|None|rapid7.com|
+|query|string|None|True|Query type e.g. ANY, A, MX, NS, etc|['A', 'AAAA', 'ANY', 'CNAME', 'MX', 'NS', 'PTR', 'SOA']|MX|
+|resolver|string|None|False|Resolver. Leave blank to use default resolver for the system|None|8.8.8.8|
 
 Example input:
 
@@ -107,10 +107,10 @@ This action is used to request a reverse lookup for an IP address.
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|address|string|None|True|Internet address to resolve|None|
-|resolver|string|None|False|Resolver. Leave blank to use default resolver for the system|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|address|string|None|True|Internet address to resolve|None|1.2.3.4|
+|resolver|string|None|False|Resolver. Leave blank to use default resolver for the system|None|8.8.8.8|
 
 Example input:
 

--- a/dig/help.md
+++ b/dig/help.md
@@ -85,7 +85,6 @@ Example output:
 }
 ```
 
-
 On failure, the raw output will look like the following:
 
 ```
@@ -99,7 +98,6 @@ On failure, the raw output will look like the following:
 },
 
 ```
-
 
 #### Reverse Lookup
 

--- a/dig/help.md
+++ b/dig/help.md
@@ -44,6 +44,17 @@ It accepts a domain name of type `string` and one of the following record types:
 |query|string|None|True|Query type e.g. ANY, A, MX, NS, etc|['A', 'AAAA', 'ANY', 'CNAME', 'MX', 'NS', 'PTR', 'SOA']|
 |resolver|string|None|False|Resolver. Leave blank to use default resolver for the system|None|
 
+Example input:
+
+```
+
+{
+  "domain": "google.com",
+  "query": "A"
+}
+
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -58,19 +69,22 @@ It accepts a domain name of type `string` and one of the following record types:
 
 On success, the raw output will look like the following:
 
-```
+Example output:
 
+```
 {
+  "last_answer": "172.217.6.14",
+  "nameserver": "192.168.65.1",
+  "question": "google.com",
   "status": "NOERROR",
-  "answer": "50.19.156.131",
-  "nameserver": "10.0.2.3",
-  "question": "komand.com",
-  "fulloutput": "\n; <<>> Dig 9.9.5-9+deb8u9-Debian <<>> komand.com A\n;; global options: +cmd\n;; Got answer:\n;; ->>HEADER<<- opcode: QUERY, status: NOERROR, id: 15364\n;; flags: qr rd ra ad; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n;; QUESTION SECTION:\n;komand.com.\t\t\tIN\tA\n\n;; ANSWER SECTION:\nkomand.com.\t\t2677\tIN\tA\t50.19.156.131\n\n;; Query time: 6 msec\n;; SERVER: 10.0.2.3#53(10.0.2.3)\n;; WHEN: Thu Jan 26 23:11:29 UTC 2017\n;; MSG SIZE  rcvd: 44\n\n"
-  "all_answers": ["50.19.156.131"],
-  "last_answer": "50.19.156.131"
-},
-
+  "all_answers": [
+    "172.217.6.14"
+  ],
+  "answer": "172.217.6.14",
+  "fulloutput": "\n; <<>> DiG 9.12.4-P2 <<>> google.com A\n;; global ..."
+}
 ```
+
 
 On failure, the raw output will look like the following:
 
@@ -86,6 +100,7 @@ On failure, the raw output will look like the following:
 
 ```
 
+
 #### Reverse Lookup
 
 This action is used to request a reverse lookup for an IP address.
@@ -96,6 +111,16 @@ This action is used to request a reverse lookup for an IP address.
 |----|----|-------|--------|-----------|----|
 |address|string|None|True|Internet address to resolve|None|
 |resolver|string|None|False|Resolver. Leave blank to use default resolver for the system|None|
+
+Example input:
+
+```
+
+{
+  "address": "8.8.8.8"
+}
+
+```
 
 ##### Output
 
@@ -161,6 +186,7 @@ Common examples:
 
 # Version History
 
+* 1.0.4 - Add example inputs
 * 1.0.3 - Use input and output constants | Change docker image from `komand/python-2-slim-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Added "f" strings | Remove duplicate code | Add user nobody to Dockerfile
 * 1.0.2 - New spec and help.md format for the Hub
 * 1.0.1 - Update to use the `komand/python-2-slim-plugin:2` Docker image to reduce plugin size

--- a/dig/komand_dig/connection/connection.py
+++ b/dig/komand_dig/connection/connection.py
@@ -9,6 +9,6 @@ class Connection(komand.Connection):
 
     def connect(self, params):
         pass
-    
+
     def test(self):
         return {}

--- a/dig/plugin.spec.yaml
+++ b/dig/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: dig
 title: Dig
 description: Dig is used for forward and reverse DNS lookups
-version: 1.0.3
+version: 1.0.4
 vendor: rapid7
 support: community
 status: []
@@ -27,10 +27,12 @@ actions:
         type: string
         description: Domain name to resolve
         required: true
+        example: rapid7.com
       resolver:
         type: string
         description: Resolver. Leave blank to use default resolver for the system
         required: false
+        example: 8.8.8.8
       query:
         type: string
         description: Query type e.g. ANY, A, MX, NS, etc
@@ -44,6 +46,7 @@ actions:
         - PTR
         - SOA
         required: true
+        example: MX
     output:
       fulloutput:
         description: Full Dig output
@@ -89,10 +92,12 @@ actions:
         type: string
         description: Resolver. Leave blank to use default resolver for the system
         required: false
+        example: 8.8.8.8
       address:
         type: string
         description: Internet address to resolve
         required: true
+        example: 1.2.3.4
     output:
       fulloutput:
         description: Full Dig output

--- a/dig/setup.py
+++ b/dig/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="dig-rapid7-plugin",
-      version="1.0.3",
+      version="1.0.4",
       description="Dig is used for forward and reverse DNS lookups",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Add example inputs raw JSON section to help.md
  - Add example inputs to input markdown table
  - Add example keys for inputs in spec

### Testing

Tested in product via custom plugin. PR assessment below.

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: forward\nExecuting command /usr/bin/dig google.com A\n",
    "meta": {},
    "output": {
      "all_answers": [
        "172.217.6.14"
      ],
      "answer": "172.217.6.14",
      "fulloutput": "\n; \u003c\u003c\u003e\u003e DiG 9.12.4-P2 \u003c\u003c\u003e\u003e google.com A\n;; global options: +cmd\n;; Got answer:\n;; -\u003e\u003eHEADER\u003c\u003c- opcode: QUERY, status: NOERROR, id: 47921\n;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n;; QUESTION SECTION:\n;google.com.\t\t\tIN\tA\n\n;; ANSWER SECTION:\ngoogle.com.\t\t377\tIN\tA\t172.217.6.14\n\n;; Query time: 37 msec\n;; SERVER: 192.168.65.1#53(192.168.65.1)\n;; WHEN: Fri Mar 20 22:30:18 UTC 2020\n;; MSG SIZE  rcvd: 44\n\n",
      "last_answer": "172.217.6.14",
      "nameserver": "192.168.65.1",
      "question": "google.com",
      "status": "NOERROR"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 run < tests/forward.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: forward\nExecuting command /usr/bin/dig asdfasdfasdfasdfasdfads.com A\n",
    "meta": {},
    "output": {
      "all_answers": [
        "Not found"
      ],
      "answer": "Not found",
      "fulloutput": "Resolution failed, nameserver 192.168.65.1 returned NXDOMAIN status",
      "last_answer": "Not found",
      "nameserver": "192.168.65.1",
      "question": "asdfasdfasdfasdfasdfads.com",
      "status": "NXDOMAIN"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 run < tests/forward_bad.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: forward\nExecuting command /usr/bin/dig www.komand.com CNAME\n",
    "meta": {},
    "output": {
      "all_answers": [
        "Not found"
      ],
      "answer": "Not found",
      "fulloutput": "Resolution failed, nameserver 192.168.65.1 returned NXDOMAIN status",
      "last_answer": "Not found",
      "nameserver": "192.168.65.1",
      "question": "www.komand.com",
      "status": "NXDOMAIN"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 run < tests/forward_cname.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: reverse\nExecuting command /usr/bin/dig -x 8.8.8.8\n",
    "meta": {},
    "output": {
      "answer": "dns.google",
      "fulloutput": "\n; \u003c\u003c\u003e\u003e DiG 9.12.4-P2 \u003c\u003c\u003e\u003e -x 8.8.8.8\n;; global options: +cmd\n;; Got answer:\n;; -\u003e\u003eHEADER\u003c\u003c- opcode: QUERY, status: NOERROR, id: 43853\n;; flags: qr rd ra; QUERY: 1, ANSWER: 1, AUTHORITY: 0, ADDITIONAL: 0\n\n;; QUESTION SECTION:\n;8.8.8.8.in-addr.arpa.\t\tIN\tPTR\n\n;; ANSWER SECTION:\n8.8.8.8.in-addr.arpa.\t4502\tIN\tPTR\tdns.google.\n\n;; Query time: 50 msec\n;; SERVER: 192.168.65.1#53(192.168.65.1)\n;; WHEN: Fri Mar 20 22:30:23 UTC 2020\n;; MSG SIZE  rcvd: 62\n\n",
      "nameserver": "192.168.65.1",
      "question": "8.8.8.8",
      "status": "NOERROR"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 run < tests/reverse.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: reverse\nExecuting command /usr/bin/dig -x 1.1.1.1.1\n",
    "meta": {},
    "output": {
      "answer": "Not found",
      "fulloutput": "Resolution failed, nameserver 192.168.65.1 returned NXDOMAIN status",
      "nameserver": "192.168.65.1",
      "question": "1.1.1.1.1",
      "status": "NXDOMAIN"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 run < tests/reverse_bad.json
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: forward\n",
    "meta": {},
    "output": {},
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 test < tests/forward.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: forward\n",
    "meta": {},
    "output": {},
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 test < tests/forward_bad.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: forward\n",
    "meta": {},
    "output": {},
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 test < tests/forward_cname.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: reverse\n",
    "meta": {},
    "output": {},
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 test < tests/reverse.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.4. Step name: reverse\n",
    "meta": {},
    "output": {},
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.4 test < tests/reverse_bad.json
</summary>
</details>
