### PR TITLE
Proofpoint URL Defense - added support for v3 links

### DIFF
--- a/proofpoint_url_defense/.CHECKSUM
+++ b/proofpoint_url_defense/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "142861855714279e43b1388497d1f50f",
-	"manifest": "fc799cc9862cc89c80cfb9b72c088fe4",
-	"setup": "6e5c53b240a42d9bd43cf93d6ae4ebfd",
+	"spec": "a8b0c5245631e9230481be690a35ab52",
+	"manifest": "20c7bf707e80cbe10200cb038ce19fde",
+	"setup": "ef5a809a597782684faeca24655e7903",
 	"schemas": [
 		{
 			"identifier": "url_decode/schema.py",

--- a/proofpoint_url_defense/.CHECKSUM
+++ b/proofpoint_url_defense/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "a8b0c5245631e9230481be690a35ab52",
+	"spec": "77a2a2e1956cecd2a6c4b11540d0ab50",
 	"manifest": "20c7bf707e80cbe10200cb038ce19fde",
 	"setup": "ef5a809a597782684faeca24655e7903",
 	"schemas": [

--- a/proofpoint_url_defense/bin/komand_proofpoint_url_defense
+++ b/proofpoint_url_defense/bin/komand_proofpoint_url_defense
@@ -4,10 +4,10 @@ import komand
 from komand_proofpoint_url_defense import connection, actions, triggers
 
 
-Name = 'Proofpoint URL Defense'
-Vendor = 'rapid7'
-Version = '1.0.1'
-Description = 'Decode Proofpoint encoded URLs'
+Name = "Proofpoint URL Defense"
+Vendor = "rapid7"
+Version = "1.1.0"
+Description = "Decode Proofpoint encoded URLs"
 
 
 class ICONProofpointUrlDefense(komand.Plugin):

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -23,7 +23,7 @@ _This plugin does not contain a connection._
 
 #### URL Decode
 
-This action decodes an encoded URL.
+This action is used to take a Proofpoint URL and decode it to the original URL.
 
 ##### Input
 

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -1,4 +1,4 @@
-## Description
+# Description
 
 [Proofpoint URL Defense](https://www.proofpoint.com/us) is a service designed to handle emails that contain 
 malicious URLs. This plugin decodes URLs that are encoded by Proofpoints URL Defense service using ppdecode.
@@ -16,6 +16,8 @@ _This plugin does not contain any requirements._
 ## Setup
 
 _This plugin does not contain a connection._
+
+## Technical Details
 
 ### Actions
 

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -1,4 +1,4 @@
-# Description
+## Description
 
 [Proofpoint URL Defense](https://www.proofpoint.com/us) is a service designed to handle emails that contain 
 malicious URLs. This plugin decodes URLs that are encoded by Proofpoints URL Defense service using ppdecode.
@@ -15,31 +15,46 @@ _This plugin does not contain any requirements._
 
 ## Setup
 
-This plugin does not contain a connection.
-
-## Technical Details
+_This plugin does not contain a connection._
 
 ### Actions
 
 #### URL Decode
 
-This action is used to take a Proofpoint URL and decode it to the original URL.
+This action decodes an encoded URL.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
-|proofpoint_url|string|None|True|Proofpoint encoded URL|None|
+|encoded_url|string|None|True|Proofpoint encoded URL or URL parameters e.g http-3A__www.example.org_url&d=BwdwBAg&c=TIwfCwdwWnrHy3gMA_uzZorHPsT2wfwvKrwfU|None|
+
+Example input:
+
+```
+{
+  "encoded_url": "http-3A__www.example.org_url&d=BwdwBAg&c=TIwfCwdwWnrHy3gMA_uzZorHPsT2wfwvKrwf"
+}
+```
 
 ##### Output
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|decoded_url|string|False|None|
+|decoded_url|string|False|Decoded Proofpoint URL|
+
+Example output:
+
+```
+{
+  "decoded_url": "http://www.example.org/url"
+}
+```
+
 
 ### Triggers
 
-This plugin does not contain any triggers.
+_This plugin does not contain any triggers._
 
 ### Custom Output Types
 
@@ -51,6 +66,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 1.1.0 - Update to URL Decode action to add support for v3 links
 * 1.0.1 - New spec and help.md format for the Hub
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Bug fix with decode parsing
 * 0.1.1 - SSL bug fix in SDK
@@ -61,5 +77,5 @@ This plugin does not contain any troubleshooting information.
 ## References
 
 * [Proofpoint URL Defense](https://www.proofpoint.com/us/products/targeted-attack-protection)
-* [ppdecode Library](https://github.com/warquel/ppdecode)
+* [Proofpoint decode utility](https://help.proofpoint.com/@api/deki/files/177/URLDefenseDecode.py?revision=2)
 

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
@@ -1,8 +1,8 @@
 import komand
-from .schema import UrlDecodeInput, UrlDecodeOutput
+from .schema import UrlDecodeInput, UrlDecodeOutput, Input, Output
 # Custom imports below
-import ppdecode
-
+# import ppdecode
+from komand_proofpoint_url_defense.util.proofpoint_decoder import URLDefenseDecoder
 
 class UrlDecode(komand.Action):
     def __init__(self):
@@ -13,28 +13,21 @@ class UrlDecode(komand.Action):
                 output=UrlDecodeOutput())
 
     def run(self, params={}):
-        url = 'https://urldefense.proofpoint.com/v2/url?u='
-        if params.get("encoded_url").startswith(url):
+        in_url = params[Input.ENCODED_URL]
+        url_v2 = 'https://urldefense.proofpoint.com/' # This is good for v1 as well
+        url_v3 = 'https://urldefense.com'
+
+        if in_url.startswith(url_v2) or in_url.startswith(url_v3):
             encoded_url = params.get("encoded_url")
-        else:
-            encoded_url = url + params.get("encoded_url")
+        else: # We assume a v2 encoded URL, this is legacy behavior
+            encoded_url = f"https://urldefense.proofpoint.com/v2/url?u={in_url}"
+
+        decoder = URLDefenseDecoder()
 
         try:
-            decoded_url = ppdecode.ppdecode(encoded_url)
+            decoded_url = decoder.decode(encoded_url)
             self.logger.info('URL has been decoded')
-            return {'decoded_url': decoded_url['decoded_url']}
+            return {'decoded_url': decoded_url}
         except Exception:
             self.logger.error("Unexpected issue occurred decoding URL")
             raise
-
-    def test(self):
-        url = 'https://urldefense.proofpoint.com/v2/url?u=http-3A__www.example.org_url&d=BwdwBAg&c=TIwfCwdwWnrHy3gMA_uzZorHPsT2wfwvKrwfU'
-
-        try:
-            decoded_url = ppdecode.ppdecode(url)
-            self.logger.info('URL has been decoded')
-        except:
-            self.logger.error("Unexpected issue occurred decoding URL")
-            raise
-
-        return {'decoded_url': decoded_url['decoded_url']}

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
@@ -1,7 +1,6 @@
 import komand
 from .schema import UrlDecodeInput, UrlDecodeOutput, Input, Output
 # Custom imports below
-# import ppdecode
 from komand_proofpoint_url_defense.util.proofpoint_decoder import URLDefenseDecoder
 
 class UrlDecode(komand.Action):

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/connection/connection.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/connection/connection.py
@@ -10,3 +10,6 @@ class Connection(komand.Connection):
 
     def connect(self, params={}):
         pass
+
+    def test(self):
+        return {}

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/util/proofpoint_decoder.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/util/proofpoint_decoder.py
@@ -1,0 +1,111 @@
+# __author__ = 'Eric Van Cleve'
+# __copyright__ = 'Copyright 2019, Proofpoint Inc'
+# __license__ = 'GPL v.3'
+# __version__ = '3.0.1'
+# __email__ = 'evancleve@proofpoint.com'
+# __status__ = 'Production'
+
+import sys
+import re
+import string
+from base64 import urlsafe_b64decode
+if sys.version_info[0] < 3:
+    from urllib import unquote
+    import HTMLParser
+    htmlparser = HTMLParser.HTMLParser()
+    unescape = htmlparser.unescape
+    from string import maketrans
+else:
+    from urllib.parse import unquote
+    from html import unescape
+    maketrans = str.maketrans
+
+
+class URLDefenseDecoder(object):
+
+    @staticmethod
+    def __init__():
+        URLDefenseDecoder.ud_pattern = re.compile(r'https://urldefense(?:\.proofpoint)?\.com/(v[0-9])/')
+        URLDefenseDecoder.v1_pattern = re.compile(r'u=(?P<url>.+?)&k=')
+        URLDefenseDecoder.v2_pattern = re.compile(r'u=(?P<url>.+?)&[dc]=')
+        URLDefenseDecoder.v3_pattern = re.compile(r'v3/__(?P<url>.+?)__;(?P<enc_bytes>.*?)!')
+        URLDefenseDecoder.v3_token_pattern = re.compile("\*(\*.)?")
+        URLDefenseDecoder.v3_run_mapping = {}
+        run_values = string.ascii_uppercase + string.ascii_lowercase + string.digits + '-' + '_'
+        run_length = 2
+        for value in run_values:
+            URLDefenseDecoder.v3_run_mapping[value] = run_length
+            run_length += 1
+
+    def decode(self, rewritten_url):
+        match = self.ud_pattern.search(rewritten_url)
+        if match:
+            if match.group(1) == 'v1':
+                return self.decode_v1(rewritten_url)
+            elif match.group(1) == 'v2':
+                return self.decode_v2(rewritten_url)
+            elif match.group(1) == 'v3':
+                return self.decode_v3(rewritten_url)
+            else:
+                raise ValueError('Unrecognized version in: ', rewritten_url)
+        else:
+            raise ValueError('Does not appear to be a URL Defense URL')
+
+    def decode_v1(self, rewritten_url):
+        match = self.v1_pattern.search(rewritten_url)
+        if match:
+            url_encoded_url = match.group('url')
+            html_encoded_url = unquote(url_encoded_url)
+            url = unescape(html_encoded_url)
+            return url
+        else:
+            raise ValueError('Error parsing URL')
+
+    def decode_v2(self, rewritten_url):
+        match = self.v2_pattern.search(rewritten_url)
+        if match:
+            special_encoded_url = match.group('url')
+            trans = maketrans('-_', '%/')
+            url_encoded_url = special_encoded_url.translate(trans)
+            html_encoded_url = unquote(url_encoded_url)
+            url = unescape(html_encoded_url)
+            return url
+        else:
+            raise ValueError('Error parsing URL')
+
+    def decode_v3(self, rewritten_url):
+        def replace_token(token):
+            if token == '*':
+                character = self.dec_bytes[self.current_marker]
+                self.current_marker += 1
+                return character
+            if token.startswith('**'):
+                run_length = self.v3_run_mapping[token[-1]]
+                run = self.dec_bytes[self.current_marker:run_length]
+                self.current_marker += 1
+                return run
+
+        def substitute_tokens(text, start_pos=0):
+            match = self.v3_token_pattern.search(text, start_pos)
+            if match:
+                start = text[start_pos:match.start()]
+                built_string = start
+                token = text[match.start():match.end()]
+                built_string += replace_token(token)
+                built_string += substitute_tokens(text, match.end())
+                return built_string
+            else:
+                return text[start_pos:len(text)]
+
+        match = self.v3_pattern.search(rewritten_url)
+        if match:
+            url = match.group('url')
+            encoded_url = unquote(url)
+            enc_bytes = match.group('enc_bytes')
+            enc_bytes += '=='
+            self.dec_bytes = (urlsafe_b64decode(enc_bytes)).decode('utf-8')
+            self.current_marker = 0
+            return substitute_tokens(encoded_url)
+
+        else:
+            raise ValueError('Error parsing URL')

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: community
 status: []
 description: Decode Proofpoint encoded URLs
-version: 1.0.1
+version: 1.1.0
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/proofpoint_url_defense
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -29,6 +29,7 @@ actions:
         title: Encoded URL
         description: Proofpoint encoded URL or URL parameters e.g http-3A__www.example.org_url&d=BwdwBAg&c=TIwfCwdwWnrHy3gMA_uzZorHPsT2wfwvKrwfU
         type: string
+        example: "http-3A__www.example.org_url&d=BwdwBAg&c=TIwfCwdwWnrHy3gMA_uzZorHPsT2wfwvKrwf"
         required: true
     output:
       decoded_url:

--- a/proofpoint_url_defense/setup.py
+++ b/proofpoint_url_defense/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 
-setup(name='proofpoint_url_defense-rapid7-plugin',
-      version='1.0.1',
-      description='Decode Proofpoint encoded URLs',
-      author='rapid7',
-      author_email='',
-      url='',
+setup(name="proofpoint_url_defense-rapid7-plugin",
+      version="1.1.0",
+      description="Decode Proofpoint encoded URLs",
+      author="rapid7",
+      author_email="",
+      url="",
       packages=find_packages(),
       install_requires=['komand'],  # Add third-party dependencies to requirements.txt, not here!
       scripts=['bin/komand_proofpoint_url_defense']

--- a/proofpoint_url_defense/unit_test/test_url_decode.py
+++ b/proofpoint_url_defense/unit_test/test_url_decode.py
@@ -1,0 +1,52 @@
+import sys
+import os
+sys.path.append(os.path.abspath('../'))
+
+from unittest import TestCase
+from komand_proofpoint_url_defense.connection.connection import Connection
+from komand_proofpoint_url_defense.actions.url_decode import UrlDecode
+import json
+import logging
+
+
+class TestUrlDecode(TestCase):
+    def test_integration_url_decode(self):
+        log = logging.getLogger("Test")
+        test_conn = Connection()
+        test_action = UrlDecode()
+
+        test_conn.logger = log
+        test_action.logger = log
+
+        try:
+            with open("../tests/url_decode.json") as file:
+                test_json = json.loads(file.read()).get("body")
+                connection_params = test_json.get("connection")
+                action_params = test_json.get("input")
+        except Exception as e:
+            message = """
+            Could not find or read sample tests from /tests directory
+            
+            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
+            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
+            """
+            self.fail(message)
+
+
+        test_conn.connect(connection_params)
+        test_action.connection = test_conn
+
+        # test V2
+        results = test_action.run(action_params)
+        self.assertEquals({'decoded_url': 'http://www.example.org/url'}, results)
+
+        # test V3
+        action_params["encoded_url"] = "https://urldefense.com/v3/__https://www.myclientline.net/publicS/publicServ/ClientLineEnrollment/complete.jsp__;!!MiZrGOEI0vA!NohzERuuhFAIty3SEYDFKwxCVMolJEd8Nz9rLcG4K7F8vlC_LdVlbApnP4DYHhi0l4wPQz_sD0PvfecXmeU0yUsS$"
+        results = test_action.run(action_params)
+        self.assertEqual({'decoded_url': 'https://www.myclientline.net/publicS/publicServ/ClientLineEnrollment/complete.jsp'}, results)
+
+        # another V2 test
+        action_params["encoded_url"] = "https://urldefense.proofpoint.com/v2/url?u=http-3A__amazon.com&d=DQIFAg&c=HUrdOLg_tCr0UMeDjWLBOM9lLDRpsndbROGxEKQRFzk&r=6rcUljFJZnpk5uomPd3v3WCzboqh0RuwO-BZyxMfi0U&m=fo458hhJrF87dIYyHwDAWZkegyOy6sGJVAGrntX1mP0&s=2r8EJkvOhZj1zr2Emwwgjav6t4vvg-O42jL_dHQUDkk&e="
+        results = test_action.run(action_params)
+        self.assertEqual({'decoded_url': 'http://amazon.com'}, results)
+


### PR DESCRIPTION
## Proposed Changes

This PR adds v3 link support to the Proofpoint URL Defense plugin 

## Validation: 
```
rmt-mbp-5357:proofpoint_url_defense jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 36.214000000000006ms
```

## Testing:
```
rmt-mbp-5357:proofpoint_url_defense jmcadams$ ./run.sh -R tests/url_decode.json -j
Running: cat tests/url_decode.json | docker run --rm   -i rapid7/proofpoint_url_defense:1.1.0  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
rapid7/Proofpoint URL Defense:1.1.0. Step name: url_decode
URL has been decoded
rapid7/Proofpoint URL Defense:1.1.0. Step name: url_decode
URL has been decoded

{
  "decoded_url": "http://www.example.org/url"
}
```