### PR TITLE
#185 diff plugin amendments

### DIFF
--- a/diff/.CHECKSUM
+++ b/diff/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "d3fa2793c495f0666d588aefe9439476",
+	"spec": "c5e6189014a9fcac9e19d7ef3679be8f",
 	"manifest": "09df8b426367b9a0f0c1b346fd71cca3",
 	"setup": "c13314c69451d0a674343fa2f9df34f4",
 	"schemas": [

--- a/diff/.CHECKSUM
+++ b/diff/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d0eac3dd52c0be67525c064efb408a20",
-	"manifest": "b8dd4d12334f2237a1eefcc57f461f8f",
-	"setup": "eb2cc2af50cf99af19da94578a0cd711",
+	"spec": "d3fa2793c495f0666d588aefe9439476",
+	"manifest": "09df8b426367b9a0f0c1b346fd71cca3",
+	"setup": "c13314c69451d0a674343fa2f9df34f4",
 	"schemas": [
 		{
 			"identifier": "diff/schema.py",

--- a/diff/Dockerfile
+++ b/diff/Dockerfile
@@ -1,4 +1,4 @@
-FROM komand/python-pypy3-plugin:2
+FROM komand/python-3-37-slim-plugin:3
 LABEL organization=komand
 LABEL sdk=python
 LABEL type=plugin
@@ -16,5 +16,7 @@ WORKDIR /python/src
 # End package dependencies
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 RUN python setup.py build && python setup.py install
+
+USER root
 
 ENTRYPOINT ["/usr/local/bin/komand_diff"]

--- a/diff/bin/komand_diff
+++ b/diff/bin/komand_diff
@@ -4,10 +4,10 @@ import komand
 from komand_diff import connection, actions, triggers
 
 
-Name = 'Diff'
-Vendor = 'rapid7'
-Version = '1.0.2'
-Description = 'Diff Utilities'
+Name = "Diff"
+Vendor = "rapid7"
+Version = "1.0.3"
+Description = "Diff Utilities"
 
 
 class ICONDiff(komand.Plugin):

--- a/diff/help.md
+++ b/diff/help.md
@@ -32,12 +32,32 @@ This action is used to `diff` strings.
 |compare|string|None|True|New data, for comparison against the old data|None|
 |label|string|None|True|Unique label to store the old data|None|
 
+Example input:
+
+```
+{
+    "compare": "hello 1234",
+    "label": "helloer"
+}
+
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
 |diff|string|False|Diff string|
 |different|boolean|False|True if different|
+
+Example output:
+
+```
+{
+  "diff": "",
+  "different": false
+}
+
+```
 
 ### Triggers
 
@@ -53,6 +73,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.0.3 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Add user nobody in Dockerfile | Use input and output constants | Added "f" strings
 * 1.0.2 - New spec and help.md format for the Hub
 * 1.0.1 - Update plugin tag `utility` to `utilities` for Marketplace searchability
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode

--- a/diff/help.md
+++ b/diff/help.md
@@ -36,8 +36,8 @@ Example input:
 
 ```
 {
-    "compare": "hello 1234",
-    "label": "helloer"
+  "compare": "hello 1234",
+  "label": "helloer"
 }
 
 ```
@@ -73,7 +73,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.3 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Add user nobody in Dockerfile | Use input and output constants | Added "f" strings
+* 1.0.3 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Add user nobody in Dockerfile | Use input and output constants | Added "f" strings | Add example inputs
 * 1.0.2 - New spec and help.md format for the Hub
 * 1.0.1 - Update plugin tag `utility` to `utilities` for Marketplace searchability
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode

--- a/diff/komand_diff/connection/connection.py
+++ b/diff/komand_diff/connection/connection.py
@@ -10,3 +10,6 @@ class Connection(komand.Connection):
 
     def connect(self, params={}):
         pass
+
+    def test(self):
+        pass

--- a/diff/plugin.spec.yaml
+++ b/diff/plugin.spec.yaml
@@ -29,10 +29,12 @@ actions:
         type: string
         description: Unique label to store the old data
         required: true
+        example: hehllo 123
       compare:
         type: string
         required: true
         description: New data, for comparison against the old data
+        example: helloer
     output:
       different:
         type: boolean

--- a/diff/plugin.spec.yaml
+++ b/diff/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: community
 status: []
 description: Diff Utilities
-version: 1.0.2
+version: 1.0.3
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/diff
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/diff/setup.py
+++ b/diff/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 
-setup(name='diff-rapid7-plugin',
-      version='1.0.2',
-      description='Diff Utilities',
-      author='rapid7',
-      author_email='',
-      url='',
+setup(name="diff-rapid7-plugin",
+      version="1.0.3",
+      description="Diff Utilities",
+      author="rapid7",
+      author_email="",
+      url="",
       packages=find_packages(),
       install_requires=['komand'],  # Add third-party dependencies to requirements.txt, not here!
       scripts=['bin/komand_diff']

--- a/diff/tests/diff.json
+++ b/diff/tests/diff.json
@@ -3,7 +3,7 @@
         "action": "diff",
         "connection": null,
         "input": {
-            "compare": "hello 123",
+            "compare": "hello 1234",
             "label": "helloer"
         },
         "meta": {}


### PR DESCRIPTION
## Proposed Changes
Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Add user nobody in Dockerfile | Use input and output constants | Added "f" strings

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [x] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [x] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [x] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/Diff:1.0.3. Step name: diff\nRun: Got or created cache file: \u003c_io.TextIOWrapper name='/var/cache/5647a1abd279c996514982055a9763ff' mode='r+' encoding='UTF-8'\u003e\n",
    "meta": {},
    "output": {
      "diff": "",
      "different": false
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/diff:1.0.3 --debug run < tests/diff.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Diff:1.0.3. Step name: diff\nRun: Got or created cache file: \u003c_io.TextIOWrapper name='/var/cache/5647a1abd279c996514982055a9763ff' mode='r+' encoding='UTF-8'\u003e\n",
    "meta": {},
    "output": {
      "diff": "",
      "different": false
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/diff:1.0.3 --debug run < tests/new.json
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Diff:1.0.3. Step name: diff\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/diff:1.0.3 --debug test < tests/diff.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/Diff:1.0.3. Step name: diff\n",
    "meta": {},
    "output": null,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/diff:1.0.3 --debug test < tests/new.json
</summary>
</details>

Autogenerate with:
<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 176.337ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
[SUCCESS] Passes flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.6
Run started:2020-03-29 21:22:24.801243

Test results:
>> Issue: [B303:blacklist] Use of insecure MD2, MD4, MD5, or SHA1 hash function.
   Severity: Medium   Confidence: High
   Location: ./komand_diff/actions/diff/action.py:46
   More Info: https://bandit.readthedocs.io/en/latest/blacklists/blacklist_calls.html#b303-md5
45          def md5sum(label_name):
46              return hashlib.md5(label_name.encode('utf-8')).hexdigest()

--------------------------------------------------

Code scanned:
        Total lines of code: 128
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 1.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 1.0
Files skipped (0):
[FAIL] Fails bandit security checks

```

<summary>
make validate
</summary>
</details>

Autogenerate with:
<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 11170.930999999999ms

```

<summary>
icon-validate --all .
</summary>
</details>