### PR TITLE
Proof Point Decode Success

### DIFF
--- a/proofpoint_url_defense/.CHECKSUM
+++ b/proofpoint_url_defense/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "03b69fcc1b1b828430f96a4ad847b481",
+	"spec": "f1d9c46a60f821dcafc6bcecc4c3f2bd",
 	"manifest": "1483691c1fe80a44b18e5c65938046fc",
 	"setup": "677a5f24270309d7a0aad11942d3df19",
 	"schemas": [
 		{
 			"identifier": "url_decode/schema.py",
-			"hash": "0f955b75d525e4332fec838177bc79cd"
+			"hash": "0d0e8e5446a87568c9931d768f73eef3"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/proofpoint_url_defense/.CHECKSUM
+++ b/proofpoint_url_defense/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "48a96aab8c5f57af101a4fff5c781979",
-	"manifest": "20c7bf707e80cbe10200cb038ce19fde",
-	"setup": "ef5a809a597782684faeca24655e7903",
+	"spec": "03b69fcc1b1b828430f96a4ad847b481",
+	"manifest": "1483691c1fe80a44b18e5c65938046fc",
+	"setup": "677a5f24270309d7a0aad11942d3df19",
 	"schemas": [
 		{
 			"identifier": "url_decode/schema.py",

--- a/proofpoint_url_defense/.CHECKSUM
+++ b/proofpoint_url_defense/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "77a2a2e1956cecd2a6c4b11540d0ab50",
+	"spec": "48a96aab8c5f57af101a4fff5c781979",
 	"manifest": "20c7bf707e80cbe10200cb038ce19fde",
 	"setup": "ef5a809a597782684faeca24655e7903",
 	"schemas": [
 		{
 			"identifier": "url_decode/schema.py",
-			"hash": "35af15c8bd53e4a657ac813393dd5ac5"
+			"hash": "0f955b75d525e4332fec838177bc79cd"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/proofpoint_url_defense/bin/komand_proofpoint_url_defense
+++ b/proofpoint_url_defense/bin/komand_proofpoint_url_defense
@@ -6,7 +6,7 @@ from komand_proofpoint_url_defense import connection, actions, triggers
 
 Name = "Proofpoint URL Defense"
 Vendor = "rapid7"
-Version = "1.1.0"
+Version = "1.2.0"
 Description = "Decode Proofpoint encoded URLs"
 
 

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -43,7 +43,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|decode_success|boolean|True|Was decode successful, if not, the original URL will be returned|
+|decoded|boolean|True|Was decode successful, if not, the original URL will be returned|
 |decoded_url|string|False|Decoded Proofpoint URL|
 
 Example output:
@@ -70,7 +70,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.2.0 - Update to URL Decode to add 'decode_success' as an output variable 
+* 1.2.0 - Update to URL Decode to add 'decoded' as an output variable 
 * 1.1.0 - Update to URL Decode action to add support for v3 links
 * 1.0.1 - New spec and help.md format for the Hub
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Bug fix with decode parsing

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -50,7 +50,8 @@ Example output:
 
 ```
 {
-  "decoded_url": "http://www.example.org/url"
+  "decoded_url": "http://www.example.org/url",
+  "decode_success": true
 }
 ```
 
@@ -69,6 +70,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 1.2.0 - Update to URL Decode to add 'decode_success' as an output variable 
 * 1.1.0 - Update to URL Decode action to add support for v3 links
 * 1.0.1 - New spec and help.md format for the Hub
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Bug fix with decode parsing

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -70,7 +70,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.2.0 - Update to URL Decode to add 'decoded' as an output variable 
+* 1.2.0 - Update to URL Decode to add `decoded` as an output variable 
 * 1.1.0 - Update to URL Decode action to add support for v3 links
 * 1.0.1 - New spec and help.md format for the Hub
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Bug fix with decode parsing
@@ -83,4 +83,3 @@ This plugin does not contain any troubleshooting information.
 
 * [Proofpoint URL Defense](https://www.proofpoint.com/us/products/targeted-attack-protection)
 * [Proofpoint decode utility](https://help.proofpoint.com/@api/deki/files/177/URLDefenseDecode.py?revision=2)
-

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -43,6 +43,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
+|decode_success|boolean|True|Was decode successful, if not, the original URL will be returned|
 |decoded_url|string|False|Decoded Proofpoint URL|
 
 Example output:

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
@@ -3,6 +3,7 @@ from .schema import UrlDecodeInput, UrlDecodeOutput, Input, Output
 # Custom imports below
 from komand_proofpoint_url_defense.util.proofpoint_decoder import URLDefenseDecoder
 
+
 class UrlDecode(komand.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
@@ -13,12 +14,12 @@ class UrlDecode(komand.Action):
 
     def run(self, params={}):
         in_url = params[Input.ENCODED_URL]
-        url_v2 = 'https://urldefense.proofpoint.com/' # This is good for v1 as well
+        url_v2 = 'https://urldefense.proofpoint.com/'  # This is good for v1 as well
         url_v3 = 'https://urldefense.com'
 
         if in_url.startswith(url_v2) or in_url.startswith(url_v3):
             encoded_url = params.get("encoded_url")
-        else: # We assume a v2 encoded URL, this is legacy behavior
+        else:  # We assume a v2 encoded URL, this is legacy behavior
             encoded_url = f"https://urldefense.proofpoint.com/v2/url?u={in_url}"
 
         decoder = URLDefenseDecoder()
@@ -26,7 +27,8 @@ class UrlDecode(komand.Action):
         try:
             decoded_url = decoder.decode(encoded_url)
             self.logger.info('URL has been decoded')
-            return {'decoded_url': decoded_url}
-        except Exception:
-            self.logger.error("Unexpected issue occurred decoding URL")
-            raise
+            return {Output.DECODED_URL: decoded_url, Output.DECODE_SUCCESS: True}
+        except (Exception, ValueError) as e:
+            self.logger.error(f"Unexpected issue occurred decoding URL: {e}")
+            return {Output.DECODED_URL: in_url, Output.DECODE_SUCCESS: False}
+

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
@@ -27,8 +27,8 @@ class UrlDecode(komand.Action):
         try:
             decoded_url = decoder.decode(encoded_url)
             self.logger.info('URL has been decoded')
-            return {Output.DECODED_URL: decoded_url, Output.DECODE_SUCCESS: True}
+            return {Output.DECODED_URL: decoded_url, Output.DECODED: True}
         except (Exception, ValueError) as e:
             self.logger.error(f"Unexpected issue occurred decoding URL: {e}")
-            return {Output.DECODED_URL: in_url, Output.DECODE_SUCCESS: False}
+            return {Output.DECODED_URL: in_url, Output.DECODED: False}
 

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/schema.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/schema.py
@@ -12,6 +12,7 @@ class Input:
     
 
 class Output:
+    DECODE_SUCCESS = "decode_success"
     DECODED_URL = "decoded_url"
     
 
@@ -44,13 +45,22 @@ class UrlDecodeOutput(komand.Output):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "decode_success": {
+      "type": "boolean",
+      "title": "Decode Success",
+      "description": "Was decode successful, if not, the original URL will be returned",
+      "order": 2
+    },
     "decoded_url": {
       "type": "string",
       "title": "Decoded Proofpoint URL",
       "description": "Decoded Proofpoint URL",
       "order": 1
     }
-  }
+  },
+  "required": [
+    "decode_success"
+  ]
 }
     """)
 

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/schema.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/schema.py
@@ -12,7 +12,7 @@ class Input:
     
 
 class Output:
-    DECODE_SUCCESS = "decode_success"
+    DECODED = "decoded"
     DECODED_URL = "decoded_url"
     
 
@@ -45,9 +45,9 @@ class UrlDecodeOutput(komand.Output):
   "type": "object",
   "title": "Variables",
   "properties": {
-    "decode_success": {
+    "decoded": {
       "type": "boolean",
-      "title": "Decode Success",
+      "title": "Decoded",
       "description": "Was decode successful, if not, the original URL will be returned",
       "order": 2
     },
@@ -59,7 +59,7 @@ class UrlDecodeOutput(komand.Output):
     }
   },
   "required": [
-    "decode_success"
+    "decoded"
   ]
 }
     """)

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -37,8 +37,8 @@ actions:
         description: Decoded Proofpoint URL
         type: string
         required: false
-      decode_success:
-        title: Decode Success
+      decoded:
+        title: Decoded
         description: Was decode successful, if not, the original URL will be returned
         type: boolean
         required: true

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: community
 status: []
 description: Decode Proofpoint encoded URLs
-version: 1.1.0
+version: 1.2.0
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/proofpoint_url_defense
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -37,3 +37,8 @@ actions:
         description: Decoded Proofpoint URL
         type: string
         required: false
+      decode_success:
+        title: Decode Success
+        description: Was decode successful, if not, the original URL will be returned
+        type: boolean
+        required: true

--- a/proofpoint_url_defense/setup.py
+++ b/proofpoint_url_defense/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_url_defense-rapid7-plugin",
-      version="1.1.0",
+      version="1.2.0",
       description="Decode Proofpoint encoded URLs",
       author="rapid7",
       author_email="",

--- a/proofpoint_url_defense/unit_test/test_url_decode.py
+++ b/proofpoint_url_defense/unit_test/test_url_decode.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath('../'))
 from unittest import TestCase
 from komand_proofpoint_url_defense.connection.connection import Connection
 from komand_proofpoint_url_defense.actions.url_decode import UrlDecode
+from komand.exceptions import PluginException
 import json
 import logging
 
@@ -38,15 +39,47 @@ class TestUrlDecode(TestCase):
 
         # test V2
         results = test_action.run(action_params)
-        self.assertEquals({'decoded_url': 'http://www.example.org/url'}, results)
+        self.assertEquals({'decoded_url': 'http://www.example.org/url', 'decode_success': True}, results)
 
         # test V3
         action_params["encoded_url"] = "https://urldefense.com/v3/__https://www.myclientline.net/publicS/publicServ/ClientLineEnrollment/complete.jsp__;!!MiZrGOEI0vA!NohzERuuhFAIty3SEYDFKwxCVMolJEd8Nz9rLcG4K7F8vlC_LdVlbApnP4DYHhi0l4wPQz_sD0PvfecXmeU0yUsS$"
         results = test_action.run(action_params)
-        self.assertEqual({'decoded_url': 'https://www.myclientline.net/publicS/publicServ/ClientLineEnrollment/complete.jsp'}, results)
+        self.assertEqual({'decoded_url': 'https://www.myclientline.net/publicS/publicServ/ClientLineEnrollment/complete.jsp', 'decode_success': True}, results)
 
         # another V2 test
         action_params["encoded_url"] = "https://urldefense.proofpoint.com/v2/url?u=http-3A__amazon.com&d=DQIFAg&c=HUrdOLg_tCr0UMeDjWLBOM9lLDRpsndbROGxEKQRFzk&r=6rcUljFJZnpk5uomPd3v3WCzboqh0RuwO-BZyxMfi0U&m=fo458hhJrF87dIYyHwDAWZkegyOy6sGJVAGrntX1mP0&s=2r8EJkvOhZj1zr2Emwwgjav6t4vvg-O42jL_dHQUDkk&e="
         results = test_action.run(action_params)
-        self.assertEqual({'decoded_url': 'http://amazon.com'}, results)
+        self.assertEqual({'decoded_url': 'http://amazon.com', 'decode_success': True}, results)
+
+    def test_integration_url_not_encoded(self):
+        log = logging.getLogger("Test")
+        test_conn = Connection()
+        test_action = UrlDecode()
+
+        test_conn.logger = log
+        test_action.logger = log
+
+        try:
+            with open("../tests/url_decode.json") as file:
+                test_json = json.loads(file.read()).get("body")
+                connection_params = test_json.get("connection")
+                action_params = test_json.get("input")
+        except Exception as e:
+            message = """
+            Could not find or read sample tests from /tests directory
+
+            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
+            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
+            """
+            self.fail(message)
+
+        test_conn.connect(connection_params)
+        test_action.connection = test_conn
+
+        # test V3
+        action_params["encoded_url"] = "http://www.google.com"
+
+        results = test_action.run(action_params)
+        self.assertFalse(results.get("decode_success"))
+        self.assertEquals(results.get("decoded_url"), "http://www.google.com")
 


### PR DESCRIPTION
## Proposed Changes

This PR adds 'decode_success' to Proof Point URL Defense. This will allow the user to know if a URL was successfully decoded, but not break a workflow if a non-encoded URL is passed in. 

## Validation: 
```
rmt-mbp-5357:proofpoint_url_defense jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 40.362ms
rmt-mbp-5357:proofpoint_url_defense jmcadams$
```

## Tests: 
```
rmt-mbp-5357:proofpoint_url_defense jmcadams$ ./run.sh -R tests/url_decode.json -j
Running: cat tests/url_decode.json | docker run --rm   -i rapid7/proofpoint_url_defense:1.2.0  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
rapid7/Proofpoint URL Defense:1.2.0. Step name: url_decode
URL has been decoded
rapid7/Proofpoint URL Defense:1.2.0. Step name: url_decode
URL has been decoded

{
  "decoded_url": "http://www.example.org/url",
  "decode_success": true
}
```