### PR TITLE
[WIP] - Microsoft Teams add support for more than 20 teams in Get Teams

### DIFF
--- a/microsoft_teams/.CHECKSUM
+++ b/microsoft_teams/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "39205ad26152a2d0c73ecbd3d058b6d6",
-	"manifest": "1f9ba037dca7f12e379c3f3e69ad8c1d",
-	"setup": "d308e1c2a7b54bc2e5ef921e54dc9da7",
+	"spec": "034c5eb3e002676171c426d2568638d2",
+	"manifest": "47e15b12bed6bbbc5228c62161dcb3cf",
+	"setup": "ecf300fc11c7b5548f58ea30473d460d",
 	"schemas": [
 		{
 			"identifier": "add_channel_to_team/schema.py",

--- a/microsoft_teams/bin/icon_microsoft_teams
+++ b/microsoft_teams/bin/icon_microsoft_teams
@@ -6,7 +6,7 @@ from icon_microsoft_teams import connection, actions, triggers
 
 Name = "Microsoft Teams"
 Vendor = "rapid7"
-Version = "2.0.0"
+Version = "2.0.1"
 Description = "The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users"
 
 

--- a/microsoft_teams/help.md
+++ b/microsoft_teams/help.md
@@ -26,6 +26,21 @@ The connection configuration accepts the following parameters:
 |directory_id|string|None|True|Directory (tenant) ID|None|
 |username_password|credential_username_password|None|True|Username and password|None|
 
+Example input:
+
+```
+{
+  "application_id": "xxxxxxx-xxxxxx-xxxxx-xxxx",
+  "application_secret": {
+    "secretKey": "xxxxxxx"
+  },
+  "directory_id": "xxxx-xxxx-xxxx-xxxx-xxx",
+  "username_password": {
+    "password": "password",
+    "username": "user@example.com"
+}
+```
+
 ## Technical Details
 
 ### Actions
@@ -47,6 +62,11 @@ Regular expressions used by this action are Python specific.
 Example input:
 
 ```
+{
+  "channel_name": "ICON Test Channel",
+  "message": "Hello!",
+  "team_name": "ICON-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -101,6 +121,11 @@ This action is used to send HTML as a message.
 Example input:
 
 ```
+{
+  "channel_name": "ICON Test Channel",
+  "message_content": "<b>Hello!</b>",
+  "team_name": "ICON-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -153,22 +178,22 @@ This action sends a message using the GUID for the team and channel. This is mor
 |message|string|None|True|Message to send|None|
 |team_guid|string|None|True|Team GUID|None|
 
-##### Output
-
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|message|message|False|The message object that was created|
-
 Example input:
 
 ```
+{
+  "channel_guid": "xxxxx-xxxxx-xxxx-xxxx",
+  "is_html": false,
+  "message": "Hello!",
+  "team_guid": "xxxxx-xxxxx-xxxx-xxxx"
+}
 ```
 
 ##### Output
 
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
-|message|message|False|The message object that was created|
+|message|message|False|The message object that was created|None|
 
 Example output:
 
@@ -218,6 +243,9 @@ Regular expressions used by this action are Python specific.
 Example input:
 
 ```
+{
+  "team_name": "Komand-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -282,6 +310,10 @@ Regular expressions used by this action are Python specific.
 Example input:
 
 ```
+{
+  "channel_name": "Komand Test Channel",
+  "team_name": "Komand-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -320,6 +352,10 @@ This action is used to add a member to a team.
 Example input:
 
 ```
+{
+  "member_login": "user@example.com",
+  "team_name": "ICON-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -351,6 +387,11 @@ This action is used to add a channel to a team.
 Example input:
 
 ```
+{
+  "channel_description": "This is a test channel.",
+  "channel_name": "test_channel",
+  "team_name": "ICON-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -381,6 +422,10 @@ This action is used to remove a channel from a team.
 Example input:
 
 ```
+{
+  "channel_name": "test_channel",
+  "team_name": "ICON-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -411,6 +456,10 @@ This action is used to remove a member from a team.
 Example input:
 
 ```
+{
+  "member_login": "user@example.com",
+  "team_name": "Komand-Test-Everyone"
+}
 ```
 
 ##### Output
@@ -445,6 +494,12 @@ This action is used to create a group in Azure and enable it for Microsoft Teams
 Example input:
 
 ```
+  "group_description": "A test group",
+  "group_name": "test_group",
+  "mail_enabled": false,
+  "mail_nickname": "TestGroup",
+  "members": "['user@example.com']",
+  "owners": "['user@example.com']"
 ```
 
 ##### Output
@@ -497,6 +552,9 @@ This action is used to delete a team and the associated group from Azure.
 Example input:
 
 ```
+{
+  "team_name": "Test Team"
+}
 ```
 
 ##### Output
@@ -532,6 +590,11 @@ Regular expressions used by this trigger are Python specific.
 Example input:
 
 ```
+{
+  "channel_name": "ICON Test Channel",
+  "message_content": "[Tt]est",
+  "team_name": "ICON-Test-Everyone"
+}
 ```
 
 ##### Output

--- a/microsoft_teams/help.md
+++ b/microsoft_teams/help.md
@@ -44,6 +44,11 @@ Regular expressions used by this action are Python specific.
 |message|string|None|True|Message to send|None|
 |team_name|string|None|True|Team name|None|
 
+Example input:
+
+```
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -92,6 +97,11 @@ This action is used to send HTML as a message.
 |channel_name|string|None|True|Channel name|None|
 |message_content|string|None|True|HTML content to send|None|
 |team_name|string|None|True|Team name|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -145,6 +155,17 @@ This action sends a message using the GUID for the team and channel. This is mor
 
 ##### Output
 
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|message|message|False|The message object that was created|
+
+Example input:
+
+```
+```
+
+##### Output
+
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
 |message|message|False|The message object that was created|
@@ -193,6 +214,11 @@ Regular expressions used by this action are Python specific.
 |Name|Type|Default|Required|Description|Enum|
 |----|----|-------|--------|-----------|----|
 |team_name|string|None|False|Optional regex-capable team name to look for|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -253,6 +279,11 @@ Regular expressions used by this action are Python specific.
 |channel_name|string|None|False|Optional regex-capable channel to look for|None|
 |team_name|string|None|True|Team name to look for|None|
 
+Example input:
+
+```
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -286,6 +317,11 @@ This action is used to add a member to a team.
 |member_login|string|None|True|Member login e.g. user@example.com|None|
 |team_name|string|None|True|Team name|None|
 
+Example input:
+
+```
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -312,6 +348,11 @@ This action is used to add a channel to a team.
 |channel_name|string|None|True|Channel name|None|
 |team_name|string|None|True|Team name|None|
 
+Example input:
+
+```
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -337,6 +378,11 @@ This action is used to remove a channel from a team.
 |channel_name|string|None|True|Channel name|None|
 |team_name|string|None|True|Team name|None|
 
+Example input:
+
+```
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -361,6 +407,11 @@ This action is used to remove a member from a team.
 |----|----|-------|--------|-----------|----|
 |member_login|string|None|True|Member Login e.g. user@example.com|None|
 |team_name|string|None|True|Team name|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -390,6 +441,11 @@ This action is used to create a group in Azure and enable it for Microsoft Teams
 |mail_nickname|string|None|True|The nickname for the email address of this group in Outlook|None|
 |members|string[]|None|False|A list of usernames to set as members|None|
 |owners|string[]|None|False|A list of usernames to set as owners|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -438,6 +494,11 @@ This action is used to delete a team and the associated group from Azure.
 |----|----|-------|--------|-----------|----|
 |team_name|string|None|True|Team Name|None|
 
+Example input:
+
+```
+```
+
 ##### Output
 
 |Name|Type|Required|Description|
@@ -467,6 +528,11 @@ Regular expressions used by this trigger are Python specific.
 |channel_name|string|None|True|Channel|None|
 |message_content|string|None|False|Regex to match new messages against|None|
 |team_name|string|None|True|Team name|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -515,6 +581,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 2.0.1 - Update to Get Teams action to support more than 20 teams
 * 2.0.0 - Fix issue where send message would not work if there were too many teams | Removed regex capability for team and channel inputs which will speed up Send Message and Send HTML Message actions
 * 1.3.0 - New action Send Message by GUID
 * 1.2.3 - New spec and help.md format for the Hub

--- a/microsoft_teams/icon_microsoft_teams/util/teams_utils.py
+++ b/microsoft_teams/icon_microsoft_teams/util/teams_utils.py
@@ -47,7 +47,7 @@ def get_teams_from_microsoft(logger: Logger,
     nextlink = teams_result.json().get("@odata.nextLink")
 
     # If there's more than 20 teams, the results will come back paginated.
-    while(nextlink):
+    while nextlink:
         try:
             new_teams = requests.get(nextlink, headers=headers)
         except Exception as e:

--- a/microsoft_teams/plugin.spec.yaml
+++ b/microsoft_teams/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
 description: The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users
-version: 2.0.0
+version: 2.0.1
 vendor: rapid7
 support: community
 status: []

--- a/microsoft_teams/setup.py
+++ b/microsoft_teams/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="microsoft_teams-rapid7-plugin",
-      version="2.0.0",
+      version="2.0.1",
       description="The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users",
       author="rapid7",
       author_email="",

--- a/microsoft_teams/tests/send_message_by_guid.json
+++ b/microsoft_teams/tests/send_message_by_guid.json
@@ -1,0 +1,14 @@
+{
+    "body": {
+        "action": "send_message_by_guid",
+        "input": {
+            "channel_guid": "",
+            "is_html": false,
+            "message": "",
+            "team_guid": ""
+        },
+        "meta": {}
+    },
+    "type": "action_start",
+    "version": "v1"
+}

--- a/microsoft_teams/unit_test/test_get_channels.py
+++ b/microsoft_teams/unit_test/test_get_channels.py
@@ -23,10 +23,10 @@ class TestGetChannels(TestCase):
         test_action.connection = test_connection
 
         run_params = {
-            "team_name": "Dream Team",
-            "channel_name": "test"
+            "team_name": "Komand-Test-Everyone",
+            "channel_name": "29_test_channel_2"
         }
 
         result = test_action.run(run_params)
         self.assertIsNotNone(result)
-        self.assertEqual(result.get("channels")[0].get("displayName"), "test123")
+        self.assertEqual(result.get("channels")[0].get("displayName"), "29_test_channel_2")

--- a/microsoft_teams/unit_test/test_teams_utils.py
+++ b/microsoft_teams/unit_test/test_teams_utils.py
@@ -4,10 +4,11 @@ from icon_microsoft_teams.util.teams_utils import create_channel, delete_channel
 
 import logging
 import json
+import time
 
 # Globals
 TEAM_ID = "7af08a76-01fe-4a1d-bfa1-84d2b5509cdd"  # Komand-Test-Everyone
-TEST_CHANNEL_NAME = "test_channel_delete_me"
+TEST_CHANNEL_NAME = "test_channel_delete_me_2"
 
 
 class TestTeamsUtils(TestCase):
@@ -23,6 +24,14 @@ class TestTeamsUtils(TestCase):
         test_connection.connect(connection_params)
 
         result = create_channel(log, test_connection, TEAM_ID, TEST_CHANNEL_NAME, "some really cool test description")
+
+        # This code is used to bulk create channels. Needed to max out a team with channels to test
+        # pagination
+
+        # for i in range(200):
+        #     channel_name = f"{i}_test_channel"
+        #     create_channel(log, test_connection, TEAM_ID, channel_name, "some really cool test description")
+
         self.assertTrue(result)
 
     def test_delete_channel(self):
@@ -36,8 +45,18 @@ class TestTeamsUtils(TestCase):
 
         test_connection.connect(connection_params)
 
-        channels = get_channels_from_microsoft(log, test_connection, TEAM_ID, TEST_CHANNEL_NAME)
+        channels = get_channels_from_microsoft(log, test_connection, TEAM_ID, TEST_CHANNEL_NAME, True)
         channel_id = channels[0].get("id")
 
         result = delete_channel(log, test_connection, TEAM_ID, channel_id)
+
+        # Leaving this code here - This can be used for bulk delete if needed
+
+        # for i in range(100):
+        #     channel_name = f"{i}_test_channel_3"
+        #     channels = get_channels_from_microsoft(log, test_connection, TEAM_ID, channel_name)
+        #     channel_id = channels[0].get("id")
+        #     delete_channel(log, test_connection, TEAM_ID, channel_id)
+        #     time.sleep(1)
+
         self.assertTrue(result)


### PR DESCRIPTION
## Proposed Changes

This PR adds pagination support to the Microsoft Teams "Get Teams" action. This adds support for more than 20 teams when looking for a team. 

### Validation: 
```
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 260.95099999999996ms

```

### Testing: 
Unit Tests passed as expected. 

```
rmt-mbp-5357:microsoft_teams jmcadams$ ./run.sh -R tests/get_teams.json -j
Running: cat tests/get_teams.json | docker run --rm   -i rapid7/microsoft_teams:2.0.1  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Refreshing auth token
Updating Auth Token...
Getting token from: https://login.microsoftonline.com/5c824599-dc8c-4d31-96fb-3b886d4f8f10/oauth2/token
Starting new HTTPS connection (1): login.microsoftonline.com:443
https://login.microsoftonline.com:443 "POST /5c824599-dc8c-4d31-96fb-3b886d4f8f10/oauth2/token HTTP/1.1" 200 2752
Authentication was successful, token is: ******************sZh3g
Detected Permissions: Directory.ReadWrite.All Group.ReadWrite.All
rapid7/Microsoft Teams:2.0.1. Step name: get_teams
Starting new HTTPS connection (1): graph.microsoft.com:443
https://graph.microsoft.com:443 "GET /beta/groups?$filter=resourceProvisioningOptions/Any(x:x%20eq%20'Team') HTTP/1.1" 200 1542
Team name: Komand-Test-Everyone
Checking team: Dream Team
Checking team: Komand-Test-Everyone
Refreshing auth token
Updating Auth Token...
Getting token from: https://login.microsoftonline.com/5c824599-dc8c-4d31-96fb-3b886d4f8f10/oauth2/token
Authentication was successful, token is: ******************sZh3g
Detected Permissions: Directory.ReadWrite.All Group.ReadWrite.All
rapid7/Microsoft Teams:2.0.1. Step name: get_teams
Team name: Komand-Test-Everyone
Checking team: Dream Team
Checking team: Komand-Test-Everyone

{
  "teams": [
    {
      "id": "7af08a76-01fe-4a1d-bfa1-84d2b5509cdd",
      "createdDateTime": "2019-10-14T17:18:55Z",
      "description": "A test team of everyone",
      "displayName": "Komand-Test-Everyone",
      "groupTypes": [
        "Unified"
      ],
      "mail": "Komand-Test-Everyone@komanddev.onmicrosoft.com",
      "mailEnabled": true,
      "mailNickname": "Komand-Test-Everyone",
      "proxyAddresses": [
        "SPO:SPO_a4dfb94d-bcd2-47fb-a123-4a3702bf6bff@SPO_5c824599-dc8c-4d31-96fb-3b886d4f8f10",
        "SMTP:Komand-Test-Everyone@komanddev.onmicrosoft.com"
      ],
      "renewedDateTime": "2019-10-14T17:18:55Z",
      "resourceBehaviorOptions": [
        "HideGroupInOutlook",
        "SubscribeMembersToCalendarEventsDisabled",
        "WelcomeEmailDisabled"
      ],
      "resourceProvisioningOptions": [
        "Team"
      ],
      "securityEnabled": false,
      "securityIdentifier": "S-1-12-1-2062584438-1243415038-3531907519-3718009013",
      "visibility": "Public",
      "onPremisesProvisioningErrors": []
    }
  ]
}
```