### PR TITLE
Replace mentions of the Hub with Extension Library

### DIFF
--- a/abuseipdb/help.md
+++ b/abuseipdb/help.md
@@ -340,7 +340,7 @@ There's a rate limit on the free API service. The following error messags `429 C
 
 * 5.0.3 - Add example inputs
 * 5.0.2 - Changed descriptions | Removed duplicated code | Use output constants | Added "f" strings
-* 5.0.1 - New spec and help.md format for the Hub
+* 5.0.1 - New spec and help.md format for the Extension Library
 * 5.0.0 - Mark certain outputs as optional as they are not always returned by the AbuseIPDB service | Clean output of null values
 * 4.0.1 - Transform null value of various output properties of Check IP action to false or empty string.
 * 4.0.0 - Update to APIv2 and new action Get Blacklist

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -354,7 +354,7 @@ paired `\(\)` are supported
 # Version History
 
 * 3.2.8 - Fix issue were adding objects to containers might fail
-* 3.2.7 - New spec and help.md format for the Hub
+* 3.2.7 - New spec and help.md format for the Extension Library
 * 3.2.6 - Update help to document supported Windows Server versions
 * 3.2.5 - Clean connection test output
 * 3.2.4 - Fix issue with Query where some output was not unescaped properly | Update to exception handling to leverage PluginException

--- a/advanced_regex/help.md
+++ b/advanced_regex/help.md
@@ -133,7 +133,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/anomali_threatstream/help.md
+++ b/anomali_threatstream/help.md
@@ -491,7 +491,7 @@ If you're unable to import data without approval, the Anomali user configured in
 # Version History
 
 * 3.1.0 - Add new actions Submit File, Submit URL and Get Sandbox Report
-* 3.0.2 - New spec and help.md format for the Hub
+* 3.0.2 - New spec and help.md format for the Extension Library
 * 3.0.1 - Update actions to use SSL Verify from connection settings
 * 3.0.0 - Add new action Get Observables | Rename action Add Approval Indicator to Import Observable | Add connection test
 * 2.0.0 - Support optional server SSL/TLS certificate validation

--- a/att_cybersecurity_alienvault_otx/help.md
+++ b/att_cybersecurity_alienvault_otx/help.md
@@ -235,7 +235,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.0 - New spec and help.md format update for the Hub | Variable names updated as acronyms
+* 2.0.0 - New spec and help.md format update for the Extension Library | Variable names updated as acronyms
 * 1.0.1 - Update custom type and added HOSTNAME as a supported indicator type for Get Indicator Details
 * 1.0.0 - Initial plugin
 

--- a/awk/help.md
+++ b/awk/help.md
@@ -90,7 +90,7 @@ by setting the ORS (Output Record Separator) variable to nothing e.g. `-v ORS= '
 
 # Version History
 
-* 1.2.1 - New spec and help.md format for the Hub | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-plugin` | Removed duplicated code | Changed string action to use bare string instead temporary file | Changed bare strings in params.get and output to static fields from schema | Repair coding style
+* 1.2.1 - New spec and help.md format for the Extension Library | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-plugin` | Removed duplicated code | Changed string action to use bare string instead temporary file | Changed bare strings in params.get and output to static fields from schema | Repair coding style
 * 1.2.0 - Support web server mode
 * 1.1.2 - Update to v2 Python plugin architecture
 * 1.1.1 - SSL bug fix in SDK

--- a/aws_securityhub/help.md
+++ b/aws_securityhub/help.md
@@ -195,7 +195,7 @@ This plugin does not contain any troubleshooting information.
 # Version History
 
 * 2.0.1 - Removed unused variables
-* 2.0.0 - New spec and help.md format for the Hub | Variable names updated as acronyms
+* 2.0.0 - New spec and help.md format for the Extension Library | Variable names updated as acronyms
 * 1.0.0 - Initial plugin
 
 # Links

--- a/aws_workspaces/help.md
+++ b/aws_workspaces/help.md
@@ -78,7 +78,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/azure_ad_admin/help.md
+++ b/azure_ad_admin/help.md
@@ -426,7 +426,7 @@ _This plugin does not contain any troubleshooting information._
 
 * 1.4.1 - Hub styling update
 * 1.4.0 - New trigger Risk Detection
-* 1.3.1 - New spec and help.md format for the Hub
+* 1.3.1 - New spec and help.md format for the Extension Library
 * 1.3.0 - New action Create User
 * 1.2.0 - New actions Get Group by Name, Add User to Group, and Remove User from Group
 * 1.1.0 - New action Force User to Change Password

--- a/azure_ad_admin/help.md
+++ b/azure_ad_admin/help.md
@@ -424,7 +424,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.4.1 - Hub styling update
+* 1.4.1 - Extension Library styling update
 * 1.4.0 - New trigger Risk Detection
 * 1.3.1 - New spec and help.md format for the Extension Library
 * 1.3.0 - New action Create User

--- a/azure_compute/help.md
+++ b/azure_compute/help.md
@@ -294,7 +294,7 @@ Error values use the standard HTTP codes (200 OK, 404 Not Found, etc)
 
 # Version History
 
-* 3.0.1 - New spec and help.md format for the Hub
+* 3.0.1 - New spec and help.md format for the Extension Library
 * 3.0.0 - Updated to support Python3 and fix issue with exception handling
 * 2.0.0 - Support web server mode | Update to new credential types | Rename "Get information about a virtual machine" to "Get Information About a Virtual Machine"
 * 1.0.0 - Update to v2 Python plugin architecture

--- a/barracuda_waf/help.md
+++ b/barracuda_waf/help.md
@@ -1777,7 +1777,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | Fix spelling of variable titled Persistence Method
+* 2.0.0 - New spec and help.md format for the Extension Library | Fix spelling of variable titled Persistence Method
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.0 - Initial plugin
 

--- a/base64/help.md
+++ b/base64/help.md
@@ -107,7 +107,7 @@ characters to `\uffd` or `?`. While ignore will drop the character from the outp
 
 * 1.1.4 - Add example inputs
 * 1.1.3 - Use input and output constants | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Change `Exception` to `PluginException` | Change descriptions in help.md | Add user nobody in Dockerfile
-* 1.1.2 - New spec and help.md format for the Hub
+* 1.1.2 - New spec and help.md format for the Extension Library
 * 1.1.1 - Fixed issue where action Decode required error parameter
 * 1.1.0 - Bug fix in decode action, added an option for error handling
 * 1.0.0 - Support web server mode

--- a/basename/help.md
+++ b/basename/help.md
@@ -62,7 +62,7 @@ If the input doesn't contain a slash `/` in the path the result will be the orig
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.1 - Update to v2 Python plugin architecture
 * 0.1.0 - Initial plugin

--- a/bhr/help.md
+++ b/bhr/help.md
@@ -185,7 +185,7 @@ This plugin currently doesn't support the ident parameter which would allow bloc
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/bitbucket/help.md
+++ b/bitbucket/help.md
@@ -142,7 +142,7 @@ Be sure the provided Bitbucket account used has permissions to perform the actio
 # Version History
 
 * 1.0.2 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` | Use input and output constants | Changed `Exception` to `PluginException` | Added "f" strings | Removed duplicated code
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/blockade/help.md
+++ b/blockade/help.md
@@ -118,7 +118,7 @@ The `Get Indicators` and `Get Events` actions do not require authentication.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/bluecoat_labs/help.md
+++ b/bluecoat_labs/help.md
@@ -64,7 +64,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Fix issue where a change in Bluecoat Labs API was causing the plugin to fail
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/box/help.md
+++ b/box/help.md
@@ -408,7 +408,7 @@ The RSA token private key, JWT, client ID and secret must be provided to the plu
 
 # Version History
 
-* 2.2.2 - New spec and help.md format for the Hub
+* 2.2.2 - New spec and help.md format for the Extension Library
 * 2.2.1 - Fix issue where a misleading error message could be given in the log
 * 2.2.0 - New actions Get User Groups and Get User Info from Login
 * 2.1.0 - New actions Get Enterprise Groups and Add User to Group

--- a/carbon_black_defense/help.md
+++ b/carbon_black_defense/help.md
@@ -320,7 +320,7 @@ Get Notifications trigger requires that the [API key type](https://developer.car
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | Fix spelling of variable titled Registry Value
+* 2.0.0 - New spec and help.md format for the Extension Library | Fix spelling of variable titled Registry Value
 * 1.1.1 - Update to Python 3.7 Slim SDK (plugin size reduction) | Fix bug in output where Security Event Code was defined as an `object` instead of a `string`
 * 1.1.0 - New action Get Details for Specific Event
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/carbon_black_live_response/help.md
+++ b/carbon_black_live_response/help.md
@@ -57,7 +57,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.3 - Bug fix for CI tool incorrectly uploading plugins
 * 0.1.2 - Update to v2 Python plugin architecture

--- a/carbon_black_protection/help.md
+++ b/carbon_black_protection/help.md
@@ -553,7 +553,7 @@ Carbon Black Protection schedules events to happen, therefore what you see in ou
 
 # Version History
 
-* 2.2.1 - New spec and help.md format for the Hub
+* 2.2.1 - New spec and help.md format for the Extension Library
 * 2.2.0 - Update to add Status to Resolve Approval Request | New action Get Approval Reqeust
 * 2.1.0 - Add Action: Create File Rule | Add Action: Get File Rule
 * 2.0.0 - Fix for Approve File Locally action | Fix for Unapprove File Locally action | Update to rename Unapprove Local Approval action to Unapprove File Locally

--- a/carbon_black_response/help.md
+++ b/carbon_black_response/help.md
@@ -729,7 +729,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 3.1.8 - New spec and help.md format for the Hub
+* 3.1.8 - New spec and help.md format for the Extension Library
 * 3.1.7 - Fix issue where Delete Watchlist action would not run successfully
 * 3.1.6 - Fix issue where output from the New Alert trigger did not match the output schema
 * 3.1.5 - Update connection tests

--- a/cef/help.md
+++ b/cef/help.md
@@ -85,7 +85,7 @@ Ensure your CEF strings are properly formatted.
 # Version History
 
 * 2.0.0 - Changed `ValueError` to `PluginException` | Use input and output constants | Added "f" strings | Move test from action to connection | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3`
-* 1.0.1 - New spec and help.md format for the Hub | Add missing title values for actions in plugin.spec.yaml
+* 1.0.1 - New spec and help.md format for the Extension Library | Add missing title values for actions in plugin.spec.yaml
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/chaosreader/help.md
+++ b/chaosreader/help.md
@@ -62,7 +62,7 @@ _This plugin does not contain any troubleshooting information._
 
 * 1.0.4 - Fix set options to exclude | Upgrade code to new version of chaos reader
 * 1.0.3 - Changed 2 spaces to 4 spaces | Changed bare strings in params.get and output to static fields from schema | Removed unnecessarily comments and variables | Changed `Exception` to `PluginException` | Changed deprecated `decodestring` to `decodebytes`
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Fix issue where run action was excluded from plugin on build
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/chardet/help.md
+++ b/chardet/help.md
@@ -63,7 +63,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.0.2 - Changed descriptions to fit style guide
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/checkdmarc/help.md
+++ b/checkdmarc/help.md
@@ -410,7 +410,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 2.1.2 - Changed description in action `check_domains_alternate_nameservers` | Fix typo in word `nameservers` to `name_servers` | Changed email addresses to `user@example.com`
-* 2.1.1 - New spec and help.md format for the Hub
+* 2.1.1 - New spec and help.md format for the Extension Library
 * 2.1.0 - Added action Check Domains Alternate Nameservers
 * 2.0.0 - Added timeout to Check Domain
 * 1.0.0 - Initial plugin

--- a/checkmarx_cxsast/help.md
+++ b/checkmarx_cxsast/help.md
@@ -269,7 +269,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/checkpoint_sand_blast/help.md
+++ b/checkpoint_sand_blast/help.md
@@ -202,7 +202,7 @@ When using the local version of Check Point SandBlast the query report action mu
 # Version History
 
 * 1.0.2 - Update Check Point branding
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/cherwell/help.md
+++ b/cherwell/help.md
@@ -320,7 +320,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.1.1 - New spec and help.md format for the Hub
+* 2.1.1 - New spec and help.md format for the Extension Library
 * 2.1.0 - New action Update Incident
 * 2.0.1 - Fixes issue where Create Incident was not properly formatting data to be passed to Cherwell
 * 2.0.0 - Fixes issue where `client_id` was using the wrong credential type | Update pinned requests version to resolve security vulnerability [CVE-2018-18074](https://cve.mitre.org/cgi-bin/cvename.cgi?name=2018-18074)

--- a/cif/help.md
+++ b/cif/help.md
@@ -86,7 +86,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Update to new credential types
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Added support for itypes
 * 0.1.1 - SSL bug fix in SDK

--- a/cisco_cloudlock/help.md
+++ b/cisco_cloudlock/help.md
@@ -153,7 +153,7 @@ No troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/cisco_firepower/help.md
+++ b/cisco_firepower/help.md
@@ -104,7 +104,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update descriptions
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.0 - Initial plugin

--- a/cisco_firepower_management_center/help.md
+++ b/cisco_firepower_management_center/help.md
@@ -67,7 +67,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/cisco_ise/help.md
+++ b/cisco_ise/help.md
@@ -182,7 +182,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.2.1 - New spec and help.md format for the Hub
+* 2.2.1 - New spec and help.md format for the Extension Library
 * 2.2.0 - New action Get ANC Endpoint
 * 2.1.2 - Fixed issue where Query Endpoint would return an error if endpoint was not found | Update to input description for Query Endpoint
 * 2.1.1 - Fixed issue where error message wasn't printed correctly in case of failure

--- a/cisco_umbrella_enforcement/help.md
+++ b/cisco_umbrella_enforcement/help.md
@@ -205,7 +205,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/cisco_umbrella_investigate/help.md
+++ b/cisco_umbrella_investigate/help.md
@@ -360,7 +360,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | Fix spelling of variable titled Co-occurrences
+* 2.0.0 - New spec and help.md format for the Extension Library | Fix spelling of variable titled Co-occurrences
 * 1.0.2 - Added change allowing categorization to work with a Tier1 API key by utilizing the single domain API endpoint instead of the bulk API endpoint when a single-element array of domains is passed in
 * 1.0.1 - Add connection test | Fix where connection was returning "Wrong api_key" on valid keys | Run plugin as least privileged user | Update to use the `komand/python-3-slim-plugin` Docker image to reduce plugin size
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/cloudshark/help.md
+++ b/cloudshark/help.md
@@ -224,7 +224,7 @@ For uploads, make sure that a supported [capture file format](https://wiki.wires
 # Version History
 
 * 2.0.0 - Add missing title values for actions in plugin.spec.yaml
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/compression/help.md
+++ b/compression/help.md
@@ -129,7 +129,7 @@ On decompression, be sure that the inputted file has been compressed using one o
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Rename "Create archive" action to "Create Archive" | Rename "Decompress bytes" action to "Decompress Bytes" | Rename "Compress bytes" action to "Compress Bytes" | Rename "Extract Archive" to "Exctract archive"
 * 1.1.0 - Port to Python v2 architecture | Support web server mode
 * 1.0.3 - Extract archive single file bug fix

--- a/confluence/help.md
+++ b/confluence/help.md
@@ -98,7 +98,7 @@ Make sure the credentials are valid and the Confluence URL is correct.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.3 - Pin Confluence python library at 0.2
 * 0.1.2 - SSL bug fix in SDK

--- a/cortex/help.md
+++ b/cortex/help.md
@@ -499,7 +499,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Pin library version to 1.0.0
 * 0.2.1 - SSL bug fix in SDK
 * 0.2.0 - Add File Analyzer action
@@ -511,6 +511,6 @@ _This plugin does not contain any troubleshooting information._
 
 * [Cortex](https://github.com/CERT-BDF/Cortex)
 * [Cortex API](https://github.com/CERT-BDF/CortexDocs/tree/master/api)
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * [cortex4py](https://pypi.python.org/pypi/cortex4py/1.0.0)
 

--- a/cortex_v2/help.md
+++ b/cortex_v2/help.md
@@ -607,7 +607,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - New action Bulk Analyze
 * 1.0.0 - Initial plugin
 

--- a/craigslist/help.md
+++ b/craigslist/help.md
@@ -93,7 +93,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/crits/help.md
+++ b/crits/help.md
@@ -640,7 +640,7 @@ Ensure that the user associated with the API key is subscribed to the `source`.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/csv/help.md
+++ b/csv/help.md
@@ -148,7 +148,7 @@ CSV files must not have non-CSV data such as comments.
 # Version History
 
 * 1.1.5 - Use input and output constants | Change docker image from `komand/python-2-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Changed `Exception` to `PluginException`
-* 1.1.4 - New spec and help.md format for the Hub | Add missing title values for actions in plugin.spec.yaml
+* 1.1.4 - New spec and help.md format for the Extension Library | Add missing title values for actions in plugin.spec.yaml
 * 1.1.3 - Fix issue where connection tests were failing, output did not match spec
 * 1.1.2 - Support webserver mode
 * 1.1.1 - Fix JSON to CSV action to account for correct input type

--- a/cuckoo/help.md
+++ b/cuckoo/help.md
@@ -772,7 +772,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Bug fix for Submit Files where Submit ID was required
 * 1.0.0 - Support web server mode | Bug fix for testing outputs | Semver compliance
 * 0.2.3 - Bug fix for Cuckoo API version 2.0.5

--- a/cymon/help.md
+++ b/cymon/help.md
@@ -446,7 +446,7 @@ the count range 1-2000 has been tested and verified working by us.
 # Version History
 
 * 2.0.0 - Add missing title values for actions in plugin.spec.yaml
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Add discontinuation of Cymon notice
 * 1.0.0 - Support web server mode
 * 0.1.4 - Bug fix for CI tool incorrectly uploading plugins

--- a/cymon_v2/help.md
+++ b/cymon_v2/help.md
@@ -610,7 +610,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Add discontinuation of Cymon notice
 * 1.0.0 - Initial plugin
 

--- a/datadog/help.md
+++ b/datadog/help.md
@@ -135,7 +135,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - New action Post Metrics | Update to use the `komand/python-3-37-slim-plugin` Docker image to reduce plugin size | Run plugin as least privileged user
 * 1.0.0 - Initial plugin
 

--- a/datetime/help.md
+++ b/datetime/help.md
@@ -211,7 +211,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.5 - New spec and help.md format for the Hub | Changed const string in params.get to Input constants | Update to use the `komand/python-3-37-slim-plugin:3` Docker image to reduce plugin size
+* 2.0.5 - New spec and help.md format for the Extension Library | Changed const string in params.get to Input constants | Update to use the `komand/python-3-37-slim-plugin:3` Docker image to reduce plugin size
 * 2.0.4 - Update plugin tag from `utility` to `utilities` for Marketplace searchability
 * 2.0.3 - Fixed issue where connection test failed
 * 2.0.2 - Fixed issue where action Date from Epoch will not accept floats

--- a/diff/help.md
+++ b/diff/help.md
@@ -53,7 +53,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update plugin tag `utility` to `utilities` for Marketplace searchability
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/dig/help.md
+++ b/dig/help.md
@@ -186,7 +186,7 @@ Common examples:
 
 * 1.0.4 - Add example inputs
 * 1.0.3 - Use input and output constants | Change docker image from `komand/python-2-slim-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Added "f" strings | Remove duplicate code | Add user nobody to Dockerfile
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update to use the `komand/python-2-slim-plugin:2` Docker image to reduce plugin size
 * 1.0.0 - Support web server mode
 * 0.3.2 - Update to v2 Python plugin architecture

--- a/digitalocean/help.md
+++ b/digitalocean/help.md
@@ -460,7 +460,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 2.0.0 - Rename various actions by removing the dash separator
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.8 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/dirname/help.md
+++ b/dirname/help.md
@@ -72,7 +72,7 @@ If the input doesn't contain a slash `/` in the path, the result will be an empt
 # Version History
 
 * 1.0.3 - Update to use the `komand/python-3-37-slim-plugin:3` Docker image | Changed description in action output | Changed `Exception` to `PluginException` | Use output constants
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update to use the `komand/python-3-slim-plugin:2` Docker image to reduce plugin size
 * 1.0.0 - Support web server mode
 * 0.1.1 - Update to v2 Python plugin architecture

--- a/docker_engine/help.md
+++ b/docker_engine/help.md
@@ -192,7 +192,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/domaintools/help.md
+++ b/domaintools/help.md
@@ -898,7 +898,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Bug fix logging credentials
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/dumbno/help.md
+++ b/dumbno/help.md
@@ -75,7 +75,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/duo_admin/help.md
+++ b/duo_admin/help.md
@@ -457,7 +457,7 @@ A User ID can be obtained by passing a username to the Get User Status action.
 # Version History
 
 * 3.3.3 - Changed `Exception` to `PluginException` | Moved constants to class init | Use fstring instead of concatenation
-* 3.3.2 - New spec and help.md format for the Hub
+* 3.3.2 - New spec and help.md format for the Extension Library
 * 3.3.1 - Update default `mintime` input and description for `Get Logs` action
 * 3.3.0 - New action Enroll User | Support Duo Admin API v2 where applicable | Various bug fixes & improvements
 * 3.2.0 - New action Get Phones by User ID

--- a/duo_auth/help.md
+++ b/duo_auth/help.md
@@ -127,7 +127,7 @@ This plugin does not contain any troubleshooting information.
 # Version History
 
 * 1.0.3 - Upgraded `duo_client` in requirements.txt to version `4.0.0` | Upgraded `duo_client` in vendor folder to version `4.0.0` | Use input and output constants |  Change docker image from `komand/python-3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Support `type` parameter as `push_type` in the `options` input of the Auth action
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Add example output
 * 0.1.1 - SSL bug fix in SDK

--- a/dynamodb/help.md
+++ b/dynamodb/help.md
@@ -111,7 +111,7 @@ Any situation in which you provide a ConditionExpression and it causes the job t
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub | Add missing title values for actions in plugin.spec.yaml
+* 1.0.2 - New spec and help.md format for the Extension Library | Add missing title values for actions in plugin.spec.yaml
 * 1.0.1 - Set `params` input in Scan action to not required
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.2 - Clean up unsatisfactory debugging message

--- a/ec2_investigations/help.md
+++ b/ec2_investigations/help.md
@@ -93,7 +93,7 @@ For example, the ClamAV action requires ClamAV to be installed on the destinatio
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/echotrail/help.md
+++ b/echotrail/help.md
@@ -305,7 +305,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/elastalert/help.md
+++ b/elastalert/help.md
@@ -58,7 +58,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to new credential types
 * 0.1.0 - Initial plugin
 

--- a/elasticsearch/help.md
+++ b/elasticsearch/help.md
@@ -149,7 +149,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.2 - New spec and help.md format for the Hub
+* 2.0.2 - New spec and help.md format for the Extension Library
 * 2.0.1 - Fix typo in plugin spec
 * 2.0.0 - Fix issue where Poll Documents trigger will sometimes not return results | Update connection to allow optional authentication
 * 1.0.1 - Fix issue where Poll Documents trigger test would always fail

--- a/eml/help.md
+++ b/eml/help.md
@@ -145,7 +145,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.1.3 - Use input and output constants | Remove unused variables | Improved variable name readability | Updated `Exception` to `PluginException`
-* 1.1.2 - New spec and help.md format for the Hub
+* 1.1.2 - New spec and help.md format for the Extension Library
 * 1.1.1 - Fix issue where plugin would fail on empty date returned
 * 1.1.0 - New action Parse EML File from String
 * 1.0.0 - Support web server mode

--- a/facebook_threat_exchange/help.md
+++ b/facebook_threat_exchange/help.md
@@ -133,7 +133,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/finger/help.md
+++ b/finger/help.md
@@ -139,7 +139,7 @@ Some `finger` daemons return answers in a different format which will cause this
 # Version History
 
 * 1.0.2 - Change docker image from `komand/python-2-plugin` to `komand/python-3-37-plugin:3` to use python 3 | Use input and output constants | Changed variables names to more readable | Changed descriptions | Added "f" strings | Removed method test from action
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/fireeye_hx/help.md
+++ b/fireeye_hx/help.md
@@ -126,7 +126,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/foremost/help.md
+++ b/foremost/help.md
@@ -74,7 +74,7 @@ Foremost only works on disk images such as those created by the `dd` tool.
 
 * 1.0.3 - Add example inputs
 * 1.0.2 - Use input and output constants | Change docker image from `komand/python-3-plugin:2` to `komand/python-3-37-plugin:3` to reduce plugin image size | Use input and output constants | Added "f" strings | Changed `Exception` to `PluginException` | Change "/tmp" to tempfile.gettempdir()
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/freegeoip/help.md
+++ b/freegeoip/help.md
@@ -82,7 +82,7 @@ A valid domain or IP address must be provided.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/freeipa/help.md
+++ b/freeipa/help.md
@@ -357,7 +357,7 @@ Note that deletion is permanent and cannot be undone.
 # Version History
 
 * 2.0.2 - Use input and output constants | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Changed `Exception` to `PluginException`
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Support web server mode | Update to new credential types
 * 1.0.0 - Initial plugin
 

--- a/ftp/help.md
+++ b/ftp/help.md
@@ -120,7 +120,7 @@ The FTP user must have permission to execute the respective tasks.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Rename "Upload file" action to "Upload File" | Rename "Download file" action to "Download File" | Rename "Delete file" action to "Delete File"
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/geoip2precision/help.md
+++ b/geoip2precision/help.md
@@ -72,7 +72,7 @@ A valid IP address must be provided.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/get_url/help.md
+++ b/get_url/help.md
@@ -79,7 +79,7 @@ Some web servers do not support cache control mechanisms, or do not use them pro
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/git/help.md
+++ b/git/help.md
@@ -167,7 +167,7 @@ If a token is used, make sure that it has sufficient permissions assigned to it.
 # Version History
 
 * 1.1.1 - New action Get File
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/github/help.md
+++ b/github/help.md
@@ -1047,7 +1047,7 @@ If two-factor authentication is enabled on the GitHub account you will need to [
 
 # Version History
 
-* 2.1.1 - New spec and help.md format for the Hub
+* 2.1.1 - New spec and help.md format for the Extension Library
 * 2.1.0 - New actions: Create Issue Comment, Close Issue, Add Issue Label
 * 2.0.1 - Fix missing Search action | Pin pygithub and python-dateutil libraries | Update to use the `komand/python-3-37-slim-plugin` Docker image to reduce plugin size | Enable verification of SSL/TLS certificates for github.com
 * 2.0.0 - Rename "User" action to "Get User"

--- a/github_enterprise/help.md
+++ b/github_enterprise/help.md
@@ -145,7 +145,7 @@ The GitHub Enterprise account must have sufficient privileges to perform the act
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/gitlab/help.md
+++ b/gitlab/help.md
@@ -208,7 +208,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/google_admin/help.md
+++ b/google_admin/help.md
@@ -92,7 +92,7 @@ _This plugin does not contain any custom output types._
 
 # Version History
 
-* 1.0.3 - New spec and help.md format for the Hub
+* 1.0.3 - New spec and help.md format for the Extension Library
 * 1.0.2 - Fix typo in plugin spec
 * 1.0.1 - Update to connection and troubleshooting documentation
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/google_cloud_compute/help.md
+++ b/google_cloud_compute/help.md
@@ -549,7 +549,7 @@ Error values use the standard HTTP codes (200 OK, 404 Not Found, etc)
 
 # Version History
 
-* 2.0.2 - New spec and help.md format for the Hub
+* 2.0.2 - New spec and help.md format for the Extension Library
 * 2.0.1 - Fix typo in plugin spec
 * 2.0.0 - Rename action titles to conform to style
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/google_cloud_pub_sub/help.md
+++ b/google_cloud_pub_sub/help.md
@@ -195,7 +195,7 @@ This plugin requires a Google [service account](https://cloud.google.com/storage
 
 # Version History
 
-* 3.1.2 - New spec and help.md format for the Hub
+* 3.1.2 - New spec and help.md format for the Extension Library
 * 3.1.1 - Fix typo in plugin spec
 * 3.1.0 - Update connection to make `admin_user` an optional input
 * 3.0.0 - Update trigger to allow for the return of multiple messages at one time

--- a/google_directory/help.md
+++ b/google_directory/help.md
@@ -135,7 +135,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Update connection to add support for the read-only Google Admin Directory OAuth scope
 * 1.2.1 - Fix typo in plugin spec
 * 1.2.0 - Add pagination to Get All Domain Users actions to support domains with 500+ users

--- a/google_docs/help.md
+++ b/google_docs/help.md
@@ -945,7 +945,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/google_drive/help.md
+++ b/google_drive/help.md
@@ -191,7 +191,7 @@ _This plugin does not contain any custom output types._
 
 # Version History
 
-* 2.1.2 - New spec and help.md format for the Hub
+* 2.1.2 - New spec and help.md format for the Extension Library
 * 2.1.1 - Fix typo in plugin spec
 * 2.1.0 - Add Download File action
 * 2.0.0 - Update to use new credential types

--- a/google_safe_browsing/help.md
+++ b/google_safe_browsing/help.md
@@ -104,7 +104,7 @@ _This plugin does not contain any custom output types._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Obsolete
 * 1.0.0 - Support web server mode | Update to new credential types
 * 0.1.8 - Bug fix for no results | Updated to v2 architecture

--- a/google_search/help.md
+++ b/google_search/help.md
@@ -75,7 +75,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Bug fix for no google module
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/google_sheets/help.md
+++ b/google_sheets/help.md
@@ -117,7 +117,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.1.2 - New spec and help.md format for the Hub
+* 1.1.2 - New spec and help.md format for the Extension Library
 * 1.1.1 - Fix typo in plugin spec
 * 1.1.0 - New action Spread List to Sheet
 * 1.0.1 - Update connection and troubleshooting documentation

--- a/google_web_risk/help.md
+++ b/google_web_risk/help.md
@@ -70,7 +70,7 @@ Google's Web Risk API requires an API key for use. Sign up for the beta [here](h
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - New inputs for lookup action
 * 1.0.0 - Initial plugin
 

--- a/grafana/help.md
+++ b/grafana/help.md
@@ -322,7 +322,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/graphite/help.md
+++ b/graphite/help.md
@@ -237,7 +237,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/grep/help.md
+++ b/grep/help.md
@@ -113,7 +113,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.3 - New spec and help.md format for the Hub | Remove duplicated code | Remove saving to file when string action | Changed bare strings to Input.* in params.get | Removed unused function
+* 1.0.3 - New spec and help.md format for the Extension Library | Remove duplicated code | Remove saving to file when string action | Changed bare strings to Input.* in params.get | Removed unused function
 * 1.0.2 - Update to use the `komand/python-3-slim-plugin:2` Docker image to reduce plugin size
 * 1.0.1 - Add `utilities` plugin tag for Marketplace searchability
 * 1.0.0 - Support web server mode

--- a/grr/help.md
+++ b/grr/help.md
@@ -308,7 +308,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Add certificate validation to connection
 * 1.0.1 - Support web server mode
 * 1.0.0 - Initial plugin

--- a/hashit/help.md
+++ b/hashit/help.md
@@ -105,7 +105,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 2.0.3 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Use input and output constants | Remove test from actions
-* 2.0.2 - New spec and help.md format for the Hub
+* 2.0.2 - New spec and help.md format for the Extension Library
 * 2.0.1 - Add `utilities` plugin tag for Marketplace searchability
 * 2.0.0 - Rename "Hash a String" action to "Hash String"
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode

--- a/haveibeenpwned/help.md
+++ b/haveibeenpwned/help.md
@@ -193,7 +193,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 4.0.2 - New spec and help.md format for the Hub
+* 4.0.2 - New spec and help.md format for the Extension Library
 * 4.0.1 - Fix issue with connection exception typo
 * 4.0.0 - Support the v3 API which requires authentication
 * 3.0.1 - Set user-agent string to Rapid7 InsightConnect | Implement use of Retry-After header for rate limit | Update documentation

--- a/hipchat/help.md
+++ b/hipchat/help.md
@@ -155,7 +155,7 @@ Error values use the standard HTTP codes (200 OK, 404 Not Found, etc)
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/hippocampe/help.md
+++ b/hippocampe/help.md
@@ -576,7 +576,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/html/help.md
+++ b/html/help.md
@@ -164,7 +164,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.2.1 - New spec and help.md format for the Hub
+* 1.2.1 - New spec and help.md format for the Extension Library
 * 1.2.0 - Update to add the Remove Scripts option to Text
 * 1.1.0 - New action: Text
 * 1.0.1 - Add `utilities` plugin tag for Marketplace searchability

--- a/hybrid_analysis/help.md
+++ b/hybrid_analysis/help.md
@@ -66,7 +66,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Update to new secret key credential type
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/ibm_resilient_incident/help.md
+++ b/ibm_resilient_incident/help.md
@@ -967,7 +967,7 @@ For actions that take a JSON object as input, Resilient will sometimes throw an 
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/ifconfig_co/help.md
+++ b/ifconfig_co/help.md
@@ -98,7 +98,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Convert to Python 3
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Rename "Lookup Your IP Address" action to "Lookup IP Address" | Rename "Check Your Ports" action to "Check Ports"
 * 0.1.1 - SSL bug fix in SDK

--- a/imperva_securesphere/help.md
+++ b/imperva_securesphere/help.md
@@ -67,7 +67,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/influxdb/help.md
+++ b/influxdb/help.md
@@ -115,7 +115,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/infoblox/help.md
+++ b/infoblox/help.md
@@ -315,7 +315,7 @@ When adding a new host make sure that a corresponding network is already created
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/ipify/help.md
+++ b/ipify/help.md
@@ -58,7 +58,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/ipinfo/help.md
+++ b/ipinfo/help.md
@@ -95,7 +95,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Convert to Python 3
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Rename "IPInfo" plugin title to "IPinfo" | Rename "Lookup Address" action to "Address Lookup"
 * 0.1.1 - SSL bug fix in SDK

--- a/ipintel/help.md
+++ b/ipintel/help.md
@@ -53,7 +53,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/ipstack/help.md
+++ b/ipstack/help.md
@@ -87,7 +87,7 @@ A valid domain or IP address must be provided.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.0 - Initial plugin
 

--- a/jamf/help.md
+++ b/jamf/help.md
@@ -266,7 +266,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Add action to get user location details by device ID
 * 1.0.0 - Initial plugin
 

--- a/jenkins/help.md
+++ b/jenkins/help.md
@@ -305,7 +305,7 @@ e.g. `{"mykeyone": false, "mykeytwo": "mystring", "mykeythree": 27}`
 # Version History
 
 * 1.1.2 - Update connection test
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Add build info action
 * 1.0.0 - Initial plugin
 

--- a/joe_sandbox/help.md
+++ b/joe_sandbox/help.md
@@ -589,7 +589,7 @@ This plugin does not contain any troubleshooting information.
 
 * 1.0.3 - Add example inputs
 * 1.0.2 - Fix misspelling in error message | Remove generic "automation" keyword
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/jq/help.md
+++ b/jq/help.md
@@ -81,7 +81,7 @@ The `--seq` and `--stream` flags are not supported in version 0.1.0 of this plug
 
 # Version History
 
-* 2.0.5 - New spec and help.md format for the Hub | Changed docker image from `komand/python-3-slim-plugin:2` to `komand/python-3-37-slim-plugin` | Change mutable function parameter to immutable | Removed comments | Changed concatenation to format in loggers
+* 2.0.5 - New spec and help.md format for the Extension Library | Changed docker image from `komand/python-3-slim-plugin:2` to `komand/python-3-37-slim-plugin` | Change mutable function parameter to immutable | Removed comments | Changed concatenation to format in loggers
 * 2.0.4 - Fix issue where jq was not available in the docker image | Update to python | Update to use the `komand/python-3-slim-plugin:2` Docker image to reduce plugin size | Set a default `timeout` of 15 seconds in the Run action
 * 2.0.3 - Add `utilities` plugin tag for Marketplace searchability
 * 2.0.2 - Regenerate with latest Go SDK to solve bug with triggers

--- a/json_edit/help.md
+++ b/json_edit/help.md
@@ -119,7 +119,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Add `utilities` plugin tag for Marketplace searchability
 * 1.0.0 - Initial plugin
 

--- a/kintone/help.md
+++ b/kintone/help.md
@@ -134,7 +134,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Fix issue where SSL Verify was set to false
 * 1.0.0 - Initial plugin
 

--- a/kolide/help.md
+++ b/kolide/help.md
@@ -157,7 +157,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - New actions Create Query, Run Query and Get Query | Removed action Query Node
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Use new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/komand/help.md
+++ b/komand/help.md
@@ -111,7 +111,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.3 - New spec and help.md format for the Hub
+* 1.0.3 - New spec and help.md format for the Extension Library
 * 1.0.2 - Add `utilities` plugin tag for Marketplace searchability
 * 1.0.1 - Fix issue where Lookup Workflow Name can crash due to excessive data
 * 1.0.0 - Support web server mode | Update to new credential types | Plugin spec revision

--- a/lastpass_enterprise/help.md
+++ b/lastpass_enterprise/help.md
@@ -98,7 +98,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update to fix connection test
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/logstash/help.md
+++ b/logstash/help.md
@@ -127,7 +127,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/malwareconfig/help.md
+++ b/malwareconfig/help.md
@@ -114,7 +114,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.0.2 - Add example inputs
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.4 - SSL bug fix in SDK
 * 0.1.3 - Fix bug dumping credentials to log

--- a/markdown/help.md
+++ b/markdown/help.md
@@ -84,7 +84,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.2.2 - New spec and help.md format for the Hub
+* 2.2.2 - New spec and help.md format for the Extension Library
 * 2.2.1 - Add `utilities` plugin tag for Marketplace searchability
 * 2.2.0 - PyPandoc bug fix | Support web server mode
 * 2.1.0 - Update to v2 Python plugin architecture | Change type of input/output to string

--- a/math/help.md
+++ b/math/help.md
@@ -103,7 +103,7 @@ _This plugin does not contain any troubleshooting information._
 
 * 1.2.0 - New action Max
 * 1.1.3 - Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Changed `Exception` to `PluginException` | Use input and output constants | Remove not secure eval for simple_eval
-* 1.1.2 - New spec and help.md format for the Hub
+* 1.1.2 - New spec and help.md format for the Extension Library
 * 1.1.1 - Update plugin tag from `utility` to `utilities` for Marketplace searchability
 * 1.1.0 - Update to v2 Python plugin architecture | Support web server mode
 * 1.0.0 - Update Calculate action: Allow freeform input

--- a/matplotlib/help.md
+++ b/matplotlib/help.md
@@ -191,7 +191,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/mcafee_epo/help.md
+++ b/mcafee_epo/help.md
@@ -114,7 +114,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.2.1 - SSL bug fix in SDK
 * 0.2.0 - Updates

--- a/mcafee_esm/help.md
+++ b/mcafee_esm/help.md
@@ -155,7 +155,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/microsoft_atp/help.md
+++ b/microsoft_atp/help.md
@@ -625,7 +625,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.5.1 - New spec and help.md format for the Hub
+* 1.5.1 - New spec and help.md format for the Extension Library
 * 1.5.0 - Fix issue where triggers always returned a blank payload
 * 1.4.0 - New trigger Get Alerts | New action Get Machine Action
 * 1.3.0 - New actions Stop and Quarantine File and Run Antivirus Scan

--- a/microsoft_atp_safe_links/help.md
+++ b/microsoft_atp_safe_links/help.md
@@ -69,7 +69,7 @@ This plugin does not contain any troubleshooting information.
 # Version History
 
 * 1.1.0 - Fixed issue where embedded URLs returned blank string
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Fixed issue where non-safelinks returned a blank string
 * 1.0.0 - Initial plugin
 

--- a/microsoft_sql/help.md
+++ b/microsoft_sql/help.md
@@ -94,7 +94,7 @@ This plugin uses version-specific drivers for Debian 9.x.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/microsoft_teams/help.md
+++ b/microsoft_teams/help.md
@@ -647,7 +647,7 @@ _This plugin does not contain any troubleshooting information._
 * 2.0.1 - Update to Get Teams action to support more than 20 teams
 * 2.0.0 - Fix issue where send message would not work if there were too many teams | Removed regex capability for team and channel inputs which will speed up Send Message and Send HTML Message actions
 * 1.3.0 - New action Send Message by GUID
-* 1.2.3 - New spec and help.md format for the Hub
+* 1.2.3 - New spec and help.md format for the Extension Library
 * 1.2.2 - Fix issue where regular expressions would only match at the beginning of a string
 * 1.2.1 - Fix issue where New Message Received trigger could receive an unauthorized error after sustained use
 * 1.2.0 - New actions Add Member to Team, Remove Member from Team, Create Teams Enabled Group, Delete Team, Add Channel to Team, and Remove Channel from Team

--- a/mimecast/help.md
+++ b/mimecast/help.md
@@ -508,7 +508,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 * 4.0.0 - Update Get TTP URL Logs to allow for better URL filtering
 * 3.1.0 - New action Delete Managed URL and Delete Group Member
-* 3.0.1 - New spec and help.md format for the Hub
+* 3.0.1 - New spec and help.md format for the Extension Library
 * 3.0.0 - Add URL in Get TTP URL Logs action to filter output | Update connection settings to the proper authentication supported by the Mimecast API
 * 2.5.0 - New action Decode URL
 * 2.4.0 - New action Get TTP URL Logs

--- a/minfraud/help.md
+++ b/minfraud/help.md
@@ -340,7 +340,7 @@ Refer to the minFraud API documentation for explicit details.
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | New titles for some output variables
+* 2.0.0 - New spec and help.md format for the Extension Library | New titles for some output variables
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Rename actions
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/misp/help.md
+++ b/misp/help.md
@@ -728,7 +728,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 4.0.0 - New spec and help.md format for the Hub | Fix spelling of variable titled Commented Explanation
+* 4.0.0 - New spec and help.md format for the Extension Library | Fix spelling of variable titled Commented Explanation
 * 3.0.0 - Fixed issue where Add URLs, Add Context, Add Email Sender, Add Email Subject and Add Email Recipient actions sent requests as a proposal | Fixed an issue where the distribution list was set incorrectly within Add URLs, Add Context, Create an Event, Add Email Sender, Add Email Subject, Add Email Recipient actions
 * 2.0.0 - Updated to new credential types | Update `hostname` variable in Connection to `url`
 * 1.0.0 - Add trigger. Add actions: Add Attachment, Remove Tag, Search Events, Publish. Support web server mode

--- a/mxtoolbox_dns/help.md
+++ b/mxtoolbox_dns/help.md
@@ -191,7 +191,7 @@ test for the existence of a value if it's needed later in the workflow.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/netmiko/help.md
+++ b/netmiko/help.md
@@ -101,7 +101,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - Updated python libraries | New spec and help.md format for the Hub
+* 1.0.1 - Updated python libraries | New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to new credential types | Rename "Execute show commands" action to "Execute Show Commands" | Rename "Execute configuration change commands" action to "Execute Configuration Commands"
 * 0.1.0 - Initial plugin
 

--- a/networktotal/help.md
+++ b/networktotal/help.md
@@ -69,7 +69,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/newrelic/help.md
+++ b/newrelic/help.md
@@ -114,7 +114,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Support web server mode and update to new credential types
 * 1.0.0 - Initial plugin
 

--- a/nmap/help.md
+++ b/nmap/help.md
@@ -105,7 +105,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Support web server mode
 * 1.0.0 - Overhaul with additional inputs and typed output
 * 0.2.0 - Update to v2 Python plugin architecture

--- a/office365_admin/help.md
+++ b/office365_admin/help.md
@@ -291,7 +291,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.4.0 - New action Lookup User By Email
-* 1.3.1 - Spec file and help changes for the Hub
+* 1.3.1 - Spec file and help changes for the Extension Library
 * 1.2.1 - Fix issue where input was undefined in Add and Delete User actions | Add office location to Add User action
 * 1.2.0 - New actions Get Subscribed SKUs and Assign License
 * 1.1.1 - Fix security bug where `password` field in Create User action was not masked

--- a/okta/help.md
+++ b/okta/help.md
@@ -902,7 +902,7 @@ by Okta themselves, or constructed by the plugin based on the information it has
 * 3.4.0 - New trigger Monitor User Groups
 * 3.3.0 - New actions Get Factors and Send Push
 * 3.2.2 - Change docker image from `komand/python-2-plugin:2` to `komand/python-3-37-slim-plugin:3` | Use input and output constants | Changed variables names to more readable | Added "f" strings | Removed duplicated code
-* 3.2.1 - New spec and help.md format for the Hub
+* 3.2.1 - New spec and help.md format for the Extension Library
 * 3.2.0 - New action Delete User
 * 3.1.2 - Update connection test
 * 3.1.1 - Update descriptions

--- a/opendxl/help.md
+++ b/opendxl/help.md
@@ -98,7 +98,7 @@ _This plugin does not contain any custom output types._
 # Version History
 
 * 1.1.3 - Update help documentation and plugin spec tags
-* 1.1.2 - New spec and help.md format for the Hub
+* 1.1.2 - New spec and help.md format for the Extension Library
 * 1.1.1 - Fix issue where certificates in connection were not being escaped correctly
 * 1.1.0 - New action Publish Event
 * 1.0.0 - Initial plugin

--- a/openphish/help.md
+++ b/openphish/help.md
@@ -74,7 +74,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/openvas/help.md
+++ b/openvas/help.md
@@ -317,7 +317,7 @@ the date given to the `create_schedule` function is given in the UTC timezone.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/ossec/help.md
+++ b/ossec/help.md
@@ -196,7 +196,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/otrs/help.md
+++ b/otrs/help.md
@@ -404,7 +404,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 5.0.0 - New spec and help.md format for the Hub | Fix spelling of variable titled Disposition and Service in Create Ticket log message
+* 5.0.0 - New spec and help.md format for the Extension Library | Fix spelling of variable titled Disposition and Service in Create Ticket log message
 * 4.0.1 - Fix issue in Retrieve action to handle Escalation parameters being returned as strings | Adds new parameter No Article to update, this will submit updates to a ticket without adding a generated article
 * 4.0.0 - Updated the Web Service configuration file | Update dependency on PyOTRS | Fixed issue where Article and Attachment was required to update a ticket in action `update` | Added an External Parameters field to action `search` | Fixed issue with action `search` where dynamic fields were not used correctly for searching | Fixed issue where Escalation parameters where not set to the right type
 * 3.0.5 - Update dependency to PyOTRS v2.1 for security bug [CWE-601](https://cwe.mitre.org/data/definitions/601.html)

--- a/p0f/help.md
+++ b/p0f/help.md
@@ -53,7 +53,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Fix issue where run action was excluded from plugin on build
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/pagerduty/help.md
+++ b/pagerduty/help.md
@@ -180,7 +180,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Fix issue to make 'service_key' required in Send Resolve Request action
 * 1.0.1 - Update to [PagerDuty REST API v2](https://v2.developer.pagerduty.com/docs/migrating-to-api-v2)
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -577,7 +577,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 # Version History
 
 * 1.5.6 - Fix issue where edit action was causing an error with certain input
-* 1.5.5 - New spec and help.md format for the Hub
+* 1.5.5 - New spec and help.md format for the Extension Library
 * 1.5.4 - Fix issue where new plugin version was causing SSL to fail
 * 1.5.3 - Fix issue where undefined objects in security configurations caused actions to crash | Add debug logging to assist with future troubleshooting | Update to use the `komand/python-3-37-slim-plugin:3` Docker image to reduce plugin size
 * 1.5.2 - Fix typo in plugin spec

--- a/paloalto_wildfire/help.md
+++ b/paloalto_wildfire/help.md
@@ -327,7 +327,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.1.2 - Fix bug where output doesn't match schema in Get Verdict action | Add improved error messaging in Submit URL action | Add example inputs
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Fixed issue where unsupported file types failed | Update to add `supported_file` to filedata type
 * 1.0.2 - Fixed issue where connection was not passing the API key properly
 * 1.0.1 - Fix plugin description

--- a/passivetotal/help.md
+++ b/passivetotal/help.md
@@ -256,7 +256,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to new credential types
 * 0.4.0 - Add trigger to pull new artifacts
 * 0.3.1 - SSL bug fix in SDK

--- a/pastebin/help.md
+++ b/pastebin/help.md
@@ -108,7 +108,7 @@ Scraping tasks require the IP of the machine running Komand to need be [whitelis
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Python 3 conversion | Bug fix updated endpoints
 * 0.1.2 - SSL bug fix in SDK
 * 0.1.1 - Force HTTPS connections, Pastebin will block HTTP requests beginning on March 1st, 2018

--- a/pdf_generator/help.md
+++ b/pdf_generator/help.md
@@ -51,7 +51,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/pdf_reader/help.md
+++ b/pdf_reader/help.md
@@ -62,7 +62,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode
 * 0.1.0 - Initial plugin
 

--- a/phabricator/help.md
+++ b/phabricator/help.md
@@ -193,7 +193,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to the new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/phishtank/help.md
+++ b/phishtank/help.md
@@ -63,7 +63,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.4 - SSL bug fix in SDK
 * 0.1.3 - Fix API usage

--- a/ping/help.md
+++ b/ping/help.md
@@ -80,7 +80,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.3 - New spec and help.md format for the Hub
+* 1.0.3 - New spec and help.md format for the Extension Library
 * 1.0.2 - Bug fix to correct regex's search pattern
 * 1.0.1 - Support web server mode
 * 1.0.0 - Initial plugin

--- a/port_knocking/help.md
+++ b/port_knocking/help.md
@@ -55,7 +55,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/powershell/help.md
+++ b/powershell/help.md
@@ -144,7 +144,7 @@ Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw
 
 # Version History
 
-* 2.1.1 - New spec and help.md format for the Hub
+* 2.1.1 - New spec and help.md format for the Extension Library
 * 2.1.0 - Add functionality to allow CredSSP connections
 * 2.0.1 - Fix issue with unicode characters
 * 2.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/presto/help.md
+++ b/presto/help.md
@@ -121,7 +121,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/proofpoint_tap/help.md
+++ b/proofpoint_tap/help.md
@@ -82,7 +82,7 @@ This plugin does not contain any troubleshooting information.
 # Version History
 
 * 1.0.5 - Parsing out the View Threat Details link from emails to its own value
-* 1.0.4 - New spec and help.md format for the Hub
+* 1.0.4 - New spec and help.md format for the Extension Library
 * 1.0.3 - Fixed issue where headers were occasionally parsed improperly
 * 1.0.2 - Sanitize example output in Parse Alert action documentation
 * 1.0.1 - Fixed issue where TAP alerts with attachments are not parsed correctly

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -72,7 +72,7 @@ This plugin does not contain any troubleshooting information.
 
 * 1.2.0 - Update to URL Decode to add `decoded` as an output variable 
 * 1.1.0 - Update to URL Decode action to add support for v3 links
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Bug fix with decode parsing
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/pushover/help.md
+++ b/pushover/help.md
@@ -69,7 +69,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/python_2_script/help.md
+++ b/python_2_script/help.md
@@ -82,7 +82,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.3 - New spec and help.md format for the Hub
+* 2.0.3 - New spec and help.md format for the Extension Library
 * 2.0.2 - Add `utilities` plugin tag for Marketplace searchability
 * 2.0.1 - Fix issue where run action was excluded from plugin on build
 * 2.0.0 - Update to v2 Python plugin architecture | Support web server mode | Pin Python library versions | Rename action to Run Function

--- a/python_3_script/help.md
+++ b/python_3_script/help.md
@@ -98,7 +98,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Add the ability to download and install third-party libraries for use while configuring the plugin Connection
 * 1.0.6 - Fix issue where undefined output exceptions were not being handled correctly
 * 1.0.5 - Add `utilities` plugin tag for Marketplace searchability

--- a/qradar/help.md
+++ b/qradar/help.md
@@ -243,7 +243,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Support web server mode | Update to new credential types | Rename "Add Data to Reference_Data Lists" action to "Add Data to Reference Data Lists"
 * 1.0.0 - Finalize plugin
 * 0.1.1 - SSL bug fix in SDK

--- a/qualys_ssl/help.md
+++ b/qualys_ssl/help.md
@@ -237,7 +237,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Fix typo in plugin spec
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/rapid7_insightappsec/help.md
+++ b/rapid7_insightappsec/help.md
@@ -498,7 +498,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/rapid7_insightidr/help.md
+++ b/rapid7_insightidr/help.md
@@ -170,7 +170,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - New Action Add Indicators to a Threat
 * 1.0.0 - Initial plugin
 

--- a/rapid7_insightops/help.md
+++ b/rapid7_insightops/help.md
@@ -101,7 +101,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Support web server mode | Use new credential types
 * 1.0.0 - Update to v2 Python plugin architecture
 * 0.1.1 - SSL bug fix in SDK

--- a/rapid7_insightvm/help.md
+++ b/rapid7_insightvm/help.md
@@ -4326,7 +4326,7 @@ This plugin does not contain any troubleshooting information.
 * 4.0.0 - Fix output for Generate Adhoc SQL Report action
 * 3.6.0 - Add Get Asset Group Assets action
 * 3.5.2 - Fix bug in New Vulnerability Exception Activity
-* 3.5.1 - New spec and help.md format for the Hub
+* 3.5.1 - New spec and help.md format for the Extension Library
 * 3.5.0 - New Actions Get Vulnerability Details, Create Vulnerability Exception Submission,  Delete Vulnerability Exception, Review Vulnerability Exception  | New Trigger New Vulnerability Exception Activity | Misc. Cleanup
 * 3.4.0 - New Action Get Asset Software | Fix issue with New Scan trigger not properly caching new scan IDs
 * 3.3.1 - Fix issue in Top Remediations action that causes assets without criticality tags to not be returned in asset list

--- a/rapid7_metasploit/help.md
+++ b/rapid7_metasploit/help.md
@@ -180,7 +180,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Update to new credential types
 * 1.0.4 - Update to use new JSON API
 * 1.0.3 - Support web server mode

--- a/rapid7_tcell/help.md
+++ b/rapid7_tcell/help.md
@@ -2244,7 +2244,7 @@ an entity with the exact same data (e.g. IP groups), and in that case an excepti
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/rapid7_vulndb/help.md
+++ b/rapid7_vulndb/help.md
@@ -132,7 +132,7 @@ _This plugin does not contain any troubleshooting information._
 * 2.0.2 - Implement workaround for VulnDB API bug in Get Content action where the `severity` datatype response differs based on the action input
 * 2.0.1 - Add identifier field to the Search Database action
 * 2.0.0 - Utilize VulnDB API
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Fix issue where Published Date input in the Search Database action would not always parse correctly | Fix issue with memory leaks
 * 1.0.1 - Update to v2 Python plugin architecture and support web server mode
 * 1.0.0 - Initial plugin

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -538,7 +538,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.5.3 - New spec and help.md format for the Hub
+* 1.5.3 - New spec and help.md format for the Extension Library
 * 1.5.2 - Fix issue where timestamp for evidenceDetails was set to integer, timestamp is now expected as datetime from RecordedFuture
 * 1.5.1 - Fix issue where parameter timestamp in evidenceDetails was set as a string in Lookup IP Address action, timestamp is now an integer
 * 1.5.0 - Add support for handling IP addresses not found for action Lookup IP Address | Add found parameter to  action Lookup IP Address

--- a/red_canary/help.md
+++ b/red_canary/help.md
@@ -1138,7 +1138,7 @@ _This plugin does not contain any custom output types._
 # Version History
 
 * 2.1.6 - Vendored dependencies
-* 2.1.5 - New spec and help.md format for the Hub
+* 2.1.5 - New spec and help.md format for the Extension Library
 * 2.1.4 - Bug fix for New Events trigger where PluginException was not supported in SDK image | Update to use the `komand/python-3-37-slim-plugin:3` Docker image to reduce plugin size
 * 2.1.3 - Bug fix for New Detection trigger cache where additional dates were being added to the cache file. When the cache was loaded from the file it would set the lastest cache to an older date, allowing old detections to be triggered on
 * 2.1.2 - Bug fix for New Detection where needed to be loaded every time the trigger was called

--- a/redhat_advisory/help.md
+++ b/redhat_advisory/help.md
@@ -67,7 +67,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub | Add missing title values for actions in plugin.spec.yaml
+* 1.0.2 - New spec and help.md format for the Extension Library | Add missing title values for actions in plugin.spec.yaml
 * 1.0.1 - Support web server mode
 * 1.0.0 - Update to v2 Python plugin architecture
 * 0.1.1 - SSL bug fix in SDK

--- a/redis/help.md
+++ b/redis/help.md
@@ -385,7 +385,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Add actions HMSET, HMGET and HINCRBY
 * 0.1.2 - Update to new plugin architecture, fix action "keys"
 * 0.1.1 - SSL bug fix in SDK

--- a/request_tracker/help.md
+++ b/request_tracker/help.md
@@ -261,7 +261,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/rest/help.md
+++ b/rest/help.md
@@ -331,7 +331,7 @@ Any issues connecting to the remote service should be present in the log of the 
 # Version History
 
 * 3.0.2 - Update to v3 Python plugin architecture | Support get endpoints returning lists
-* 3.0.1 - New spec and help.md format for the Hub
+* 3.0.1 - New spec and help.md format for the Extension Library
 * 3.0.0 - Add basic auth support
 * 2.0.0 - Update connection to handle SSL verification
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode

--- a/rpm/help.md
+++ b/rpm/help.md
@@ -90,7 +90,7 @@ The complexity of this plugin overwhelmingly involves hacking around with yum, w
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to v2 Python plugin architecture
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/rss/help.md
+++ b/rss/help.md
@@ -172,7 +172,7 @@ Between workflow runs, new items will *not* be reported on.
 
 # Version History
 
-* 1.0.3 - New spec and help.md format for the Hub
+* 1.0.3 - New spec and help.md format for the Extension Library
 * 1.0.2 - Fixed issue where Poll Feed was logging unnecessary information
 * 1.0.1 - Support web server mode
 * 1.0.0 - Update to v2 Python plugin architecture | Add granular object output

--- a/salesforce/help.md
+++ b/salesforce/help.md
@@ -353,7 +353,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/samanage/help.md
+++ b/samanage/help.md
@@ -1403,7 +1403,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/screenshot_machine/help.md
+++ b/screenshot_machine/help.md
@@ -62,7 +62,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Rename action to "Capture URL Screenshot"
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/sed/help.md
+++ b/sed/help.md
@@ -93,7 +93,7 @@ If a literal double-quote is required it must be escaped by a backslash `\`. For
 
 # Version History
 
-* 2.0.2 - New spec and help.md format for the Hub | Refactor duplicate code | Remove returning dummy output in connection test | Refactor Exception to PluginException | Changed type in help to be the same as in plugin spec
+* 2.0.2 - New spec and help.md format for the Extension Library | Refactor duplicate code | Remove returning dummy output in connection test | Refactor Exception to PluginException | Changed type in help to be the same as in plugin spec
 * 2.0.1 - Fix issue with both actions not returning all results
 * 2.0.0 - Update action inputs to allow for multiple expressions
 * 1.0.1 - Add `utilities` plugin tag for Marketplace searchability

--- a/sentinelone/help.md
+++ b/sentinelone/help.md
@@ -934,7 +934,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.2.0 - New spec and help.md format for the Hub | New actions activities_list, activities_types, agents_abort_scan, agents_connect, agents_decommission, agents_disconnect, agents_fetch_logs, agents_initiate, agents_processes, agents_reload, agents_restart, agents_shutdown, agents_summary, agents_uninstall, apps_by_agent_ids, name_available
+* 1.2.0 - New spec and help.md format for the Extension Library | New actions activities_list, activities_types, agents_abort_scan, agents_connect, agents_decommission, agents_disconnect, agents_fetch_logs, agents_initiate, agents_processes, agents_reload, agents_restart, agents_shutdown, agents_summary, agents_uninstall, apps_by_agent_ids, name_available
 * 1.1.0 - New trigger Get Threats | New actions Mitigate Threat, Mark as Benign, Mark as Threat and Create IOC Threat
 * 1.0.1 - Update to add Blacklist by IoC Hash and Blacklist by Content Hash
 * 1.0.0 - Initial plugin

--- a/sentry/help.md
+++ b/sentry/help.md
@@ -218,7 +218,7 @@ Example output:
       ],
       "message": "SyntaxError Hello! \"myself\"",
       "sdk": {
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
         "version": "1.0.0",
         "name": "komand",
         "upstream": {
@@ -314,7 +314,7 @@ DSN configuration and Auth Tokens can be managed in your Sentry.io account setti
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/servicenow/help.md
+++ b/servicenow/help.md
@@ -561,7 +561,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 3.1.1 - New spec and help.md format for the Hub
+* 3.1.1 - New spec and help.md format for the Extension Library
 * 3.1.0 - Add action Get Incident Comments and Work Notes
 * 3.0.0 - Rewrite in Python | Renamed incident specific actions | New actions Create CI, Get CI, Update CI, Search CI
 * 2.0.5 - Update descriptions

--- a/shattered/help.md
+++ b/shattered/help.md
@@ -53,7 +53,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.0.2 - Fix issue in spec description
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/shodan/help.md
+++ b/shodan/help.md
@@ -84,7 +84,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/sketchify/help.md
+++ b/sketchify/help.md
@@ -64,7 +64,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/sleep/help.md
+++ b/sleep/help.md
@@ -52,7 +52,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.0.2 - Use input and output constants | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` to reduce plugin image size | Add interval input validation
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/smb/help.md
+++ b/smb/help.md
@@ -214,7 +214,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/smtp/help.md
+++ b/smtp/help.md
@@ -83,7 +83,7 @@ If you are passing a variable into the Attachment 'Content' field, you must make
 ## Version History
 
 * 2.0.5 - Fix issue sending emails without attachment
-* 2.0.4 - New spec and help.md format for the Hub
+* 2.0.4 - New spec and help.md format for the Extension Library
 * 2.0.3 - Fix issue with reliability in regards to previous Send action empty attachment fix
 * 2.0.2 - Fix issue where Send action doesn't handle empty attachments correctly
 * 2.0.1 - Fix issue where credentials were required

--- a/snortlabslist/help.md
+++ b/snortlabslist/help.md
@@ -55,7 +55,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - Feed URL [http://www.talosintelligence.com/feeds/ip-filter.blf](http://www.talosintelligence.com/feeds/ip-filter.blf) moved to S3, redirect required
 * 0.1.0 - Initial plugin

--- a/sophos_xg_firewall/help.md
+++ b/sophos_xg_firewall/help.md
@@ -157,7 +157,7 @@ To enable API access within Sophos XG, the setting is located in Backup & Firmwa
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Update to new credential types
 * 1.0.0 - Support web server mode | Update to v2 Python plugin architecture
 * 0.1.0 - Initial plugin

--- a/splunk/help.md
+++ b/splunk/help.md
@@ -233,7 +233,7 @@ _This plugin does not contain any custom output types._
 # Version History
 
 * 3.0.2 - Fix issue with typos in help.md and plugin description
-* 3.0.1 - New spec and help.md format for the Hub
+* 3.0.1 - New spec and help.md format for the Extension Library
 * 3.0.0 - Remove Komand-specific Alert trigger | Fix invalid output properties | Numerous typographical fixes | Improve error handling | Smaller plugin size due to slim SDK migration | New connection test code
 * 2.0.0 - Support SSL Verify option in the Connection | Improve error handling in Connection | Update documentation
 * 1.1.0 - Add support for user specified number of results in the Search action

--- a/sql/help.md
+++ b/sql/help.md
@@ -80,7 +80,7 @@ For the SQL query action, be sure that your query is valid SQL.
 
 # Version History
 
-* 2.0.5 - New spec and help.md format for the Hub
+* 2.0.5 - New spec and help.md format for the Extension Library
 * 2.0.4 - Add support for Microsoft SQL server
 * 2.0.3 - Fix issue where credentials used incorrect username | Update help
 * 2.0.2 - Fix issue where credentials was spelled wrong in connection

--- a/sqlmap/help.md
+++ b/sqlmap/help.md
@@ -219,7 +219,7 @@ To troubleshoot SQLmap, look at the INFO logs that are printed to see where the 
 
 # Version History
 
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Support web server mode
 * 1.0.0 - Initial plugin
 

--- a/ssh/help.md
+++ b/ssh/help.md
@@ -92,7 +92,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 2.0.0 - Update Run action output to return 3 output fields i.e. `stderr`, `stdout`, and `all_output`
-* 1.0.3 - New spec and help.md format for the Hub
+* 1.0.3 - New spec and help.md format for the Extension Library
 * 1.0.2 - Fixed issue where Run was excluded
 * 1.0.1 - Fix issue where run action was excluded from plugin on build
 * 1.0.0 - Support web server mode | Update to new credential types | Rename "Run remote command" action to "Run Remote Command"

--- a/statsd/help.md
+++ b/statsd/help.md
@@ -210,7 +210,7 @@ The sample `rate` value defaults to 1 if not provided by the user.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to Python v2 architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/storage/help.md
+++ b/storage/help.md
@@ -131,7 +131,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/string/help.md
+++ b/string/help.md
@@ -226,7 +226,7 @@ If this is the case, consider using the Python 3 Script plugin instead.
 
 # Version History
 
-* 1.2.1 - New spec and help.md format for the Hub
+* 1.2.1 - New spec and help.md format for the Extension Library
 * 1.2.0 - New action Trim
 * 1.1.0 - New action Set Encoding
 * 1.0.1 - Update plugin tag from `util` to `utilities` for Marketplace searchability

--- a/subnet/help.md
+++ b/subnet/help.md
@@ -61,7 +61,7 @@ However, the number of network does include the all-ones and all-zeros network.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Add `utilities` plugin tag for Marketplace searchability
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/sumologic/help.md
+++ b/sumologic/help.md
@@ -68,7 +68,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/symantec_bcs/help.md
+++ b/symantec_bcs/help.md
@@ -61,7 +61,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/syslog_forwarder/help.md
+++ b/syslog_forwarder/help.md
@@ -70,7 +70,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to Python v2 architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/tcpdump/help.md
+++ b/tcpdump/help.md
@@ -54,8 +54,8 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.1.0 - Updated spec and help.md format for the Hub, spec description changes
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.1.0 - Updated spec and help.md format for the Extension Library, spec description changes
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update to use the `komand/python-3-slim-plugin:2` Docker image to reduce plugin size
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/tcpxtract/help.md
+++ b/tcpxtract/help.md
@@ -76,7 +76,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Update to v2 Python plugin architecture
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/tenable_io/help.md
+++ b/tenable_io/help.md
@@ -104,7 +104,7 @@ This plugin does not contain any troubleshooting information.
 # Version History
 
 * 1.0.2 - Additional help.md edits for Hub
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/tenable_io/help.md
+++ b/tenable_io/help.md
@@ -103,7 +103,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - Additional help.md edits for Hub
+* 1.0.2 - Additional help.md edits for Extension Library
 * 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/tenable_nessus/help.md
+++ b/tenable_nessus/help.md
@@ -289,7 +289,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Use new credential types
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/thehive/help.md
+++ b/thehive/help.md
@@ -403,7 +403,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.5 - New spec and help.md format for the Hub. Update help key features and fix description capitalisation
+* 2.0.5 - New spec and help.md format for the Extension Library. Update help key features and fix description capitalisation
 * 2.0.4 - Update to use the `komand/python-2-27-slim-plugin` Docker image to reduce plugin size and to support SSL Verify
 * 2.0.3 - Fix issue where SSL Verify was not used in actions that utilize requests | Updated test method and moved it to connection
 * 2.0.2 - Fix issue where SSL Verify was not used in the connection

--- a/threat_connect/help.md
+++ b/threat_connect/help.md
@@ -232,7 +232,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to Python v2 architecture | Support web server mode | Use new credential types | Rename "Threat Connect" plugin title to "ThreatConnect" | Rename "Email's Retrieve" to "Email Retrieve"
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/threatminer/help.md
+++ b/threatminer/help.md
@@ -391,7 +391,7 @@ The [jq](https://market.komand.com/plugins/komand/jq/0.1.0) and [JSON](https://m
 # Version History
 
 * 2.0.0 - Update to v3 Python plugin architecture | Convert import_hash_report API status codes to int | Update documentation
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Rename "Email (Reverse WHOIS) - Report tagging" action to "Email (Reverse WHOIS) - Report Tagging"
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/threatq/help.md
+++ b/threatq/help.md
@@ -171,7 +171,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 1.0.2 - Fix issue with dependency
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Rename "Get indicator" action to "Get Indicator" | Rename "Get event" action to "Get Event"
 * 0.2.3 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/threatstack/help.md
+++ b/threatstack/help.md
@@ -791,7 +791,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/tr/help.md
+++ b/tr/help.md
@@ -63,7 +63,7 @@ In case an error is raised, make sure that the given expression can be correctly
 
 # Version History
 
-* 2.0.2 - New spec and help.md format for the Hub
+* 2.0.2 - New spec and help.md format for the Extension Library
 * 2.0.1 - Add `utilities` plugin tag for Marketplace searchability
 * 2.0.0 - Rename "Tr" plugin title to "Translate"
 * 1.0.0 - Initial plugin

--- a/traceroute/help.md
+++ b/traceroute/help.md
@@ -81,7 +81,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Support web server mode
 * 1.0.0 - Initial plugin
 

--- a/trello/help.md
+++ b/trello/help.md
@@ -251,7 +251,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 3.0.0 - Update spec titles and descriptions for AcronymValidator to pass
-* 2.0.2 - New spec and help.md format for the Hub
+* 2.0.2 - New spec and help.md format for the Extension Library
 * 2.0.1 - Remove erroneous data from plugin spec
 * 2.0.0 - Update to new secret key credential type
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types

--- a/trufflehog/help.md
+++ b/trufflehog/help.md
@@ -93,8 +93,8 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.1.3 - Updated spec and help.md format for the Hub
-* 1.1.2 - New spec and help.md format for the Hub
+* 1.1.3 - Updated spec and help.md format for the Extension Library
+* 1.1.2 - New spec and help.md format for the Extension Library
 * 1.1.1 - Fix issue where custom_regexes input field in Search action was not working
 * 1.1.0 - Update to v2 Python plugin architecture | Support web server mode
 * 1.0.0 - Initial plugin

--- a/try_bro/help.md
+++ b/try_bro/help.md
@@ -78,7 +78,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Fix issue where run action was excluded from plugin on build
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/tshark/help.md
+++ b/tshark/help.md
@@ -100,7 +100,7 @@ For example, `-V` is used to return the following `dump_contents` array where ea
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | Title rename from "Base64 Encoded Pcap" to "Base64 Encoded PCAP" for Run action file input
+* 2.0.0 - New spec and help.md format for the Extension Library | Title rename from "Base64 Encoded Pcap" to "Base64 Encoded PCAP" for Run action file input
 * 1.0.1 - Fix issue where run action was excluded from plugin on build
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/tsv/help.md
+++ b/tsv/help.md
@@ -74,7 +74,7 @@ TSV files must not have non-TSV data such as comments.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/twilio/help.md
+++ b/twilio/help.md
@@ -64,7 +64,7 @@ Before sending the SMS make sure that the country you're sending the message to 
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update Twilio dependency to 6.19.1
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/twitter/help.md
+++ b/twitter/help.md
@@ -188,7 +188,7 @@ If you suspect the failures are caused by a bug in the plugin, please contact Ko
 
 # Version History
 
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Support web server mode | Update to new credential types
 * 1.0.1 - Fix long integer bug for `message_id` in Destroy action and `id` in Messages trigger
 * 1.0.0 - Update to v2 Python plugin architecture

--- a/typo_squatter/help.md
+++ b/typo_squatter/help.md
@@ -87,7 +87,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Support web server mode | Rename "Score domain" action to "Score Domain" | Rename "Search certstream" trigger to "Search Certstream"
 * 0.1.1 - Search certstream flag bug fix
 * 0.1.0 - Initial plugin

--- a/uniq/help.md
+++ b/uniq/help.md
@@ -72,7 +72,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Update plugin tag from `utility` to `utilities` for Marketplace searchability
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK

--- a/unshorten/help.md
+++ b/unshorten/help.md
@@ -89,7 +89,7 @@ Note that the API is limited to 10 requests per hour per IP address.
 # Version History
 
 * 1.0.3 - Use input and output constants | Changed `Exception` to `PluginException` | Change docker image from `komand/python-pypy3-plugin:2` to `komand/python-3-37-slim-plugin:3` | Add user nobody in Dockerfile
-* 1.0.2 - New spec and help.md format for the Hub
+* 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Graceful exit for invalid URLs
 * 1.0.0 - Initial plugin
 

--- a/url_expander/help.md
+++ b/url_expander/help.md
@@ -88,7 +88,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.1.3 - New spec and help.md format for the Hub
+* 1.1.3 - New spec and help.md format for the Extension Library
 * 1.1.2 - Fix typo in plugin spec
 * 1.1.1 - Add `utilities` plugin tag for Marketplace searchability
 * 1.1.0 - Support web server mode

--- a/urlscan/help.md
+++ b/urlscan/help.md
@@ -268,7 +268,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 2.1.4 - Use input and output constants | Added "f" strings
-* 2.1.3 - New spec and help.md format for the Hub
+* 2.1.3 - New spec and help.md format for the Extension Library
 * 2.1.2 - Set User-Agent string to Rapid7 InsightConnect | Update to use the `komand/python-3-37-slim-plugin:3` Docker image to reduce plugin size | Run plugin as least privileged user | Improve error handling and logging | Fix issue in Submit URL for Scan action where improper POST body was sent
 * 2.1.1 - Add error messaging to Get Scan Results action to provide assistance for unavailable scan results | Update to Python 3.7 Slim SDK (plugin size reduction)
 * 2.1.0 - Added ScreenshotURL to get scan results output

--- a/viper/help.md
+++ b/viper/help.md
@@ -725,8 +725,8 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.1.0 - Updated connection description for the Hub
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.1.0 - Updated connection description for the Extension Library
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Update plugin to use the Viper v3 API
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK

--- a/virustotal_yara/help.md
+++ b/virustotal_yara/help.md
@@ -70,7 +70,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Support web server mode
 * 1.0.0 - Undocumented update
 * 0.1.0 - Initial plugin

--- a/vmray/help.md
+++ b/vmray/help.md
@@ -527,7 +527,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 5.0.0 - New Titles for output data (spelling corrections)
-* 4.0.2 - New spec and help.md format for the Hub
+* 4.0.2 - New spec and help.md format for the Extension Library
 * 4.0.1 - Update actions and Submit URL to specify what analyzer to use | Update file type support for the Submit File action
 * 4.0.0 - New actions Get Samples and Submit URL | Removed action Get Analysis by Hash | Fixed issue where Submit File results are not available in the workflow builder, and filename would not be included when submitting the file for analysis | Get Samples should replace Get Analysis by Hash
 * 3.0.0 - Added action Get Analysis | Ported over to Python from Go

--- a/vxstream_sandbox/help.md
+++ b/vxstream_sandbox/help.md
@@ -215,7 +215,7 @@ This plugin does not contain any troubleshooting information.
 # Version History
 
 * 3.0.0 - Updated variable titles, spelling mistakes
-* 2.0.1 - New spec and help.md format for the Hub
+* 2.0.1 - New spec and help.md format for the Extension Library
 * 2.0.0 - Support web server mode | Update to new credential types | Rename "Lookup By Hash" to "Lookup by Hash"
 * 1.0.1 - Update to v2 Python plugin architecture, edit to input parsing for lookup, report, and query actions
 * 1.0.0 - Invalid key in types section of plugin specification, and style updates

--- a/wazuh_ossec/help.md
+++ b/wazuh_ossec/help.md
@@ -607,7 +607,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 2.0.0 - Removed colon from variable names wazuh-modules_oscap and wazuh-modules_database | New spec and help.md format for the Hub
+* 2.0.0 - Removed colon from variable names wazuh-modules_oscap and wazuh-modules_database | New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/whois/help.md
+++ b/whois/help.md
@@ -170,8 +170,8 @@ _This plugin has no references._
 # Version History
 
 * 2.0.0 - Add example inputs | Fix capitalization in the title of the `last_updated` output.
-* 1.0.7 - Upgrade komand/python-whois version to 0.4.2 | Update whois.conf to support .in domains | Updated help.md for the Hub
-* 1.0.6 - New spec and help.md format for the Hub
+* 1.0.7 - Upgrade komand/python-whois version to 0.4.2 | Update whois.conf to support .in domains | Updated help.md for the Extension Library
+* 1.0.6 - New spec and help.md format for the Extension Library
 * 1.0.5 - Upgrade komand/python-whois version to 0.4.1 | Upgrade SDK
 * 1.0.4 - Fix variable name in domain lookup
 * 1.0.3 - Handle instances where domain name is prefixed with a protocol

--- a/wigle/help.md
+++ b/wigle/help.md
@@ -1115,7 +1115,7 @@ In the case where this plugin is used extensively, the API can respond with 'Too
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Initial plugin
 
 # Links

--- a/wordpress/help.md
+++ b/wordpress/help.md
@@ -98,7 +98,7 @@ the discovery process does not work on locally run web servers, as the API root 
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | Added titles for the actions
+* 2.0.0 - New spec and help.md format for the Extension Library | Added titles for the actions
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/zendesk/help.md
+++ b/zendesk/help.md
@@ -484,7 +484,7 @@ _This plugin does not contain any troubleshooting information._
 # Version History
 
 * 2.0.0 - Remove unwanted input fields, add comment field in action Update Ticket | Fix enum fields issue with Create Ticket action
-* 1.1.1 - New spec and help.md format for the Hub
+* 1.1.1 - New spec and help.md format for the Extension Library
 * 1.1.0 - Updated Search action to return multiple results
 * 1.0.1 - Updated to use PyPy3 SDK
 * 1.0.0 - Add Update Ticket action and fix for documentation | Support web server mode

--- a/zenhub/help.md
+++ b/zenhub/help.md
@@ -365,7 +365,7 @@ Note: GitHub Repository IDs (repo_id) can be obtained via the GitHub API at the 
 
 # Version History
 
-* 2.0.0 - New spec and help.md format for the Hub | Variable title updated
+* 2.0.0 - New spec and help.md format for the Extension Library | Variable title updated
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Rename "Move Issue between Pipelines" action to "Move Issue Between Pipelines"
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin

--- a/zeus_tracker/help.md
+++ b/zeus_tracker/help.md
@@ -182,7 +182,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.0.1 - New spec and help.md format for the Hub
+* 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Rename "Host" action to "Host Feed"
 * 0.1.1 - SSL bug fix in SDK
 * 0.1.0 - Initial plugin


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

 - Replace mentions of the Hub in Version History with its branding name Extension Library

```
gsed -i '/for the Hub/s/Hub/Extension Library/' */help.md
```

### Testing

Word boundary search, remaining items unrelated.

```
$ grep -w 'Hub' */help.md
aws_securityhub/help.md:[AWS Security Hub](https://aws.amazon.com/security-hub/) is a comprehensive view of your high-priority security alerts and compliance status across AWS accounts.
aws_securityhub/help.md:The AWS Security Hub InsightConnect plugin allows you to list and describe security hub-aggregated findings and retrieve SQS messages.
aws_securityhub/help.md:This plugin utilizes the [AWS Security Hub API](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Operations.html) and [Boto3](https://github.com/boto/boto3) Python library.
aws_securityhub/help.md:* Lists and describes Security Hub-aggregated findings
aws_securityhub/help.md:This action is used to lists and describes Security Hub-aggregated findings that are specified by filter attributes.
aws_securityhub/help.md:|Findings|[]Findings|False|Security Hub-aggregated findings|
aws_securityhub/help.md:          "Text": "For directions on how to fix this issue, please consult the AWS Security Hub CIS documentation.",
aws_securityhub/help.md:        "aws/securityhub/ProductName": "Security Hub",
aws_securityhub/help.md:|Message|Message|False|Security Hub message|
aws_securityhub/help.md:|ResponseMetadata|ResponseMetadata|False|Security Hub response metadata|
aws_securityhub/help.md:|securityhubevent|securityHubPayload|False|Security Hub event payload|
aws_securityhub/help.md:* [AWS Security Hub](https://aws.amazon.com/security-hub/)
aws_securityhub/help.md:* [AWS Security Hub API](https://docs.aws.amazon.com/securityhub/1.0/APIReference/API_Operations.html)
```