### PR TITLE
Mcafee EPO - Fix issue with wrong type in action System Information

### DIFF
--- a/mcafee_epo/.CHECKSUM
+++ b/mcafee_epo/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a2d87e2d4a374171f6fc30ac8ac56467",
-	"manifest": "4547f33bb40d8c0362b72fbaf1abdf5c",
-	"setup": "1fce141a3ee9623d5ba48b1031a63b4a",
+	"spec": "4c68faee73a162060cf4340ef44e7c3d",
+	"manifest": "1ef71c0c00fe8806b785db76ee81bc98",
+	"setup": "3afec9eba9fd38c712ee33a0c6d380be",
 	"schemas": [
 		{
 			"identifier": "add_permission_set_to_user/schema.py",
@@ -17,11 +17,11 @@
 		},
 		{
 			"identifier": "system_info/schema.py",
-			"hash": "be8c7af170227d82224a93a38fba9abb"
+			"hash": "e0ddcfa039f5c08fda74894da6ceb200"
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "c5e1532f1cad39c398595c2f167164a0"
+			"hash": "06413c4ea88446becf714e697263dc34"
 		}
 	]
 }

--- a/mcafee_epo/bin/komand_mcafee_epo
+++ b/mcafee_epo/bin/komand_mcafee_epo
@@ -4,10 +4,10 @@ import komand
 from komand_mcafee_epo import connection, actions, triggers
 
 
-Name = 'McAfee ePO'
-Vendor = 'rapid7'
-Version = '1.0.1'
-Description = 'McAfee ePolicy Orchestrator provides a web API for McAfee endpoint protection management activities'
+Name = "McAfee ePO"
+Vendor = "rapid7"
+Version = "1.0.2"
+Description = "McAfee ePolicy Orchestrator provides a web API for McAfee endpoint protection management activities"
 
 
 class ICONMcafeeEpo(komand.Plugin):

--- a/mcafee_epo/help.md
+++ b/mcafee_epo/help.md
@@ -18,11 +18,16 @@ This plugin utilizes libraries available through McAfee's ePolicy Orchestrator M
 
 The connection configuration accepts the following parameters:
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|url|string|None|True|McAfee ePO address e.g. epo.company.com|None|
-|credentials|credential_username_password|None|True|Username and password to access McAfee ePO e.g. admin|None|
-|port|number|None|True|McAfee ePO Port e.g. 8443|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|credentials|credential_username_password|None|True|Username and password to access McAfee ePO e.g. admin|None|None|
+|port|number|None|True|McAfee ePO Port e.g. 8443|None|None|
+|url|string|None|True|McAfee ePO address e.g. epo.company.com|None|None|
+
+Example input:
+
+```
+```
 
 ## Technical Details
 
@@ -34,9 +39,14 @@ This action is used to list information about system(s).
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|query|string|None|False|System search query e.g Device-1|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|query|string|None|False|System search query e.g Device-1|None|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -55,10 +65,15 @@ This action is used to assign the given tag to a supplied list of systems.
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|tag|string|None|True|The tag to apply|None|
-|devices|[]string|None|True|Array of all devices to tag e.g. ["Device-1","Device-2"]|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|devices|[]string|None|True|Array of all devices to tag e.g. ["Device-1","Device-2"]|None|None|
+|tag|string|None|True|The tag to apply|None|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -72,10 +87,15 @@ This action is used to add permission set(s) to a specified user.
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|user|string|None|False|Username of the target user|None|
-|permission_set|string|None|False|String name of the permission set to apply e.g. Group Admin|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|permission_set|string|None|False|String name of the permission set to apply e.g. Group Admin|None|None|
+|user|string|None|False|Username of the target user|None|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -89,10 +109,15 @@ This action is used to clear the given tag to a supplied list of systems.
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|tag|string|None|True|The tag to clear|None|
-|devices|[]string|None|True|Array of all devices to clear tag e.g. ["Device-1","Device-2"]|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|devices|[]string|None|True|Array of all devices to clear tag e.g. ["Device-1","Device-2"]|None|None|
+|tag|string|None|True|The tag to clear|None|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
@@ -102,7 +127,7 @@ This action is used to clear the given tag to a supplied list of systems.
 
 ### Triggers
 
-This plugin does not contain any triggers.
+_This plugin does not contain any triggers._
 
 ### Custom Output Types
 
@@ -113,7 +138,7 @@ _This plugin does not contain any custom output types._
 This plugin does not contain any troubleshooting information.
 
 # Version History
-
+* 1.0.2 - Fix issue with wrong type in action System Information
 * 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.2.1 - SSL bug fix in SDK

--- a/mcafee_epo/komand_mcafee_epo/actions/system_info/schema.py
+++ b/mcafee_epo/komand_mcafee_epo/actions/system_info/schema.py
@@ -150,7 +150,7 @@ class SystemInfoOutput(komand.Output):
           "order": 6
         },
         "EPOComputerProperties.LastAgentHandler": {
-          "type": "string",
+          "type": "integer",
           "title": "Last Agent Handler",
           "order": 49
         },

--- a/mcafee_epo/komand_mcafee_epo/connection/schema.py
+++ b/mcafee_epo/komand_mcafee_epo/connection/schema.py
@@ -51,12 +51,14 @@ class ConnectionSchema(komand.Input):
           "title": "Password",
           "displayType": "password",
           "description": "The password",
-          "format": "password"
+          "format": "password",
+          "order": 2
         },
         "username": {
           "type": "string",
           "title": "Username",
-          "description": "The username to log in with"
+          "description": "The username to log in with",
+          "order": 1
         }
       },
       "required": [

--- a/mcafee_epo/plugin.spec.yaml
+++ b/mcafee_epo/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: community
 status: []
 description: McAfee ePolicy Orchestrator provides a web API for McAfee endpoint protection management activities
-version: 1.0.1
+version: 1.0.2
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/mcafee_epo
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
@@ -216,7 +216,7 @@ types:
       required: false
     EPOComputerProperties.LastAgentHandler:
       title: Last Agent Handler
-      type: string
+      type: integer
       required: false
 connection:
   url:

--- a/mcafee_epo/setup.py
+++ b/mcafee_epo/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 
-setup(name='mcafee_epo-rapid7-plugin',
-      version='1.0.1',
-      description='McAfee ePolicy Orchestrator provides a web API for McAfee endpoint protection management activities',
-      author='rapid7',
-      author_email='',
-      url='',
+setup(name="mcafee_epo-rapid7-plugin",
+      version="1.0.2",
+      description="McAfee ePolicy Orchestrator provides a web API for McAfee endpoint protection management activities",
+      author="rapid7",
+      author_email="",
+      url="",
       packages=find_packages(),
       install_requires=['komand'],  # Add third-party dependencies to requirements.txt, not here!
       scripts=['bin/komand_mcafee_epo']


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "status": "ok",
    "output": {
      "properties": [
        {
          "EPOComputerProperties.CPUSpeed": 1608,
          "EPOComputerProperties.OSPlatform": "Workstation",
          "EPOComputerProperties.ComputerName": "DESKTOP-C27R09E",
          "EPOComputerProperties.UserName": "vagrant",
          "EPOComputerProperties.NetAddress": "08002796868E",
          "EPOComputerProperties.IsPortable": 1,
          "EPOComputerProperties.Total_Space_of_Drive_C": 81368,
          "EPOLeafNode.ManagedState": 1,
          "EPOComputerProperties.FreeMemory": 2405154816,
          "EPOBranchNode.AutoID": 2,
          "EPOComputerProperties.DefaultLangID": "0409",
          "EPOComputerProperties.TotalPhysicalMemory": 4294496256,
          "EPOComputerProperties.Free_Space_of_Drive_C": 60158,
          "EPOComputerProperties.OSOEMID": "00330-80000-00000-AA435",
          "EPOComputerProperties.IPAddress": "10.0.2.15",
          "EPOComputerProperties.DomainName": "WORKGROUP",
          "EPOComputerProperties.IPHostName": "DESKTOP-C27R09E",
          "EPOComputerProperties.IPV6": "0:0:0:0:0:FFFF:A00:20F",
          "EPOComputerProperties.IPSubnet": "0:0:0:0:0:FFFF:A00:200",
          "EPOComputerProperties.IPXAddress": "N/A",
          "EPOComputerProperties.NumOfCPU": 2,
          "EPOComputerProperties.CPUSerialNumber": "N/A",
          "EPOComputerProperties.OSBuildNum": 16299,
          "EPOLeafNode.AgentGUID": "FF64B9A9-D018-469D-92A0-7C144A6E5A04",
          "EPOComputerProperties.Vdi": 0,
          "EPOComputerProperties.CPUType": "Intel(R) Core(TM) i5-8210Y CPU @ 1.60GHz",
          "EPOComputerProperties.ComputerDescription": "N/A",
          "EPOComputerProperties.OSVersion": "10.0",
          "EPOComputerProperties.IPSubnetMask": "0:0:0:0:0:FFFF:FFFF:FF00",
          "EPOComputerProperties.TimeZone": "Romance Standard Time",
          "EPOComputerProperties.OSBitMode": 1,
          "EPOComputerProperties.SubnetMask": "255.255.255.0",
          "EPOComputerProperties.OSType": "Windows 10",
          "EPOLeafNode.AgentVersion": "5.5.1.342",
          "EPOComputerProperties.TotalDiskSpace": 81368,
          "EPOComputerProperties.FreeDiskSpace": 60158,
          "EPOComputerProperties.SubnetAddress": "10.0.2.0",
          "EPOLeafNode.LastUpdate": "2020-05-18T08:14:04-07:00",
          "EPOLeafNode.Tags": "Workstation",
          "EPOComputerProperties.ParentID": 1,
          "EPOComputerProperties.LastAgentHandler": 1
        }
      ]
    },
    "meta": {},
    "log": "Connect: Connecting..\nConnected\nrapid7/McAfee ePO:1.0.1. Step name: system_info\nSystem information has been gathered\n"
  },
  "version": "v1",
  "type": "action_event"
}

```

<summary>
docker run --rm -i rapid7/mcafee_epo:1.0.1 --debug run < tests/system_info.json
</summary>
</details>
<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator ExceptionValidator
WARNING: Use of 'PluginException' or 'ConnectionTestException' is recommended when raising an exception.
violation: komand_mcafee_epo/mcafee.py: line,  85
violation: komand_mcafee_epo/mcafee.py: line,  87
violation: komand_mcafee_epo/mcafee.py: line,  483
violation: komand_mcafee_epo/mcafee.py: line,  486
violation: komand_mcafee_epo/mcafee.py: line,  523
violation: komand_mcafee_epo/mcafee.py: line,  613
violation: komand_mcafee_epo/mcafee.py: line,  628
violation: komand_mcafee_epo/mcafee.py: line,  630
violation: komand_mcafee_epo/urlquote.py: line,  50
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "TitleValidator" failed!
        Cause: ('Plugin title not valid.', ValidationException("Title contains a lowercase 'ePO' when it should not."))

Validator "DockerfileParentValidator" failed!
        Cause: Unrecognized parent Dockerfile.


----
[*] Total time elapsed: 13264.606ms

```

<summary>
icon-validate --all .
</summary>
</details>