### PR TITLE
[SOAR-1308] PAN OS - fixed names

### DIFF
--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "1e3c2670622869d80090bf498f8311b9",
+	"spec": "366755fe5fe334285d576163a47f1b62",
 	"manifest": "0fdee9122de91d7e3f35ec88d44b9fa8",
 	"setup": "fb892008f6e9843a44367327a8977265",
 	"schemas": [
@@ -57,7 +57,7 @@
 		},
 		{
 			"identifier": "set_address_object/schema.py",
-			"hash": "acb8c602b8052a9e29d1bc1140f68fa2"
+			"hash": "07d13e859d42a1ce738f8caebc293b50"
 		},
 		{
 			"identifier": "set_security_policy_rule/schema.py",

--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "8b3e81b2a4d9f6a98f110fcab97cb385",
-	"manifest": "5359e0c5fa48b73e7c95d041c3e122b6",
-	"setup": "2e90b11b6be78edf057e758997d7b5d7",
+	"spec": "1e3c2670622869d80090bf498f8311b9",
+	"manifest": "0fdee9122de91d7e3f35ec88d44b9fa8",
+	"setup": "fb892008f6e9843a44367327a8977265",
 	"schemas": [
 		{
 			"identifier": "add_external_dynamic_list/schema.py",
@@ -57,7 +57,7 @@
 		},
 		{
 			"identifier": "set_address_object/schema.py",
-			"hash": "6dfe033b5246aa56dac377d8b1322609"
+			"hash": "acb8c602b8052a9e29d1bc1140f68fa2"
 		},
 		{
 			"identifier": "set_security_policy_rule/schema.py",

--- a/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -6,7 +6,7 @@ from komand_palo_alto_pan_os import connection, actions, triggers
 
 Name = "Palo Alto PAN-OS"
 Vendor = "rapid7"
-Version = "3.0.0"
+Version = "4.0.0"
 Description = "Manage Palo Alto Networks devices via PAN-OS"
 
 

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -136,6 +136,11 @@ This action is used to get a policy.
 Example input:
 
 ```
+{
+  "device_name": "localhost.localdomain",
+  "policy_name": "InsightConnect Block List",
+  "virtual_system": "vsys1"
+}
 ```
 
 ##### Output

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -58,7 +58,7 @@ Example input:
 {
   "address": "198.51.100.100",
   "device_name": "localhost.localdomain",
-  "enable_search": true,
+  "enable_search": false,
   "group": "ICON Block List",
   "virtual_system": "vsys1"
 }
@@ -136,11 +136,6 @@ This action is used to get a policy.
 Example input:
 
 ```
-{
-  "device_name": "localhost.localdomain",
-  "policy_name": "InsightConnect Block List",
-  "virtual_system": "vsys1"
-}
 ```
 
 ##### Output
@@ -823,6 +818,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
+* 4.0.0 - Update to Create Address Object to make input consistent with other actions
 * 3.0.0 - New action Remove Address Object from Group | Update to Check if Address in Group to match input of Remove Address Object from Group 
 * 2.2.0 - New action Check if Address in Group
 * 2.1.0 - New action Get Policy

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -136,11 +136,6 @@ This action is used to get a policy.
 Example input:
 
 ```
-{
-  "device_name": "localhost.localdomain",
-  "policy_name": "InsightConnect Block List",
-  "virtual_system": "vsys1"
-}
 ```
 
 ##### Output
@@ -212,9 +207,9 @@ In this case, we will strip the /32 from the end and check the IP against the wh
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|address_object|string|None|True|The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com google.com|None|1.1.1.1|
-|object_description|string|None|False|A description for the address object|None|Blocked host from Insight Connect|
-|object_name|string|None|True|The name of the address object|None|Blocked host|
+|address|string|None|True|The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com google.com|None|1.1.1.1|
+|address_object|string|None|True|The name of the address object|None|Blocked host|
+|description|string|None|False|A description for the address object|None|Blocked host from Insight Connect|
 |tags|string|None|False|Tags for the address object. Use commas to separate multiple tags|None|malware|
 |whitelist|[]string|None|False|This list contains a set of network objects that should not be blocked. This can include IPs, CIDR notation, or domains. It can not include an IP range (such as 10.0.0.0-10.0.0.10)|None|["198.51.100.100", "192.0.2.0/24", "example.com"]|
 
@@ -222,9 +217,9 @@ Example input:
 
 ```
 {
-  "address_object": "1.1.1.1",
-  "object_description": "Blocked host from Insight Connect",
-  "object_name": "Blocked host",
+  "address": "1.1.1.1",
+  "address_object": "Blocked host",
+  "description": "Blocked host from Insight Connect",
   "tags": "malware",
   "whitelist": [
     "198.51.100.100",

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
@@ -51,10 +51,10 @@ class SetAddressObject(komand.Action):
         return False
 
     def run(self, params={}):
-        address = params.get(Input.ADDRESS_OBJECT)
+        address = params.get(Input.ADDRESS)
         # object_type = params.get(Input.TYPE)
-        name = params.get(Input.OBJECT_NAME)
-        description = params.get(Input.OBJECT_DESCRIPTION)
+        name = params.get(Input.ADDRESS_OBJECT)
+        description = params.get(Input.DESCRIPTION)
         tag_list = params.get(Input.TAGS)
         whitelist = params.get(Input.WHITELIST)
 

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
@@ -29,19 +29,19 @@ class SetAddressObjectInput(komand.Input):
   "properties": {
     "address_object": {
       "type": "string",
-      "title": "Address Object",
+      "title": "Address",
       "description": "The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com google.com",
       "order": 1
     },
     "object_description": {
       "type": "string",
-      "title": "Object Description",
+      "title": "Description",
       "description": "A description for the address object",
       "order": 3
     },
     "object_name": {
       "type": "string",
-      "title": "Object Name",
+      "title": "Address Object",
       "description": "The name of the address object",
       "order": 2
     },

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
@@ -8,9 +8,9 @@ class Component:
 
 
 class Input:
+    ADDRESS = "address"
     ADDRESS_OBJECT = "address_object"
-    OBJECT_DESCRIPTION = "object_description"
-    OBJECT_NAME = "object_name"
+    DESCRIPTION = "description"
     TAGS = "tags"
     WHITELIST = "whitelist"
     
@@ -27,23 +27,23 @@ class SetAddressObjectInput(komand.Input):
   "type": "object",
   "title": "Variables",
   "properties": {
-    "address_object": {
+    "address": {
       "type": "string",
       "title": "Address",
       "description": "The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com google.com",
       "order": 1
     },
-    "object_description": {
-      "type": "string",
-      "title": "Description",
-      "description": "A description for the address object",
-      "order": 3
-    },
-    "object_name": {
+    "address_object": {
       "type": "string",
       "title": "Address Object",
       "description": "The name of the address object",
       "order": 2
+    },
+    "description": {
+      "type": "string",
+      "title": "Description",
+      "description": "A description for the address object",
+      "order": 3
     },
     "tags": {
       "type": "string",
@@ -62,8 +62,8 @@ class SetAddressObjectInput(komand.Input):
     }
   },
   "required": [
-    "address_object",
-    "object_name"
+    "address",
+    "address_object"
   ]
 }
     """)

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -609,20 +609,20 @@ actions:
     title: Create Address Object
     description: Create a new address object
     input:
-      address_object:
+      address:
         title: Address
         description: The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com
           google.com
         type: string
         example: 1.1.1.1
         required: true
-      object_name:
+      address_object:
         title: Address Object
         description: The name of the address object
         type: string
         example: Blocked host
         required: true
-      object_description:
+      description:
         title: Description
         description: A description for the address object
         type: string

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto PAN-OS
 description: Manage Palo Alto Networks devices via PAN-OS
-version: 3.0.0
+version: 4.0.0
 vendor: rapid7
 support: rapid7
 status: []
@@ -610,20 +610,20 @@ actions:
     description: Create a new address object
     input:
       address_object:
-        title: Address Object
+        title: Address
         description: The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com
           google.com
         type: string
         example: 1.1.1.1
         required: true
       object_name:
-        title: Object Name
+        title: Address Object
         description: The name of the address object
         type: string
         example: Blocked host
         required: true
       object_description:
-        title: Object Description
+        title: Description
         description: A description for the address object
         type: string
         example: Blocked host from Insight Connect

--- a/palo_alto_pan_os/setup.py
+++ b/palo_alto_pan_os/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
-      version="3.0.0",
+      version="4.0.0",
       description="Manage Palo Alto Networks devices via PAN-OS",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

This change updates the PAN OS Create Address Object names to match other actions. 

## Validation: 
NOTE: Validation errors are known validation bugs. 
```
rmt-mbp-5357:palo_alto_pan_os jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
Validator "TitleValidator" failed!
	Cause: ("actions key 'check_if_address_object_in_group''s title ends with period when it should not.", ValidationException("Title contains a lowercase 'if' when it should not."))
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
Input violations: Action -> "Create Address Object": Missing ["|whitelist|[]string|None|False|This list contains a set of network objects that should not be blocked. This can include IPs, CIDR notation, or domains. It can not include an IP range (such as 10.0.0.0-10.0.0.10)|None|['198.51.100.100', '192.0.2.0/24', 'example.com']|"] in help.md
Validator "HelpInputOutputValidator" failed!
	Cause: Help.md is not in sync with plugin.spec.yaml. Please regenerate help.md by running 'icon-plugin generate python --regenerate' to rectify violations.
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*]Plugin failed validation!

----
[*] Total time elapsed: 467.44ms
```

## Testing: 
```
rmt-mbp-5357:palo_alto_pan_os jmcadams$ ./run.sh -R tests/set_address_object.json -j
Running: cat tests/set_address_object.json | docker run --rm   -i rapid7/palo_alto_pan_os:4.0.0  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Connect: Connecting..
Starting new HTTPS connection (1): pa-vm-9-0.vuln.lax.rapid7.com:443
/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
https://pa-vm-9-0.vuln.lax.rapid7.com:443 "GET /api/?type=keygen&user=admin&password=notpassword HTTP/1.1" 200 200
Key obtained
rapid7/Palo Alto PAN-OS:4.0.0. Step name: set_address_object
/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
https://pa-vm-9-0.vuln.lax.rapid7.com:443 "POST /api/?type=config&action=set&key=LUFRPT1kVlQ0ODkrOXdMcHhDOHpWS3Yzc0pGRmlKNUE9VlI1REg0YUdFOHA5aHMzTk9kT3JIeEVlYmwzMEVLRHcxT0crTDAwSHpLSmFZTU80c0M2bVlzVitFK2ZIdVUwMQ%3D%3D&xpath=%2Fconfig%2Fdevices%2Fentry%2Fvsys%2Fentry%2Faddress%2Fentry%5B%40name%3D%27another+name%27%5D&element=%3Cip-netmask%3E1.1.1.5%3C%2Fip-netmask%3E%3Cdescription%3EA+Test+from+ICON%3C%2Fdescription%3E HTTP/1.1" 200 76
Connect: Connecting..
Key obtained
rapid7/Palo Alto PAN-OS:4.0.0. Step name: set_address_object

{
  "message": "command succeeded",
  "status": "success",
  "code": "20"
}
```