### PR TITLE
[SOAR-1024] - Palo Alto update PAN-OS to Firewall

### DIFF
--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "17f31ee0f79a61754ca34f2114309add",
+	"spec": "7121150d59908184310ec04f1bcb8846",
 	"manifest": "84070f7a862fb0c0996de3000e1a1a4d",
 	"setup": "4f6f139d572893d7c047343ac82570a5",
 	"schemas": [

--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "0ee4be32576bddb75aed4c139e3c8da3",
-	"manifest": "d6a954b4db2ec0d8ae92c1ad12e84a48",
-	"setup": "8443312d13cbdfb56ca6e84e38b5302d",
+	"spec": "17f31ee0f79a61754ca34f2114309add",
+	"manifest": "84070f7a862fb0c0996de3000e1a1a4d",
+	"setup": "4f6f139d572893d7c047343ac82570a5",
 	"schemas": [
 		{
 			"identifier": "add_external_dynamic_list/schema.py",

--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,15 +1,15 @@
 {
-	"spec": "366755fe5fe334285d576163a47f1b62",
-	"manifest": "0fdee9122de91d7e3f35ec88d44b9fa8",
-	"setup": "fb892008f6e9843a44367327a8977265",
+	"spec": "0ee4be32576bddb75aed4c139e3c8da3",
+	"manifest": "d6a954b4db2ec0d8ae92c1ad12e84a48",
+	"setup": "8443312d13cbdfb56ca6e84e38b5302d",
 	"schemas": [
 		{
 			"identifier": "add_external_dynamic_list/schema.py",
-			"hash": "1c9f28b04ad28b8eff60788de35642d1"
+			"hash": "917f7f3fb5c8edaf8b1baac35655f61b"
 		},
 		{
 			"identifier": "add_to_policy/schema.py",
-			"hash": "2382ce2b561ceae49b04fe73f074b83c"
+			"hash": "101c94e89a84667bd78516ab47074271"
 		},
 		{
 			"identifier": "check_if_address_object_in_group/schema.py",
@@ -17,19 +17,19 @@
 		},
 		{
 			"identifier": "commit/schema.py",
-			"hash": "cae6eb290f28b4d63a2cb73a67c38f25"
+			"hash": "c95dc3c1c6f1984b96a0ed60216c2f30"
 		},
 		{
 			"identifier": "delete/schema.py",
-			"hash": "a199f87f5b4dd668c79f30db7c62b335"
+			"hash": "7b805a5bfbdff46ab69af9d5bdf800de"
 		},
 		{
 			"identifier": "edit/schema.py",
-			"hash": "9859baede8e037fd9ba9a35f6a6c19e5"
+			"hash": "2c074fd881cbdf215716a29a5810542c"
 		},
 		{
 			"identifier": "get/schema.py",
-			"hash": "44edf318f15fd914cc88f057396a5dcc"
+			"hash": "07e52e47180b9fed885727070fa41c55"
 		},
 		{
 			"identifier": "get_policy/schema.py",
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "op/schema.py",
-			"hash": "cfab33108d74bd33d6b9e56c52425673"
+			"hash": "4c1abd0217e012d988a0eb7a8bd2e265"
 		},
 		{
 			"identifier": "remove_address_object_from_group/schema.py",
@@ -45,31 +45,31 @@
 		},
 		{
 			"identifier": "remove_from_policy/schema.py",
-			"hash": "586bcabe6bc0d354b73614ed1a680790"
+			"hash": "e6f3544bfea89521710f1b4ad174b5f7"
 		},
 		{
 			"identifier": "retrieve_logs/schema.py",
-			"hash": "f17eb1d9ac6488e5d8e5684e3952c50e"
+			"hash": "d9f7bf3428ad3eda2e8d44bb3f73e87f"
 		},
 		{
 			"identifier": "set/schema.py",
-			"hash": "a9fc0a8b1190db25d09fd8eacc70a4df"
+			"hash": "3979cba70b04a4abccfde50cf805304f"
 		},
 		{
 			"identifier": "set_address_object/schema.py",
-			"hash": "07d13e859d42a1ce738f8caebc293b50"
+			"hash": "d455962eb686d697bea1c00c5f4a068b"
 		},
 		{
 			"identifier": "set_security_policy_rule/schema.py",
-			"hash": "3c7ac086de7583fe3f8a08345e0c399c"
+			"hash": "389562f97bd7203600e1431a30d70c6a"
 		},
 		{
 			"identifier": "show/schema.py",
-			"hash": "08ceb4760371d35bd962c929faac6873"
+			"hash": "5f5f613ad9955be585c418ed5b78051f"
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "90a53d7b1bcfa8112a3e798a31819dc0"
+			"hash": "bd4c5a79f67234c416a7195ea1e791a6"
 		}
 	]
 }

--- a/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -6,7 +6,7 @@ from komand_palo_alto_pan_os import connection, actions, triggers
 
 Name = "Palo Alto Firewall"
 Vendor = "rapid7"
-Version = "4.0.0"
+Version = "5.0.0"
 Description = "Manage Palo Alto Networks firewall devices"
 
 

--- a/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -4,10 +4,10 @@ import komand
 from komand_palo_alto_pan_os import connection, actions, triggers
 
 
-Name = "Palo Alto PAN-OS"
+Name = "Palo Alto Firewall"
 Vendor = "rapid7"
 Version = "4.0.0"
-Description = "Manage Palo Alto Networks devices via PAN-OS"
+Description = "Manage Palo Alto Networks firewall devices"
 
 
 class ICONPaloAltoPanOs(komand.Plugin):

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -1,6 +1,6 @@
 # Description
 
-[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto firewall appliance(s).
+[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto Firewall appliance(s).
 
 # Key Features
 
@@ -26,7 +26,7 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |credentials|credential_username_password|None|True|Username and password|None|None|
-|server|string|None|True|URL pointing to instance of a Palo Alto firewall|None|None|
+|server|string|None|True|URL pointing to instance of a Palo Alto Firewall|None|None|
 |verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting the firewall over HTTPS|None|None|
 
 Example input:

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -32,6 +32,14 @@ The connection configuration accepts the following parameters:
 Example input:
 
 ```
+{
+  "credentials": {
+    "password": "password",
+    "username": "username"
+  },
+  "server": "https://www.example.com",
+  "verify_cert": true
+}
 ```
 
 ## Technical Details

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -823,7 +823,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
-* 5.0.0 - Update to plugin title and documentation from PAN-OS to firewall
+* 5.0.0 - Update to plugin title and documentation to remove PAN OS
 * 4.0.0 - Update to Create Address Object to make input consistent with other actions
 * 3.0.0 - New action Remove Address Object from Group | Update to Check if Address in Group to match input of Remove Address Object from Group 
 * 2.2.0 - New action Check if Address in Group

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -26,20 +26,12 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |credentials|credential_username_password|None|True|Username and password|None|None|
-|server|string|None|True|URL pointing to instance of a Palo Alto Firewall|None|None|
+|server|string|None|True|URL pointing to instance of a Palo Alto firewall|None|None|
 |verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting the firewall over HTTPS|None|None|
 
 Example input:
 
 ```
-{
-  "credentials": {
-    "username": "username"
-    "password": "password",   
-  },
-  "server": "https://www.example.com",
-  "verify_cert": true
-}
 ```
 
 ## Technical Details
@@ -831,6 +823,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
+* 5.0.0 - Update to plugin title and documentation from PAN-OS to firewall
 * 4.0.0 - Update to Create Address Object to make input consistent with other actions
 * 3.0.0 - New action Remove Address Object from Group | Update to Check if Address in Group to match input of Remove Address Object from Group 
 * 2.2.0 - New action Check if Address in Group

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -34,8 +34,8 @@ Example input:
 ```
 {
   "credentials": {
-    "password": "password",
     "username": "username"
+    "password": "password",   
   },
   "server": "https://www.example.com",
   "verify_cert": true

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -136,6 +136,11 @@ This action is used to get a policy.
 Example input:
 
 ```
+{
+  "device_name": "localhost.localdomain",
+  "policy_name": "InsightConnect Block List",
+  "virtual_system": "vsys1"
+}
 ```
 
 ##### Output

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -1,6 +1,6 @@
 # Description
 
-[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto PAN-OS firewall appliance(s).
+[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto firewall appliance(s).
 
 # Key Features
 
@@ -15,7 +15,7 @@
 
 # Requirements
 
-* PAN-OS credentials
+* Firewall credentials
 
 # Documentation
 
@@ -26,8 +26,8 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |credentials|credential_username_password|None|True|Username and password|None|None|
-|server|string|None|True|URL pointing to instance of PAN-OS|None|None|
-|verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting PAN-OS over HTTPS|None|None|
+|server|string|None|True|URL pointing to instance of a Palo Alto firewall|None|None|
+|verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting the firewall over HTTPS|None|None|
 
 Example input:
 
@@ -136,11 +136,6 @@ This action is used to get a policy.
 Example input:
 
 ```
-{
-  "device_name": "localhost.localdomain",
-  "policy_name": "InsightConnect Block List",
-  "virtual_system": "vsys1"
-}
 ```
 
 ##### Output
@@ -238,7 +233,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|code|string|False|Response code from PAN-OS|
+|code|string|False|Response code from the firewall|
 |message|string|False|A message with more detail about the status|
 |status|string|False|The status of the requested operation e.g. success, error, etc|
 
@@ -264,7 +259,7 @@ This action is used to create a new security policy rule.
 |application|string|None|True|Applications for which this rule will be applied e.g. adobe-cloud, dropbox,  any|None|None|
 |description|string|None|True|Description of the rule and what it does|None|None|
 |destination|string|None|True|Destinations for which this rule will be applied e.g. 10.0.0.1, computername, any|None|None|
-|disable_server_response_inspection|boolean|None|True|If true, PAN-OS will not inspect this traffic|None|None|
+|disable_server_response_inspection|boolean|None|True|If true, the firewall will not inspect this traffic|None|None|
 |disabled|boolean|None|True|If true, rule is disabled|None|None|
 |dst_zone|string|None|True|Zone which the traffic is going to e.g. server zone, any|None|None|
 |log_end|boolean|None|True|Generates a traffic log entry for the end of a session|None|None|
@@ -286,7 +281,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|config|False|Response from PAN-OS|
+|response|config|False|Response from the firewall|
 
 Example output:
 
@@ -321,7 +316,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|object|False|Response from PAN-OS|
+|response|object|False|Response from the firewall|
 
 Example output:
 
@@ -355,7 +350,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|config|False|Response from PAN-OS|
+|response|config|False|Response from the firewall|
 
 Example output:
 
@@ -409,7 +404,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|object|False|Response from PAN-OS|
+|response|object|False|Response from the firewall|
 
 Example output:
 
@@ -443,7 +438,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|config|False|Response from PAN-OS|
+|response|config|False|Response from the firewall|
 
 Example output:
 
@@ -520,7 +515,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|log|False|Response from PAN-OS|
+|response|log|False|Response from the firewall|
 
 Example output:
 
@@ -587,7 +582,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|object|False|Response from PAN-OS|
+|response|object|False|Response from the firewall|
 
 Example output:
 
@@ -624,7 +619,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|config|False|Response from PAN-OS|
+|response|config|False|Response from the firewall|
 
 Example output:
 
@@ -658,7 +653,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|response|object|False|Response from PAN-OS|
+|response|object|False|Response from the firewall|
 
 Example output:
 
@@ -703,7 +698,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|code|string|False|Response code from PAN-OS|
+|code|string|False|Response code from firewall|
 |message|string|False|A message with more detail about the status|
 |status|string|False|Status of the requested operation e.g. success, error, etc|
 
@@ -747,7 +742,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|code|string|False|Response code from PAN-OS|
+|code|string|False|Response code from the firewall|
 |message|string|False|A message with more detail about the status|
 |status|string|False|Status of the requested operation e.g. success, error, etc|
 
@@ -773,7 +768,7 @@ This action is used to add an external dynamic list.
 |day|string||True|If repeat is weekly, choose a day to update|['', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday', 'Sunday']|None|
 |description|string|None|True|A description of the list|None|None|
 |list_type|string|None|True|The type of list|['IP List', 'Domain List', 'URL List']|None|
-|name|string|None|True|An arbitrary name for the list. This name will be used to identify the list in PAN-OS|None|None|
+|name|string|None|True|An arbitrary name for the list. This name will be used to identify the list in the firewall|None|None|
 |repeat|string|None|True|The interval at which to retrieve updates from the list|['Five Minute', 'Hourly', 'Daily', 'Weekly']|None|
 |source|string|None|True|The web site you will pull the list from e.g. https://www.example.com/test.txt|None|None|
 |time|string||True|If repeat is daily or weekly, choose an hour on a 24 hour clock to update (Default: '')|['', '00', '01', '02', '03', '04', '05', '06', '07', 8, 9, '10', '11', '12', '13', '14', '15', '16', '17', '18', '19', '20', '21', '22', '23']|None|
@@ -787,7 +782,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|code|string|False|Response code from PAN-OS|
+|code|string|False|Response code from the firewall|
 |message|string|False|A message with more detail about the status|
 |status|string|False|The status of the requested operation e.g. success, error, etc|
 

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -25,13 +25,21 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|credentials|credential_username_password|None|True|Username and password|None|None|
-|server|string|None|True|URL pointing to instance of a Palo Alto firewall|None|None|
-|verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting the firewall over HTTPS|None|None|
+|credentials|credential_username_password|None|True|Username and password|None|{"username":"username", "password":"password"}|
+|server|string|None|True|URL pointing to instance of a Palo Alto firewall|None|http://www.example.com|
+|verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting the firewall over HTTPS|None|True|
 
 Example input:
 
 ```
+{
+  "credentials": {
+      "username": "username", 
+      "password": "password"
+  },
+  "server": "http://www.example.com",
+  "verify_cert": true
+}
 ```
 
 ## Technical Details

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_external_dynamic_list/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_external_dynamic_list/schema.py
@@ -66,7 +66,7 @@ class AddExternalDynamicListInput(komand.Input):
     "name": {
       "type": "string",
       "title": "The Name of the List",
-      "description": "An arbitrary name for the list. This name will be used to identify the list in PAN-OS",
+      "description": "An arbitrary name for the list. This name will be used to identify the list in the firewall",
       "order": 1
     },
     "repeat": {
@@ -147,7 +147,7 @@ class AddExternalDynamicListOutput(komand.Output):
     "code": {
       "type": "string",
       "title": "Code",
-      "description": "Response code from PAN-OS",
+      "description": "Response code from the firewall",
       "order": 2
     },
     "message": {

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_to_policy/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_to_policy/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Add a rule to a PAN-OS security policy"
+    DESCRIPTION = "Add a rule to a firewall security policy"
 
 
 class Input:
@@ -131,7 +131,7 @@ class AddToPolicyOutput(komand.Output):
     "code": {
       "type": "string",
       "title": "Code",
-      "description": "Response code from PAN-OS",
+      "description": "Response code from firewall",
       "order": 2
     },
     "message": {

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/commit/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/commit/schema.py
@@ -55,7 +55,7 @@ class CommitOutput(komand.Output):
     "response": {
       "type": "object",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   }

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/delete/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/delete/schema.py
@@ -47,7 +47,7 @@ class DeleteOutput(komand.Output):
     "response": {
       "$ref": "#/definitions/config",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   },

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/edit/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/edit/schema.py
@@ -55,7 +55,7 @@ class EditOutput(komand.Output):
     "response": {
       "type": "object",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   }

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/get/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/get/schema.py
@@ -47,7 +47,7 @@ class GetOutput(komand.Output):
     "response": {
       "$ref": "#/definitions/config",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   },

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/op/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/op/schema.py
@@ -44,7 +44,7 @@ class OpOutput(komand.Output):
     "response": {
       "type": "object",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   }

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/remove_from_policy/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/remove_from_policy/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Remove a rule from a PAN-OS security policy"
+    DESCRIPTION = "Remove a rule from a firewall security policy"
 
 
 class Input:
@@ -131,7 +131,7 @@ class RemoveFromPolicyOutput(komand.Output):
     "code": {
       "type": "string",
       "title": "Code",
-      "description": "Response code from PAN-OS",
+      "description": "Response code from the firewall",
       "order": 2
     },
     "message": {

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/retrieve_logs/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/retrieve_logs/schema.py
@@ -103,7 +103,7 @@ class RetrieveLogsOutput(komand.Output):
     "response": {
       "$ref": "#/definitions/log",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   },

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set/schema.py
@@ -55,7 +55,7 @@ class SetOutput(komand.Output):
     "response": {
       "type": "object",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   }

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
@@ -81,7 +81,7 @@ class SetAddressObjectOutput(komand.Output):
     "code": {
       "type": "string",
       "title": "Code",
-      "description": "Response code from PAN-OS",
+      "description": "Response code from the firewall",
       "order": 2
     },
     "message": {

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_security_policy_rule/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_security_policy_rule/schema.py
@@ -63,7 +63,7 @@ class SetSecurityPolicyRuleInput(komand.Input):
     "disable_server_response_inspection": {
       "type": "boolean",
       "title": "Disable Server Response Inspection",
-      "description": "If true, PAN-OS will not inspect this traffic",
+      "description": "If true, the firewall will not inspect this traffic",
       "order": 8
     },
     "disabled": {
@@ -167,7 +167,7 @@ class SetSecurityPolicyRuleOutput(komand.Output):
     "response": {
       "$ref": "#/definitions/config",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   },

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/show/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/show/schema.py
@@ -47,7 +47,7 @@ class ShowOutput(komand.Output):
     "response": {
       "$ref": "#/definitions/config",
       "title": "Response",
-      "description": "Response from PAN-OS",
+      "description": "Response from the firewall",
       "order": 1
     }
   },

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/connection/schema.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/connection/schema.py
@@ -24,13 +24,13 @@ class ConnectionSchema(komand.Input):
     "server": {
       "type": "string",
       "title": "Server",
-      "description": "URL pointing to instance of PAN-OS",
+      "description": "URL pointing to instance of a Palo Alto firewall",
       "order": 1
     },
     "verify_cert": {
       "type": "boolean",
       "title": "Verify Cert",
-      "description": "If true, validate the server's TLS certificate when contacting PAN-OS over HTTPS",
+      "description": "If true, validate the server's TLS certificate when contacting the firewall over HTTPS",
       "order": 3
     }
   },

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -2,8 +2,8 @@ plugin_spec_version: v2
 extension: plugin
 products: [insightconnect]
 name: palo_alto_pan_os
-title: Palo Alto PAN-OS
-description: Manage Palo Alto Networks devices via PAN-OS
+title: Palo Alto Firewall
+description: Manage Palo Alto Networks firewall devices
 version: 4.0.0
 vendor: rapid7
 support: rapid7
@@ -31,7 +31,7 @@ connection:
   server:
     title: Server
     type: string
-    description: URL pointing to instance of PAN-OS
+    description: URL pointing to instance of a Palo Alto firewall
     required: true
   credentials:
     title: Credentials
@@ -41,7 +41,7 @@ connection:
   verify_cert:
     title: Verify Cert
     type: boolean
-    description: If true, validate the server's TLS certificate when contacting PAN-OS
+    description: If true, validate the server's TLS certificate when contacting the firewall
       over HTTPS
     required: true
 actions:
@@ -91,7 +91,7 @@ actions:
         required: true
       disable_server_response_inspection:
         title: Disable Server Response Inspection
-        description: If true, PAN-OS will not inspect this traffic
+        description: If true, the firewall will not inspect this traffic
         type: boolean
         required: true
       negate_source:
@@ -137,7 +137,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: config
         required: false
   show:
@@ -152,7 +152,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: config
         required: false
   get:
@@ -167,7 +167,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: config
         required: false
   delete:
@@ -182,7 +182,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: config
         required: false
   set:
@@ -202,7 +202,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: object
         required: false
   edit:
@@ -223,7 +223,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: object
         required: false
   commit:
@@ -244,7 +244,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: object
         required: false
   op:
@@ -259,7 +259,7 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: object
         required: false
   retrieve_logs:
@@ -321,12 +321,12 @@ actions:
     output:
       response:
         title: Response
-        description: Response from PAN-OS
+        description: Response from the firewall
         type: log
         required: false
   add_to_policy:
     title: Add to Policy
-    description: Add a rule to a PAN-OS security policy
+    description: Add a rule to a firewall security policy
     input:
       rule_name:
         title: Rule Name
@@ -405,7 +405,7 @@ actions:
         required: false
       code:
         title: Code
-        description: Response code from PAN-OS
+        description: Response code from firewall
         type: string
         required: false
       message:
@@ -415,7 +415,7 @@ actions:
         required: false
   remove_from_policy:
     title: Remove from Policy
-    description: Remove a rule from a PAN-OS security policy
+    description: Remove a rule from a firewall security policy
     input:
       rule_name:
         title: Rule Name
@@ -494,7 +494,7 @@ actions:
         required: false
       code:
         title: Code
-        description: Response code from PAN-OS
+        description: Response code from the firewall
         type: string
         required: false
       message:
@@ -509,7 +509,7 @@ actions:
       name:
         title: The Name of the List
         description: An arbitrary name for the list. This name will be used to identify
-          the list in PAN-OS
+          the list in the firewall
         type: string
         required: true
       list_type:
@@ -597,7 +597,7 @@ actions:
         required: false
       code:
         title: Code
-        description: Response code from PAN-OS
+        description: Response code from the firewall
         type: string
         required: false
       message:
@@ -649,7 +649,7 @@ actions:
         required: false
       code:
         title: Code
-        description: Response code from PAN-OS
+        description: Response code from the firewall
         type: string
         required: false
       message:

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto Firewall
 description: Manage Palo Alto Networks firewall devices
-version: 4.0.0
+version: 5.0.0
 vendor: rapid7
 support: rapid7
 status: []

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -33,17 +33,20 @@ connection:
     type: string
     description: URL pointing to instance of a Palo Alto firewall
     required: true
+    example: http://www.example.com
   credentials:
     title: Credentials
     description: Username and password
     type: credential_username_password
     required: true
+    example: '{"username":"username", "password":"password"}'
   verify_cert:
     title: Verify Cert
     type: boolean
     description: If true, validate the server's TLS certificate when contacting the firewall
       over HTTPS
     required: true
+    example: true
 actions:
   set_security_policy_rule:
     title: Set Security Policy Rule

--- a/palo_alto_pan_os/setup.py
+++ b/palo_alto_pan_os/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
-      version="4.0.0",
+      version="5.0.0",
       description="Manage Palo Alto Networks firewall devices",
       author="rapid7",
       author_email="",

--- a/palo_alto_pan_os/setup.py
+++ b/palo_alto_pan_os/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
       version="4.0.0",
-      description="Manage Palo Alto Networks devices via PAN-OS",
+      description="Manage Palo Alto Networks firewall devices",
       author="rapid7",
       author_email="",
       url="",


### PR DESCRIPTION
## Proposed Changes

This PR rebrands the Palo Alto Pan-OS plugin to Palo Alto Firewall

## Verification: 
Note: Verification errors are the result of verification bugs
```
rmt-mbp-5357:palo_alto_pan_os jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
Validator "TitleValidator" failed!
	Cause: ("actions key 'check_if_address_object_in_group''s title ends with period when it should not.", ValidationException("Title contains a lowercase 'if' when it should not."))
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
Input violations: Action -> "Create Address Object": Missing ["|whitelist|[]string|None|False|This list contains a set of network objects that should not be blocked. This can include IPs, CIDR notation, or domains. It can not include an IP range (such as 10.0.0.0-10.0.0.10)|None|['198.51.100.100', '192.0.2.0/24', 'example.com']|"] in help.md
Validator "HelpInputOutputValidator" failed!
	Cause: Help.md is not in sync with plugin.spec.yaml. Please regenerate help.md by running 'icon-plugin generate python --regenerate' to rectify violations.
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*]Plugin failed validation!

----
[*] Total time elapsed: 435.76ms
```

## Testing: 
```
rmt-mbp-5357:palo_alto_pan_os jmcadams$ ./run.sh -R tests/set_address_object.json -j
Running: cat tests/set_address_object.json | docker run --rm   -i rapid7/palo_alto_pan_os:4.0.0  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Connect: Connecting..
Starting new HTTPS connection (1): pa-vm-9-0.vuln.lax.rapid7.com:443
/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
https://pa-vm-9-0.vuln.lax.rapid7.com:443 "GET /api/?type=keygen&user=admin&password=notpassword HTTP/1.1" 200 200
Key obtained
rapid7/Palo Alto Firewall:4.0.0. Step name: set_address_object
/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
https://pa-vm-9-0.vuln.lax.rapid7.com:443 "POST /api/?type=config&action=set&key=LUFRPT1EM1FoWnVhaThqWk9VWXVBRXNzanNGOTBZdzg9VlI1REg0YUdFOHA5aHMzTk9kT3JINkZYbTdRNUtEa3pzUlZkeXpURTBvWU5FVXp1M291a1hmTVJNSWNEbmxERA%3D%3D&xpath=%2Fconfig%2Fdevices%2Fentry%2Fvsys%2Fentry%2Faddress%2Fentry%5B%40name%3D%27ICON+IP%27%5D&element=%3Cip-netmask%3E1.1.1.5%3C%2Fip-netmask%3E%3Cdescription%3EA+Test+from+ICON%3C%2Fdescription%3E HTTP/1.1" 200 76
Connect: Connecting..
Key obtained
rapid7/Palo Alto Firewall:4.0.0. Step name: set_address_object

{
  "message": "command succeeded",
  "status": "success",
  "code": "20"
}
```