### PR TITLE
Palo Alto - fixed help

### DIFF
--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -185,6 +185,11 @@ This action is used to get a policy.
 Example input:
 
 ```
+{
+  "device_name": "localhost.localdomain",
+  "policy_name": "InsightConnect Block Policy",
+  "virtual_system": "vsys1"
+}
 ```
 
 ##### Output


### PR DESCRIPTION
This PR fixes missing input example in Palo Alto Firewall help

## Testing: 
None - Doc only change. 