### PR TITLE
[WIP][SOAR-1278] - Fix crash in whois plugin

### DIFF
--- a/whois/.CHECKSUM
+++ b/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "45c5de9ecfdc746c7b0228fbee0ef756",
-	"manifest": "081008b9d5c0cba6deb421179ceaad08",
-	"setup": "6cf000c28d5f90fe2b89ba4e858c4d2e",
+	"spec": "226ad3eeabcca864f4daf8d4be21ec62",
+	"manifest": "ba337aede390f0c7a3c9361e8b22724e",
+	"setup": "552fca45fbe4189042a1536392a97c24",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",
@@ -14,6 +14,42 @@
 		{
 			"identifier": "connection/schema.py",
 			"hash": "da5382221ca2a33a2f854e17b068d502"
+		},
+		{
+			"identifier": "insightconnect_plugin_runtime/schema.py",
+			"hash": "98e2cf8bf394d0b6f97cdfeb657ea71b"
+		},
+		{
+			"identifier": "marshmallow/schema.py",
+			"hash": "7c9fc22caa77ab8be9957e79867f426a"
+		},
+		{
+			"identifier": "hello/schema.py",
+			"hash": "92ec4b966e523fe43b8d3e1589ecd235"
+		},
+		{
+			"identifier": "return_bad_json/schema.py",
+			"hash": "bb41c13e9e71e212c1545150a16f8b73"
+		},
+		{
+			"identifier": "throw_exception/schema.py",
+			"hash": "f59f8278af731495ae3b2367744224f2"
+		},
+		{
+			"identifier": "connection/schema.py",
+			"hash": "f1bf7d508c81c245888665a322d984e8"
+		},
+		{
+			"identifier": "hello_trigger/schema.py",
+			"hash": "6fda62f9b28a899e2ecb7aab1311bbb2"
+		},
+		{
+			"identifier": "return_bad_json_trigger/schema.py",
+			"hash": "9a207816ba5b0ab0f9e4f40d86c4cc3e"
+		},
+		{
+			"identifier": "throw_exception_trigger/schema.py",
+			"hash": "23e4aee31e1c532d9ed50830efad1b8d"
 		}
 	]
 }

--- a/whois/.CHECKSUM
+++ b/whois/.CHECKSUM
@@ -14,42 +14,6 @@
 		{
 			"identifier": "connection/schema.py",
 			"hash": "da5382221ca2a33a2f854e17b068d502"
-		},
-		{
-			"identifier": "insightconnect_plugin_runtime/schema.py",
-			"hash": "98e2cf8bf394d0b6f97cdfeb657ea71b"
-		},
-		{
-			"identifier": "marshmallow/schema.py",
-			"hash": "7c9fc22caa77ab8be9957e79867f426a"
-		},
-		{
-			"identifier": "hello/schema.py",
-			"hash": "92ec4b966e523fe43b8d3e1589ecd235"
-		},
-		{
-			"identifier": "return_bad_json/schema.py",
-			"hash": "bb41c13e9e71e212c1545150a16f8b73"
-		},
-		{
-			"identifier": "throw_exception/schema.py",
-			"hash": "f59f8278af731495ae3b2367744224f2"
-		},
-		{
-			"identifier": "connection/schema.py",
-			"hash": "f1bf7d508c81c245888665a322d984e8"
-		},
-		{
-			"identifier": "hello_trigger/schema.py",
-			"hash": "6fda62f9b28a899e2ecb7aab1311bbb2"
-		},
-		{
-			"identifier": "return_bad_json_trigger/schema.py",
-			"hash": "9a207816ba5b0ab0f9e4f40d86c4cc3e"
-		},
-		{
-			"identifier": "throw_exception_trigger/schema.py",
-			"hash": "23e4aee31e1c532d9ed50830efad1b8d"
 		}
 	]
 }

--- a/whois/Dockerfile
+++ b/whois/Dockerfile
@@ -7,14 +7,17 @@ ENV SSL_CERT_FILE /etc/ssl/certs/ca-certificates.crt
 ENV SSL_CERT_DIR /etc/ssl/certs
 ENV REQUESTS_CA_BUNDLE  /etc/ssl/certs/ca-certificates.crt
 
-ADD ./whois.conf /etc/whois.conf
+# ADD ./whois.conf /etc/whois.conf
 ADD ./plugin.spec.yaml /plugin.spec.yaml
 ADD . /python/src
 
 WORKDIR /python/src
+
 # Add any package dependencies here
-RUN apt-get update && apt-get install -y whois git
-RUN pip install git+https://github.com/komand/python-whois.git@0.4.2
+# Removed our fork in 2.0.2
+RUN apt-get update && apt-get install -y whois
+# git
+# RUN pip install git+https://github.com/komand/python-whois.git@0.4.2
 
 # End package dependencies
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi

--- a/whois/bin/komand_whois
+++ b/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from komand_whois import connection, actions, triggers
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "2.0.1"
+Version = "2.0.2"
 Description = "The WHOIS plugin enables address and domain lookups in the WHOIS databases"
 
 

--- a/whois/help.md
+++ b/whois/help.md
@@ -97,7 +97,7 @@ Example input:
 
 ```
 {
-  "address": "185.231.155.180"
+  "address": "198.51.100.100"
 }
 ```
 
@@ -169,6 +169,7 @@ _This plugin has no references._
 
 # Version History
 
+* 2.0.2 - Fix issue where certain domains could cause an exception
 * 2.0.1 - Update to v4 Python plugin runtime
 * 2.0.0 - Add example inputs | Fix capitalization in the title of the `last_updated` output.
 * 1.0.7 - Upgrade komand/python-whois version to 0.4.2 | Update whois.conf to support .in domains | Updated help.md for the Extension Library

--- a/whois/help.md
+++ b/whois/help.md
@@ -137,9 +137,9 @@ Example output:
   "postal": "98109",
   "country": "US",
   "org_tech_phone": "+1-206-266-4064",
-  "org_tech_email": "amzn-noc-contact@amazon.com",
+  "org_tech_email": "user@example.com",
   "org_abuse_phone": "+1-206-266-4064",
-  "org_abuse_email": "abuse@amazonaws.com"
+  "org_abuse_email": "user@example.com"
 }
 ```
 

--- a/whois/help.md
+++ b/whois/help.md
@@ -64,23 +64,19 @@ Example input:
 Example output:
 
 ```
-
 {
-  "registrar_whois_server": "whois.markmonitor.com",
-  "registry_domain_id": "2138514_domain_com-vrsn",
-  "last_updated": "2011-07-20T16:55:31",
-  "registrar_iana_id": "292",
+  "name": "rapid7.com",
   "registrar": "MarkMonitor Inc.",
-  "dnssec": "unsigned",
-  "domain_status": ["clientdeleteprohibited https://icann.org/epp#clientdeleteprohibited", "clienttransferprohibited https://icann.org/epp#clienttransferprohibited", "clientupdateprohibited https://icann.org/epp#clientupdateprohibited", "serverdeleteprohibited https://icann.org/epp#serverdeleteprohibited", "servertransferprohibited https://icann.org/epp#servertransferprohibited", "serverupdateprohibited https://icann.org/epp#serverupdateprohibited"],
-  "registrar_url": "http://www.markmonitor.com",
-  "creation_date": "1997-09-15T04:00:00",
-  "name_servers": ["ns2.google.com", "ns3.google.com", "ns1.google.com", "ns4.google.com"],
-  "registrar_abuse_contact_email": "user@example.com",
-  "registrar_abuse_contact_phone": "+1.2083895740",
-  "name": "google.com"
+  "creation_date": "2000-05-25 19:00:54",
+  "expiration_date": "2021-05-25 19:00:54",
+  "status": "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited",
+  "name_servers": [
+    "ns-1653.awsdns-14.co.uk",
+    "ns-439.awsdns-54.com",
+    "ns-1390.awsdns-45.org",
+    "ns-739.awsdns-28.net"
+  ]
 }
-
 ```
 
 #### Address Lookup
@@ -126,27 +122,25 @@ Example input:
 Example output:
 
 ```
-
 {
-  "address": "1025 Eldorado Blvd.",
-  "cidr": "8.0.0.0/8",
-  "city": "Broomfield",
+  "netrange": "54.240.128.0 - 54.240.191.255",
+  "cidr": "54.240.128.0/18",
+  "netname": "AMAZO-CF1",
+  "nettype": "Reallocated",
+  "organization": "A100 US LLC (UL-42)",
+  "regdate": "2013-01-30",
+  "update": "2014-07-01",
+  "orgname": "A100 US LLC",
+  "address": "1919 8th Ave",
+  "city": "Seattle",
+  "state": "WA",
+  "postal": "98109",
   "country": "US",
-  "netname": "LVLT-ORG-8-8",
-  "netrange": "8.0.0.0 - 8.255.255.255",
-  "nettype": "Direct Allocation",
-  "org_abuse_email": "user@example.com",
-  "org_abuse_phone": "+1-877-453-8353 ",
-  "org_tech_email": "user@example.com",
-  "org_tech_phone": "+1-877-453-8353 ",
-  "organization": "Level 3 Communications, Inc. (LVLT)",
-  "orgname": "Level 3 Communications, Inc.",
-  "postal": "80021",
-  "regdate": "1992-12-01",
-  "state": "CO",
-  "update": "2012-02-24"
+  "org_tech_phone": "+1-206-266-4064",
+  "org_tech_email": "amzn-noc-contact@amazon.com",
+  "org_abuse_phone": "+1-206-266-4064",
+  "org_abuse_email": "abuse@amazonaws.com"
 }
-
 ```
 
 ### Triggers

--- a/whois/komand_whois/actions/domain/action.py
+++ b/whois/komand_whois/actions/domain/action.py
@@ -1,11 +1,10 @@
 import insightconnect_plugin_runtime
-from .schema import DomainInput, DomainOutput, Input, Output
+from .schema import DomainInput, DomainOutput, Input
 
 # Custom imports below
 import whois
 import datetime
 from insightconnect_plugin_runtime.exceptions import PluginException
-
 
 class Domain(insightconnect_plugin_runtime.Action):
 
@@ -25,7 +24,7 @@ class Domain(insightconnect_plugin_runtime.Action):
                                   assistance="Ensure the domain is not prefixed with a protocol.")
 
         try:
-            lookup_results = whois.query(domain, ignore_returncode=1)  # ignore_returncode required for plugin
+            lookup_results = whois.query(domain, ignore_returncode=1)  # ignore_return code required for plugin
         except Exception as e:
             self.logger.error("Error occurred: %s" % e)
             raise e

--- a/whois/komand_whois/actions/domain/action.py
+++ b/whois/komand_whois/actions/domain/action.py
@@ -1,5 +1,5 @@
 import insightconnect_plugin_runtime
-from .schema import DomainInput, DomainOutput, Input
+from .schema import DomainInput, DomainOutput, Input, Output
 
 # Custom imports below
 import whois

--- a/whois/komand_whois/actions/domain/action.py
+++ b/whois/komand_whois/actions/domain/action.py
@@ -27,7 +27,8 @@ class Domain(insightconnect_plugin_runtime.Action):
             lookup_results = whois.query(domain, ignore_returncode=1)  # ignore_return code required for plugin
         except Exception as e:
             self.logger.error("Error occurred: %s" % e)
-            raise e
+            raise PluginException(cause="The whois command failed.",
+                                  assistance=f"{e}")
 
         result_dict = insightconnect_plugin_runtime.helper.clean_dict(lookup_results.__dict__)
 

--- a/whois/plugin.spec.yaml
+++ b/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: The WHOIS plugin enables address and domain lookups in the WHOIS databases
-version: 2.0.1
+version: 2.0.2
 vendor: rapid7
 support: community
 status: []

--- a/whois/requirements.txt
+++ b/whois/requirements.txt
@@ -1,3 +1,4 @@
-# List third-party dependencies here, separated by newlines. 
+# List third-party dependencies here, separated by newlines.
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
+whois==0.9.7

--- a/whois/setup.py
+++ b/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="2.0.1",
+      version="2.0.2",
       description="The WHOIS plugin enables address and domain lookups in the WHOIS databases",
       author="rapid7",
       author_email="",

--- a/whois/unit_test/test_address.py
+++ b/whois/unit_test/test_address.py
@@ -1,0 +1,72 @@
+import sys
+import os
+sys.path.append(os.path.abspath('../'))
+
+from unittest import TestCase
+from komand_whois.connection.connection import Connection
+from komand_whois.actions.address import Address
+import json
+import logging
+
+
+class TestAddress(TestCase):
+    def test_integration_address(self):
+        """
+        TODO: Implement assertions at the end of this test case
+
+        This is an integration test that will connect to the services your plugin uses. It should be used
+        as the basis for tests below that can run independent of a "live" connection.
+
+        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
+        be json samples that contain all the data needed to run this test. To generate samples run:
+
+        icon-plugin generate samples
+
+        """
+
+        log = logging.getLogger("Test")
+        test_conn = Connection()
+        test_action = Address()
+
+        test_conn.logger = log
+        test_action.logger = log
+
+        try:
+            with open("../tests/address.json") as file:
+                test_json = json.loads(file.read()).get("body")
+                connection_params = test_json.get("connection")
+                action_params = test_json.get("input")
+        except Exception as e:
+            message = """
+            Could not find or read sample tests from /tests directory
+            
+            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
+            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
+            """
+            self.fail(message)
+
+
+        test_conn.connect(connection_params)
+        test_action.connection = test_conn
+        results = test_action.run(action_params)
+
+        # TODO: Remove this line
+        self.fail("Unimplemented test case")
+
+        # TODO: The following assert should be updated to look for data from your action
+        # For example: self.assertEquals({"success": True}, results) 
+        self.assertEquals({}, results)
+
+    def test_address(self):
+        """
+        TODO: Implement test cases here
+
+        Here you can mock the connection with data returned from the above integration test.
+        For information on mocking and unit testing please go here:
+
+        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
+
+        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
+        action for testing.
+        """
+        self.fail("Unimplemented Test Case")

--- a/whois/unit_test/test_domain.py
+++ b/whois/unit_test/test_domain.py
@@ -1,0 +1,41 @@
+import sys
+import os
+sys.path.append(os.path.abspath('../'))
+
+from unittest import TestCase
+from komand_whois.connection.connection import Connection
+from komand_whois.actions.domain import Domain
+import json
+import logging
+
+
+class TestDomain(TestCase):
+    def test_integration_domain(self):
+        log = logging.getLogger("Test")
+        test_conn = Connection()
+        test_action = Domain()
+
+        test_conn.logger = log
+        test_action.logger = log
+
+        try:
+            with open("../tests/domain.json") as file:
+                test_json = json.loads(file.read()).get("body")
+                connection_params = test_json.get("connection")
+                action_params = test_json.get("input")
+        except Exception as e:
+            message = """
+            Could not find or read sample tests from /tests directory
+            
+            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
+            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
+            """
+            self.fail(message)
+
+
+        test_conn.connect(connection_params)
+        test_action.connection = test_conn
+        results = test_action.run(action_params)
+
+        print(results)
+        self.assertIsNotNone(results)


### PR DESCRIPTION
## Proposed Changes

This fixes an issue where certain domains could crash the whois plugin

## Valdiation: 
```
rmt-mbp-5357:whois jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 112.098ms
```

## Tests: 
```
rmt-mbp-5357:whois jmcadams$ ./run.sh -R all
Running: cat tests/address.json | docker run --rm   -i rapid7/whois:2.0.2  run
rapid7/WHOIS:2.0.2. Step name: address
Info: Using registry: arin
{"body": {"log": "rapid7/WHOIS:2.0.2. Step name: address\nInfo: Using registry: arin\n", "status": "ok", "meta": {}, "output": {"netrange": "54.240.128.0 - 54.240.191.255", "cidr": "54.240.128.0/18", "netname": "AMAZO-CF1", "nettype": "Reallocated", "organization": "A100 US LLC (UL-42)", "regdate": "2013-01-30", "update": "2014-07-01", "orgname": "A100 US LLC", "address": "1919 8th Ave", "city": "Seattle", "state": "WA", "postal": "98109", "country": "US", "org_abuse_phone": "+1-206-266-4064", "org_abuse_email": "abuse@amazonaws.com", "org_tech_phone": "+1-206-266-4064", "org_tech_email": "amzn-noc-contact@amazon.com"}}, "version": "v1", "type": "action_event"}
Running: cat tests/domain.json | docker run --rm   -i rapid7/whois:2.0.2  run
rapid7/WHOIS:2.0.2. Step name: domain
Getting whois information for stuff.com.br
{"body": {"log": "rapid7/WHOIS:2.0.2. Step name: domain\nGetting whois information for stuff.com.br\n", "status": "ok", "meta": {}, "output": {"name": "stuff.com.br", "registrar": "Nic.br", "creation_date": "2002-07-05 00:00:00", "expiration_date": "2021-07-05 00:00:00", "last_updated": "2019-01-17 00:00:00", "status": "published", "name_servers": ["ns13.wixdns.net", "ns12.wixdns.net"], "owner": "Patricia Rodrigues da Silva e Cia Ltda"}}, "version": "v1", "type": "action_event"}
Running: cat tests/domain2.json | docker run --rm   -i rapid7/whois:2.0.2  run
rapid7/WHOIS:2.0.2. Step name: domain
Getting whois information for www.google.com
{"body": {"log": "rapid7/WHOIS:2.0.2. Step name: domain\nGetting whois information for www.google.com\n", "status": "ok", "meta": {}, "output": {"name": "google.com", "registrar": "MarkMonitor Inc.", "creation_date": "1997-09-15 04:00:00", "expiration_date": "2028-09-14 04:00:00", "status": "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited", "name_servers": ["ns4.google.com", "ns3.google.com", "ns1.google.com", "ns2.google.com"]}}, "version": "v1", "type": "action_event"}
Running: cat tests/domain3.json | docker run --rm   -i rapid7/whois:2.0.2  run
rapid7/WHOIS:2.0.2. Step name: domain
Getting whois information for www.rapid7.com
{"body": {"log": "rapid7/WHOIS:2.0.2. Step name: domain\nGetting whois information for www.rapid7.com\n", "status": "ok", "meta": {}, "output": {"name": "rapid7.com", "registrar": "MarkMonitor Inc.", "creation_date": "2000-05-25 19:00:54", "expiration_date": "2021-05-25 19:00:54", "status": "clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited", "name_servers": ["ns-739.awsdns-28.net", "ns-1390.awsdns-45.org", "ns-439.awsdns-54.com", "ns-1653.awsdns-14.co.uk"]}}, "version": "v1", "type": "action_event"}
```