### PR TITLE
Cylance Protect - Add SHA256 input validation in Blacklist action

### DIFF
--- a/cylance_protect/.CHECKSUM
+++ b/cylance_protect/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "31100ce5f063d09a75b19007dd1c6a53",
-	"manifest": "9c6975231ecafd32b792fb7405a27148",
-	"setup": "c403ba35414f4d61679a7c226c403f76",
+	"spec": "2b192fbcf4c7f9d179fd3cbf3d4d94ee",
+	"manifest": "73bdeac5def193717bff00c5e87ffbcc",
+	"setup": "95e482d4f690a54b546e1582f5191a8b",
 	"schemas": [
 		{
 			"identifier": "blacklist/schema.py",

--- a/cylance_protect/bin/icon_cylance_protect
+++ b/cylance_protect/bin/icon_cylance_protect
@@ -6,7 +6,7 @@ from icon_cylance_protect import connection, actions, triggers
 
 Name = "Blackberry CylancePROTECT"
 Vendor = "rapid7"
-Version = "1.0.0"
+Version = "1.0.1"
 Description = "Automate detection and response operations using CylancePROTECT"
 
 

--- a/cylance_protect/help.md
+++ b/cylance_protect/help.md
@@ -149,6 +149,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.0.1 - Add SHA256 input validation in Blacklist action
 * 1.0.0 - Initial plugin
 
 # Links

--- a/cylance_protect/icon_cylance_protect/actions/blacklist/action.py
+++ b/cylance_protect/icon_cylance_protect/actions/blacklist/action.py
@@ -18,8 +18,8 @@ class Blacklist(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         sha1_hash = params.get(Input.HASH)
         if not match(r"^[A-Fa-f0-9]{64}$", sha1_hash):
-            raise PluginException(cause="Wrong HASH.",
-                                  assistance="API supported only SHA256. Make sure you enter correct HASH.")
+            raise PluginException(cause="The Cylance API only supports SHA256.",
+                                  assistance="Please enter a SHA256 hash and try again.")
 
         if params.get(Input.BLACKLIST_STATE) is True:
             errors = self.connection.client.create_blacklist_item({

--- a/cylance_protect/icon_cylance_protect/actions/blacklist/action.py
+++ b/cylance_protect/icon_cylance_protect/actions/blacklist/action.py
@@ -1,3 +1,5 @@
+from re import match
+
 import insightconnect_plugin_runtime
 from .schema import BlacklistInput, BlacklistOutput, Input, Output, Component
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -15,6 +17,10 @@ class Blacklist(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         sha1_hash = params.get(Input.HASH)
+        if not match(r"^[A-Fa-f0-9]{64}$", sha1_hash):
+            raise PluginException(cause="Wrong HASH.",
+                                  assistance="API supported only SHA256. Make sure you enter correct HASH.")
+
         if params.get(Input.BLACKLIST_STATE) is True:
             errors = self.connection.client.create_blacklist_item({
                 "sha256": sha1_hash,

--- a/cylance_protect/plugin.spec.yaml
+++ b/cylance_protect/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: cylance_protect
 title: Blackberry CylancePROTECT
 description: Automate detection and response operations using CylancePROTECT
-version: 1.0.0
+version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []

--- a/cylance_protect/setup.py
+++ b/cylance_protect/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="cylance_protect-rapid7-plugin",
-      version="1.0.0",
+      version="1.0.1",
       description="Automate detection and response operations using CylancePROTECT",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Add SHA256 input validation in Blacklist action

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/Blackberry CylancePROTECT:1.0.0. Step name: blacklist\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/cylance_protect:1.0.0 --debug run < tests/blacklist.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.",
    "log": "Connect: Connecting...\nrapid7/Blackberry CylancePROTECT:1.0.0. Step name: blacklist\nAn error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 307, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 428, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/cylance_protect_rapid7_plugin-1.0.0-py3.8.egg/icon_cylance_protect/actions/blacklist/action.py\", line 21, in run\n    raise PluginException(cause=\"Wrong HASH.\",\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/cylance_protect:1.0.0 --debug run < tests/blacklist_numbers_bad.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.",
    "log": "Connect: Connecting...\nrapid7/Blackberry CylancePROTECT:1.0.0. Step name: blacklist\nAn error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 307, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 428, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/cylance_protect_rapid7_plugin-1.0.0-py3.8.egg/icon_cylance_protect/actions/blacklist/action.py\", line 21, in run\n    raise PluginException(cause=\"Wrong HASH.\",\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/cylance_protect:1.0.0 --debug run < tests/blacklist_sha1_bad.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.",
    "log": "Connect: Connecting...\nrapid7/Blackberry CylancePROTECT:1.0.0. Step name: blacklist\nAn error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 307, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 428, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/cylance_protect_rapid7_plugin-1.0.0-py3.8.egg/icon_cylance_protect/actions/blacklist/action.py\", line 21, in run\n    raise PluginException(cause=\"Wrong HASH.\",\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/cylance_protect:1.0.0 --debug run < tests/blacklist_sha256_with_extra_number_bad.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.",
    "log": "Connect: Connecting...\nrapid7/Blackberry CylancePROTECT:1.0.0. Step name: blacklist\nAn error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 307, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.0.2-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 428, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/cylance_protect_rapid7_plugin-1.0.0-py3.8.egg/icon_cylance_protect/actions/blacklist/action.py\", line 21, in run\n    raise PluginException(cause=\"Wrong HASH.\",\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nWrong HASH. API supported only SHA256. Make sure you enter correct HASH.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/cylance_protect:1.0.0 --debug run < tests/blacklist_text_bad.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[136]: https://protectapi.cylance.com
violation: plugin.spec.yaml[137]: https://protectapi.cylance.com
[*] Plugin successfully validated!

----
[*] Total time elapsed: 21760.003ms

```

<summary>
icon-validate --all .
</summary>
</details>
