### PR TITLE
Carbon Black Cloud - Fixed get in retry call

### DIFF
--- a/carbon_black_cloud/.CHECKSUM
+++ b/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "f1e3bcb8062f0509e80e80f33230a9fc",
-	"manifest": "6b93a1a0545b7d519d935dc7e35611f8",
-	"setup": "7805185cea6be573129c3da4ba66e7a8",
+	"spec": "e7d6ff63d149b8a758fa81fde7ef7b14",
+	"manifest": "63c0eb99d432e4939d1557e47afdf361",
+	"setup": "7157d9a27a7a809f4db2c7e527a935da",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from icon_carbon_black_cloud import connection, actions, triggers
 
 Name = "Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "1.0.0"
+Version = "1.0.1"
 Description = "Quarantine endpoints and get device details with the VMware Carbon Black Cloud plugin"
 
 

--- a/carbon_black_cloud/help.md
+++ b/carbon_black_cloud/help.md
@@ -17,8 +17,6 @@ Manage and contain threats on your Carbon Black endpoints using this plugin.
 
 ## Setup
 
-For information on how to get the API credentials and your base URL please see the [Carbon Black Authentication](https://developer.carbonblack.com/reference/carbon-black-cloud/authentication/) documentation.
-
 The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|
@@ -214,6 +212,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.0.1 - Fix issue where retry on error call could crash plugin
 * 1.0.0 - Initial plugin
 
 # Links

--- a/carbon_black_cloud/help.md
+++ b/carbon_black_cloud/help.md
@@ -17,6 +17,8 @@ Manage and contain threats on your Carbon Black endpoints using this plugin.
 
 ## Setup
 
+For information on how to get the API credentials and your base URL please see the [Carbon Black Authentication](https://developer.carbonblack.com/reference/carbon-black-cloud/authentication/) documentation.
+
 The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|

--- a/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
+++ b/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
@@ -83,7 +83,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
                                       data=result.text)
             if result.status_code == 503: # This is usually an API limit error or server error, try again
                 time.sleep(5)
-                result = requests.get(url, headers=self.headers, json=payload)
+                result = requests.post(url, headers=self.headers, json=payload)
 
                 try:
                     result.raise_for_status()

--- a/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
+++ b/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
@@ -89,7 +89,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 self.logger.error("Retry on 503 failed.")
                 self.logger.error(str(e))
                 self.logger.error(result.text)
-                raise PluginException.Preset.UNKNOWN
+                raise PluginException(PluginException.Preset.UNKNOWN)
 
         if result.status_code != 204:
             return result.json()

--- a/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
+++ b/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
@@ -91,14 +91,6 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 self.logger.error(result.text)
                 raise PluginException.Preset.UNKNOWN
 
-
-
-
-            self.logger.error(f"Exception was:\n{e}")
-            self.logger.error(f"Result text was:\n{result.text}")
-            raise PluginException(PluginException.Preset.UNKNOWN)
-
-
         if result.status_code != 204:
             return result.json()
         else:

--- a/carbon_black_cloud/plugin.spec.yaml
+++ b/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: Carbon Black Cloud
 description: Quarantine endpoints and get device details with the VMware Carbon Black Cloud plugin
-version: 1.0.0
+version: 1.0.1
 vendor: rapid7
 support: rapid7
 status: []

--- a/carbon_black_cloud/setup.py
+++ b/carbon_black_cloud/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="carbon_black_cloud-rapid7-plugin",
-      version="1.0.0",
+      version="1.0.1",
       description="Quarantine endpoints and get device details with the VMware Carbon Black Cloud plugin",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

This PR fixes an issue where if a retry was needed on 503, the connection would call "get" instead of "post" 

## Validation: 
```
rmt-mbp-5357:carbon_black_cloud jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 791.3639999999999ms
```


## Tests:
```
rmt-mbp-5357:carbon_black_cloud jmcadams$ ./run.sh -R tests/get_agent_details.json -j
Running: cat tests/get_agent_details.json | docker run --rm   -i rapid7/carbon_black_cloud:1.0.1  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
rapid7/Carbon Black Cloud:1.0.1. Step name: get_agent_details
Looking for: 10.4.23.247
Searching at https://defense.conferdeploy.net/appservices/v6/orgs/7DESJ9GN/devices/_search
Starting new HTTPS connection (1): defense.conferdeploy.net:443
https://defense.conferdeploy.net:443 "POST /appservices/v6/orgs/7DESJ9GN/devices/_search HTTP/1.1" 200 2707
rapid7/Carbon Black Cloud:1.0.1. Step name: get_agent_details
Looking for: 10.4.23.247
Searching at https://defense.conferdeploy.net/appservices/v6/orgs/7DESJ9GN/devices/_search

{
  "agent": {
    "activation_code": "2Y536Z",
    "activation_code_expiry_time": "2020-06-04T16:22:07.105Z",
    "ad_group_id": 0,
    "av_ave_version": "8.3.60.44",
    "av_engine": "4.13.0.207-ave.8.3.60.44:avpack.8.5.0.60:vdf.8.18.2.144:apc.2.10.0.149",
    "av_master": false,
    "av_pack_version": "8.5.0.60",
    "av_product_version": "4.13.0.207",
    "av_status": [
      "AV_ACTIVE",
      "ONDEMAND_SCAN_DISABLED"
    ],
    "av_vdf_version": "8.18.2.144",
    "current_sensor_policy_name": "test",
    "device_meta_data_item_list": [
      {
        "key_name": "OS_MAJOR_VERSION",
        "key_value": "Windows",
        "position": 0
      },
      {
        "key_name": "SUBNET",
        "key_value": "128.177.65",
        "position": 0
      }
    ],
    "device_owner_id": 447874,
    "email": "sgoncharov@rapid7.com",
    "encoded_activation_code": "YVGTAQWE3UT",
    "first_name": "Serge",
    "id": 3466056,
    "last_contact_time": "2020-06-16T18:30:57.854Z",
    "last_device_policy_changed_time": "2020-06-11T08:19:47.149Z",
    "last_device_policy_requested_time": "2020-06-11T09:35:32.228Z",
    "last_external_ip_address": "128.177.65.3",
    "last_internal_ip_address": "10.4.23.247",
    "last_location": "OFFSITE",
    "last_name": "Goncharov",
    "last_policy_updated_time": "2020-02-13T03:56:45.796Z",
    "last_reported_time": "2020-06-16T18:14:50.521Z",
    "login_user_name": "CB-KOMAND-W12\\Administrator",
    "mac_address": "000000000000",
    "name": "cb-komand-w12",
    "organization_id": 1105,
    "organization_name": "cb-internal-alliances.com",
    "os": "WINDOWS",
    "os_version": "Server 2012 x64",
    "passive_mode": false,
    "policy_id": 32064,
    "policy_name": "test",
    "policy_override": true,
    "quarantined": false,
    "registered_time": "2020-05-28T16:23:17.120Z",
    "sensor_kit_type": "WINDOWS",
    "sensor_out_of_date": false,
    "sensor_pending_update": false,
    "sensor_states": [
      "ACTIVE",
      "LIVE_RESPONSE_NOT_RUNNING",
      "LIVE_RESPONSE_NOT_KILLED",
      "LIVE_RESPONSE_ENABLED",
      "SECURITY_CENTER_OPTLN_DISABLED"
    ],
    "sensor_version": "3.5.0.1680",
    "status": "REGISTERED",
    "target_priority": "HIGH",
    "uninstall_code": "ZALVZVN7",
    "virtual_machine": false,
    "virtualization_provider": "UNKNOWN"
  }
}
```