### PR TITLE
Fix issue where connection test always success

### DIFF
--- a/sql/.CHECKSUM
+++ b/sql/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "67cc98cabde9cf5e534e5aa959644fef",
-	"manifest": "9225b855a0922c4050a954e428cfa47f",
-	"setup": "16c9914b9b8ad982648c5860b5ddd3e6",
+	"spec": "53bf6570384b2fea920053542fa6961a",
+	"manifest": "c6d9ead4d14c3608bf0a59da9a9a672a",
+	"setup": "0127c726d42b520fa70566a400c73300",
 	"schemas": [
 		{
 			"identifier": "query/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "847dcf3e7a1d9b30f9aa3f12f1660234"
+			"hash": "15be07625a077440f2d46d372779d30f"
 		}
 	]
 }

--- a/sql/bin/komand_sql
+++ b/sql/bin/komand_sql
@@ -4,10 +4,10 @@ import komand
 from komand_sql import connection, actions, triggers
 
 
-Name = 'SQL'
-Vendor = 'rapid7'
-Version = '2.0.5'
-Description = 'The SQL plugin allows you to run SQL queries'
+Name = "SQL"
+Vendor = "rapid7"
+Version = "2.0.6"
+Description = "The SQL plugin allows you to run SQL queries"
 
 
 class ICONSql(komand.Plugin):

--- a/sql/help.md
+++ b/sql/help.md
@@ -19,13 +19,18 @@ This plugin allows users to run and execute queries against a SQL database.
 
 The connection configuration accepts the following parameters:
 
-  |Name|Type|Default|Required|Description|Enum|
-  |----|----|-------|--------|-----------|----|
-  |type|string|None|True|Database type (i.e. mysql, postgres... etc.)|None|
-  |host|string|None|True|Database hostname|None|
-  |port|string|None|False|Database port|None|
-  |db|string|None|True|Database name|None|
-  |credentials|credential_username_password|None|True|Database username and password|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|credentials|credential_username_password|None|True|Database username and password|None|None|
+|db|string|None|True|Database name|None|None|
+|host|string|None|True|Database hostname|None|None|
+|port|string|None|False|Database port|None|None|
+|type|string|None|True|Database type (i.e. mysql, postgres... etc.)|None|None|
+
+Example input:
+
+```
+```
 
 ## Technical Details
 
@@ -37,18 +42,23 @@ This action is used to run an arbitrary SQL query against the connected database
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|query|string|None|True|query to run|None|
-|parameters|object|None|True|parameter for parameterized query|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|parameters|object|None|False|Parameters for query|None|None|
+|query|string|None|True|Query to run|None|None|
+
+Example input:
+
+```
+```
 
 ##### Output
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|status|string|True|Status message|
 |header|[]string|False|Array of header fields for the columns|
 |results|[]object|False|Result rows, each as an object with header keys|
+|status|string|True|Status message|
 
 Example output:
 
@@ -80,6 +90,7 @@ For the SQL query action, be sure that your query is valid SQL.
 
 # Version History
 
+* 2.0.6 - Fix issue where connection test always success
 * 2.0.5 - New spec and help.md format for the Extension Library
 * 2.0.4 - Add support for Microsoft SQL server
 * 2.0.3 - Fix issue where credentials used incorrect username | Update help

--- a/sql/komand_sql/connection/connection.py
+++ b/sql/komand_sql/connection/connection.py
@@ -1,5 +1,6 @@
 import komand
 from .schema import ConnectionSchema
+from komand.exceptions import ConnectionTestException
 import sqlalchemy
 from sqlalchemy.orm import sessionmaker
 
@@ -51,7 +52,7 @@ class Connection(komand.Connection):
         self.params = params
         self.params['user'] = username
         self.params['password'] = password
-        
+
         type_connection_string = {
             'postgresql': Connection.postgres_conn_string,
             'postgres': Connection.postgres_conn_string,
@@ -66,8 +67,11 @@ class Connection(komand.Connection):
         self.logger.info("Connect: Connecting...")
 
     def test(self):
-        session = self.connection.session
-        if session:
-            return {"status": "operation success"}
-        else:
-            raise Exception("Connection was not active. Please check your connection settings.")
+        try:
+            self.connection.session.execute("select 1")
+            return True
+        except Exception as e:
+            raise ConnectionTestException(
+                cause="Unable to connect to the server.",
+                assistance="Check connection credentials."
+            )

--- a/sql/komand_sql/connection/schema.py
+++ b/sql/komand_sql/connection/schema.py
@@ -66,12 +66,14 @@ class ConnectionSchema(komand.Input):
           "title": "Password",
           "displayType": "password",
           "description": "The password",
-          "format": "password"
+          "format": "password",
+          "order": 2
         },
         "username": {
           "type": "string",
           "title": "Username",
-          "description": "The username to log in with"
+          "description": "The username to log in with",
+          "order": 1
         }
       },
       "required": [

--- a/sql/plugin.spec.yaml
+++ b/sql/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: sql
 title: SQL
 description: The SQL plugin allows you to run SQL queries
-version: 2.0.5
+version: 2.0.6
 vendor: rapid7
 support: community
 status: []

--- a/sql/setup.py
+++ b/sql/setup.py
@@ -2,12 +2,12 @@
 from setuptools import setup, find_packages
 
 
-setup(name='sql-rapid7-plugin',
-      version='2.0.5',
-      description='The SQL plugin allows you to run SQL queries',
-      author='rapid7',
-      author_email='',
-      url='',
+setup(name="sql-rapid7-plugin",
+      version="2.0.6",
+      description="The SQL plugin allows you to run SQL queries",
+      author="rapid7",
+      author_email="",
+      url="",
       packages=find_packages(),
       install_requires=['komand'],  # Add third-party dependencies to requirements.txt, not here!
       scripts=['bin/komand_sql']


### PR DESCRIPTION
## Proposed Changes
Fix issue where connection test always success

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Using postgres connection string...\nConnect: Connecting...\nrapid7/SQL:2.0.5. Step name: query\n{'Node Type': 'Result', 'Parallel Aware': False, 'Startup Cost': 0.0, 'Total Cost': 0.01, 'Plan Rows': 1, 'Plan Width': 4, 'Actual Startup Time': 0.001, 'Actual Total Time': 0.001, 'Actual Rows': 1, 'Actual Loops': 1, 'Shared Hit Blocks': 0, 'Shared Read Blocks': 0, 'Shared Dirtied Blocks': 0, 'Shared Written Blocks': 0, 'Local Hit Blocks': 0, 'Local Read Blocks': 0, 'Local Dirtied Blocks': 0, 'Local Written Blocks': 0, 'Temp Read Blocks': 0, 'Temp Written Blocks': 0}\n",
    "meta": {},
    "output": {
      "header": [
        "?column?"
      ],
      "results": [
        {
          "?column?": "1"
        }
      ],
      "status": "operation success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/sql:2.0.5 run < tests/query.json
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Using postgres connection string...\nConnect: Connecting...\nrapid7/SQL:2.0.5. Step name: query\n",
    "meta": {},
    "output": true,
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/sql:2.0.5 test < tests/query.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Using postgres connection string...\nConnect: Connecting...\nrapid7/SQL:2.0.5. Step name: query\nConnection test failed! Unable to connect to the server. Check connection credentials.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py\", line 2158, in _wrap_pool_connect\n    return fn()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 403, in connect\n    return _ConnectionFairy._checkout(self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 782, in _checkout\n    fairy = _ConnectionRecord.checkout(pool)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 532, in checkout\n    rec = pool._do_get()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 1186, in _do_get\n    self._dec_overflow()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py\", line 66, in __exit__\n    compat.reraise(exc_type, exc_value, exc_tb)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py\", line 187, in reraise\n    raise value\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 1183, in _do_get\n    return self._create_connection()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 350, in _create_connection\n    return _ConnectionRecord(self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 477, in __init__\n    self.__connect(first_connect_check=True)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 667, in __connect\n    connection = pool._invoke_creator(self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/strategies.py\", line 105, in connect\n    return dialect.connect(*cargs, **cparams)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/default.py\", line 410, in connect\n    return self.dbapi.connect(*cargs, **cparams)\n  File \"/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py\", line 130, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\npsycopg2.OperationalError: FATAL:  password authentication failed for user \"user\"\n\n\nThe above exception was the direct cause of the following exception:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.6/site-packages/sql_rapid7_plugin-2.0.5-py3.6.egg/komand_sql/connection/connection.py\", line 71, in test\n    self.connection.session.execute(\"select 1\")\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 1176, in execute\n    bind, close_with_result=True).execute(clause, params or {})\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 1040, in _connection_for_bind\n    engine, execution_options)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/orm/session.py\", line 409, in _connection_for_bind\n    conn = bind.contextual_connect()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py\", line 2123, in contextual_connect\n    self._wrap_pool_connect(self.pool.connect, None),\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py\", line 2162, in _wrap_pool_connect\n    e, dialect, self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py\", line 1476, in _handle_dbapi_exception_noconnection\n    exc_info\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py\", line 203, in raise_from_cause\n    reraise(type(exception), exception, tb=exc_tb, cause=cause)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py\", line 186, in reraise\n    raise value.with_traceback(tb)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/base.py\", line 2158, in _wrap_pool_connect\n    return fn()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 403, in connect\n    return _ConnectionFairy._checkout(self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 782, in _checkout\n    fairy = _ConnectionRecord.checkout(pool)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 532, in checkout\n    rec = pool._do_get()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 1186, in _do_get\n    self._dec_overflow()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/util/langhelpers.py\", line 66, in __exit__\n    compat.reraise(exc_type, exc_value, exc_tb)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/util/compat.py\", line 187, in reraise\n    raise value\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 1183, in _do_get\n    return self._create_connection()\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 350, in _create_connection\n    return _ConnectionRecord(self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 477, in __init__\n    self.__connect(first_connect_check=True)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/pool.py\", line 667, in __connect\n    connection = pool._invoke_creator(self)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/strategies.py\", line 105, in connect\n    return dialect.connect(*cargs, **cparams)\n  File \"/usr/local/lib/python3.6/site-packages/sqlalchemy/engine/default.py\", line 410, in connect\n    return self.dbapi.connect(*cargs, **cparams)\n  File \"/usr/local/lib/python3.6/site-packages/psycopg2/__init__.py\", line 130, in connect\n    conn = _connect(dsn, connection_factory=connection_factory, **kwasync)\nsqlalchemy.exc.OperationalError: (psycopg2.OperationalError) FATAL:  password authentication failed for user \"user\"\n (Background on this error at: http://sqlalche.me/e/e3q8)\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.6/site-packages/komand-1.0.1-py3.6.egg/komand/plugin.py\", line 307, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.6/site-packages/komand-1.0.1-py3.6.egg/komand/plugin.py\", line 417, in start_step\n    output = func()\n  File \"/usr/local/lib/python3.6/site-packages/sql_rapid7_plugin-2.0.5-py3.6.egg/komand_sql/connection/connection.py\", line 76, in test\n    assistance=\"Check connection credentials.\"\nkomand.exceptions.ConnectionTestException: Connection test failed! Unable to connect to the server. Check connection credentials.\n",
    "status": "error",
    "meta": {},
    "error": "Connection test failed! Unable to connect to the server. Check connection credentials."
  },
  "version": "v1",
  "type": "action_event"
}

```

<summary>
docker run --rm -i rapid7/sql:2.0.5 test < tests/query_bad.json
</summary>
</details>

Autogenerate with:
<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator ExceptionValidator
WARNING: Use of 'PluginException' or 'ConnectionTestException' is recommended when raising an exception.
violation: komand_sql/actions/query/action.py: line,  33
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 22110.878ms

```

<summary>
icon-validate --all .
</summary>
</details>