### PR TITLE
Plugin spec to manifest

### DIFF
--- a/tools/spec_to_manifest.py
+++ b/tools/spec_to_manifest.py
@@ -25,7 +25,6 @@ def main():
             write_to_json(json_obj, path)
             print("Wrote manifest at " + path)
         else:
-            print(filename)
             logging.warning("ERROR: Wrong file type specified")
 
 

--- a/tools/spec_to_manifest.py
+++ b/tools/spec_to_manifest.py
@@ -14,7 +14,7 @@ def main():
         path = sys.argv[2]
         correct_params = True
     except IndexError:
-        logging.warning('ERROR: Insufficient parameters')
+        logging.warning("ERROR: Insufficient parameters")
 
     if correct_params:
         if verify_yaml(filename):
@@ -25,6 +25,7 @@ def main():
             write_to_json(json_obj, path)
             print("Wrote manifest at " + path)
         else:
+            print(filename)
             logging.warning("ERROR: Wrong file type specified")
 
 
@@ -32,45 +33,60 @@ def parse_fields(yaml_obj):
     # Manifest Version -- mandatory
     manifest_obj = {"manifest_version": 1}
 
+    resources = yaml_obj.get("resources")
+    cloud_ready = yaml_obj.get("cloud_ready")
+    unique_name = yaml_obj.get("name")
+    publisher = yaml_obj.get("vendor")
+    support = yaml_obj.get("support")
+
     # Extension -- mandatory
-    # In this case, only workflows
+    # From yaml, other info changes based on extension
     extension_type = yaml_obj.get("extension")
     extension_obj = {"type": extension_type}
     if extension_type == "workflow":
-        extension_obj[extension_type] = yaml_obj.get("name") + ".icon"
-    # if extension_type == plugin....
+        extension_obj[extension_type] = unique_name + ".icon"
+    if extension_type == "plugin":
+        extension_obj["externalPluginName"] = unique_name
+        if cloud_ready:
+            extension_obj["cloudReady"] = "true"
+        else:
+            extension_obj["cloudReady"] = "false"
 
     manifest_obj["extension"] = extension_obj
 
     # ID -- mandatory
     # From yaml
-    manifest_obj["id"] = yaml_obj.get("name")
+    manifest_obj["id"] = unique_name
 
     # Title -- mandatory
     # From yaml
     manifest_obj["title"] = yaml_obj.get("title")
 
-    # Description -- Mandatory
+    # Overview -- Mandatory
     # from yaml
-    manifest_obj["tagline"] = yaml_obj.get("description")
+    manifest_obj["overview"] = yaml_obj.get("description")
 
-    # Overview -- mandatory
-    # Tricky extraction of overview from .md
-    # For now, keep as blank
-    manifest_obj["overview"] = ""
+    # Description -- mandatory
+    # Tricky extraction of description from .md
+    manifest_obj["description"] = ""
 
     # Key Features -- mandatory
-    # From .md, for now, keep as blank
+    # From .md
     manifest_obj["key_features"] = []
 
     # Requirements -- Optional
     # Tricky reading from .md, due to different formatting....
-    # Keep blank for now
     manifest_obj["requirements"] = []
 
     # Resources -- optional
-    # Don't know where to pull this info from.....
-    manifest_obj["resources"] = []
+    # Pull from .md
+    if resources:
+        vendor_url = resources.get("vendor_url")
+        if vendor_url:
+            manifest_obj["resources"] = [{"text": "Vendor Website", "url":vendor_url}]
+        else:
+            # Append references --> links from .md
+            manifest_obj["resources"] = []
 
     # Version -- optional
     # Directly from yaml, parsed as string in manifest
@@ -82,14 +98,17 @@ def parse_fields(yaml_obj):
 
     # Publisher -- mandatory
     # "Vendor" field from yaml
-    manifest_obj["publisher"] = yaml_obj.get("vendor")
+    manifest_obj["publisher"] = publisher
 
     # Support -- mandatory
     # from yaml if R7, where to get info on "community" support?
-    if yaml_obj.get("support") == "rapid7":
-        support_obj = {"type": "publisher", "url": "http://www.rapid7.com/discuss"}
+    if support == "rapid7":
+        support_obj = {"type": "publisher", "url": "http://www.rapid7.com"}
     else:
-        support_obj = {"type": "community", "url": ""}
+        if vendor_url:
+            support_obj = {"type": "community", "url": vendor_url}
+        else:
+            support_obj = {"type": "community", "url": ""}
     manifest_obj["support"] = support_obj
 
     # Rapid7 Products -- mandatory
@@ -104,24 +123,26 @@ def parse_fields(yaml_obj):
     manifest_obj["rapid7_products"] = r7_products
 
     # Required R7 Features -- Required
-    # Different rules for workflows, plugins, etc....Workflows --> need orchestrator
-    if extension_type == 'workflow' or extension_type == 'plugin':
-        cloud_ready = yaml_obj.get("cloud_ready")
-        if not yaml_obj.get('cloud_ready'):
-            manifest_obj["required_rapid7_features"] = ["orchestrator"]
+    # Different rules for workflows, plugins, etc...
+
+    if extension_type == "workflow" or extension_type == "plugin":
+        if unique_name == "rapid7_insight_agent":
+            manifest_obj ["required_rapid7_features"] = ["orchestrator", "agent"]
         else:
-            manifest_obj["required_rapid7_features"] = []
+            if not cloud_ready:
+                manifest_obj["required_rapid7_features"] = ["orchestrator"]
+            else:
+                manifest_obj["required_rapid7_features"] = []
 
     # Status -- optional
     # From yaml
     manifest_obj["status"] = yaml_obj.get("status")
 
     # Logos -- optional
-    # Not sure what this would mean for a workflow....
-    manifest_obj["logos"] = {}
+    manifest_obj["logos"] = {"primary": "extension.png", "secondary":[]}
 
     # Display Options -- mandatory
-    # No sense of this in spec.....
+    # No sense of this in spec/md -- only "credit_author" is valid
     manifest_obj["display_options"] = []
 
     # Tags -- Mandatory
@@ -132,7 +153,7 @@ def parse_fields(yaml_obj):
     categories = hub_tags.get("use_cases")
 
     # Tags.third_party_products -- optional
-    # Is this in tha YAML????
+    # This info is not readily available yet
     third_party_products = []
 
     # Tags.keywords -- optional
@@ -141,48 +162,55 @@ def parse_fields(yaml_obj):
                             "keywords": keywords}
 
     # Documentation -- optional
-    # Not entirely sure how to handle this either, not in yaml
-    manifest_obj["documentation"] = []
+    documentation_obj = {}
+    if resources.get("docs_url"):
+        documentation_obj["type"] = "url"
+        documentation_obj["source"] = resources.get("docs_url")
+    else:
+        documentation_obj["type"] = "file"
+        documentation_obj["source"] = "help.md"
+
+    manifest_obj["documentation"] = documentation_obj
 
     # Media -- optional
-    # Small conversions from yaml
-    screenshots = yaml_obj.get("resources").get("screenshots")
-    if screenshots:
-        media_list = []
-        for media in yaml_obj.get("resources").get("screenshots"):
-            image_pattern = r'\S+\.(?:png|jpe?g)'
-            video_pattern = r'\S+\.(?:mp4)'
-            type_of_media = ""
-            if re.match(image_pattern, media['name']):
-                type_of_media = "image"
-            if re.match(video_pattern, media['name']):
-                type_of_media = "video"
-            media_info = {"source": media.get('name'), "title": media.get('title'), 'type': type_of_media}
-            media_list.append(media_info)
-        manifest_obj['media'] = media_list
+    # Conversions from yaml -- plugins don't have screenshots
+    if resources:
+        screenshots = resources.get("screenshots")
+        if screenshots:
+            media_list = []
+            for media in yaml_obj.get("resources").get("screenshots"):
+                image_pattern = r"\S+\.(?:png|jpe?g)"
+                video_pattern = r"\S+\.(?:mp4)"
+                type_of_media = ""
+                if re.match(image_pattern, media["name"]):
+                    type_of_media = "image"
+                if re.match(video_pattern, media["name"]):
+                    type_of_media = "video"
+                media_info = {"source": media.get("name"), "title": media.get("title"), "type": type_of_media}
+                media_list.append(media_info)
+            manifest_obj["media"] = media_list
 
     # Links -- optional
     # Conversion from yaml
     src = ""
     lic = ""
-    if yaml_obj.get('resources'):
-        resources = yaml_obj.get('resources')
-        if resources.get('source_url'):
-            src = resources['source_url']
-        if resources.get('license_url'):
-            lic = yaml_obj['resources']['license_url']
+    if resources:
+        if resources.get("source_url"):
+            src = resources["source_url"]
+        if resources.get("license_url"):
+            lic = yaml_obj["resources"]["license_url"]
 
-        manifest_obj['links'] = {'source_url': src, 'license_url': lic}
+        manifest_obj["links"] = {"source_url": src, "license_url": lic}
 
     # Processing Instructions -- optional
     # No sense of this in yaml...
-    manifest_obj['processing_instructions'] = []
+    manifest_obj["processing_instructions"] = []
 
     return manifest_obj
 
 
 def verify_yaml(file):
-    return file and re.match(r'^\S*workflow.spec.yaml$', file)
+    return file and re.match(r"^\S*.spec.yaml$", file)
 
 
 def open_and_read_spec(file):
@@ -192,9 +220,9 @@ def open_and_read_spec(file):
 
 
 def write_to_json(obj, path):
-    with open(path + "/manifest.json", 'w') as json_out:
+    with open(path + "/manifest.json", "w") as json_out:
         json.dump(obj, json_out, indent=4)
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     main()


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Added more details to fields to allow initial plugin conversion of spec to manifest

### Testing

```
ncramer@BOS-MBP-8176 tools % python3 ./spec_to_manifest.py /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/basename/plugin.spec.yaml /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/basename/
Read spec file at /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/basename/plugin.spec.yaml
Converted fields
Wrote manifest at /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/basename/

ncramer@BOS-MBP-8176 tools % python3 ./spec_to_manifest.py /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/google_docs/plugin.spec.yaml /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/google_docs/
Read spec file at /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/google_docs/plugin.spec.yaml
Converted fields
Wrote manifest at /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/google_docs/

ncramer@BOS-MBP-8176 tools % python3 ./spec_to_manifest.py /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/rapid7_insight_agent/plugin.spec.yaml /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/rapid7_insight_agent/
Read spec file at /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/rapid7_insight_agent/plugin.spec.yaml
Converted fields
Wrote manifest at /Users/ncramer/Desktop/Scripts/SpecToManifest/Plugins/rapid7_insight_agent/
```

```
{
    "manifest_version": 1,
    "extension": {
        "type": "plugin",
        "externalPluginName": "rapid7_insight_agent",
        "cloudReady": "false"
    },
    "id": "rapid7_insight_agent",
    "title": "Rapid7 Insight Agent",
    "overview": "Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization",
    "description": "",
    "key_features": [],
    "requirements": [],
    "resources": [
        {
            "text": "Vendor Website",
            "url": "https://www.rapid7.com"
        }
    ],
    "version": "1.0.0",
    "version_history": [],
    "publisher": "rapid7",
    "support": {
        "type": "publisher",
        "url": "http://www.rapid7.com"
    },
    "rapid7_products": [
        {
            "name": "insightconnect",
            "role": "primary"
        }
    ],
    "required_rapid7_features": [
        "orchestrator",
        "agent"
    ],
    "status": [],
    "logos": {
        "primary": "extension.png",
        "secondary": []
    },
    "display_options": [],
    "tags": {
        "categories": [
            "threat_detection_and_response"
        ],
        "third_party_products": [],
        "keywords": [
            "rapid7",
            "agent",
            "endpoint",
            "response",
            "detection",
            "insight",
            "idr",
            "ivm"
        ]
    },
    "documentation": {
        "type": "url",
        "source": "https://docs.rapid7.com/insightconnect/insight-agent"
    },
    "links": {
        "source_url": "https://github.com/rapid7/insightconnect-plugins/tree/master/rapid7_insight_agent",
        "license_url": "https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE"
    },
    "processing_instructions": []
}
```

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR.
4. Add UI screenshot of the workflow used for testing
5. Add UI screenshot of the job output used for testing
6. Add UI screenshot of the artifact (See rules in UI Checklist) used for testing
