### PR TITLE
[SOAR-2758] - Fix issue with IPv6 in palo alto pan os

### DIFF
--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b4f88ca2dccb0a4ce3880768b48d9aee",
-	"manifest": "580cfe81cdc1209cec0f35117a11d1dd",
-	"setup": "c8314cafd827b300016ecc3351bb38c4",
+	"spec": "c75f672449741ae9b3793815b7d84cc5",
+	"manifest": "2bbbd957467c38e34e27e4543874fd79",
+	"setup": "148b018a60ca2ba111a18618bcc70f60",
 	"schemas": [
 		{
 			"identifier": "add_address_object_to_group/schema.py",

--- a/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -6,7 +6,7 @@ from komand_palo_alto_pan_os import connection, actions, triggers
 
 Name = "Palo Alto Firewall"
 Vendor = "rapid7"
-Version = "6.0.1"
+Version = "6.0.2"
 Description = "Manage Palo Alto Networks firewall devices"
 
 

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -33,7 +33,10 @@ Example input:
 
 ```
 {
-  "credentials": "{\"username\":\"username\", \"password\":\"password\"}",
+  "credentials": {
+    "username":"username",
+    "password":"password"
+  },
   "server": "http://www.example.com",
   "verify_cert": true
 }
@@ -185,6 +188,11 @@ This action is used to get a policy.
 Example input:
 
 ```
+{
+  "device_name": "localhost.localdomain",
+  "policy_name": "InsightConnect Block Policy",
+  "virtual_system": "vsys1"
+}
 ```
 
 ##### Output
@@ -869,7 +877,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
-* 6.0.2 - Fix issue with IPv6 in Set Address Object
+* 6.0.2 - Fix issue where Set Network Object did not support IPv6
 * 6.0.1 - Improve error handling in `pa_os_request.py`
 * 6.0.0 - Update to Create Address Object to add Skip RFC 1918 input
 * 5.1.1 - Fix issue where IPv6 address were not supported

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -33,10 +33,7 @@ Example input:
 
 ```
 {
-  "credentials": {
-    "username":"username",
-    "password":"password"
-  },
+  "credentials": "{\"username\":\"username\", \"password\":\"password\"}",
   "server": "http://www.example.com",
   "verify_cert": true
 }
@@ -188,11 +185,6 @@ This action is used to get a policy.
 Example input:
 
 ```
-{
-  "device_name": "localhost.localdomain",
-  "policy_name": "InsightConnect Block Policy",
-  "virtual_system": "vsys1"
-}
 ```
 
 ##### Output
@@ -877,6 +869,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
+* 6.0.2 - Fix issue with IPv6 in Set Address Object
 * 6.0.1 - Improve error handling in `pa_os_request.py`
 * 6.0.0 - Update to Create Address Object to add Skip RFC 1918 input
 * 5.1.1 - Fix issue where IPv6 address were not supported

--- a/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
+++ b/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
@@ -15,6 +15,11 @@ class SetAddressObject(komand.Action):
                 output=SetAddressObjectOutput())
 
     def determine_address_type(self, address):
+        try:
+            ip_address(address)
+            return "ip-netmask"
+        except:
+            pass
         if re.search('[a-zA-Z]', address):
             return "fqdn"
         if re.search('/', address):

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto Firewall
 description: Manage Palo Alto Networks firewall devices
-version: 6.0.1
+version: 6.0.2
 vendor: rapid7
 support: rapid7
 status: []

--- a/palo_alto_pan_os/setup.py
+++ b/palo_alto_pan_os/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
-      version="6.0.1",
+      version="6.0.2",
       description="Manage Palo Alto Networks firewall devices",
       author="rapid7",
       author_email="",

--- a/palo_alto_pan_os/unit_test/test_set_address_object.py
+++ b/palo_alto_pan_os/unit_test/test_set_address_object.py
@@ -74,6 +74,8 @@ class TestSetAddressObject(TestCase):
         self.assertEquals(test_action.determine_address_type("1.1.1.1/32"), "ip-netmask")
         self.assertEquals(test_action.determine_address_type("www.google.com"), "fqdn")
         self.assertEquals(test_action.determine_address_type("10.1.1.1-10.1.1.255"), "ip-range")
+        self.assertEquals(test_action.determine_address_type("1:2:3:4:5:6:7:8"), "ip-netmask")
+        self.assertEquals(test_action.determine_address_type("2001:0db8:85a3:0000:0000:8a2e:0370:7334"), "ip-netmask")
 
     def test_check_if_private(self):
         test_action = SetAddressObject()


### PR DESCRIPTION
## Description: 

Fix issue with IPv6 in palo alto pan os

## Validation: 
```
RMT-X270-4700:palo_alto_pan_os jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpValidator" failed!
	Cause: Help section contains non-matching title in line: [PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto firewall appliance(s).

Validator "TitleValidator" failed!
	Cause: ("actions key 'check_if_address_object_in_group''s title ends with period when it should not.", ValidationException("Title contains a lowercase 'if' when it should not."))


----
[*] Total time elapsed: 970.697ms
```

## Testing: 
```
RMT-X270-4700:palo_alto_pan_os jmcadams$ ./run.sh -R tests/set_address_object.json -j
Running: cat tests/set_address_object.json | docker run --rm   -i rapid7/palo_alto_pan_os:6.0.2  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Connect: Connecting..
Starting new HTTPS connection (1): pa-vm-9-0.vuln.lax.rapid7.com:443
/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
https://pa-vm-9-0.vuln.lax.rapid7.com:443 "GET /api/?type=keygen&user=admin&password=notpassword HTTP/1.1" 200 200
Key obtained
rapid7/Palo Alto Firewall:6.0.2. Step name: set_address_object
/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py:851: InsecureRequestWarning: Unverified HTTPS request is being made. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning)
https://pa-vm-9-0.vuln.lax.rapid7.com:443 "POST /api/?type=config&action=set&key=LUFRPT1SWHpjNlcyMXZ2NHViRmV0R0pQZy9lU2lnYmc9VlI1REg0YUdFOHA5aHMzTk9kT3JIMEQzK1Y1WmFLYkIranNkV2Vpb1VabmxtQURhWnlsQ3hRbGRGZWVYUkpPYw%3D%3D&xpath=%2Fconfig%2Fdevices%2Fentry%2Fvsys%2Fentry%2Faddress%2Fentry%5B%40name%3D%27IPv6%27%5D&element=%3Cip-netmask%3E2001%3A0db8%3A85a3%3A0000%3A0000%3A8a2e%3A0370%3A7334%3C%2Fip-netmask%3E%3Cdescription%3EA+Test+from+ICON%3C%2Fdescription%3E HTTP/1.1" 200 76
Connect: Connecting..
Key obtained
rapid7/Palo Alto Firewall:6.0.2. Step name: set_address_object

{
  "message": "command succeeded",
  "status": "success",
  "code": "20"
}
```