### PR TITLE
Whois - Add input Registrar to Address Lookup action

### DIFF
--- a/whois/.CHECKSUM
+++ b/whois/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "2b7ac8369fbdbd0fda1bfda6a849fc14",
-	"manifest": "bb6f46aa50f039029228b2c5f3cd2112",
-	"setup": "d06bc382868a02a91ae949d939e59ed0",
+	"spec": "1a1701b13095b1600efaa2d0798a0728",
+	"manifest": "095c4176c6bdebe05929caa365f99ca1",
+	"setup": "d1ea69771118e5ea8594dd47e7d5412c",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",
-			"hash": "46b8631b7e98088764479f9811b74768"
+			"hash": "0cc9eeec848619d580985ff56b407ced"
 		},
 		{
 			"identifier": "domain/schema.py",

--- a/whois/bin/komand_whois
+++ b/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from komand_whois import connection, actions, triggers
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "2.0.3"
+Version = "3.0.0"
 Description = "The WHOIS plugin enables address and domain lookups in the WHOIS databases"
 
 

--- a/whois/help.md
+++ b/whois/help.md
@@ -171,7 +171,7 @@ _This plugin has no references._
 
 # Version History
 
-* 3.0.0 - Add input `Registrar` to `Address Lookup` action
+* 3.0.0 - Add input `registrar` for manual server selection to Address Lookup action
 * 2.0.3 - Upgrade to latest Python plugin runtime | Define `cloud_ready` in spec
 * 2.0.2 - Fix issue where com.br style domains could crash the plugin
 * 2.0.1 - Update to v4 Python plugin runtime

--- a/whois/help.md
+++ b/whois/help.md
@@ -92,12 +92,14 @@ This action is used to retrieve data about an IP address.
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |address|string|None|True|IP to Lookup|None|198.51.100.100|
+|registrar|string|Autodetect|False|Domain Registrar|['Autodetect', 'RIPE', 'ARIN', 'LACNIC', 'APNIC']|Autodetect|
 
 Example input:
 
 ```
 {
-  "address": "198.51.100.100"
+  "address": "198.51.100.100",
+  "registrar": "Autodetect"
 }
 ```
 
@@ -169,6 +171,7 @@ _This plugin has no references._
 
 # Version History
 
+* 3.0.0 - Add input `Registrar` to `Address Lookup` action
 * 2.0.3 - Upgrade to latest Python plugin runtime | Define `cloud_ready` in spec
 * 2.0.2 - Fix issue where com.br style domains could crash the plugin
 * 2.0.1 - Update to v4 Python plugin runtime

--- a/whois/komand_whois/actions/address/schema.py
+++ b/whois/komand_whois/actions/address/schema.py
@@ -9,6 +9,7 @@ class Component:
 
 class Input:
     ADDRESS = "address"
+    REGISTRAR = "registrar"
     
 
 class Output:
@@ -42,6 +43,20 @@ class AddressInput(insightconnect_plugin_runtime.Input):
       "title": "Address",
       "description": "IP to Lookup",
       "order": 1
+    },
+    "registrar": {
+      "type": "string",
+      "title": "Registrar",
+      "description": "Domain Registrar",
+      "default": "Autodetect",
+      "enum": [
+        "Autodetect",
+        "RIPE",
+        "ARIN",
+        "LACNIC",
+        "APNIC"
+      ],
+      "order": 2
     }
   },
   "required": [

--- a/whois/plugin.spec.yaml
+++ b/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: The WHOIS plugin enables address and domain lookups in the WHOIS databases
-version: 2.0.3
+version: 3.0.0
 vendor: rapid7
 support: community
 status: []
@@ -121,6 +121,19 @@ actions:
         description: IP to Lookup
         example: 198.51.100.100
         required: true
+      registrar:
+        title: Registrar
+        type: string
+        description: Domain Registrar
+        example: Autodetect
+        required: false
+        default: Autodetect
+        enum:
+          - Autodetect
+          - RIPE
+          - ARIN
+          - LACNIC
+          - APNIC
     output:
       netname:
         title: Network Name

--- a/whois/setup.py
+++ b/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="2.0.3",
+      version="3.0.0",
       description="The WHOIS plugin enables address and domain lookups in the WHOIS databases",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Whois - Add input `Registrar` to `Address Lookup` action

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: arin\n",
    "meta": {},
    "output": {
      "address": "1538 S Fern Dr.",
      "cidr": "149.112.3.0/24",
      "city": "Gilbert",
      "country": "US",
      "netname": "48IX-IP4-PEERING1",
      "netrange": "149.112.3.0 - 149.112.3.255",
      "nettype": "Direct Allocation",
      "org_abuse_email": "abuse@48ix.net",
      "org_abuse_phone": "+1-602-935-9850",
      "org_tech_email": "matt@48ix.net",
      "org_tech_phone": "+1-480-757-4549",
      "organization": "48 IX, Inc. (IXINC)",
      "orgname": "48 IX, Inc.",
      "postal": "85296",
      "regdate": "2020-05-19",
      "state": "AZ",
      "update": "2020-06-30"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: apnic\n",
    "meta": {},
    "output": {
      "address": "7F, No.99, Huaihai Rd (E), Shanghai,200021",
      "cidr": "116.236.215.224 - 116.236.215.227",
      "country": "CN",
      "netname": "KAIYU",
      "netrange": "116.236.215.224 - 116.236.215.227",
      "nettype": "ASSIGNED NON-PORTABLE",
      "org_abuse_email": "huangyong@163.com",
      "org_abuse_phone": "+86-21-53063160-607",
      "orgname": "Shanghai Huangpu Kaiyu Culture Business Train Center",
      "update": "2009-11-09T08"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_apnic.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: arin\n",
    "meta": {},
    "output": {
      "address": "1600 Amphitheatre Parkway",
      "cidr": "8.8.8.0/24",
      "city": "Mountain View",
      "country": "US",
      "netname": "LVLT-GOGL-8-8-8",
      "netrange": "8.8.8.0 - 8.8.8.255",
      "nettype": "Reallocated",
      "org_abuse_email": "network-abuse@google.com",
      "org_abuse_phone": "+1-650-253-0000",
      "org_tech_email": "arin-contact@google.com",
      "org_tech_phone": "+1-650-253-0000",
      "orgname": "Google LLC",
      "postal": "94043",
      "regdate": "2000-03-30",
      "state": "CA",
      "update": "2019-10-31"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_arin.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: lacnic\n",
    "meta": {},
    "output": {
      "address": "2A - Panama -",
      "cidr": "186.74.0.0/15",
      "country": "PA",
      "netname": "PA-CWPA-LACNIC",
      "netrange": "186.74.0.0/15",
      "nettype": "allocated",
      "org_abuse_email": "networks@cwpanama.net",
      "org_abuse_phone": "+507  2642238",
      "orgname": "Cable \u0026 Wireless Panama",
      "regdate": "20030428",
      "update": "20030430"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_lacnic.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: ripe\n",
    "meta": {},
    "output": {
      "address": "1-st Frezernaya str. 2/1 korp. 2",
      "country": "RU",
      "netname": "VDSINA-NET",
      "netrange": "185.231.155.0 - 185.231.155.255",
      "nettype": "ASSIGNED PA",
      "org_abuse_email": "abuse@vdsina.ru",
      "orgname": "VDSINA VDS Hosting",
      "regdate": "2018-02-19T16",
      "updated": "2018-02-19T16"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_ripe_autodetect.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: ripe\n",
    "meta": {},
    "output": {
      "address": "1-st Frezernaya str. 2/1 korp. 2",
      "country": "RU",
      "netname": "VDSINA-NET",
      "netrange": "185.231.155.0 - 185.231.155.255",
      "nettype": "ASSIGNED PA",
      "org_abuse_email": "abuse@vdsina.ru",
      "orgname": "VDSINA VDS Hosting",
      "regdate": "2018-02-19T16",
      "updated": "2018-02-19T16"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_ripe_default.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: lacnic\n",
    "meta": {},
    "output": {
      "address": "1-st Frezernaya str. 2/1 korp. 2",
      "cidr": "185.231.155.0 - 185.231.155.255",
      "country": "RU",
      "netrange": "185.231.155.0 - 185.231.155.255",
      "nettype": "ASSIGNED PA",
      "regdate": "2018-02-19T16"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_ripe_lacnic.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.0. Step name: address\nInfo: Using registry: ripe\n",
    "meta": {},
    "output": {
      "address": "1-st Frezernaya str. 2/1 korp. 2",
      "country": "RU",
      "netname": "VDSINA-NET",
      "netrange": "185.231.155.0 - 185.231.155.255",
      "nettype": "ASSIGNED PA",
      "org_abuse_email": "abuse@vdsina.ru",
      "orgname": "VDSINA VDS Hosting",
      "regdate": "2018-02-19T16",
      "updated": "2018-02-19T16"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.0 --debug run < tests/address_ripe_ripe.json
</summary>
</details>

### Validate

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 1153.259ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
./unit_test/test_address.py:5:1: E402 module level import not at top of file
./unit_test/test_address.py:6:1: E402 module level import not at top of file
./unit_test/test_address.py:7:1: E402 module level import not at top of file
./unit_test/test_address.py:8:1: E402 module level import not at top of file
./unit_test/test_address.py:9:1: E402 module level import not at top of file
./unit_test/test_address.py:39:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_address.py:42:1: W293 blank line contains whitespace
./unit_test/test_address.py:43:110: W291 trailing whitespace
./unit_test/test_address.py:49:9: E303 too many blank lines (2)
./unit_test/test_address.py:57:69: W291 trailing whitespace
./unit_test/test_address.py:72:45: W292 no newline at end of file
./unit_test/test_domain.py:5:1: E402 module level import not at top of file
./unit_test/test_domain.py:6:1: E402 module level import not at top of file
./unit_test/test_domain.py:7:1: E402 module level import not at top of file
./unit_test/test_domain.py:8:1: E402 module level import not at top of file
./unit_test/test_domain.py:9:1: E402 module level import not at top of file
./unit_test/test_domain.py:26:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_domain.py:29:1: W293 blank line contains whitespace
./unit_test/test_domain.py:30:110: W291 trailing whitespace
./unit_test/test_domain.py:36:9: E303 too many blank lines (2)
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2020-09-16 21:16:12.024443

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 610
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] Checking for typos with Misspell...
[FAIL] Fails Misspell check
whois.conf:491:2: "immobilien" is a misspelling of "immobile"

```

<summary>
make validate
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 42669.193ms

```

<summary>
icon-validate --all .
</summary>
</details>