### PR TITLE
Change json_to_spec.py to run in Python3.7

### DIFF
--- a/tools/json_to_spec.py
+++ b/tools/json_to_spec.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3.7
 import json
 from past.builtins import basestring
 from future.utils import iteritems
@@ -17,7 +17,7 @@ this_dir = os.path.dirname(__file__)
 rel_path = "templates/template.json_to_spec.j2"
 abs_path_template = os.path.join(this_dir,rel_path)
 
-with open(filename) as data_file:    
+with open(filename) as data_file:
     data = json.load(data_file)
 
 with open(abs_path_template) as f:
@@ -32,13 +32,13 @@ output = OrderedDict()
 def type_name_unused(name):
     if not name in types:
         return name
-    i = 0 
+    i = 0
     while True:
         name = '%s_%d' % (name, i)
         if not name in types:
             return name
         i += 1
-    
+
 def detect_type(name, value, level=0):
    if isinstance(value, basestring):
        return 'string'
@@ -56,7 +56,7 @@ def detect_type(name, value, level=0):
 
    if isinstance(value, dict):
        keys = sorted(value.keys())
-       if len(keys) == 0 or OBJECTS_ONLY: 
+       if len(keys) == 0 or OBJECTS_ONLY:
            return 'object'
        list_key = str(keys)
        if list_key in type_refs:


### PR DESCRIPTION
## Proposed Changes

This changes the json_to_spec.py script to force it to run in py3.7...Py 2.x is incompatible with newer versions of openSSL which causes failures on OSX. 

## Testing
```
rmt-mbp-5357:tools jmcadams$ ./json_to_spec.py ../recorded_future/examples/analyst_notes.json
types:
  context_entities:
    description:
      title: "Description"
      type: string
      description: "Description"
      required: false
    id:
      title: "Id"
      type: string
      description: "Id"
      required: false
    name:
      title: "Name"
      type: string
      description: "Name"
      required: false
    type:
      title: "Type"
      type: string
      description: "Type"
      required: false
  labels:
    id:
      title: "Id"
      type: string
      description: "Id"
      required: false
    name:
      title: "Name"
      type: string
      description: "Name"
      required: false
    type:
      title: "Type"
      type: string
      description: "Type"
      required: false
  attributes:
    context_entities:
      title: "Context Entities"
      type: "[]context_entities"
      description: "Context entities"
      required: false
    labels:
      title: "Labels"
      type: "[]labels"
      description: "Labels"
      required: false
    note_entities:
      title: "Note Entities"
      type: "[]labels"
      description: "Note entities"
      required: false
    published:
      title: "Published"
      type: string
      description: "Published"
      required: false
    text:
      title: "Text"
      type: string
      description: "Text"
      required: false
    title:
      title: "Title"
      type: string
      description: "Title"
      required: false
    topic:
      title: "Topic"
      type: context_entities
      description: "Topic"
      required: false
    validated_on:
      title: "Validated On"
      type: string
      description: "Validated on"
      required: false
    validation_urls:
      title: "Validation Urls"
      type: "[]labels"
      description: "Validation urls"
      required: false
  analystNotes:
    attributes:
      title: "Attributes"
      type: attributes
      description: "Attributes"
      required: false
    id:
      title: "Id"
      type: string
      description: "Id"
      required: false
    source:
      title: "Source"
      type: labels
      description: "Source"
      required: false


output:
  analystNotes:
      title: "Analystnotes"
      type: "[]analystNotes"
      description: "Analystnotes"
      required: false
```