### PR TITLE
Dig plugin - fix bug when `answers` in function `execute_command` is str

### DIFF
--- a/dig/.CHECKSUM
+++ b/dig/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "7a7596e110e56dd5a588cb784eecc269",
-	"manifest": "95e7a6a89c6fa6b5972a5197a2032da1",
-	"setup": "b7bb50d4add11bebc0235b4f02008864",
+	"spec": "90d0406874c08c3c63c9850e20a072b0",
+	"manifest": "009b12ea53c072dead8fe692e55c0017",
+	"setup": "abba6b514d9bf0b64e8432437735388f",
 	"schemas": [
 		{
 			"identifier": "forward/schema.py",

--- a/dig/bin/komand_dig
+++ b/dig/bin/komand_dig
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Dig"
 Vendor = "rapid7"
-Version = "1.0.7"
+Version = "1.0.8"
 Description = "Dig is used for forward and reverse DNS lookups"
 
 

--- a/dig/help.md
+++ b/dig/help.md
@@ -194,6 +194,7 @@ Common examples:
 
 # Version History
 
+* 1.0.8 - Fix bug when `answers` in function `execute_command` is str
 * 1.0.7 - Fix bug in `safe_parse` function
 * 1.0.6 - Upgrade to latest Python plugin runtime | Define `cloud_ready` in spec
 * 1.0.5 - Update to v4 Python plugin runtime

--- a/dig/komand_dig/util/util.py
+++ b/dig/komand_dig/util/util.py
@@ -28,17 +28,17 @@ def execute_command(logger, cmd, answer_section_regex, flags):
     ns = util.safe_parse(re.search('SERVER: (.+?)#', stdout))
     # Grab number of answers
     answers = util.safe_parse(re.search(r'ANSWER: ([0-9]+)', stdout))
+    answer_section = None
     if util.not_empty(answers):
         answers = int(answers)
 
-    answer_section = None
-    # We need answers to continue
-    if answers > 0:
-        # Grab resolved address section
-        if flags is None:
-            answer_section = util.safe_parse(re.search(answer_section_regex, stdout))
-        else:
-            answer_section = util.safe_parse(re.search(answer_section_regex, stdout, flags=flags))
+        # We need answers to continue
+        if answers > 0:
+            # Grab resolved address section
+            if flags is None:
+                answer_section = util.safe_parse(re.search(answer_section_regex, stdout))
+            else:
+                answer_section = util.safe_parse(re.search(answer_section_regex, stdout, flags=flags))
 
     if status != "NOERROR":
         stdout = f'Resolution failed, nameserver {ns} returned {status} status'

--- a/dig/plugin.spec.yaml
+++ b/dig/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: dig
 title: Dig
 description: Dig is used for forward and reverse DNS lookups
-version: 1.0.7
+version: 1.0.8
 vendor: rapid7
 support: community
 status: []

--- a/dig/setup.py
+++ b/dig/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="dig-rapid7-plugin",
-      version="1.0.7",
+      version="1.0.8",
       description="Dig is used for forward and reverse DNS lookups",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Dig plugin - fix bug when `answers` in function `execute_command` is str

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)


## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.8. Step name: forward\nExecuting command /usr/bin/dig sdf ANY\n",
    "meta": {},
    "output": {
      "all_answers": [
        "Not found"
      ],
      "answer": "Not found",
      "fulloutput": "Resolution failed, nameserver 10.0.2.3 returned NXDOMAIN status",
      "last_answer": "Not found",
      "nameserver": "10.0.2.3",
      "question": "sdf",
      "status": "NXDOMAIN"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.8 --debug run < tests/forward.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Dig:1.0.8. Step name: forward\nExecuting command /usr/bin/dig rapid7.com ANY\n",
    "meta": {},
    "output": {
      "all_answers": [
        "ns-1390.awsdns-45.org",
        "ns-1653.awsdns-14.co.uk",
        "86400",
        "ns-439.awsdns-54.com",
        "ns-739.awsdns-28.net",
        "NO MATCHES FOUND",
        "SECTION:",
        "ns-1653.awsdns-14.co.uk",
        "ns-439.awsdns-54.com",
        "ns-739.awsdns-28.net",
        "ns-1390.awsdns-45.org"
      ],
      "answer": "ns-1390.awsdns-45.org",
      "fulloutput": "\n; \u003c\u003c\u003e\u003e DiG 9.14.12 \u003c\u003c\u003e\u003e rapid7.com ANY\n;; global options: +cmd\n;; Got answer:\n;; -\u003e\u003eHEADER\u003c\u003c- opcode: QUERY, status: NOERROR, id: 26421\n;; flags: qr rd ra; QUERY: 1, ANSWER: 5, AUTHORITY: 4, ADDITIONAL: 0\n\n;; QUESTION SECTION:\n;rapid7.com.\t\t\tIN\tANY\n\n;; ANSWER SECTION:\nrapid7.com.\t\t688\tIN\tNS\tns-1390.awsdns-45.org.\nrapid7.com.\t\t688\tIN\tNS\tns-1653.awsdns-14.co.uk.\nrapid7.com.\t\t599\tIN\tSOA\tns-1653.awsdns-14.co.uk. awsdns-hostmaster.amazon.com. 1 7200 900 1209600 86400\nrapid7.com.\t\t688\tIN\tNS\tns-439.awsdns-54.com.\nrapid7.com.\t\t688\tIN\tNS\tns-739.awsdns-28.net.\n\n;; AUTHORITY SECTION:\nrapid7.com.\t\t688\tIN\tNS\tns-1653.awsdns-14.co.uk.\nrapid7.com.\t\t688\tIN\tNS\tns-439.awsdns-54.com.\nrapid7.com.\t\t688\tIN\tNS\tns-739.awsdns-28.net.\nrapid7.com.\t\t688\tIN\tNS\tns-1390.awsdns-45.org.\n\n;; Query time: 3 msec\n;; SERVER: 10.0.2.3#53(10.0.2.3)\n;; WHEN: Sun Oct 04 00:42:22 UTC 2020\n;; MSG SIZE  rcvd: 282\n\n",
      "last_answer": "ns-1390.awsdns-45.org",
      "nameserver": "10.0.2.3",
      "question": "rapid7.com",
      "status": "NOERROR"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/dig:1.0.8 --debug run < tests/forward2.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: help.md[167]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
violation: help.md[218]: https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml
[*] Plugin successfully validated!

----
[*] Total time elapsed: 40472.396ms

```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 1106.419ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
[SUCCESS] Passes flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2020-10-04 00:46:41.313263

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 337
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check

```

<summary>
make validate
</summary>
</details>


