### PR TITLE
SOAR-3402 - Fix AD/LDAP plugin connection documentation

### DIFF
--- a/active_directory_ldap/.CHECKSUM
+++ b/active_directory_ldap/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "3e9a8679032ab827994d83f2ca02db26",
+	"spec": "82223ceceb080bec2e18eb3cf6826268",
 	"manifest": "fe93707e8065d5735d3688e04f95051f",
 	"setup": "7129d622a722a4f1cbbf751e739bdb67",
 	"schemas": [
@@ -45,7 +45,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "f9fbb2a0ae6dbbb1014f6734d622cc9b"
+			"hash": "5bc196941c7740eda51dd412b39a4150"
 		}
 	]
 }

--- a/active_directory_ldap/.CHECKSUM
+++ b/active_directory_ldap/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "81ebc33f0eee0a3a47d1098840e21d01",
+	"spec": "22fd8c8175adc62867d006d6e0311d0d",
 	"manifest": "817d20715fb24e3aeb77603152b90702",
 	"setup": "c35399b18a56ab7b5942173582d43ec4",
 	"schemas": [
@@ -45,7 +45,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "5bc196941c7740eda51dd412b39a4150"
+			"hash": "e5e4d9f4158c745bfb6fe08bfa1058a4"
 		}
 	]
 }

--- a/active_directory_ldap/.CHECKSUM
+++ b/active_directory_ldap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "82223ceceb080bec2e18eb3cf6826268",
-	"manifest": "fe93707e8065d5735d3688e04f95051f",
-	"setup": "7129d622a722a4f1cbbf751e739bdb67",
+	"spec": "81ebc33f0eee0a3a47d1098840e21d01",
+	"manifest": "817d20715fb24e3aeb77603152b90702",
+	"setup": "c35399b18a56ab7b5942173582d43ec4",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/active_directory_ldap/bin/komand_active_directory_ldap
+++ b/active_directory_ldap/bin/komand_active_directory_ldap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Active Directory LDAP"
 Vendor = "rapid7"
-Version = "4.0.2"
+Version = "4.0.3"
 Description = "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
 
 

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -37,7 +37,7 @@ Example input:
   "host": "example.com",
   "port": 389,
   "use_ssl": true,
-  "username_password": {"username":"user1", "password":"mypassword"}
+  "username_password": "{\"username\":\"user1\", \"password\":\"mypassword\"}"
 }
 ```
 
@@ -97,15 +97,9 @@ Example input:
 
 ```
 {
-  "account_disabled": "true",
-  "additional_parameters": {"telephoneNumber":"(617)555-1234"},
-  "domain_name": "example.com",
-  "first_name": "John",
-  "last_name": "Doe",
-  "logon_name": "jdoe",
-  "password": "mypassword",
-  "user_ou": "Users",
-  "user_principal_name": "user@example.com"
+  "add_remove": "add",
+  "distinguished_name": "CN=user,OU=domain_users,DC=mydomain,DC=com",
+  "group_dn": "CN=group_name,OU=domain_groups,DC=example,DC=com"
 }
 ```
 
@@ -146,7 +140,7 @@ Example input:
 ```
 {
   "account_disabled": "true",
-  "additional_parameters": {"telephoneNumber":"(617)555-1234"},
+  "additional_parameters": "{\"telephoneNumber\":\"(617)555-1234\"}",
   "domain_name": "example.com",
   "first_name": "John",
   "last_name": "Doe",

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -25,7 +25,7 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|host|string|None|True|Server Host, e.g. ldap://example.com. Must use either ldap:// or ldaps:// for SSL prefix|None|ldaps://example.com|
+|host|string|None|True|Server Host, e.g. example.com|None|example.com|
 |port|integer|389|True|Port, e.g. 389|None|389|
 |use_ssl|boolean|None|True|Use SSL?|None|True|
 |username_password|credential_username_password|None|True|Username and password|None|{"username":"user1", "password":"mypassword"}|
@@ -34,7 +34,7 @@ Example input:
 
 ```
 {
-  "host": "ldaps://example.com",
+  "host": "example.com",
   "port": 389,
   "use_ssl": true,
   "username_password": {"username":"user1", "password":"mypassword"}

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -37,7 +37,7 @@ Example input:
   "host": "example.com",
   "port": 389,
   "use_ssl": true,
-  "username_password": "{"username":"user1", "password":"mypassword"}"
+  "username_password": {"username":"user1", "password":"mypassword"}
 }
 ```
 
@@ -140,7 +140,7 @@ Example input:
 ```
 {
   "account_disabled": "true",
-  "additional_parameters": "{"telephoneNumber":"(617)555-1234"}",
+  "additional_parameters": {"telephoneNumber":"(617)555-1234"},
   "domain_name": "example.com",
   "first_name": "John",
   "last_name": "Doe",

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -37,7 +37,7 @@ Example input:
   "host": "example.com",
   "port": 389,
   "use_ssl": true,
-  "username_password": "{\"username\":\"user1\", \"password\":\"mypassword\"}"
+  "username_password": "{"username":"user1", "password":"mypassword"}"
 }
 ```
 
@@ -140,7 +140,7 @@ Example input:
 ```
 {
   "account_disabled": "true",
-  "additional_parameters": "{\"telephoneNumber\":\"(617)555-1234\"}",
+  "additional_parameters": "{"telephoneNumber":"(617)555-1234"}",
   "domain_name": "example.com",
   "first_name": "John",
   "last_name": "Doe",

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -492,6 +492,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 4.0.3 - Fix issue with connection documentation
 * 4.0.2 - Fix issue where some host names were being incorrectly parsed
 * 4.0.1 - Fix issue were logging of connection info did not display hostname correctly
 * 4.0.0 - New action Modify Object | Rename Modify Groups action to 'Add or Remove an Object from Group' | Fix issue where non-ASCII characters were not being escaped

--- a/active_directory_ldap/komand_active_directory_ldap/connection/schema.py
+++ b/active_directory_ldap/komand_active_directory_ldap/connection/schema.py
@@ -19,7 +19,7 @@ class ConnectionSchema(komand.Input):
     "host": {
       "type": "string",
       "title": "Host",
-      "description": "Server Host, e.g. example.com for SSL prefix",
+      "description": "Server Host, e.g. example.com",
       "order": 1
     },
     "port": {

--- a/active_directory_ldap/komand_active_directory_ldap/connection/schema.py
+++ b/active_directory_ldap/komand_active_directory_ldap/connection/schema.py
@@ -19,7 +19,7 @@ class ConnectionSchema(komand.Input):
     "host": {
       "type": "string",
       "title": "Host",
-      "description": "Server Host, e.g. ldap://example.com. Must use either ldap:// or ldaps:// for SSL prefix",
+      "description": "Server Host, e.g. example.com for SSL prefix",
       "order": 1
     },
     "port": {

--- a/active_directory_ldap/plugin.spec.yaml
+++ b/active_directory_ldap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: active_directory_ldap
 title: Active Directory LDAP
 description: "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
-version: 4.0.2
+version: 4.0.3
 vendor: rapid7
 support: rapid7
 status: []

--- a/active_directory_ldap/plugin.spec.yaml
+++ b/active_directory_ldap/plugin.spec.yaml
@@ -30,7 +30,6 @@ connection:
   host:
     title: Host
     description: Server Host, e.g. example.com
-      for SSL prefix
     type: string
     required: true
     example: example.com

--- a/active_directory_ldap/plugin.spec.yaml
+++ b/active_directory_ldap/plugin.spec.yaml
@@ -29,11 +29,11 @@ types:
 connection:
   host:
     title: Host
-    description: Server Host, e.g. ldap://example.com. Must use either ldap:// or ldaps://
+    description: Server Host, e.g. example.com
       for SSL prefix
     type: string
     required: true
-    example: ldaps://example.com
+    example: example.com
   port:
     title: Port
     description: Port, e.g. 389

--- a/active_directory_ldap/setup.py
+++ b/active_directory_ldap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="active_directory_ldap-rapid7-plugin",
-      version="4.0.2",
+      version="4.0.3",
       description="This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Description: 

This PR corrects the connection example for host in the active directory LDAP plugin. 

## Validation: 
```
LAX-X260-3213:active_directory_ldap jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
Input violations: Action -> "Add": Missing ["|account_disabled|string|true|True|Set this to true to disable the user account at creation|['true', 'false']|true|"] in help.md
Input violations: Action -> "Modify Object": Missing ['|attribute_value|string|None|True|The value of the attribute|None|2114|'] in help.md
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpInputOutputValidator" failed!
	Cause: Help.md is not in sync with plugin.spec.yaml. Please regenerate help.md by running 'icon-plugin generate python --regenerate' to rectify violations.
```

## Testing: 
```
LAX-X260-3213:active_directory_ldap jmcadams$ ./run.sh -R tests/query.json -j
Running: cat tests/query.json | docker run --rm   -i rapid7/active_directory_ldap:4.0.3  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Connecting to 10.4.22.248:389
Connected!
rapid7/Active Directory LDAP:4.0.3. Step name: query
Escaped query: (&(objectcategory=computer)(name=*))
Connecting to 10.4.22.248:389
Connected!
rapid7/Active Directory LDAP:4.0.3. Step name: query
Escaped query: (&(objectcategory=computer)(name=*))

{
  "results": [
    {
      "attributes": {
        "accountExpires": "9999-12-31 23:59:59.999999+00:00",
        "badPasswordTime": "1601-01-01 00:00:00+00:00",
        "badPwdCount": 0,
        "cn": "IAGENT5-DCWIN12",
        "codePage": 0,
        "countryCode": 0,
        "dNSHostName": "iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
        "dSCorePropagationData": [
          "2020-08-24 17:13:07+00:00",
          "1601-01-01 00:00:01+00:00"
        ],
        "distinguishedName": "CN=IAGENT5-DCWIN12,OU=Domain Controllers,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com",
        "instanceType": 4,
        "isCriticalSystemObject": true,
        "lastLogoff": "1601-01-01 00:00:00+00:00",
        "lastLogon": "2020-11-06 07:42:25.783710+00:00",
        "lastLogonTimestamp": "2020-11-04 07:42:15.991854+00:00",
        "localPolicyFlags": 0,
        "logonCount": 462,
        "msDFSR-ComputerReferenceBL": [
          "CN=IAGENT5-DCWIN12,CN=Topology,CN=Domain System Volume,CN=DFSR-GlobalSettings,CN=System,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com"
        ],
        "msDS-GenerationId": {
          "encoded": "BhnLYVOsKNk=",
          "encoding": "base64"
        },
        "msDS-SupportedEncryptionTypes": 28,
        "name": "IAGENT5-DCWIN12",
        "objectCategory": "CN=Computer,CN=Schema,CN=Configuration,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com",
        "objectClass": [
          "top",
          "person",
          "organizationalPerson",
          "user",
          "computer"
        ],
        "objectGUID": "{de6f12fb-7895-46d1-92ef-a6c77ec1236f}",
        "objectSid": "S-1-5-21-2677061338-3577197041-828036409-1004",
        "operatingSystem": "Windows Server 2012 R2 Standard",
        "operatingSystemVersion": "6.3 (9600)",
        "primaryGroupID": 516,
        "pwdLastSet": "2020-10-23 23:11:23.238735+00:00",
        "rIDSetReferences": [
          "CN=RID Set,CN=IAGENT5-DCWIN12,OU=Domain Controllers,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com"
        ],
        "sAMAccountName": "IAGENT5-DCWIN12$",
        "sAMAccountType": 805306369,
        "serverReferenceBL": [
          "CN=IAGENT5-DCWIN12,CN=Servers,CN=Default-First-Site-Name,CN=Sites,CN=Configuration,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com"
        ],
        "servicePrincipalName": [
          "Dfsr-12F9A27C-BF97-4787-9364-D31B6C55EB04/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
          "ldap/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/ForestDnsZones.soarcerrors.vuln.lax.rapid7.com",
          "ldap/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/DomainDnsZones.soarcerrors.vuln.lax.rapid7.com",
          "TERMSRV/IAGENT5-DCWIN12",
          "TERMSRV/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
          "DNS/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
          "GC/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/soarcerrors.vuln.lax.rapid7.com",
          "RestrictedKrbHost/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
          "RestrictedKrbHost/IAGENT5-DCWIN12",
          "RPC/567f808f-2c0d-4710-90b8-a74da0b45f69._msdcs.soarcerrors.vuln.lax.rapid7.com",
          "HOST/IAGENT5-DCWIN12/SOARCERRORS",
          "HOST/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/SOARCERRORS",
          "HOST/IAGENT5-DCWIN12",
          "HOST/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
          "HOST/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/soarcerrors.vuln.lax.rapid7.com",
          "E3514235-4B06-11D1-AB04-00C04FC2DCD2/567f808f-2c0d-4710-90b8-a74da0b45f69/soarcerrors.vuln.lax.rapid7.com",
          "ldap/IAGENT5-DCWIN12/SOARCERRORS",
          "ldap/567f808f-2c0d-4710-90b8-a74da0b45f69._msdcs.soarcerrors.vuln.lax.rapid7.com",
          "ldap/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/SOARCERRORS",
          "ldap/IAGENT5-DCWIN12",
          "ldap/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com",
          "ldap/iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com/soarcerrors.vuln.lax.rapid7.com"
        ],
        "uSNChanged": 31903,
        "uSNCreated": 12293,
        "userAccountControl": 532480,
        "whenChanged": "2020-11-04 07:42:15+00:00",
        "whenCreated": "2020-08-24 17:13:07+00:00"
      },
      "dn": "CN=IAGENT5-DCWIN12,OU=Domain Controllers,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com"
    },
    {
      "attributes": {
        "accountExpires": "9999-12-31 23:59:59.999999+00:00",
        "badPasswordTime": "1601-01-01 00:00:00+00:00",
        "badPwdCount": 0,
        "cn": "10006483",
        "codePage": 0,
        "countryCode": 0,
        "dSCorePropagationData": [
          "1601-01-01 00:00:00+00:00"
        ],
        "distinguishedName": "CN=10006483,OU=SSP,OU=Americas,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com",
        "instanceType": 4,
        "isCriticalSystemObject": false,
        "lastLogoff": "1601-01-01 00:00:00+00:00",
        "lastLogon": "1601-01-01 00:00:00+00:00",
        "localPolicyFlags": 0,
        "logonCount": 0,
        "memberOf": [
          "CN=Flexible SSL Allow Access,OU=Flexible SSL,OU=Applications,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com"
        ],
        "name": "10006483",
        "objectCategory": "CN=Computer,CN=Schema,CN=Configuration,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com",
        "objectClass": [
          "top",
          "person",
          "organizationalPerson",
          "user",
          "computer"
        ],
        "objectGUID": "{6382860e-df96-4309-924b-2a70765d575a}",
        "objectSid": "S-1-5-21-2677061338-3577197041-828036409-1615",
        "primaryGroupID": 515,
        "pwdLastSet": "2020-10-08 15:27:34.159369+00:00",
        "sAMAccountName": "10006483$",
        "sAMAccountType": 805306369,
        "uSNChanged": 29125,
        "uSNCreated": 29120,
        "userAccountControl": 4128,
        "whenChanged": "2020-10-08 15:27:34+00:00",
        "whenCreated": "2020-10-08 15:27:34+00:00"
      },
      "dn": "CN=10006483,OU=SSP,OU=Americas,DC=soarcerrors,DC=vuln,DC=lax,DC=rapid7,DC=com"
    }
  ]
}
```