### PR TITLE
[MC-198] Recorded Future output bug in Lookup Domain action

### DIFF
--- a/recorded_future/.CHECKSUM
+++ b/recorded_future/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "08df3a1864efd344a17df16c06172c4e",
-	"manifest": "dae24629c47a7df86d8ccf7eecd98dcc",
-	"setup": "2e59b74c63aa00840d2e256fb80d6e10",
+	"spec": "b97c32ed0b5ee41a6c6527675f4bb7a3",
+	"manifest": "db9eba9cbff9d2cf70b2f844063bf590",
+	"setup": "9d18df3f0e8b6b0c6822fa55470d679c",
 	"schemas": [
 		{
 			"identifier": "download_IP_addresses_risk_list/schema.py",
@@ -53,7 +53,7 @@
 		},
 		{
 			"identifier": "lookup_domain/schema.py",
-			"hash": "612d2c7823b4e3d764124f94000ba132"
+			"hash": "b8829e40b0d29a16e9d81ed4aa32e6bc"
 		},
 		{
 			"identifier": "lookup_entity_list/schema.py",

--- a/recorded_future/bin/komand_recorded_future
+++ b/recorded_future/bin/komand_recorded_future
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Recorded Future"
 Vendor = "rapid7"
-Version = "4.0.1"
+Version = "4.0.2"
 Description = "Recorded Future arms threat analysts, security operators, and incident responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7 InsightConnect, users can search domain lists, entity lists, and more"
 
 

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -2037,7 +2037,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 4.0.2 - Fix type of output parameters `analystNotes` and `threatLists` in Lookup Domain action
+* 4.0.2 - Return full `analystNotes` and `threatLists` data outputs in Lookup Domain action
 * 4.0.1 - Improve connection error messaging
 * 4.0.0 - Remove `fields` input in Lookup Domain, Lookup Hash, Lookup IP Address and Lookup URL actions - all fields will now be returned
 * 3.1.2 - Update to request headers to add plugin information

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -1341,7 +1341,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|analystNotes|[]string|False|Notes from an analyst|
+|analystNotes|[]analystNote|False|Notes from an analyst|
 |counts|[]counts|False|Counts|
 |enterpriseLists|[]enterpriseLists|False|Enterprise lists|
 |entity|entity|False|Entity|
@@ -1350,7 +1350,7 @@ Example input:
 |relatedEntities|[]relatedEntities|False|Related entities|
 |risk|risk|False|Risk|
 |sightings|[]sightings|False|Sightings|
-|threatLists|[]string|False|Threat lists|
+|threatLists|[]threatLists|False|Threat lists|
 |timestamps|timestamps|False|Timestamps|
 
 Example output:
@@ -2037,6 +2037,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.0.2 - Fix type of output parameters `analystNotes` and `threatLists` in Lookup Domain action
 * 4.0.1 - Improve connection error messaging
 * 4.0.0 - Remove `fields` input in Lookup Domain, Lookup Hash, Lookup IP Address and Lookup URL actions - all fields will now be returned
 * 3.1.2 - Update to request headers to add plugin information

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/schema.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/schema.py
@@ -66,7 +66,7 @@ class LookupDomainOutput(komand.Output):
       "title": "Analyst Notes",
       "description": "Notes from an analyst",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/analystNote"
       },
       "order": 3
     },
@@ -138,7 +138,7 @@ class LookupDomainOutput(komand.Output):
       "title": "Threat Lists",
       "description": "Threat lists",
       "items": {
-        "type": "string"
+        "$ref": "#/definitions/threatLists"
       },
       "order": 9
     },
@@ -150,6 +150,326 @@ class LookupDomainOutput(komand.Output):
     }
   },
   "definitions": {
+    "analystNote": {
+      "type": "object",
+      "title": "analystNote",
+      "properties": {
+        "attributes": {
+          "$ref": "#/definitions/attributes",
+          "title": "Attributes",
+          "order": 1
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "order": 2
+        },
+        "source": {
+          "$ref": "#/definitions/labels",
+          "title": "Source",
+          "order": 3
+        }
+      },
+      "definitions": {
+        "attributes": {
+          "type": "object",
+          "title": "attributes",
+          "properties": {
+            "context_entities": {
+              "type": "array",
+              "title": "Context Entities",
+              "items": {
+                "$ref": "#/definitions/context_entities"
+              },
+              "order": 1
+            },
+            "labels": {
+              "type": "array",
+              "title": "Labels",
+              "items": {
+                "$ref": "#/definitions/labels"
+              },
+              "order": 2
+            },
+            "note_entities": {
+              "type": "array",
+              "title": "Note Entities",
+              "items": {
+                "$ref": "#/definitions/labels"
+              },
+              "order": 3
+            },
+            "published": {
+              "type": "string",
+              "title": "Published",
+              "order": 4
+            },
+            "text": {
+              "type": "string",
+              "title": "Text",
+              "order": 5
+            },
+            "title": {
+              "type": "string",
+              "title": "Title",
+              "order": 6
+            },
+            "topic": {
+              "$ref": "#/definitions/context_entities",
+              "title": "Topic",
+              "order": 7
+            },
+            "validated_on": {
+              "type": "string",
+              "title": "Validated On",
+              "order": 8
+            },
+            "validation_urls": {
+              "type": "array",
+              "title": "Validation Urls",
+              "items": {
+                "$ref": "#/definitions/labels"
+              },
+              "order": 9
+            }
+          },
+          "definitions": {
+            "context_entities": {
+              "type": "object",
+              "title": "context_entities",
+              "properties": {
+                "description": {
+                  "type": "string",
+                  "title": "Description",
+                  "order": 1
+                },
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "order": 2
+                },
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "order": 3
+                },
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "order": 4
+                }
+              }
+            },
+            "labels": {
+              "type": "object",
+              "title": "labels",
+              "properties": {
+                "id": {
+                  "type": "string",
+                  "title": "Id",
+                  "order": 1
+                },
+                "name": {
+                  "type": "string",
+                  "title": "Name",
+                  "order": 2
+                },
+                "type": {
+                  "type": "string",
+                  "title": "Type",
+                  "order": 3
+                }
+              }
+            }
+          }
+        },
+        "context_entities": {
+          "type": "object",
+          "title": "context_entities",
+          "properties": {
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "order": 1
+            },
+            "id": {
+              "type": "string",
+              "title": "Id",
+              "order": 2
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "order": 3
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "order": 4
+            }
+          }
+        },
+        "labels": {
+          "type": "object",
+          "title": "labels",
+          "properties": {
+            "id": {
+              "type": "string",
+              "title": "Id",
+              "order": 1
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "order": 2
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "order": 3
+            }
+          }
+        }
+      }
+    },
+    "attributes": {
+      "type": "object",
+      "title": "attributes",
+      "properties": {
+        "context_entities": {
+          "type": "array",
+          "title": "Context Entities",
+          "items": {
+            "$ref": "#/definitions/context_entities"
+          },
+          "order": 1
+        },
+        "labels": {
+          "type": "array",
+          "title": "Labels",
+          "items": {
+            "$ref": "#/definitions/labels"
+          },
+          "order": 2
+        },
+        "note_entities": {
+          "type": "array",
+          "title": "Note Entities",
+          "items": {
+            "$ref": "#/definitions/labels"
+          },
+          "order": 3
+        },
+        "published": {
+          "type": "string",
+          "title": "Published",
+          "order": 4
+        },
+        "text": {
+          "type": "string",
+          "title": "Text",
+          "order": 5
+        },
+        "title": {
+          "type": "string",
+          "title": "Title",
+          "order": 6
+        },
+        "topic": {
+          "$ref": "#/definitions/context_entities",
+          "title": "Topic",
+          "order": 7
+        },
+        "validated_on": {
+          "type": "string",
+          "title": "Validated On",
+          "order": 8
+        },
+        "validation_urls": {
+          "type": "array",
+          "title": "Validation Urls",
+          "items": {
+            "$ref": "#/definitions/labels"
+          },
+          "order": 9
+        }
+      },
+      "definitions": {
+        "context_entities": {
+          "type": "object",
+          "title": "context_entities",
+          "properties": {
+            "description": {
+              "type": "string",
+              "title": "Description",
+              "order": 1
+            },
+            "id": {
+              "type": "string",
+              "title": "Id",
+              "order": 2
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "order": 3
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "order": 4
+            }
+          }
+        },
+        "labels": {
+          "type": "object",
+          "title": "labels",
+          "properties": {
+            "id": {
+              "type": "string",
+              "title": "Id",
+              "order": 1
+            },
+            "name": {
+              "type": "string",
+              "title": "Name",
+              "order": 2
+            },
+            "type": {
+              "type": "string",
+              "title": "Type",
+              "order": 3
+            }
+          }
+        }
+      }
+    },
+    "context_entities": {
+      "type": "object",
+      "title": "context_entities",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "order": 1
+        },
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "order": 2
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "order": 3
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "order": 4
+        }
+      }
+    },
     "counts": {
       "type": "object",
       "title": "counts",
@@ -308,6 +628,27 @@ class LookupDomainOutput(komand.Output):
           "type": "string",
           "title": "Timestamp",
           "order": 5
+        }
+      }
+    },
+    "labels": {
+      "type": "object",
+      "title": "labels",
+      "properties": {
+        "id": {
+          "type": "string",
+          "title": "Id",
+          "order": 1
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "order": 2
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "order": 3
         }
       }
     },
@@ -547,6 +888,36 @@ class LookupDomainOutput(komand.Output):
           "type": "string",
           "title": "Url",
           "order": 6
+        }
+      }
+    },
+    "threatLists": {
+      "type": "object",
+      "title": "threatLists",
+      "properties": {
+        "description": {
+          "type": "string",
+          "title": "Description",
+          "description": "Description",
+          "order": 1
+        },
+        "id": {
+          "type": "string",
+          "title": "ID",
+          "description": "ID",
+          "order": 2
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "Name",
+          "order": 3
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "Type",
+          "order": 4
         }
       }
     },

--- a/recorded_future/plugin.spec.yaml
+++ b/recorded_future/plugin.spec.yaml
@@ -9,7 +9,7 @@ status: []
 description: "Recorded Future arms threat analysts, security operators, and incident
   responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7
 InsightConnect, users can search domain lists, entity lists, and more"
-version: 4.0.1
+version: 4.0.2
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/recorded_future
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
@@ -743,7 +743,7 @@ actions:
       analystNotes:
         title: "Analyst Notes"
         description: "Notes from an analyst"
-        type: "[]string"
+        type: "[]analystNote"
         required: false
       counts:
         title: "Counts"
@@ -773,7 +773,7 @@ actions:
       threatLists:
         title: "Threat Lists"
         description: "Threat lists"
-        type: "[]string"
+        type: "[]threatLists"
         required: false
       risk:
         title: "Risk"

--- a/recorded_future/setup.py
+++ b/recorded_future/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="recorded_future-rapid7-plugin",
-      version="4.0.1",
+      version="4.0.2",
       description="Recorded Future arms threat analysts, security operators, and incident responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7 InsightConnect, users can search domain lists, entity lists, and more",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://komand.github.io/python/style.html)

- [ ] For dependencies, pin [OS package](https://komand.github.io/python/style.html#dockerfile) and [Python package](https://komand.github.io/python/style.html#requirements-txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://komand.github.io/python/sdk.html#sdk-versions) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://komand.github.io/python/error_handling.html#plugin-exceptions) and [ConnectionTestException](https://komand.github.io/python/error_handling.html#connection-exceptions)
- [ ] For logging, use [self.logger](https://komand.github.io/python/sdk.html#logging)
- [ ] For docs, use [changelog style](https://komand.github.io/python/style.html#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://komand.github.io/python/style.html#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 3423.71ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
./komand_recorded_future/actions/list_domain_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/list_hash_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/list_IP_addresses_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/list_vulnerability_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/lookup_alert/action.py:7:1: E303 too many blank lines (3)
./komand_recorded_future/actions/lookup_alert/action.py:20:1: W391 blank line at end of file
./komand_recorded_future/triggers/get_new_alerts/trigger.py:7:1: E302 expected 2 blank lines, found 1
./unit_test/test_get_new_alerts.py:5:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:6:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:7:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:8:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:9:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:10:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:11:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:28:1: E302 expected 2 blank lines, found 1
./unit_test/test_get_new_alerts.py:33:1: E302 expected 2 blank lines, found 1
./unit_test/test_get_new_alerts.py:55:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_get_new_alerts.py:58:1: W293 blank line contains whitespace
./unit_test/test_get_new_alerts.py:59:110: W291 trailing whitespace
./unit_test/test_get_new_alerts.py:74:20: E261 at least two spaces before inline comment
./unit_test/test_get_new_alerts.py:82:40: W292 no newline at end of file
./unit_test/test_lookup_alert.py:5:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:6:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:7:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:8:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:9:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_lookup_alert.py:30:1: W293 blank line contains whitespace
./unit_test/test_lookup_alert.py:31:110: W291 trailing whitespace
./unit_test/test_lookup_alert.py:37:9: E303 too many blank lines (2)
./unit_test/test_lookup_vulnerability.py:5:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:6:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:7:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:8:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:9:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_lookup_vulnerability.py:30:1: W293 blank line contains whitespace
./unit_test/test_lookup_vulnerability.py:31:110: W291 trailing whitespace
./unit_test/test_lookup_vulnerability.py:37:9: E303 too many blank lines (2)
./unit_test/test_search_vulnerabilities.py:5:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:6:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:7:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:8:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:9:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_search_vulnerabilities.py:30:1: W293 blank line contains whitespace
./unit_test/test_search_vulnerabilities.py:31:110: W291 trailing whitespace
./unit_test/test_search_vulnerabilities.py:37:9: E303 too many blank lines (2)
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
92 [0.. 50.. ]
Run started:2020-11-23 13:01:12.906164

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 13840
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check

```

<summary>
make validate
</summary>
</details>


<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: help.md[223]: http://stix.recordedfuture.com/
violation: help.md[1689]: http://stix.recordedfuture.com/
violation: help.md[1785]: http://stix.recordedfuture.com/
violation: help.md[228]: http://stix.mitre.org/Indicator-2
violation: help.md[1536]: http://stix.mitre.org/Indicator-2
violation: help.md[278]: https://app.recordedfuture.com/live/sc/entity/url%!A(MISSING)http%!A(MISSING)%!F(MISSING)%!F(MISSING)bolizarsospos.com%!F(MISSING)raph9xccgxt
violation: help.md[1584]: https://app.recordedfuture.com/live/sc/entity/ip%!...
violation: help.md[1629]: https://app.recordedfuture.com/live/sc/entity/ip%!...
violation: help.md[2073]: https://api.recordedfuture.com/v2
violation: help.md[230]: http://stix.mitre.org/common-1
violation: help.md[1545]: http://stix.mitre.org/common-1
violation: help.md[1789]: http://stix.mitre.org/common-1
violation: help.md[1787]: http://stix.mitre.org/ExploitTarget-1
violation: help.md[231]: http://stix.mitre.org/default_vocabularies-1
violation: help.md[1692]: http://stix.mitre.org/default_vocabularies-1
violation: help.md[232]: http://stix.mitre.org/TTP-1
violation: help.md[1538]: http://stix.mitre.org/TTP-1
violation: help.md[229]: http://stix.mitre.org/stix-1
violation: help.md[1537]: http://stix.mitre.org/stix-1
violation: help.md[1788]: http://stix.mitre.org/stix-1
[*] Plugin successfully validated!

----
[*] Total time elapsed: 80036.447ms

```

<summary>
icon-validate --all .
</summary>
</details>


[tests_recoded_future.txt](https://github.com/rapid7/insightconnect-plugins/files/5583138/tests_recoded_future.txt)

