### PR TITLE
[SOAR-3716] - Add debug logging to Okta

### DIFF
--- a/okta/.CHECKSUM
+++ b/okta/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d080ab322267476b51ac0502398e3ec3",
-	"manifest": "fed470393a5190aeb5704650d41aa3e3",
-	"setup": "f1e24f4e0f3d6e321b4ef954075ec619",
+	"spec": "2d0ea679599bfea6ee52821da3c13990",
+	"manifest": "05174b189f692d9a9f5c432f99622449",
+	"setup": "245ebde1530b8d74b515d2307a47df78",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",

--- a/okta/bin/komand_okta
+++ b/okta/bin/komand_okta
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Okta"
 Vendor = "rapid7"
-Version = "3.5.0"
+Version = "3.5.1"
 Description = "Secure identity management and single sign-on to any application"
 
 

--- a/okta/help.md
+++ b/okta/help.md
@@ -977,6 +977,7 @@ by Okta themselves, or constructed by the plugin based on the information it has
 
 # Version History
 
+* 3.5.1 - Update to trigger to add logging
 * 3.5.0 - New action Update Blacklist Zones
 * 3.4.3 - Fix issue where trigger did not return empty arrays when users were removed or added to group
 * 3.4.2 - Fix issue where Monitor User Groups trigger would erroneously detect logins as an addition/removal of a group member

--- a/okta/help.md
+++ b/okta/help.md
@@ -977,7 +977,7 @@ by Okta themselves, or constructed by the plugin based on the information it has
 
 # Version History
 
-* 3.5.1 - Update to trigger to add logging
+* 3.5.1 - Update to add additional logging to Monitor User Groups trigger
 * 3.5.0 - New action Update Blacklist Zones
 * 3.4.3 - Fix issue where trigger did not return empty arrays when users were removed or added to group
 * 3.4.2 - Fix issue where Monitor User Groups trigger would erroneously detect logins as an addition/removal of a group member

--- a/okta/komand_okta/triggers/users_added_removed_from_group/trigger.py
+++ b/okta/komand_okta/triggers/users_added_removed_from_group/trigger.py
@@ -99,12 +99,17 @@ class UsersAddedRemovedFromGroup(komand.Trigger):
                     removed.append({"group_name": group_names[index], "group_id": value, "users": removed_users})
 
             if added and removed:
+                self.logger.info("Users added and removed, sending to orchestrator.")
                 self.send({Output.USERS_ADDED_FROM_GROUPS: added, Output.USERS_REMOVED_FROM_GROUPS: removed})
             elif added and not removed:
+                self.logger.info("Users added, sending to orchestrator.")
                 self.send({Output.USERS_ADDED_FROM_GROUPS: added, Output.USERS_REMOVED_FROM_GROUPS: []})
             elif removed and not added:
+                self.logger.info("Users removed, sending to orchestrator.")
                 self.send({Output.USERS_REMOVED_FROM_GROUPS: removed, Output.USERS_ADDED_FROM_GROUPS: []})
 
             current_list = new_list
 
-            time.sleep(params.get(Input.INTERVAL, 300))
+            sleep_time = params.get(Input.INTERVAL, 300)
+            self.logger.info(f"Loop complete, sleeping for {sleep_time}...")
+            time.sleep(sleep_time)

--- a/okta/plugin.spec.yaml
+++ b/okta/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: rapid7
 status: []
 description: Secure identity management and single sign-on to any application
-version: 3.5.0
+version: 3.5.1
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/okta
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/okta/setup.py
+++ b/okta/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="okta-rapid7-plugin",
-      version="3.5.0",
+      version="3.5.1",
       description="Secure identity management and single sign-on to any application",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

This PR adds logging to the Okta plugin to show when it has sent messages to the orchestrator

## Testing: 
```
RMT-MBP-5357:okta jmcadams$ ./run.sh -R tests/users_added_removed_from_group.json
Running: cat tests/users_added_removed_from_group.json | docker run --rm   -i rapid7/okta:3.5.1 --debug run
This is a trigger ^C to continue
Connect: Connecting...
rapid7/Okta:3.5.1. Step name: users_added_removed_from_group
Loop complete, sleeping for 10 seconds...
Loop complete, sleeping for 10 seconds...
```