### PR TITLE
Proofpoint - fix url scheme

### DIFF
--- a/proofpoint_url_defense/.CHECKSUM
+++ b/proofpoint_url_defense/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "34b14da2d9b1a192c137a890abc56a73",
-	"manifest": "604b25d762d6e4f6ce4a4fe2b99fb61b",
-	"setup": "30ad98ff0b595422c48f1daf8177670f",
+	"spec": "baf4a1b06588f03c1a3043412cde7434",
+	"manifest": "ab54dff110940dd76bb3e0a439585bea",
+	"setup": "79e85bb711601ae916a9dd7dd45436cc",
 	"schemas": [
 		{
 			"identifier": "url_decode/schema.py",

--- a/proofpoint_url_defense/bin/komand_proofpoint_url_defense
+++ b/proofpoint_url_defense/bin/komand_proofpoint_url_defense
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint URL Defense"
 Vendor = "rapid7"
-Version = "1.2.2"
+Version = "1.2.3"
 Description = "Decode Proofpoint encoded URLs"
 
 

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -69,6 +69,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 1.2.3 - Fix decoded URL scheme
 * 1.2.2 - Fully decode URLs which contain hxxp as the protocol in action URL Decode
 * 1.2.1 - Update to use the `insightconnect-python-3-38-slim-plugin:4` Docker image | Update plugin.spec.yaml to include `cloud_ready`
 * 1.2.0 - Update to URL Decode to add `decoded` as an output variable

--- a/proofpoint_url_defense/help.md
+++ b/proofpoint_url_defense/help.md
@@ -69,7 +69,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 1.2.3 - Fix decoded URL scheme
+* 1.2.3 - Fix issue where the decoded URL scheme was missing the double forward slash in the protocol prefix e.g. https:/
 * 1.2.2 - Fully decode URLs which contain hxxp as the protocol in action URL Decode
 * 1.2.1 - Update to use the `insightconnect-python-3-38-slim-plugin:4` Docker image | Update plugin.spec.yaml to include `cloud_ready`
 * 1.2.0 - Update to URL Decode to add `decoded` as an output variable

--- a/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
+++ b/proofpoint_url_defense/komand_proofpoint_url_defense/actions/url_decode/action.py
@@ -2,6 +2,7 @@ import insightconnect_plugin_runtime
 from .schema import UrlDecodeInput, UrlDecodeOutput, Input, Output
 # Custom imports below
 from komand_proofpoint_url_defense.util.proofpoint_decoder import URLDefenseDecoder
+import re
 
 
 class UrlDecode(insightconnect_plugin_runtime.Action):
@@ -31,7 +32,15 @@ class UrlDecode(insightconnect_plugin_runtime.Action):
         try:
             decoded_url = decoder.decode(encoded_url)
             self.logger.info('URL has been decoded')
-            return {Output.DECODED_URL: decoded_url, Output.DECODED: True}
+            if re.compile('http:/[^/]').match(decoded_url):
+                decoded_url = decoded_url.replace('http:/', 'http://')
+            if re.compile('https:/[^/]').match(decoded_url):
+                decoded_url = decoded_url.replace('https:/', 'https://')
+
+            return {
+                Output.DECODED_URL: decoded_url,
+                Output.DECODED: True
+            }
         except (Exception, ValueError) as e:
             self.logger.error(f"Unexpected issue occurred decoding URL: {e}")
             return {Output.DECODED_URL: in_url, Output.DECODED: False}

--- a/proofpoint_url_defense/plugin.spec.yaml
+++ b/proofpoint_url_defense/plugin.spec.yaml
@@ -8,7 +8,7 @@ support: community
 status: []
 cloud_ready: true
 description: Decode Proofpoint encoded URLs
-version: 1.2.2
+version: 1.2.3
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/proofpoint_url_defense
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/proofpoint_url_defense/setup.py
+++ b/proofpoint_url_defense/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_url_defense-rapid7-plugin",
-      version="1.2.2",
+      version="1.2.3",
       description="Decode Proofpoint encoded URLs",
       author="rapid7",
       author_email="",

--- a/proofpoint_url_defense/unit_test/test_url_decode.py
+++ b/proofpoint_url_defense/unit_test/test_url_decode.py
@@ -19,7 +19,7 @@ class TestUrlDecode(TestCase):
         test_action.logger = log
 
         try:
-            with open("../tests/url_decode_http_with_one_slash.json") as file:
+            with open("../tests/url_decode.json") as file:
                 test_json = json.loads(file.read()).get("body")
                 connection_params = test_json.get("connection")
                 action_params = test_json.get("input")
@@ -59,7 +59,7 @@ class TestUrlDecode(TestCase):
         test_action.logger = log
 
         try:
-            with open("../tests/url_decode_http_with_one_slash.json") as file:
+            with open("../tests/url_decode.json") as file:
                 test_json = json.loads(file.read()).get("body")
                 connection_params = test_json.get("connection")
                 action_params = test_json.get("input")

--- a/proofpoint_url_defense/unit_test/test_url_decode.py
+++ b/proofpoint_url_defense/unit_test/test_url_decode.py
@@ -19,7 +19,7 @@ class TestUrlDecode(TestCase):
         test_action.logger = log
 
         try:
-            with open("../tests/url_decode.json") as file:
+            with open("../tests/url_decode_http_with_one_slash.json") as file:
                 test_json = json.loads(file.read()).get("body")
                 connection_params = test_json.get("connection")
                 action_params = test_json.get("input")
@@ -59,7 +59,7 @@ class TestUrlDecode(TestCase):
         test_action.logger = log
 
         try:
-            with open("../tests/url_decode.json") as file:
+            with open("../tests/url_decode_http_with_one_slash.json") as file:
                 test_json = json.loads(file.read()).get("body")
                 connection_params = test_json.get("connection")
                 action_params = test_json.get("input")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "decoded": true,
  "decoded_url": "http://example.com"
}

```

<summary>
docker run --rm -i rapid7/proofpoint_url_defense:1.2.3 --debug run < tests/url_decode_http_with_one_slash.json
</summary>
</details>

<details>

```
{
  "decoded": true,
  "decoded_url": "http://example.com"
}

```

<summary>
docker run --rm -i rapid7/proofpoint_url_defense:1.2.3 --debug run < tests/url_decode_http_with_two_slashes.json
</summary>
</details>

<details>

```
{
  "decoded": true,
  "decoded_url": "https://example.com"
}

```

<summary>
docker run --rm -i rapid7/proofpoint_url_defense:1.2.3 --debug run < tests/url_decode_https_with_one_slash.json
</summary>
</details>

<details>

```
{
  "decoded": true,
  "decoded_url": "https://example.com"
}

```

<summary>
docker run --rm -i rapid7/proofpoint_url_defense:1.2.3 --debug run < tests/url_decode_https_with_two_slashes.json
</summary>
</details>

### Validate

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "VersionPinValidator" failed!
        Cause: All Python dependencies must be version pinned. Please update all modules in requirements.txt with a specific version pin e.g. lxml==3.7.1


----
[*] Total time elapsed: 1012.0899999999999ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
./unit_test/test_url_decode.py:5:1: E402 module level import not at top of file
./unit_test/test_url_decode.py:6:1: E402 module level import not at top of file
./unit_test/test_url_decode.py:7:1: E402 module level import not at top of file
./unit_test/test_url_decode.py:8:1: E402 module level import not at top of file
./unit_test/test_url_decode.py:9:1: E402 module level import not at top of file
./unit_test/test_url_decode.py:26:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_url_decode.py:29:1: W293 blank line contains whitespace
./unit_test/test_url_decode.py:30:110: W291 trailing whitespace
./unit_test/test_url_decode.py:36:9: E303 too many blank lines (2)
./unit_test/test_url_decode.py:66:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_url_decode.py:70:110: W291 trailing whitespace
./unit_test/test_url_decode.py:84:1: W391 blank line at end of file
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2021-01-01 19:00:18.331773

Test results:
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: '*'
   Severity: Low   Confidence: Medium
   Location: ./komand_proofpoint_url_defense/util/proofpoint_decoder.py:80
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
79              def replace_token(token):
80                  if token == '*':
81                      character = self.dec_bytes[self.current_marker]

--------------------------------------------------

Code scanned:
        Total lines of code: 281
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 1.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 1.0
                High: 0.0
Files skipped (0):
[FAIL] Fails bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check

```

<summary>
make validate
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
WARNING: Use of 'PluginException' or 'ConnectionTestException' is recommended when raising an exception.
violation: komand_proofpoint_url_defense/util/proofpoint_decoder.py: line,  52
violation: komand_proofpoint_url_defense/util/proofpoint_decoder.py: line,  54
violation: komand_proofpoint_url_defense/util/proofpoint_decoder.py: line,  64
violation: komand_proofpoint_url_defense/util/proofpoint_decoder.py: line,  76
violation: komand_proofpoint_url_defense/util/proofpoint_decoder.py: line,  113
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: help.md[53]: http://www.example.org/url
[*] Plugin failed validation! The following validation errors occurred:

Validator "VersionPinValidator" failed!
        Cause: All Python dependencies must be version pinned. Please update all modules in requirements.txt with a specific version pin e.g. lxml==3.7.1


----
[*] Total time elapsed: 6983.879ms

```

<summary>
icon-validate --all .
</summary>
</details>