### PR TITLE
Improve Query action in Active Directory LDAP

### DIFF
--- a/active_directory_ldap/.CHECKSUM
+++ b/active_directory_ldap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "22fd8c8175adc62867d006d6e0311d0d",
-	"manifest": "817d20715fb24e3aeb77603152b90702",
-	"setup": "c35399b18a56ab7b5942173582d43ec4",
+	"spec": "3eb118646acd48f2bf8da859514ca31f",
+	"manifest": "79b2e997bc80365749098ef480e6e0fa",
+	"setup": "56e94ceea30fcfd5363542b33a4bbe42",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "query/schema.py",
-			"hash": "3805cf1daf8674d3a0dc3eaa05aff6a8"
+			"hash": "b98954163c3eabee3cb9b42c1ae909bb"
 		},
 		{
 			"identifier": "reset_password/schema.py",

--- a/active_directory_ldap/bin/komand_active_directory_ldap
+++ b/active_directory_ldap/bin/komand_active_directory_ldap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Active Directory LDAP"
 Vendor = "rapid7"
-Version = "4.0.3"
+Version = "4.1.0"
 Description = "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
 
 

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -54,7 +54,7 @@ This action is used to modify the attributes of an Active Directory object.
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |attribute_to_modify|string|None|True|The name of the attribute to modify|None|postalCode|
-|attribute_value|string|None|True|The value of the attribute|None|1100|
+|attribute_value|string|None|True|The value of the attribute|None|2114|
 |distinguished_name|string|None|True|The distinguished name of the object to modify|None|CN=user,OU=domain_users,DC=example,DC=com|
 
 Example input:
@@ -125,7 +125,7 @@ This action is used to add the specified Active Directory user.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|account_disabled|string|True|True|Set this to true to disable the user account at creation|['true', 'false']|True|
+|account_disabled|string|true|True|Set this to true to disable the user account at creation|['true', 'false']|true|
 |additional_parameters|object|None|False|Add additional user parameters in JSON format|None|{"telephoneNumber":"(617)555-1234"}|
 |domain_name|string|None|True|The domain name this user will belong to|None|example.com|
 |first_name|string|None|True|User's first name|None|John|
@@ -175,6 +175,7 @@ For more information on LDAP queries see https://ldap3.readthedocs.io/tutorial_s
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|attributes|[]string|None|False|Attributes to search. If empty return all attributes|None|["createTimestamp", "creatorsName"]|
 |search_base|string|None|True|The base of the search request|None|DC=example,DC=com|
 |search_filter|string|None|True|The filter of the search request. It must conform to the LDAP filter syntax specified in RFC4515|None|(sAMAccountName=joesmith)|
 
@@ -182,6 +183,10 @@ Example input:
 
 ```
 {
+  "attributes": [
+    "createTimestamp",
+    "creatorsName"
+  ],
   "search_base": "DC=example,DC=com",
   "search_filter": "(sAMAccountName=joesmith)"
 }
@@ -191,6 +196,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
+|count|integer|False|Number of results|
 |results|[]result|False|Results returned|
 
 Example output:
@@ -471,7 +477,6 @@ For example `CN=Robert (Bob) Smith,OU=domain_users,DC=rapid7,DC=com` is supporte
 but `CN=Robert Bob) Smith,OU=domain_users,DC=rapid7,DC=com` is not.
 
 All inputs to the query action must be correctly escaped.
-  
 
 If you cannot connect, ensure that network access is available, and view the logs to identify any auth errors.
 
@@ -486,6 +491,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 4.1.0 - Add new input Attributes in action Query | Add new output Count in action Query
 * 4.0.3 - Fix issue with connection documentation incorrectly stating a protocol prefix is required
 * 4.0.2 - Fix issue where some host names were being incorrectly parsed
 * 4.0.1 - Fix issue were logging of connection info did not display hostname correctly

--- a/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
@@ -1,5 +1,5 @@
 import komand
-from .schema import QueryInput, QueryOutput
+from .schema import QueryInput, QueryOutput, Input, Output
 # Custom imports below
 from komand_active_directory_ldap.util.utils import ADUtils
 import json
@@ -10,10 +10,10 @@ class Query(komand.Action):
 
     def __init__(self):
         super(self.__class__, self).__init__(
-                name='query',
-                description='Run a LDAP query',
-                input=QueryInput(),
-                output=QueryOutput())
+            name='query',
+            description='Run a LDAP query',
+            input=QueryInput(),
+            output=QueryOutput())
 
     def run(self, params={}):
         formatter = ADUtils()
@@ -30,13 +30,21 @@ class Query(komand.Action):
         escaped_query = formatter.escape_brackets_for_query(query, pairs)
         self.logger.info(f"Escaped query: {escaped_query}")
 
-        conn.search(search_base=params.get('search_base'),
-                    search_filter=escaped_query,
-                    attributes=[ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES]
-                    )
+        attributes = params.get(Input.ATTRIBUTES)
+        if not attributes:
+            attributes = [ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES]
+
+        conn.search(
+            search_base=params.get('search_base'),
+            search_filter=escaped_query,
+            attributes=attributes
+        )
 
         result_list_json = conn.response_to_json()
         result_list_object = json.loads(result_list_json)
         entries = result_list_object["entries"]
 
-        return {'results': entries}
+        return {
+            Output.RESULTS: entries,
+            Output.COUNT: len(entries)
+        }

--- a/active_directory_ldap/komand_active_directory_ldap/actions/query/schema.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/query/schema.py
@@ -8,11 +8,13 @@ class Component:
 
 
 class Input:
+    ATTRIBUTES = "attributes"
     SEARCH_BASE = "search_base"
     SEARCH_FILTER = "search_filter"
     
 
 class Output:
+    COUNT = "count"
     RESULTS = "results"
     
 
@@ -22,6 +24,15 @@ class QueryInput(komand.Input):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "attributes": {
+      "type": "array",
+      "title": "Attributes",
+      "description": "Attributes to search. If empty return all attributes",
+      "items": {
+        "type": "string"
+      },
+      "order": 3
+    },
     "search_base": {
       "type": "string",
       "title": "Search Base",
@@ -52,6 +63,12 @@ class QueryOutput(komand.Output):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "count": {
+      "type": "integer",
+      "title": "Count",
+      "description": "Number of results",
+      "order": 2
+    },
     "results": {
       "type": "array",
       "title": "Results",

--- a/active_directory_ldap/plugin.spec.yaml
+++ b/active_directory_ldap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: active_directory_ldap
 title: Active Directory LDAP
 description: "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
-version: 4.0.3
+version: 4.1.0
 vendor: rapid7
 support: rapid7
 status: []
@@ -70,10 +70,21 @@ actions:
         description: The base of the search request
         required: true
         example: "DC=example,DC=com"
+      attributes:
+        title: Attributes
+        description: Attributes to search. If empty return all attributes
+        required: false
+        type: '[]string'
+        example: ["createTimestamp", "creatorsName"]
     output:
       results:
         description: Results returned
         type: '[]result'
+        required: false
+      count:
+        title: Count
+        description: Number of results
+        type: integer
         required: false
   delete:
     title: Delete

--- a/active_directory_ldap/setup.py
+++ b/active_directory_ldap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="active_directory_ldap-rapid7-plugin",
-      version="4.0.3",
+      version="4.1.0",
       description="This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Improve Query action in Active Directory LDAP

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connecting to 10.0.2.15:10389\nConnected!\nrapid7/Active Directory LDAP:4.1.0. Step name: query\nEscaped query: (ou=people)\n",
    "meta": {},
    "output": {
      "count": 1,
      "results": [
        {
          "attributes": {
            "createTimestamp": "2021-01-04 16:20:52+00:00",
            "creatorsName": "cn=admin,dc=example,dc=com",
            "description": [
              "Planet Express crew"
            ],
            "entryCSN": [
              "20210104162052.599998Z#000000#000#000000"
            ],
            "entryDN": "ou=people,dc=example,dc=com",
            "entryUUID": "8f29d8e8-e2f4-103a-967f-f3c7194a9f0d",
            "hasSubordinates": true,
            "modifiersName": "cn=admin,dc=example,dc=com",
            "modifyTimestamp": "2021-01-04 16:20:52+00:00",
            "objectClass": [
              "top",
              "organizationalUnit"
            ],
            "ou": [
              "people"
            ],
            "structuralObjectClass": "organizationalUnit",
            "subschemaSubentry": "cn=Subschema"
          },
          "dn": "ou=people,dc=example,dc=com"
        }
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/active_directory_ldap:4.1.0 --debug run < tests/query.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connecting to 10.0.2.15:10389\nConnected!\nrapid7/Active Directory LDAP:4.1.0. Step name: query\nEscaped query: (description=Human)\n",
    "meta": {},
    "output": {
      "count": 4,
      "results": [
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com"
            ],
            "sn": [
              "Kroker"
            ],
            "title": []
          },
          "dn": "cn=Amy Wong+sn=Kroker,ou=people,dc=example,dc=com"
        },
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com"
            ],
            "sn": [
              "Fry"
            ],
            "title": []
          },
          "dn": "cn=Philip J. Fry,ou=people,dc=example,dc=com"
        },
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com"
            ],
            "sn": [
              "Conrad"
            ],
            "title": []
          },
          "dn": "cn=User Example, ou=people,dc=example,dc=com"
        },
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com",
              "user1@example.com"
            ],
            "sn": [
              "Farnsworth"
            ],
            "title": [
              "Professor"
            ]
          },
          "dn": "cn=Hubert J. Farnsworth,ou=people,dc=example,dc=com"
        }
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/active_directory_ldap:4.1.0 --debug run < tests/query_count_more_than_one.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connecting to 10.0.2.15:10389\nConnected!\nrapid7/Active Directory LDAP:4.1.0. Step name: query\nEscaped query: (description=Human)\n",
    "meta": {},
    "output": {
      "count": 4,
      "results": [
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com"
            ],
            "sn": [
              "Kroker"
            ],
            "title": []
          },
          "dn": "cn=User Example+sn=User,ou=people,dc=example,dc=com"
        },
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com"
            ],
            "sn": [
              "Fry"
            ],
            "title": []
          },
          "dn": "cn=Philip J. Fry,ou=people,dc=example,dc=com"
        },
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com"
            ],
            "sn": [
              "Conrad"
            ],
            "title": []
          },
          "dn": "cn=Hermes Conrad,ou=people,dc=example,dc=com"
        },
        {
          "attributes": {
            "description": [
              "Human"
            ],
            "mail": [
              "user@example.com",
              "user1@example.com"
            ],
            "sn": [
              "User"
            ],
            "title": [
              "Pro User"
            ]
          },
          "dn": "cn=User Example,ou=people,dc=example,dc=com"
        }
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/active_directory_ldap:4.1.0 --debug run < tests/query_count_more_than_one_multiple_attributes.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connecting to 10.0.2.15:10389\nConnected!\nrapid7/Active Directory LDAP:4.1.0. Step name: query\nEscaped query: (ou=people)\n",
    "meta": {},
    "output": {
      "count": 1,
      "results": [
        {
          "attributes": {
            "createTimestamp": "2021-01-04 16:20:52+00:00"
          },
          "dn": "ou=people,dc=example,dc=com"
        }
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/active_directory_ldap:4.1.0 --debug run < tests/query_one_attribute.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connecting to 10.0.2.15:10389\nConnected!\nrapid7/Active Directory LDAP:4.1.0. Step name: query\nEscaped query: (ou=people)\n",
    "meta": {},
    "output": {
      "count": 1,
      "results": [
        {
          "attributes": {
            "createTimestamp": "2021-01-04 16:20:52+00:00",
            "creatorsName": "cn=admin,dc=example,dc=com",
            "description": [
              "Planet Express crew"
            ]
          },
          "dn": "ou=people,dc=example,dc=com"
        }
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/active_directory_ldap:4.1.0 --debug run < tests/query_three_attribute.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connecting to 10.0.2.15:10389\nConnected!\nrapid7/Active Directory LDAP:4.1.0. Step name: query\nEscaped query: (ou=people)\n",
    "meta": {},
    "output": {
      "count": 1,
      "results": [
        {
          "attributes": {
            "createTimestamp": "2021-01-04 16:20:52+00:00",
            "creatorsName": "cn=admin,dc=example,dc=com"
          },
          "dn": "ou=people,dc=example,dc=com"
        }
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/active_directory_ldap:4.1.0 --debug run < tests/query_two_attribute.json
</summary>
</details>


<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 1336.143ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
./komand_active_directory_ldap/actions/modify_groups/action.py:7:1: F403 'from ldap3.core.exceptions import *' used; unable to detect undefined names
./komand_active_directory_ldap/actions/modify_groups/action.py:38:20: F405 'LDAPInvalidDnError' may be undefined, or defined from star imports: ldap3.core.exceptions
./komand_active_directory_ldap/actions/modify_groups/action.py:45:20: F405 'LDAPInvalidDnError' may be undefined, or defined from star imports: ldap3.core.exceptions
./komand_active_directory_ldap/actions/modify_object/action.py:6:1: F401 'ldap3.MODIFY_ADD' imported but unused
./komand_active_directory_ldap/connection/connection.py:52:9: E722 do not use bare 'except'
./komand_active_directory_ldap/connection/connection.py:76:13: F841 local variable 'test' is assigned to but never used
./komand_active_directory_ldap/connection/connection.py:77:9: E722 do not use bare 'except'
./komand_active_directory_ldap/util/utils.py:128:143: E226 missing whitespace around arithmetic operator
./unit_test/test_query.py:2:1: F401 'komand_active_directory_ldap.actions.Query' imported but unused
./unit_test/test_query.py:3:1: F401 'komand_active_directory_ldap.connection.Connection' imported but unused
./unit_test/test_query.py:4:1: F401 'logging' imported but unused
./unit_test/test_query.py:5:1: F401 'json' imported but unused
./unit_test/test_query.py:7:1: E302 expected 2 blank lines, found 1
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2021-01-31 20:38:51.334318

Test results:
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'password'
   Severity: Low   Confidence: Medium
   Location: ./komand_active_directory_ldap/actions/add_user/schema.py:17
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
16          LOGON_NAME = "logon_name"
17          PASSWORD = "password"
18          USER_OU = "user_ou"

--------------------------------------------------
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'new_password'
   Severity: Low   Confidence: Medium
   Location: ./komand_active_directory_ldap/actions/reset_password/schema.py:12
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
11          DISTINGUISHED_NAME = "distinguished_name"
12          NEW_PASSWORD = "new_password"
13

--------------------------------------------------
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'username_password'
   Severity: Low   Confidence: Medium
   Location: ./komand_active_directory_ldap/connection/schema.py:10
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
9           USE_SSL = "use_ssl"
10          USERNAME_PASSWORD = "username_password"
11

--------------------------------------------------

Code scanned:
        Total lines of code: 1317
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 3.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 3.0
                High: 0.0
Files skipped (0):
[FAIL] Fails bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check

```

<summary>
make validate
</summary>
</details>

<details>

```

[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 16307.541000000001ms
```

<summary>
icon-validate --all .
</summary>
</details>


