### PR TITLE
Support epochs in ms, μs and ns in Date from Epoch action in Datetime plugin

### DIFF
--- a/datetime/.CHECKSUM
+++ b/datetime/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "0edc8f05ec178e2f770934cd14e6e7ac",
-	"manifest": "a817a06c69483c82aae5d66fcefe6200",
-	"setup": "fab53d479c9e6509422c20de26e3705c",
+	"spec": "6b72bff5d9e968d54315223d5399aa34",
+	"manifest": "b2ec28e5bbb6a36656edb9e146966ce6",
+	"setup": "907c6e9886125758508f05dcae0732b8",
 	"schemas": [
 		{
 			"identifier": "add_to_datetime/schema.py",

--- a/datetime/.CHECKSUM
+++ b/datetime/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2a03fb73075d3c91b75efcfcae94cf7c",
-	"manifest": "e45177320404e62bd71ebc337de18ba8",
-	"setup": "53440a4f59f484fb9c2084f058ce5121",
+	"spec": "0edc8f05ec178e2f770934cd14e6e7ac",
+	"manifest": "a817a06c69483c82aae5d66fcefe6200",
+	"setup": "fab53d479c9e6509422c20de26e3705c",
 	"schemas": [
 		{
 			"identifier": "add_to_datetime/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "date_from_epoch/schema.py",
-			"hash": "97235381877a596a5e7f0a58634a576a"
+			"hash": "90fa631188e6b15c38376b53daa3a9ba"
 		},
 		{
 			"identifier": "epoch_from_date/schema.py",

--- a/datetime/bin/komand_datetime
+++ b/datetime/bin/komand_datetime
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Datetime"
 Vendor = "rapid7"
-Version = "2.2.0"
+Version = "2.2.1"
 Description = "This plugin manipulates timestamps using Python's maya library"
 
 

--- a/datetime/bin/komand_datetime
+++ b/datetime/bin/komand_datetime
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Datetime"
 Vendor = "rapid7"
-Version = "2.2.1"
+Version = "3.0.0"
 Description = "This plugin manipulates timestamps using Python's maya library"
 
 

--- a/datetime/help.md
+++ b/datetime/help.md
@@ -383,7 +383,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.2.1 - Add support for epochs in milliseconds, microseconds and nanoseconds in Date from Epoch action
+* 3.0.0 - Add support for epochs in milliseconds, microseconds and nanoseconds in Date from Epoch action
 * 2.2.0 - Add new action Get Future Time
 * 2.1.1 - Update to latest plugin runtime with support for gevent worker class
 * 2.1.0 - New actions To UTC and To Localtime

--- a/datetime/help.md
+++ b/datetime/help.md
@@ -269,7 +269,7 @@ This action is used to convert an epoch as an integer to a Datetime.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|epoch|number|None|True|Epoch as integer or float|None|1595452833|
+|epoch|string|None|True|Epoch as integer or float|None|1595452833|
 
 Example input:
 
@@ -383,6 +383,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 2.2.1 - Add support for epochs in milliseconds, microseconds and nanoseconds in Date from Epoch action
 * 2.2.0 - Add new action Get Future Time
 * 2.1.1 - Update to latest plugin runtime with support for gevent worker class
 * 2.1.0 - New actions To UTC and To Localtime

--- a/datetime/komand_datetime/actions/date_from_epoch/action.py
+++ b/datetime/komand_datetime/actions/date_from_epoch/action.py
@@ -1,6 +1,8 @@
 import insightconnect_plugin_runtime
 from .schema import DateFromEpochInput, DateFromEpochOutput, Input, Output
+from insightconnect_plugin_runtime.exceptions import PluginException
 import maya
+import re
 
 
 class DateFromEpoch(insightconnect_plugin_runtime.Action):
@@ -13,5 +15,25 @@ class DateFromEpoch(insightconnect_plugin_runtime.Action):
                 output=DateFromEpochOutput())
 
     def run(self, params={}):
-        new_datetime = maya.MayaDT(params.get(Input.EPOCH)).rfc3339()
-        return {Output.DATE: new_datetime}
+        epoch = params.get(Input.EPOCH)
+        if re.search('([0-9]){21,}', epoch):
+            raise PluginException(
+                cause="The given epoch is out of range.",
+                assistance="This action supports seconds, milliseconds, microseconds, and nanoseconds. Please check "
+                           "that the given epoch is correct."
+            )
+        return {
+            Output.DATE: maya.MayaDT(float(epoch) / self.seconds_division_number(epoch)).rfc3339()
+        }
+
+    @staticmethod
+    def seconds_division_number(epoch: str) -> int:
+        split_epoch = epoch.split('.')
+        if len(split_epoch[0]) > 17:
+            return 1000000000
+        elif 15 <= len(split_epoch[0]) <= 17:
+            return 1000000
+        elif 12 <= len(split_epoch[0]) <= 14:
+            return 1000
+        else:
+            return 1

--- a/datetime/komand_datetime/actions/date_from_epoch/schema.py
+++ b/datetime/komand_datetime/actions/date_from_epoch/schema.py
@@ -22,7 +22,7 @@ class DateFromEpochInput(insightconnect_plugin_runtime.Input):
   "title": "Variables",
   "properties": {
     "epoch": {
-      "type": "number",
+      "type": "string",
       "title": "Epoch",
       "description": "Epoch as integer or float",
       "order": 1

--- a/datetime/plugin.spec.yaml
+++ b/datetime/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: datetime
 title: Datetime
 description: This plugin manipulates timestamps using Python's maya library
-version: 2.2.0
+version: 2.2.1
 vendor: rapid7
 support: rapid7
 status: []
@@ -156,7 +156,7 @@ actions:
     description: Convert an epoch as an integer or float to a Datetime
     input:
       epoch:
-        type: number
+        type: string
         description: Epoch as integer or float
         required: true
         example: 1595452833

--- a/datetime/plugin.spec.yaml
+++ b/datetime/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: datetime
 title: Datetime
 description: This plugin manipulates timestamps using Python's maya library
-version: 2.2.1
+version: 3.0.0
 vendor: rapid7
 support: rapid7
 status: []

--- a/datetime/setup.py
+++ b/datetime/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="datetime-rapid7-plugin",
-      version="2.2.0",
+      version="2.2.1",
       description="This plugin manipulates timestamps using Python's maya library",
       author="rapid7",
       author_email="",

--- a/datetime/setup.py
+++ b/datetime/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="datetime-rapid7-plugin",
-      version="2.2.1",
+      version="3.0.0",
       description="This plugin manipulates timestamps using Python's maya library",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

Add support for epochs in milliseconds, microseconds and nanoseconds in Date from Epoch action

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)


## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "1975-02-07T13:32:42.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_microseconds.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2021-01-08T15:27:09.8Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_microseconds2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2480-03-23T10:31:38.7Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_microseconds3.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "1975-02-07T13:32:42.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_microseconds_float.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "1975-02-07T13:32:42.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_milliseconds.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2021-01-08T15:27:09.8Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_milliseconds2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2480-03-23T10:31:38.7Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_milliseconds3.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "1975-02-07T13:32:42.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_milliseconds_float.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "1975-02-07T13:32:42.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_nanoseconds.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2021-01-08T15:27:09.8Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_nanoseconds2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2480-03-23T10:31:38.7Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_nanoseconds3.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "5138-11-16T09:46:40.0Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_nanoseconds4.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "1975-02-07T13:32:42.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_nanoseconds_float.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nThe given epoch is out of range. This action supports seconds, milliseconds, microseconds, and nanoseconds. Please check that the given epoch is correct.",
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\nAn error occurred during plugin execution!\n\nThe given epoch is out of range. This action supports seconds, milliseconds, microseconds, and nanoseconds. Please check that the given epoch is correct.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.2.0-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 326, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.2.0-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 476, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/datetime_rapid7_plugin-3.0.0-py3.8.egg/komand_datetime/actions/date_from_epoch/action.py\", line 20, in run\n    raise PluginException(\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nThe given epoch is out of range. This action supports seconds, milliseconds, microseconds, and nanoseconds. Please check that the given epoch is correct.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_nanoseconds_out_of_range_bad.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2021-01-08T15:27:00.0Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_seconds.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2480-03-23T10:30:00.0Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_seconds2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Datetime:3.0.0. Step name: date_from_epoch\n",
    "meta": {},
    "output": {
      "date": "2021-01-08T15:27:00.9Z"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/datetime:3.0.0 --debug run < tests/date_from_epoch_seconds_float.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed! 
	Cause: All inputs should have example field in plugin.spec. 
In action "subtract_from_datetime": input "years", there is no example field.
In action "subtract_from_datetime": input "months", there is no example field.
In action "subtract_from_datetime": input "days", there is no example field.
In action "subtract_from_datetime": input "hours", there is no example field.
In action "subtract_from_datetime": input "minutes", there is no example field.
In action "subtract_from_datetime": input "seconds", there is no example field.
In action "add_to_datetime": input "years", there is no example field.
In action "add_to_datetime": input "months", there is no example field.
In action "add_to_datetime": input "days", there is no example field.
In action "add_to_datetime": input "hours", there is no example field.
In action "add_to_datetime": input "minutes", there is no example field.
In action "add_to_datetime": input "seconds", there is no example field.


----
[*] Total time elapsed: 151265.173ms
```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed! 
	Cause: All inputs should have example field in plugin.spec. 
In action "subtract_from_datetime": input "years", there is no example field.
In action "subtract_from_datetime": input "months", there is no example field.
In action "subtract_from_datetime": input "days", there is no example field.
In action "subtract_from_datetime": input "hours", there is no example field.
In action "subtract_from_datetime": input "minutes", there is no example field.
In action "subtract_from_datetime": input "seconds", there is no example field.
In action "add_to_datetime": input "years", there is no example field.
In action "add_to_datetime": input "months", there is no example field.
In action "add_to_datetime": input "days", there is no example field.
In action "add_to_datetime": input "hours", there is no example field.
In action "add_to_datetime": input "minutes", there is no example field.
In action "add_to_datetime": input "seconds", there is no example field.


----
[*] Total time elapsed: 1536.119ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] For Markdown linting, install mdl: gem install mdl

[*] Validating python files for style...
[SUCCESS] Passes flake8 linting

[*] Validating python files for security vulnerabilities...
[main]	INFO	profile include tests: None
[main]	INFO	profile exclude tests: None
[main]	INFO	cli include tests: None
[main]	INFO	cli exclude tests: None
[main]	INFO	running on Python 3.7.3
Run started:2021-01-26 13:26:52.504998

Test results:
	No issues identified.

Code scanned:
	Total lines of code: 1579
	Total lines skipped (#nosec): 0

Run metrics:
	Total issues (by severity):
		Undefined: 0.0
		Low: 0.0
		Medium: 0.0
		High: 0.0
	Total issues (by confidence):
		Undefined: 0.0
		Low: 0.0
		Medium: 0.0
		High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] For spell checking, install misspell: go get -u github.com/client9/misspell/cmd/misspell
```

<summary>
make validate
</summary>
</details>
