### PR TITLE
SOAR-3688: Add script to generate a custom dictionary for a plugin

### DIFF
--- a/tools/generate_custom_dictionary.py
+++ b/tools/generate_custom_dictionary.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+import contextlib
+import json
+import gzip
+import os
+import re
+from collections import Counter
+from nltk.tag import pos_tag
+from nltk.tokenize import RegexpTokenizer
+
+
+def load_files(dirname):
+    files = list()
+    for dirpath, dirnames, filenames in os.walk(dirname):
+        for filename in [f for f in filenames if f.endswith(".md") or f.endswith(".yaml")]:
+            print("found " + os.path.join(dirpath, filename))
+            files.append(os.path.join(dirpath, filename))
+    return files
+
+
+@contextlib.contextmanager
+def load_file(filename, encoding="utf-8"):
+    if filename[-3:].lower() == ".gz":
+        with gzip.open(filename, mode="rt", encoding=encoding) as file:
+            yield file
+    else:
+        with open(filename, mode="r", encoding=encoding) as file:
+            yield file
+
+
+def export_word_frequency(filepath, word_frequency):
+    with open(filepath, 'w') as f:
+        json.dump(word_frequency, f, indent="", sort_keys=True, ensure_ascii=False)
+
+
+def build_word_frequency(dirpath, output_path):
+    word_frequency = Counter()
+    tok = RegexpTokenizer(r'\w+')
+
+    rows = 0
+
+    files = load_files(dirpath)
+
+    for filepath in files:
+        with load_file(filepath, 'utf-8') as file:
+            for line in file:
+                line = re.sub('[^0-9a-zA-Z]+', ' ', line)
+                parts = tok.tokenize(line)
+                tagged_sent = pos_tag(parts)
+                words = [word[0].lower() for word in tagged_sent if
+                         word[0] and word[0][0].isalpha()]
+                if words:
+                    word_frequency.update(words)
+
+                rows += 1
+
+                if rows % 100000 == 0:
+                    print("completed: {} rows".format(rows))
+
+    print("completed: {} rows".format(rows))
+    export_word_frequency(output_path, word_frequency)
+    print("exported custom dictionary to {}".format(output_path))
+    return word_frequency
+
+
+def _parse_args():
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description='Build a new custom dictionary for an InsightConnect Plugin')
+    parser.add_argument("-p", "--path", help="The path to the plugin to build a custom dictionary for")
+
+    args = parser.parse_args()
+
+    # validate that we have a path, if needed!
+    if not args.path:
+        raise Exception("A path is required to generate a custom dictionary")
+
+    if args.path:
+        args.path = os.path.abspath(os.path.realpath(args.path))
+        if not os.path.exists(args.path):
+            raise FileNotFoundError("A valid path is required to generate a custom dictionary")
+
+    return args
+
+
+if __name__ == '__main__':
+    args = _parse_args()
+    script_path = os.path.dirname(os.path.abspath(__file__))
+    export_path = os.path.abspath("{}/custom_dict.json".format(args.path))
+    word_frequency = build_word_frequency(args.path, export_path)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - This change adds a script to `/tools` to generate a custom dictionary for a plugin by running `tools/generate_custom_dictionary.py -p {PLUGIN_PATH}`. Custom dictionaries are used to exempt plugin-specific words from the spellcheck validator in `insightconnect-integrations-validators`. Generated dictionaries are saved as `custom_dict.json` in the plugin directory.

### Testing

Tested locally.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [x] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [x] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [x] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR.
4. Add UI screenshot of the workflow used for testing
5. Add UI screenshot of the job output used for testing
6. Add UI screenshot of the artifact (See rules in UI Checklist) used for testing
