### PR TITLE
Number of bug fixes

### DIFF
--- a/active_directory_ldap/.CHECKSUM
+++ b/active_directory_ldap/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "6b32c063baba193567953569469d2abb",
+	"spec": "ffafdc33b5f0d4332815e80c9f1ac7d8",
 	"manifest": "82ee56b1301f45f70c02b20d923bcb14",
 	"setup": "ef23ccb0bd93abc1e52393914fc1c030",
 	"schemas": [

--- a/active_directory_ldap/help.md
+++ b/active_directory_ldap/help.md
@@ -25,6 +25,7 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|auto_referrals|boolean|True|True|Allows the plugin to follow referrals from the specified Active Directory server to other Active Directory servers|None|True|
 |host|string|None|True|Server Host, e.g. example.com|None|example.com|
 |port|integer|389|True|Port, e.g. 389|None|389|
 |use_ssl|boolean|None|True|Use SSL?|None|True|
@@ -34,10 +35,13 @@ Example input:
 
 ```
 {
+  "auto_referrals": true,
   "host": "example.com",
   "port": 389,
   "use_ssl": true,
-  "username_password": {"username":"user1", "password":"mypassword"}
+  "username_password": {
+    "username": "user1", "password": "mypassword"
+  }
 }
 ```
 
@@ -54,7 +58,7 @@ This action is used to modify the attributes of an Active Directory object.
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |attribute_to_modify|string|None|True|The name of the attribute to modify|None|postalCode|
-|attribute_value|string|None|True|The value of the attribute|None|2114|
+|attribute_value|string|None|True|The value of the attribute|None|02114|
 |distinguished_name|string|None|True|The distinguished name of the object to modify|None|CN=user,OU=domain_users,DC=example,DC=com|
 
 Example input:
@@ -62,7 +66,7 @@ Example input:
 ```
 {
   "attribute_to_modify": "postalCode",
-  "attribute_value": 1100,
+  "attribute_value": "02114",
   "distinguished_name": "CN=user,OU=domain_users,DC=example,DC=com"
 }
 ```
@@ -139,8 +143,10 @@ Example input:
 
 ```
 {
-  "account_disabled": "true",
-  "additional_parameters": {"telephoneNumber":"(617)555-1234"},
+  "account_disabled": true,
+  "additional_parameters": {
+    "telephoneNumber": "(617)555-1234"
+  },
   "domain_name": "example.com",
   "first_name": "John",
   "last_name": "Doe",
@@ -471,7 +477,6 @@ For example `CN=Robert (Bob) Smith,OU=domain_users,DC=rapid7,DC=com` is supporte
 but `CN=Robert Bob) Smith,OU=domain_users,DC=rapid7,DC=com` is not.
 
 All inputs to the query action must be correctly escaped.
-  
 
 If you cannot connect, ensure that network access is available, and view the logs to identify any auth errors.
 
@@ -486,6 +491,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 5.0.1 - Removed trailing spaces | Move duplicate code to library
 * 5.0.0 - Add new input to connection to allow for Auto Referrals | A number of bug fixes
 * 4.0.3 - Fix issue with connection documentation incorrectly stating a protocol prefix is required
 * 4.0.2 - Fix issue where some host names were being incorrectly parsed

--- a/active_directory_ldap/komand_active_directory_ldap/actions/disable_user/action.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/disable_user/action.py
@@ -1,64 +1,25 @@
 import komand
-from .schema import DisableUserInput, DisableUserOutput
+
 # Custom imports below
-from komand.exceptions import PluginException
 from komand_active_directory_ldap.util.utils import ADUtils
-from ldap3 import MODIFY_REPLACE
+from .schema import DisableUserInput, DisableUserOutput, Input, Output
 
 
 class DisableUser(komand.Action):
 
     def __init__(self):
         super(self.__class__, self).__init__(
-                name='disable_user',
-                description='Disable a account',
-                input=DisableUserInput(),
-                output=DisableUserOutput())
+            name='disable_user',
+            description='Disable a account',
+            input=DisableUserInput(),
+            output=DisableUserOutput())
 
     def run(self, params={}):
-        formatter = ADUtils()
-        conn = self.connection.conn
-        dn = params.get('distinguished_name')
-        dn, search_base = formatter.format_dn(dn)
-        self.logger.info(f'Escaped DN {dn}')
-
-        pairs = formatter.find_parentheses_pairs(dn)
-        self.logger.info(pairs)
-        # replace ( and ) when they are part of a name rather than a search parameter
-        if pairs:
-            dn = formatter.escape_brackets_for_query(dn, pairs)
-
-        self.logger.info(f'Search DN {dn}')
-
-        conn.search(search_base=search_base,
-                    search_filter=f'(distinguishedName={dn})',
-                    attributes=['userAccountControl']
-                    )
-        results = conn.response
-        dn_test = [d['dn'] for d in results if 'dn' in d]
-        try:
-            dn_test[0]
-        except Exception as ex:
-            self.logger.error('The DN ' + dn + ' was not found')
-            raise PluginException(cause="The DN was not found",
-                                  assistance="The DN " + dn + " was not found") from ex
-        user_list = [d['attributes'] for d in results if 'attributes' in d]
-        user_control = user_list[0]
-        try:
-            account_status = user_control['userAccountControl']
-        except Exception as ex:
-            self.logger.error('The DN ' + dn + ' is not a user')
-            raise PluginException(cause="The DN is not a user",
-                                  assistance="The DN " + dn + " is not a user") from ex
-        user_account_flag = 2
-        account_status = account_status | user_account_flag
-
-        conn.modify(dn, {'userAccountControl': [(MODIFY_REPLACE, [account_status])]})
-        result = conn.result
-        output = result['description']
-
-        if result['result'] == 0:
-            return {'success': True}
-
-        self.logger.error('failed: error message %s' % output)
-        return {'success': False}
+        return {
+            Output.SUCCESS: ADUtils.change_account_status(
+                self.connection.conn,
+                params.get(Input.DISTINGUISHED_NAME),
+                False,
+                self.logger
+            )
+        }

--- a/active_directory_ldap/komand_active_directory_ldap/actions/enable_user/action.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/enable_user/action.py
@@ -1,63 +1,25 @@
 import komand
-from .schema import EnableUserInput, EnableUserOutput
+
 # Custom imports below
-from komand.exceptions import PluginException
 from komand_active_directory_ldap.util.utils import ADUtils
-from ldap3 import MODIFY_REPLACE
+from .schema import EnableUserInput, EnableUserOutput, Input, Output
 
 
 class EnableUser(komand.Action):
 
     def __init__(self):
         super(self.__class__, self).__init__(
-                name='enable_user',
-                description='Enable a account',
-                input=EnableUserInput(),
-                output=EnableUserOutput())
+            name='enable_user',
+            description='Enable a account',
+            input=EnableUserInput(),
+            output=EnableUserOutput())
 
     def run(self, params={}):
-        formatter = ADUtils()
-        conn = self.connection.conn
-        dn = params.get('distinguished_name')
-        dn, search_base = formatter.format_dn(dn)
-        self.logger.info(f'Escaped DN {dn}')
-
-        pairs = formatter.find_parentheses_pairs(dn)
-        # replace ( and ) when they are part of a name rather than a search parameter
-        if pairs:
-            dn = formatter.escape_brackets_for_query(dn, pairs)
-
-        self.logger.info(f'Search DN {dn}')
-
-        conn.search(search_base=search_base,
-                    search_filter=f'(distinguishedName={dn})',
-                    attributes=['userAccountControl']
-                    )
-        results = conn.response
-        dn_test = [d['dn'] for d in results if 'dn' in d]
-        try:
-            dn_test[0]
-        except Exception as ex:
-            self.logger.error('The DN ' + dn + ' was not found')
-            raise PluginException(cause='The DN was not found',
-                                  assistance='The DN ' + dn + ' was not found') from ex
-        user_list = [d["attributes"] for d in results if "attributes" in d]
-        user_control = user_list[0]
-        try:
-            account_status = user_control['userAccountControl']
-        except Exception as ex:
-            self.logger.error('The DN ' + dn + ' is not a user')
-            raise PluginException(cause='The DN is not a user',
-                                  assistance='The DN ' + dn + ' is not a user') from ex
-        user_account_flag = 2
-        account_status = account_status & ~user_account_flag
-
-        conn.modify(dn, {'userAccountControl': [(MODIFY_REPLACE, [account_status])]})
-        result = conn.result
-        output = result['description']
-
-        if result['result'] == 0:
-            return {'success': True}
-
-        self.logger.error('failed: error message %s' % output)
-        return {'success': False}
+        return {
+            Output.SUCCESS: ADUtils.change_account_status(
+                self.connection.conn,
+                params.get(Input.DISTINGUISHED_NAME),
+                True,
+                self.logger
+            )
+        }

--- a/active_directory_ldap/komand_active_directory_ldap/actions/modify_groups/action.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/modify_groups/action.py
@@ -1,77 +1,67 @@
 import komand
-from .schema import ModifyGroupsInput, ModifyGroupsOutput
+from .schema import ModifyGroupsInput, ModifyGroupsOutput, Input, Output
 # Custom imports below
 from komand.exceptions import PluginException
 from komand_active_directory_ldap.util.utils import ADUtils
 from ldap3 import extend
-from ldap3.core.exceptions import *
+from ldap3.core.exceptions import LDAPInvalidDnError
 
 
 class ModifyGroups(komand.Action):
 
     def __init__(self):
         super(self.__class__, self).__init__(
-                name='modify_groups',
-                description='Add or remove a user from AD groups',
-                input=ModifyGroupsInput(),
-                output=ModifyGroupsOutput())
+            name='modify_groups',
+            description='Add or remove a user from AD groups',
+            input=ModifyGroupsInput(),
+            output=ModifyGroupsOutput())
 
     def run(self, params={}):
-        formatter = ADUtils()
         conn = self.connection.conn
-        dn = params.get('distinguished_name')
-        group_dn = params.get('group_dn')
-        add_remove = params.get('add_remove')
+        dn = params.get(Input.DISTINGUISHED_NAME)
+        group_dn = params.get(Input.GROUP_DN)
+        add_remove = params.get(Input.ADD_REMOVE)
 
         # Normalize dn
-        dn, search_base = formatter.format_dn(dn)
-        dn = formatter.unescape_asterisk(dn)
+        dn, search_base = ADUtils.format_dn(dn)
+        dn = ADUtils.unescape_asterisk(dn)
         self.logger.info(f'Escaped DN {dn}')
         # Normalize group dn
-        group_dn = formatter.format_dn(group_dn)[0]
-        group_dn = formatter.unescape_asterisk(group_dn)
+        group_dn = ADUtils.format_dn(group_dn)[0]
+        group_dn = ADUtils.unescape_asterisk(group_dn)
         self.logger.info(f'Escaped group DN {group_dn}')
 
         # Check that dn exists in AD
-        self.check_that_user_dn_is_valid(conn, dn, search_base)
+        if not ADUtils.check_user_dn_is_valid(conn, dn, search_base):
+            self.logger.error(f'The DN {dn} was not found')
+            raise PluginException(
+                cause='The DN was not found.',
+                assistance=f'The DN {dn} was not found.'
+            )
 
         if add_remove == 'add':
             try:
                 group = extend.ad_add_members_to_groups(conn, dn, group_dn)
             except LDAPInvalidDnError as e:
-                raise PluginException(cause='Either the user or group distinguished name was not found.',
-                                      assistance='Please check that the distinguished names are correct',
-                                      data=e)
+                raise PluginException(
+                    cause='Either the user or group distinguished name was not found.',
+                    assistance='Please check that the distinguished names are correct',
+                    data=e
+                )
         else:
             try:
                 group = extend.ad_remove_members_from_groups(conn, dn, group_dn, fix=True)
             except LDAPInvalidDnError as e:
-                raise PluginException(cause='Either the user or group distinguished name was not found.',
-                                      assistance='Please check that the distinguished names are correct',
-                                      data=e)
+                raise PluginException(
+                    cause='Either the user or group distinguished name was not found.',
+                    assistance='Please check that the distinguished names are correct',
+                    data=e
+                )
 
         if group is False:
-            self.logger.error('ModifyGroups: Unexpected result for group. Group was ' + str(group))
+            self.logger.error(f'ModifyGroups: Unexpected result for group. Group was {str(group)}')
             raise PluginException(preset=PluginException.Preset.UNKNOWN)
 
-        return {'success': group}
-
-    def check_that_user_dn_is_valid(self, conn, user_dn: str, search_base: str) -> None:
-        formatter = ADUtils()
-        pairs = formatter.find_parentheses_pairs(user_dn)
-        # replace ( and ) when they are part of a name rather than a search parameter
-        if pairs:
-            user_dn = formatter.escape_brackets_for_query(user_dn, pairs)
-
-        conn.search(search_base=search_base,
-                    search_filter=f'(distinguishedName={user_dn})',
-                    attributes=['userAccountControl']
-                    )
-        results = conn.response
-        dn_test = [d['dn'] for d in results if 'dn' in d]
-        try:
-            dn_test[0]
-        except Exception as ex:
-            self.logger.error('The DN ' + user_dn + ' was not found')
-            raise PluginException(cause='The DN was not found',
-                                  assistance='The DN ' + user_dn + ' was not found') from ex
+        return {
+            Output.SUCCESS: group
+        }

--- a/active_directory_ldap/komand_active_directory_ldap/actions/modify_object/action.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/modify_object/action.py
@@ -3,7 +3,7 @@ from .schema import ModifyObjectInput, ModifyObjectOutput, Input, Output, Compon
 # Custom imports below
 from komand.exceptions import PluginException
 from komand_active_directory_ldap.util.utils import ADUtils
-from ldap3 import MODIFY_ADD, MODIFY_REPLACE, ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES
+from ldap3 import MODIFY_REPLACE, ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES
 from json import loads
 
 

--- a/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
+++ b/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
@@ -10,10 +10,10 @@ class Query(komand.Action):
 
     def __init__(self):
         super(self.__class__, self).__init__(
-                name='query',
-                description='Run a LDAP query',
-                input=QueryInput(),
-                output=QueryOutput())
+            name='query',
+            description='Run a LDAP query',
+            input=QueryInput(),
+            output=QueryOutput())
 
     def run(self, params={}):
         formatter = ADUtils()
@@ -30,10 +30,11 @@ class Query(komand.Action):
         escaped_query = formatter.escape_brackets_for_query(query, pairs)
         self.logger.info(f"Escaped query: {escaped_query}")
 
-        conn.search(search_base=params.get('search_base'),
-                    search_filter=escaped_query,
-                    attributes=[ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES]
-                    )
+        conn.search(
+            search_base=params.get('search_base'),
+            search_filter=escaped_query,
+            attributes=[ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES]
+        )
 
         result_list_json = conn.response_to_json()
         result_list_object = json.loads(result_list_json)

--- a/active_directory_ldap/plugin.spec.yaml
+++ b/active_directory_ldap/plugin.spec.yaml
@@ -285,7 +285,7 @@ actions:
         description: The value of the attribute
         type: string
         required: true
-        example: 02114
+        example: "02114"
     output:
       success:
         title: Success

--- a/active_directory_ldap/unit_test/test_host_formatter.py
+++ b/active_directory_ldap/unit_test/test_host_formatter.py
@@ -2,7 +2,8 @@ from unittest import TestCase, mock
 from komand_active_directory_ldap import connection
 import logging
 
-class MockServer():
+
+class MockServer:
 
     def __init__(self, host, port, use_ssl, get_info):
         self.host = host
@@ -10,9 +11,10 @@ class MockServer():
         self.use_ssl = use_ssl
         self.get_info = get_info
 
-class MockConnection():
 
-    def __init__(self, server, user, password,auto_encode,auto_escape,auto_bind,auto_referrals,authentication):
+class MockConnection:
+
+    def __init__(self, server, user, password, auto_encode, auto_escape, auto_bind, auto_referrals, authentication):
         self.server = server
         self.user = user
 
@@ -25,14 +27,15 @@ class TestHostFormatter(TestCase):
         params = {"host": "ldaps://12.12.12.12", "port": 345, "use_ssl": False,
                   "username_and_password": {"username": "bob", "password": "foobar"}}
         logger = logging.getLogger('logger')
-        conn =connection.Connection()
+        conn = connection.Connection()
         conn.logger = logger
         conn.connect(params)
 
     def test_host_formatter(self):
         host_types = ['10.10.10.10', '11.11.11.11:345', 'ldaps://12.12.12.12', 'ldaps://14.14.14.14:345',
                       'mydomain.com', 'mydomain.com:345', 'ldaps://mydomain.com', 'ldaps://mydomain.com:345',
-                      'mydomain.com/stuff', 'mydomain.com/stuff:345', 'ldaps://mydomain.com/stuff', 'ldaps://mydomain.com/stuff:345']
+                      'mydomain.com/stuff', 'mydomain.com/stuff:345', 'ldaps://mydomain.com/stuff',
+                      'ldaps://mydomain.com/stuff:345']
         output = list()
         conn = connection.Connection()
         for item in host_types:

--- a/active_directory_ldap/unit_test/test_query.py
+++ b/active_directory_ldap/unit_test/test_query.py
@@ -1,8 +1,9 @@
 from unittest import TestCase
-from komand_active_directory_ldap.actions import Query
-from komand_active_directory_ldap.connection import Connection
-import logging
-import json
+# from komand_active_directory_ldap.actions import Query
+# from komand_active_directory_ldap.connection import Connection
+# import logging
+# import json
+
 
 class TestQuery(TestCase):
     def test_query(self):


### PR DESCRIPTION
## Proposed Changes
Removed trailing spaces
Move duplicate code to library

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment
### Run
<details>

```
{
  "body": {
    "log": "Connecting to example.com:389\nConnected!\nrapid7/Active Directory LDAP:5.0.0. Step name: disable_user\nEscaped DN CN=User,CN=Users,DC=example,DC=com\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}
```
<summary>
docker run --rm -i rapid7/active_directory_ldap:5.0.0 --debug run < tests/disable_user.json
</summary>
</details>
<details>

```
{
  "body": {
    "log": "Connecting to example.com:389\nConnected!\nrapid7/Active Directory LDAP:5.0.0. Step name: disable_user\nEscaped DN CN=User,CN=Users,DC=example,DC=com\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}
```
<summary>
docker run --rm -i rapid7/active_directory_ldap:5.0.0 --debug run < tests/enable_user.json
</summary>
</details>
<details>

```
{
  "body": {
    "log": "Connecting to example.com:389\nConnected!\nrapid7/Active Directory LDAP:5.0.0. Step name: modify_groups\nEscaped DN CN=User,CN=Users,DC=example,DC=com\nEscaped group DN CN=Schema Admins,CN=Users,DC=example,DC=com\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}
```
<summary>
docker run --rm -i rapid7/active_directory_ldap:5.0.0 --debug run < tests/modify_groups_add.json
</summary>
</details>
<details>

```
{
  "body": {
    "log": "Connecting to example.com:389\nConnected!\nrapid7/Active Directory LDAP:5.0.0. Step name: modify_groups\nEscaped DN CN=User,CN=Users,DC=example,DC=com\nEscaped group DN CN=Schema Admins,CN=Users,DC=example,DC=com\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}
```
<summary>
docker run --rm -i rapid7/active_directory_ldap:5.0.0 --debug run < tests/modify_groups_remove.json
</summary>
</details>

### Validate
<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 1362.696ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
[SUCCESS] Passes flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2021-02-08 03:38:39.242274

Test results:
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'password'
   Severity: Low   Confidence: Medium
   Location: ./komand_active_directory_ldap/actions/add_user/schema.py:17
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
16          LOGON_NAME = "logon_name"
17          PASSWORD = "password"
18          USER_OU = "user_ou"

--------------------------------------------------
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'new_password'
   Severity: Low   Confidence: Medium
   Location: ./komand_active_directory_ldap/actions/reset_password/schema.py:12
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
11          DISTINGUISHED_NAME = "distinguished_name"
12          NEW_PASSWORD = "new_password"
13

--------------------------------------------------
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'username_password'
   Severity: Low   Confidence: Medium
   Location: ./komand_active_directory_ldap/connection/schema.py:11
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
10          USE_SSL = "use_ssl"
11          USERNAME_PASSWORD = "username_password"
12

--------------------------------------------------

Code scanned:
        Total lines of code: 1358
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 3.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 3.0
                High: 0.0
Files skipped (0):
[FAIL] Fails bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check
```
<summary>
make validate
</summary>
</details>
<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 14471.554ms
```
<summary>
icon-validate --all .
</summary>
</details>