### PR TITLE
MC-330 - Recorded Future - Lookup Domain - Improve Input Handling

### DIFF
--- a/recorded_future/.CHECKSUM
+++ b/recorded_future/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b97c32ed0b5ee41a6c6527675f4bb7a3",
-	"manifest": "db9eba9cbff9d2cf70b2f844063bf590",
-	"setup": "9d18df3f0e8b6b0c6822fa55470d679c",
+	"spec": "e179f09814fb026dcbe4313ec7e2e194",
+	"manifest": "1979c933b4b96b21c61fb30b3c6fb36e",
+	"setup": "47b2ba1982780d87554cc12142d5f88b",
 	"schemas": [
 		{
 			"identifier": "download_IP_addresses_risk_list/schema.py",

--- a/recorded_future/.CHECKSUM
+++ b/recorded_future/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "e179f09814fb026dcbe4313ec7e2e194",
+	"spec": "c0ca7453f1135ceef66534c0732aa9fb",
 	"manifest": "1979c933b4b96b21c61fb30b3c6fb36e",
 	"setup": "47b2ba1982780d87554cc12142d5f88b",
 	"schemas": [

--- a/recorded_future/bin/komand_recorded_future
+++ b/recorded_future/bin/komand_recorded_future
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Recorded Future"
 Vendor = "rapid7"
-Version = "4.0.2"
+Version = "4.0.3"
 Description = "Recorded Future arms threat analysts, security operators, and incident responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7 InsightConnect, users can search domain lists, entity lists, and more"
 
 

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -2037,6 +2037,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.0.3 - Update Lookup Domain action to handle `http://` and `https://` prefix
 * 4.0.2 - Return full `analystNotes` and `threatLists` data outputs in Lookup Domain action
 * 4.0.1 - Improve connection error messaging
 * 4.0.0 - Remove `fields` input in Lookup Domain, Lookup Hash, Lookup IP Address and Lookup URL actions - all fields will now be returned

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -2037,7 +2037,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 4.0.3 - Update Lookup Domain action to handle `http://` and `https://` prefix
+* 4.0.3 - Update Lookup Domain action to accept HTTP and HTTPS URLs as input
 * 4.0.2 - Return full `analystNotes` and `threatLists` data outputs in Lookup Domain action
 * 4.0.1 - Improve connection error messaging
 * 4.0.0 - Remove `fields` input in Lookup Domain, Lookup Hash, Lookup IP Address and Lookup URL actions - all fields will now be returned

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -15,7 +15,7 @@ class LookupDomain(komand.Action):
 
     def run(self, params={}):
         try:
-            domain = params.get(Input.DOMAIN).strip('https://')
+            domain = params.get(Input.DOMAIN).strip('https://').split('/')[0]
             comment = params.get(Input.COMMENT)
             fields = [
                 "analystNotes",

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -15,7 +15,7 @@ class LookupDomain(komand.Action):
 
     def run(self, params={}):
         try:
-            domain = params.get(Input.DOMAIN)
+            domain = params.get(Input.DOMAIN).strip('https://')
             comment = params.get(Input.COMMENT)
             fields = [
                 "analystNotes",

--- a/recorded_future/plugin.spec.yaml
+++ b/recorded_future/plugin.spec.yaml
@@ -9,7 +9,7 @@ status: []
 description: "Recorded Future arms threat analysts, security operators, and incident
   responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7
 InsightConnect, users can search domain lists, entity lists, and more"
-version: 4.0.2
+version: 4.0.3
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/recorded_future
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/recorded_future/setup.py
+++ b/recorded_future/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="recorded_future-rapid7-plugin",
-      version="4.0.2",
+      version="4.0.3",
       description="Recorded Future arms threat analysts, security operators, and incident responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7 InsightConnect, users can search domain lists, entity lists, and more",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - strip `http://` and `https://` prefixes from the domain input

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment
#### Run
Assessment test details are attached in the comments below, as they were too long to be in the initial PR comment.

#### Plugin Validation

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: help.md[231]: http://stix.mitre.org/default_vocabularies-1
violation: help.md[1693]: http://stix.mitre.org/default_vocabularies-1
violation: help.md[223]: http://stix.recordedfuture.com/
violation: help.md[1690]: http://stix.recordedfuture.com/
violation: help.md[1786]: http://stix.recordedfuture.com/
violation: help.md[1585]: https://app.recordedfuture.com/live/sc/entity/ip%!...
violation: help.md[1630]: https://app.recordedfuture.com/live/sc/entity/ip%!...
violation: help.md[232]: http://stix.mitre.org/TTP-1
violation: help.md[1539]: http://stix.mitre.org/TTP-1
violation: help.md[228]: http://stix.mitre.org/Indicator-2
violation: help.md[1537]: http://stix.mitre.org/Indicator-2
violation: help.md[230]: http://stix.mitre.org/common-1
violation: help.md[1546]: http://stix.mitre.org/common-1
violation: help.md[1790]: http://stix.mitre.org/common-1
violation: help.md[1788]: http://stix.mitre.org/ExploitTarget-1
violation: help.md[229]: http://stix.mitre.org/stix-1
violation: help.md[1538]: http://stix.mitre.org/stix-1
violation: help.md[1789]: http://stix.mitre.org/stix-1
violation: help.md[278]: https://app.recordedfuture.com/live/sc/entity/url%!A(MISSING)http%!A(MISSING)%!F(MISSING)%!F(MISSING)bolizarsospos.com%!F(MISSING)raph9xccgxt
violation: help.md[2075]: https://api.recordedfuture.com/v2
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed! 
        Cause: All inputs should have example field in plugin.spec. 
In action "search_domains": input "from", there is no example field.
In action "search_hashes": input "from", there is no example field.
In action "search_IP_addresses": input "from", there is no example field.
In action "search_malware": input "from", there is no example field.
In action "search_vulnerabilities": input "from", there is no example field.
In action "search_urls": input "from", there is no example field.


----
[*] Total time elapsed: 96370.914ms
```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed! 
        Cause: All inputs should have example field in plugin.spec. 
In action "search_domains": input "from", there is no example field.
In action "search_hashes": input "from", there is no example field.
In action "search_IP_addresses": input "from", there is no example field.
In action "search_malware": input "from", there is no example field.
In action "search_vulnerabilities": input "from", there is no example field.
In action "search_urls": input "from", there is no example field.


----
[*] Total time elapsed: 5231.709000000001ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] For Markdown linting, install mdl: gem install mdl

[*] Validating python files for style...
./unit_test/test_lookup_vulnerability.py:5:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:6:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:7:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:8:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:9:1: E402 module level import not at top of file
./unit_test/test_lookup_vulnerability.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_lookup_vulnerability.py:30:1: W293 blank line contains whitespace
./unit_test/test_lookup_vulnerability.py:31:110: W291 trailing whitespace
./unit_test/test_lookup_vulnerability.py:37:9: E303 too many blank lines (2)
./unit_test/test_lookup_alert.py:5:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:6:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:7:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:8:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:9:1: E402 module level import not at top of file
./unit_test/test_lookup_alert.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_lookup_alert.py:30:1: W293 blank line contains whitespace
./unit_test/test_lookup_alert.py:31:110: W291 trailing whitespace
./unit_test/test_lookup_alert.py:37:9: E303 too many blank lines (2)
./unit_test/test_get_new_alerts.py:5:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:6:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:7:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:8:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:9:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:10:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:11:1: E402 module level import not at top of file
./unit_test/test_get_new_alerts.py:28:1: E302 expected 2 blank lines, found 1
./unit_test/test_get_new_alerts.py:33:1: E302 expected 2 blank lines, found 1
./unit_test/test_get_new_alerts.py:55:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_get_new_alerts.py:58:1: W293 blank line contains whitespace
./unit_test/test_get_new_alerts.py:59:110: W291 trailing whitespace
./unit_test/test_get_new_alerts.py:74:20: E261 at least two spaces before inline comment
./unit_test/test_get_new_alerts.py:82:40: W292 no newline at end of file
./unit_test/test_search_vulnerabilities.py:5:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:6:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:7:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:8:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:9:1: E402 module level import not at top of file
./unit_test/test_search_vulnerabilities.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_search_vulnerabilities.py:30:1: W293 blank line contains whitespace
./unit_test/test_search_vulnerabilities.py:31:110: W291 trailing whitespace
./unit_test/test_search_vulnerabilities.py:37:9: E303 too many blank lines (2)
./komand_recorded_future/triggers/get_new_alerts/trigger.py:7:1: E302 expected 2 blank lines, found 1
./komand_recorded_future/actions/list_domain_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/lookup_alert/action.py:7:1: E303 too many blank lines (3)
./komand_recorded_future/actions/lookup_alert/action.py:20:1: W391 blank line at end of file
./komand_recorded_future/actions/list_hash_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/list_IP_addresses_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
./komand_recorded_future/actions/list_vulnerability_risk_rules/action.py:17:13: F841 local variable 'risklist' is assigned to but never used
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
92 [0.. 50.. ]
Run started:2021-02-17 21:17:09.905721

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 13840
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] Checking for typos with Misspell...
[FAIL] Fails Misspell check
.output/action_lookup_vulnerability.json:11852:119: "THN" is a misspelling of "THEN"
```

<summary>
make validate
</summary>
</details>
