### PR TITLE
[SOAR-4588] Rf fix lookup domain

### DIFF
--- a/recorded_future/.CHECKSUM
+++ b/recorded_future/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "c0ca7453f1135ceef66534c0732aa9fb",
-	"manifest": "1979c933b4b96b21c61fb30b3c6fb36e",
-	"setup": "47b2ba1982780d87554cc12142d5f88b",
+	"spec": "3a9c7a34f01e1ae0b6700df768d73413",
+	"manifest": "78cfaa5a84d297298205d4a2888e993f",
+	"setup": "9ab889ed18c6d355f74d2373cbb2d713",
 	"schemas": [
 		{
 			"identifier": "download_IP_addresses_risk_list/schema.py",

--- a/recorded_future/bin/komand_recorded_future
+++ b/recorded_future/bin/komand_recorded_future
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Recorded Future"
 Vendor = "rapid7"
-Version = "4.0.3"
+Version = "4.0.4"
 Description = "Recorded Future arms threat analysts, security operators, and incident responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7 InsightConnect, users can search domain lists, entity lists, and more"
 
 

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -1337,7 +1337,7 @@ Example input:
 }
 ```
 
-URLs given to this action will be stripped to their domains before they are used.
+URLs given to this action will be stripped to their domain before they are used.
 
 For example: 
 

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -1337,6 +1337,16 @@ Example input:
 }
 ```
 
+URLs given to this action will be stripped to their domains before they are used.
+
+For example: 
+
+`https://www.example.com/path/to/file`
+
+will become
+
+`www.example.com`
+
 ##### Output
 
 |Name|Type|Required|Description|

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -2037,6 +2037,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.0.4 - Fix issue where Lookup Domain could corrupt non-common domain name extensions
 * 4.0.3 - Update Lookup Domain action to accept HTTP and HTTPS URLs as input
 * 4.0.2 - Return full `analystNotes` and `threatLists` data outputs in Lookup Domain action
 * 4.0.1 - Improve connection error messaging

--- a/recorded_future/help.md
+++ b/recorded_future/help.md
@@ -1320,6 +1320,8 @@ Example output:
 #### Lookup Domain
 
 This action is used to return information about a specific domain entry.
+It accepts both domains and URLs as input. If a URL is given, it will be stripped to its domain.
+For example, `https://www.example.com/path/to/file` will become `www.example.com`.
 
 ##### Input
 
@@ -1336,16 +1338,6 @@ Example input:
   "domain": "example.com"
 }
 ```
-
-URLs given to this action will be stripped to their domain before they are used.
-
-For example: 
-
-`https://www.example.com/path/to/file`
-
-will become
-
-`www.example.com`
 
 ##### Output
 

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -40,4 +40,7 @@ class LookupDomain(komand.Action):
             clean_report = komand.helper.clean(domain_report["data"])
             return clean_report
         except Exception as e:
-            PluginException(cause=f"Error: {e}", assistance="Review exception")
+            raise PluginException(cause="Recorded Future did not return results",
+                                  assistance="This is usually because the domain entered was malformed. Please check the domain to make sure it is a valid domain",
+                                  data=f"\nDomain input: {original_domain}\n Exception:\n{e}")
+

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -16,7 +16,7 @@ class LookupDomain(komand.Action):
     def run(self, params={}):
         try:
             original_domain = params.get(Input.DOMAIN)
-            domain = original_domain.replace('https://','').split('/')[0]
+            domain = original_domain.replace('https://','').replace('http://','').split('/')[0]
             comment = params.get(Input.COMMENT)
             fields = [
                 "analystNotes",

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -16,7 +16,7 @@ class LookupDomain(komand.Action):
     def run(self, params={}):
         try:
             original_domain = params.get(Input.DOMAIN)
-            domain = original_domain.replace('https://','').replace('http://','').split('/')[0]
+            domain = self.get_domain(original_domain)
             comment = params.get(Input.COMMENT)
             fields = [
                 "analystNotes",
@@ -43,4 +43,10 @@ class LookupDomain(komand.Action):
             raise PluginException(cause="Recorded Future did not return results",
                                   assistance="This is usually because the domain entered was malformed. Please check the domain to make sure it is a valid domain",
                                   data=f"\nDomain input: {original_domain}\n Exception:\n{e}")
+
+    def get_domain(self, original_domain):
+        stripped = original_domain.replace('https://', '').replace('http://', '').split('/')[0]
+        if stripped.startswith("www."):
+            stripped = stripped[4:]
+        return stripped
 

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -15,7 +15,8 @@ class LookupDomain(komand.Action):
 
     def run(self, params={}):
         try:
-            domain = params.get(Input.DOMAIN).lstrip('https://').split('/')[0]
+            original_domain = params.get(Input.DOMAIN)
+            domain = original_domain.replace('https://','').split('/')[0]
             comment = params.get(Input.COMMENT)
             fields = [
                 "analystNotes",

--- a/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
+++ b/recorded_future/komand_recorded_future/actions/lookup_domain/action.py
@@ -15,7 +15,7 @@ class LookupDomain(komand.Action):
 
     def run(self, params={}):
         try:
-            domain = params.get(Input.DOMAIN).strip('https://').split('/')[0]
+            domain = params.get(Input.DOMAIN).lstrip('https://').split('/')[0]
             comment = params.get(Input.COMMENT)
             fields = [
                 "analystNotes",
@@ -36,6 +36,7 @@ class LookupDomain(komand.Action):
             domain_report = self.connection.client.lookup_domain(domain, fields=fields, comment=comment)
             if domain_report.get("warnings", False):
                 self.logger.warning(f"Warning: {domain_report.get('warnings')}")
-            return komand.helper.clean(domain_report["data"])
+            clean_report = komand.helper.clean(domain_report["data"])
+            return clean_report
         except Exception as e:
             PluginException(cause=f"Error: {e}", assistance="Review exception")

--- a/recorded_future/plugin.spec.yaml
+++ b/recorded_future/plugin.spec.yaml
@@ -9,7 +9,7 @@ status: []
 description: "Recorded Future arms threat analysts, security operators, and incident
   responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7
 InsightConnect, users can search domain lists, entity lists, and more"
-version: 4.0.3
+version: 4.0.4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/recorded_future
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/recorded_future/setup.py
+++ b/recorded_future/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="recorded_future-rapid7-plugin",
-      version="4.0.3",
+      version="4.0.4",
       description="Recorded Future arms threat analysts, security operators, and incident responders to rapidly connect the dots and reveal unknown threats. Using the Recorded Future plugin for Rapid7 InsightConnect, users can search domain lists, entity lists, and more",
       author="rapid7",
       author_email="",

--- a/recorded_future/unit_test/test_lookup_domain.py
+++ b/recorded_future/unit_test/test_lookup_domain.py
@@ -45,3 +45,19 @@ class TestLookupDomain(TestCase):
         self.assertTrue("analystNotes" in results.keys())
         self.assertTrue("metrics" in results.keys())
         self.assertTrue("risk" in results.keys())
+
+    def test_get_domain(self):
+        log = logging.getLogger("Test")
+        test_action = LookupDomain()
+
+        actual = test_action.get_domain("www.google.com")
+        self.assertEquals(actual, "google.com")
+
+        actual = test_action.get_domain("google.gs")
+        self.assertEquals(actual, "google.gs")
+
+        actual = test_action.get_domain("http://google.gs")
+        self.assertEquals(actual, "google.gs")
+
+        actual = test_action.get_domain("https://www.google.gs")
+        self.assertEquals(actual, "google.gs")

--- a/recorded_future/unit_test/test_lookup_domain.py
+++ b/recorded_future/unit_test/test_lookup_domain.py
@@ -61,3 +61,6 @@ class TestLookupDomain(TestCase):
 
         actual = test_action.get_domain("https://www.google.gs")
         self.assertEquals(actual, "www.google.gs")
+
+        actual = test_action.get_domain("https://www.example.com/path/to/file")
+        self.assertEquals(actual, "www.example.com")

--- a/recorded_future/unit_test/test_lookup_domain.py
+++ b/recorded_future/unit_test/test_lookup_domain.py
@@ -51,7 +51,7 @@ class TestLookupDomain(TestCase):
         test_action = LookupDomain()
 
         actual = test_action.get_domain("www.google.com")
-        self.assertEquals(actual, "google.com")
+        self.assertEquals(actual, "www.google.com")
 
         actual = test_action.get_domain("google.gs")
         self.assertEquals(actual, "google.gs")
@@ -60,4 +60,4 @@ class TestLookupDomain(TestCase):
         self.assertEquals(actual, "google.gs")
 
         actual = test_action.get_domain("https://www.google.gs")
-        self.assertEquals(actual, "google.gs")
+        self.assertEquals(actual, "www.google.gs")

--- a/recorded_future/unit_test/test_lookup_domain.py
+++ b/recorded_future/unit_test/test_lookup_domain.py
@@ -1,0 +1,47 @@
+import sys
+import os
+sys.path.append(os.path.abspath('../'))
+
+from unittest import TestCase
+from komand_recorded_future.connection.connection import Connection
+from komand_recorded_future.actions.lookup_domain import LookupDomain
+import json
+import logging
+
+
+class TestLookupDomain(TestCase):
+    def test_integration_lookup_domain(self):
+
+        log = logging.getLogger("Test")
+        test_conn = Connection()
+        test_action = LookupDomain()
+
+        test_conn.logger = log
+        test_action.logger = log
+
+        try:
+            with open("../tests/lookup_domain.json") as file:
+                test_json = json.loads(file.read()).get("body")
+                connection_params = test_json.get("connection")
+                action_params = test_json.get("input")
+        except Exception as e:
+            message = """
+            Could not find or read sample tests from /tests directory
+            
+            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
+            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
+            """
+            self.fail(message)
+
+
+        test_conn.connect(connection_params)
+        test_action.connection = test_conn
+        results = test_action.run(action_params)
+
+        # TODO: The following assert should be updated to look for data from your action
+        # For example: self.assertEquals({"success": True}, results)
+        self.assertIsNotNone(results)
+        self.assertTrue("entity" in results.keys())
+        self.assertTrue("analystNotes" in results.keys())
+        self.assertTrue("metrics" in results.keys())
+        self.assertTrue("risk" in results.keys())


### PR DESCRIPTION
## Proposed Changes

This PR fixes a problem in Recorded Future Lookup Domain where if the domain ended in an s, it would strip the s...
"bob.us" would become "bob.u" 
This caused the action to fail

## Validation: 
Note: Validator seems to be broken
```
RMT-MBP-5357:recorded_future jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator ExampleInputValidator
Traceback (most recent call last):
  File "/usr/local/bin/icon-validate", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.9/site-packages/icon_validator/__main__.py", line 52, in main
    validate(directory=path, spec_file_name=spec_file_name)
  File "/usr/local/lib/python3.9/site-packages/icon_validator/validate.py", line 35, in validate
    v.validate(spec)
  File "/usr/local/lib/python3.9/site-packages/icon_validator/rules/plugin_validators/example_input_validator.py", line 10, in validate
    action_messages = self.get_all_empty_example_message(plugin_spec.get("actions", {}), "action", "input")
  File "/usr/local/lib/python3.9/site-packages/icon_validator/rules/plugin_validators/example_input_validator.py", line 33, in get_all_empty_example_message
    empty_example_messages.extend(ExampleInputValidator.get_empty_example_message(
  File "/usr/local/lib/python3.9/site-packages/icon_validator/rules/plugin_validators/example_input_validator.py", line 43, in get_empty_example_message
    for input_name, input_item in elements.items():
AttributeError: 'NoneType' object has no attribute 'items'
```

## Testing: 
```
RMT-MBP-5357:recorded_future jmcadams$ ./run.sh -R tests/lookup_domain.json -j
Running: cat tests/lookup_domain.json | docker run --rm   -i rapid7/recorded_future:4.0.4  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Plugin Version: 4.0.4
rapid7/Recorded Future:4.0.4. Step name: lookup_domain
Requesting query path_info=domain/arcadiacommunications.us
Starting new HTTPS connection (1): api.recordedfuture.com:443
https://api.recordedfuture.com:443 "GET /v2/domain/arcadiacommunications.us?fields=analystNotes%2Ccounts%2CenterpriseLists%2Centity%2CintelCard%2Cmetrics%2CrelatedEntities%2Crisk%2Csightings%2CthreatLists%2Ctimestamps&app_id=rapid7_insightconnect%2F4.0.4+%28Linux-4.19.121-linuxkit-x86_64-with%29+rfapi-python%2F2.6.0 HTTP/1.1" 200 None
Plugin Version: 4.0.4
rapid7/Recorded Future:4.0.4. Step name: lookup_domain

{
  "analystNotes": [
    {
      "attributes": {
        "validated_on": "2019-05-31T18:50:58.673Z",
        "published": "2019-05-31T18:50:58.673Z",
        "text": "According to Recorded Future’s New Domain Registrations, a cluster of new domains emulating GMail were registered between May 25, and May 31, 2019. These domains, gm5ail.com, gmavil.com, and gmuail.com, are all hosted on the same IP address, 54.231.73.184. This IP was found to be a relative infestation of fake email domains, targeting Outlook, GMail, iCloud, Hotmail, and Yahoo, among others. Due to the volume of domains found on the IP address, Recorded Future cannot confirm if this IP address is a phishing sinkhole, or a malicious host. Regardless, Recorded Future recommends monitoring or blocking traffic to domains on this host.\n\ngimal.co\nmx.gimal.co\nmx.gmaik.co\nyahok.co.uk\narcadiacommunications.us\ndjdje.com\ngmskl.com\ngnaim.com\ngnaip.com\nhot7d.com\nmchdi.com\nmcjsi.com\n9gamil.com\ngeimal.com\ngemaul.com\ngilmel.com\ngimsil.com\ngm5ail.com\nmx.gm5ail.com\ngmavil.com\ngmhail.com\ngmuail.com\nhemeil.com\nicliyd.com\nicluld.com\nicoukd.com\nivlouf.com\nntlwod.com\nocloid.com\n123gmil.com\ngmail12.com\ngmail23.com\ngmail34.com\ngmail44.com\nmx.gmail44.com\ngmailcl.com\nguimeil.com\nhormaik.com\nhormaim.com\nhornsil.com\nisfrica.com\nmx.isfrica.com\nsjsjsjs.com\nmx.sjsjsjs.com\nthrowam.com\nushdhot.com\nuwalumi.com\nmx.uwalumi.com\n1234gmil.com\nmx.1234gmil.com\n123gamil.com\nembarqma.com\ngotmaill.com\ncrprairie.com\nhotmaolil.com\nliberviet.com\nnaopossui.com\nmx.naopossui.com\nntllworld.com\nntlworldd.com\nshopvipvn.com\nbankloanus.com\nembarqmaul.com\nkuratemail.com\nmindspeing.com\nmindsprimg.com\nmindsprong.com\nrockekmail.com\nmx.rockekmail.com\n2014outlook.com\n2016outlook.com\nbropenworld.com\nbtopenwotld.com\nbyopenworld.com\ngogiftclues.com\nindiferenca.com\nkevzmailbox.com\nhayhaymovies.com\nxn--ahoo-4ra.com\nmx.ottonline.net\nmx.sbcglobabal.net\nzoomintetnet.net\nmx.zooninternet.net\ndgs99.org\nhmcsdstudents.org\nmx.hmcsdstudents.org\nmx.mobgame.asia\nmx.dr69.site",
        "topic": {
          "id": "TXSFt4",
          "name": "Indicator",
          "type": "Topic",
          "description": "Used in conjunction with another Topic to capture bulk indicators of compromise for a particular threat."
        },
        "context_entities": [
          {
            "id": "idn:gemaul.com",
            "name": "gemaul.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hmcsdstudents.org",
            "name": "hmcsdstudents.org",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.rockekmail.com",
            "name": "mx.rockekmail.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.zooninternet.net",
            "name": "mx.zooninternet.net",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.gimal.co",
            "name": "mx.gimal.co",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:yahok.co.uk",
            "name": "yahok.co.uk",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:isfrica.com",
            "name": "isfrica.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:dgs99.org",
            "name": "dgs99.org",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.dr69.site",
            "name": "mx.dr69.site",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mindsprimg.com",
            "name": "mindsprimg.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mindsprong.com",
            "name": "mindsprong.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:shopvipvn.com",
            "name": "shopvipvn.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:2014outlook.com",
            "name": "2014outlook.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:liberviet.com",
            "name": "liberviet.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.ottonline.net",
            "name": "mx.ottonline.net",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:9gamil.com",
            "name": "9gamil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:icluld.com",
            "name": "icluld.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmail44.com",
            "name": "gmail44.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:ntlworldd.com",
            "name": "ntlworldd.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.naopossui.com",
            "name": "mx.naopossui.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:indiferenca.com",
            "name": "indiferenca.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:2016outlook.com",
            "name": "2016outlook.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gimsil.com",
            "name": "gimsil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "0eyAM",
            "name": "Phishing",
            "type": "AttackVector"
          },
          {
            "id": "idn:mx.isfrica.com",
            "name": "mx.isfrica.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.hmcsdstudents.org",
            "name": "mx.hmcsdstudents.org",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hotmaolil.com",
            "name": "hotmaolil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:djdje.com",
            "name": "djdje.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hormaim.com",
            "name": "hormaim.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:1234gmil.com",
            "name": "1234gmil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hormaik.com",
            "name": "hormaik.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.sbcglobabal.net",
            "name": "mx.sbcglobabal.net",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.gm5ail.com",
            "name": "mx.gm5ail.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmhail.com",
            "name": "gmhail.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:geimal.com",
            "name": "geimal.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.1234gmil.com",
            "name": "mx.1234gmil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hayhaymovies.com",
            "name": "hayhaymovies.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gnaip.com",
            "name": "gnaip.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:icoukd.com",
            "name": "icoukd.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:icliyd.com",
            "name": "icliyd.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hornsil.com",
            "name": "hornsil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mchdi.com",
            "name": "mchdi.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmail34.com",
            "name": "gmail34.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:byopenworld.com",
            "name": "byopenworld.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:guimeil.com",
            "name": "guimeil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:arcadiacommunications.us",
            "name": "arcadiacommunications.us",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mindspeing.com",
            "name": "mindspeing.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:123gmil.com",
            "name": "123gmil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.sjsjsjs.com",
            "name": "mx.sjsjsjs.com",
            "type": "InternetDomainName"
          },
          {
            "id": "B_FBR",
            "name": "Yahoo",
            "type": "Company"
          },
          {
            "id": "idn:gmailcl.com",
            "name": "gmailcl.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:embarqma.com",
            "name": "embarqma.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gimal.co",
            "name": "gimal.co",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:kuratemail.com",
            "name": "kuratemail.com",
            "type": "InternetDomainName"
          },
          {
            "id": "D2ijDn",
            "name": "Microsoft Hotmail",
            "type": "Product"
          },
          {
            "id": "idn:123gamil.com",
            "name": "123gamil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:throwam.com",
            "name": "throwam.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:ntllworld.com",
            "name": "ntllworld.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gogiftclues.com",
            "name": "gogiftclues.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:ocloid.com",
            "name": "ocloid.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hemeil.com",
            "name": "hemeil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:bankloanus.com",
            "name": "bankloanus.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:ushdhot.com",
            "name": "ushdhot.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:sjsjsjs.com",
            "name": "sjsjsjs.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mcjsi.com",
            "name": "mcjsi.com",
            "type": "InternetDomainName"
          },
          {
            "id": "BLql9H",
            "name": "iCloud",
            "type": "Product"
          },
          {
            "id": "idn:mx.uwalumi.com",
            "name": "mx.uwalumi.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:uwalumi.com",
            "name": "uwalumi.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:hot7d.com",
            "name": "hot7d.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmail12.com",
            "name": "gmail12.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmail23.com",
            "name": "gmail23.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:ivlouf.com",
            "name": "ivlouf.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.gmail44.com",
            "name": "mx.gmail44.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:embarqmaul.com",
            "name": "embarqmaul.com",
            "type": "InternetDomainName"
          },
          {
            "id": "CeCFg",
            "name": "Google Mail",
            "type": "Product"
          },
          {
            "id": "idn:xn--ahoo-4ra.com",
            "name": "ýahoo.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gilmel.com",
            "name": "gilmel.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gnaim.com",
            "name": "gnaim.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:kevzmailbox.com",
            "name": "kevzmailbox.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:naopossui.com",
            "name": "naopossui.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:bropenworld.com",
            "name": "bropenworld.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:ntlwod.com",
            "name": "ntlwod.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:crprairie.com",
            "name": "crprairie.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:rockekmail.com",
            "name": "rockekmail.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:zoomintetnet.net",
            "name": "zoomintetnet.net",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:btopenwotld.com",
            "name": "btopenwotld.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.gmaik.co",
            "name": "mx.gmaik.co",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:mx.mobgame.asia",
            "name": "mx.mobgame.asia",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmskl.com",
            "name": "gmskl.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gotmaill.com",
            "name": "gotmaill.com",
            "type": "InternetDomainName"
          }
        ],
        "title": "Recorded Future’s New Domain Registrations Observes Bulk Registration of Spoofed Email Domains",
        "note_entities": [
          {
            "id": "ip:54.231.73.184",
            "name": "54.231.73.184",
            "type": "IpAddress"
          },
          {
            "id": "idn:gm5ail.com",
            "name": "gm5ail.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmavil.com",
            "name": "gmavil.com",
            "type": "InternetDomainName"
          },
          {
            "id": "idn:gmuail.com",
            "name": "gmuail.com",
            "type": "InternetDomainName"
          }
        ]
      },
      "source": {
        "id": "VKz42X",
        "name": "Insikt Group",
        "type": "Source"
      },
      "id": "aN5VoN"
    }
  ],
  "enterpriseLists": [],
  "risk": {
    "criticalityLabel": "Unusual",
    "riskString": "1/46",
    "rules": 1,
    "criticality": 1,
    "riskSummary": "1 of 46 Risk Rules currently observed.",
    "score": 5,
    "evidenceDetails": [
      {
        "evidenceString": "1 sighting on 1 source: Insikt Group. 1 report: Recorded Future’s New Domain Registrations Observes Bulk Registration of Spoofed Email Domains. Most recent link (May 31, 2019): https://app.recordedfuture.com/live/sc/6fYtaae6SpQU.",
        "rule": "Historically Referenced by Insikt Group",
        "criticality": 1,
        "timestamp": "2019-05-31T00:00:00.000Z",
        "criticalityLabel": "Unusual"
      }
    ]
  },
  "intelCard": "https://app.recordedfuture.com/live/sc/entity/idn%3Aarcadiacommunications.us",
  "sightings": [
    {
      "source": "New Domain Registrations",
      "published": "2019-05-31T00:00:00.000Z",
      "title": "Domain Registration",
      "type": "mostRecent"
    },
    {
      "source": "Insikt Group",
      "published": "2019-05-31T18:50:58.673Z",
      "fragment": "According to Recorded Future’s New Domain Registrations, a cluster of new domains emulating GMail were registered between May 25, and May 31, 2019. These domains, gm5ail.com, gmavil.com, and gmuail.com, are all hosted on the same IP address, 54.231.73.184. This IP was found to be a relative infestation of fake email domains, targeting Outlook, GMail, iCloud, Hotmail, and Yahoo, among others. Due to the volume of domains found on the IP address, Recorded Future cannot confirm if this IP address is a phishing sinkhole, or a malicious host. Regardless, Recorded Future recommends monitoring or blocking traffic to domains on this host.\n\ngimal.co\nmx.gimal.co\nmx.gmaik.co\nyahok.co.uk\narcadiacommunications.us\ndjdje.com\ngmskl.com\ngnaim.com\ngnaip.com\nhot7d.com\nmchdi.com\nmcjsi.com\n9gamil.com\ngeimal.com\ngemaul.com\ngilmel.com\ngimsil.com\ngm5ail.com\nmx.gm5ail.com\ngmavil.com\ngmhail.com\ngmuail.com\nhemeil.com\nicliyd.com\nicluld.com\nicoukd.com\nivlouf.com\nntlwod.com\nocloid.com\n123gmil.com\ngmail12.com\ngmail2",
      "title": "Recorded Future’s New Domain Registrations Observes Bulk Registration of Spoofed Email Domains",
      "type": "first"
    }
  ],
  "entity": {
    "id": "idn:arcadiacommunications.us",
    "name": "arcadiacommunications.us",
    "type": "InternetDomainName"
  },
  "relatedEntities": [
    {
      "entities": [
        {
          "count": 1,
          "entity": {
            "id": "idn:1234gmil.com",
            "name": "1234gmil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:123gamil.com",
            "name": "123gamil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:123gmil.com",
            "name": "123gmil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:2014outlook.com",
            "name": "2014outlook.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:2016outlook.com",
            "name": "2016outlook.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:9gamil.com",
            "name": "9gamil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:bankloanus.com",
            "name": "bankloanus.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:bropenworld.com",
            "name": "bropenworld.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:btopenwotld.com",
            "name": "btopenwotld.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:byopenworld.com",
            "name": "byopenworld.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:crprairie.com",
            "name": "crprairie.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:dgs99.org",
            "name": "dgs99.org",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:djdje.com",
            "name": "djdje.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:dr69.site",
            "name": "dr69.site",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:embarqma.com",
            "name": "embarqma.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:embarqmaul.com",
            "name": "embarqmaul.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:geimal.com",
            "name": "geimal.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gemaul.com",
            "name": "gemaul.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gilmel.com",
            "name": "gilmel.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gimal.co",
            "name": "gimal.co",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gimsil.com",
            "name": "gimsil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gm5ail.com",
            "name": "gm5ail.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmaik.co",
            "name": "gmaik.co",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmail12.com",
            "name": "gmail12.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmail23.com",
            "name": "gmail23.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmail34.com",
            "name": "gmail34.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmail44.com",
            "name": "gmail44.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmailcl.com",
            "name": "gmailcl.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmavil.com",
            "name": "gmavil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmhail.com",
            "name": "gmhail.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmskl.com",
            "name": "gmskl.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gmuail.com",
            "name": "gmuail.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gnaim.com",
            "name": "gnaim.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gnaip.com",
            "name": "gnaip.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gogiftclues.com",
            "name": "gogiftclues.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:gotmaill.com",
            "name": "gotmaill.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:guimeil.com",
            "name": "guimeil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hayhaymovies.com",
            "name": "hayhaymovies.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hemeil.com",
            "name": "hemeil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hmcsdstudents.org",
            "name": "hmcsdstudents.org",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hormaik.com",
            "name": "hormaik.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hormaim.com",
            "name": "hormaim.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hornsil.com",
            "name": "hornsil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hot7d.com",
            "name": "hot7d.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:hotmaolil.com",
            "name": "hotmaolil.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:icliyd.com",
            "name": "icliyd.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:icluld.com",
            "name": "icluld.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:icoukd.com",
            "name": "icoukd.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:indiferenca.com",
            "name": "indiferenca.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:isfrica.com",
            "name": "isfrica.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ivlouf.com",
            "name": "ivlouf.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:kevzmailbox.com",
            "name": "kevzmailbox.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:kuratemail.com",
            "name": "kuratemail.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:liberviet.com",
            "name": "liberviet.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:mchdi.com",
            "name": "mchdi.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:mcjsi.com",
            "name": "mcjsi.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:mindspeing.com",
            "name": "mindspeing.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:mindsprimg.com",
            "name": "mindsprimg.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:mindsprong.com",
            "name": "mindsprong.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:mobgame.asia",
            "name": "mobgame.asia",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:naopossui.com",
            "name": "naopossui.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ntllworld.com",
            "name": "ntllworld.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ntlwod.com",
            "name": "ntlwod.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ntlworldd.com",
            "name": "ntlworldd.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ocloid.com",
            "name": "ocloid.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ottonline.net",
            "name": "ottonline.net",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:rockekmail.com",
            "name": "rockekmail.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:sbcglobabal.net",
            "name": "sbcglobabal.net",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:shopvipvn.com",
            "name": "shopvipvn.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:sjsjsjs.com",
            "name": "sjsjsjs.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:throwam.com",
            "name": "throwam.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:ushdhot.com",
            "name": "ushdhot.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:uwalumi.com",
            "name": "uwalumi.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:xn--ahoo-4ra.com",
            "name": "ýahoo.com",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:yahok.co.uk",
            "name": "yahok.co.uk",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:zoomintetnet.net",
            "name": "zoomintetnet.net",
            "type": "InternetDomainName"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "idn:zooninternet.net",
            "name": "zooninternet.net",
            "type": "InternetDomainName"
          }
        }
      ],
      "type": "RelatedInternetDomainName"
    },
    {
      "entities": [
        {
          "count": 1,
          "entity": {
            "id": "ip:54.231.73.184",
            "name": "54.231.73.184",
            "type": "IpAddress"
          }
        }
      ],
      "type": "RelatedIpAddress"
    },
    {
      "entities": [
        {
          "count": 1,
          "entity": {
            "id": "0eyAM",
            "name": "Phishing",
            "type": "AttackVector"
          }
        }
      ],
      "type": "RelatedAttackVector"
    },
    {
      "entities": [
        {
          "count": 1,
          "entity": {
            "id": "CeCFg",
            "name": "Google Mail",
            "type": "Product"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "BLql9H",
            "name": "iCloud",
            "type": "Product"
          }
        },
        {
          "count": 1,
          "entity": {
            "id": "D2ijDn",
            "name": "Microsoft Hotmail",
            "type": "Product"
          }
        }
      ],
      "type": "RelatedProduct"
    }
  ],
  "timestamps": {
    "lastSeen": "2019-05-31T21:16:21.231Z",
    "firstSeen": "2019-05-31T18:55:56.834Z"
  },
  "threatLists": [],
  "counts": [
    {
      "date": "2019-05-31",
      "count": 2
    }
  ],
  "metrics": [
    {
      "type": "sevenDaysHits",
      "value": 0
    },
    {
      "type": "relatedNote",
      "value": 1
    },
    {
      "type": "oneDayHits",
      "value": 0
    },
    {
      "type": "c2Subscore",
      "value": 0
    },
    {
      "type": "phishingSubscore",
      "value": 0
    },
    {
      "type": "whitelistedCount",
      "value": 0
    },
    {
      "type": "maliciousHits",
      "value": 1
    },
    {
      "type": "totalHits",
      "value": 2
    },
    {
      "type": "relatedNoteSightings",
      "value": 1
    },
    {
      "type": "socialMediaHits",
      "value": 0
    },
    {
      "type": "undergroundForumHits",
      "value": 0
    },
    {
      "type": "infoSecHits",
      "value": 0
    },
    {
      "type": "darkWebHits",
      "value": 0
    },
    {
      "type": "publicSubscore",
      "value": 5
    },
    {
      "type": "pasteHits",
      "value": 0
    },
    {
      "type": "mitigatedCount",
      "value": 0
    },
    {
      "type": "criticality",
      "value": 1
    },
    {
      "type": "technicalReportingHits",
      "value": 0
    },
    {
      "type": "malwareSubscore",
      "value": 0
    },
    {
      "type": "sixtyDaysHits",
      "value": 0
    }
  ]
}

RMT-MBP-5357:recorded_future jmcadams$
```