### PR TITLE
Fix bug in test method in connection

### DIFF
--- a/rest/.CHECKSUM
+++ b/rest/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "3660e8c80ad014115cc2a9bae984e481",
-	"manifest": "7b06270fae0b5d5173144c634af6161d",
-	"setup": "cd833f4bbc375588941507cbb1a28406",
+	"spec": "4c649a09bd6edb843165f84f2a789ccb",
+	"manifest": "219519cd736a21d86eaa2618547d1be4",
+	"setup": "48edc61b085f667e1338b1b0162c3cfb",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",

--- a/rest/bin/komand_rest
+++ b/rest/bin/komand_rest
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "HTTP Requests"
 Vendor = "rapid7"
-Version = "4.0.0"
+Version = "4.0.1"
 Description = "The HTTP Requests plugin to make it easy to integrate with RESTful services"
 
 

--- a/rest/help.md
+++ b/rest/help.md
@@ -445,6 +445,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
+* 4.0.1 - Fix issue where test fail when `base_url` have path
 * 4.0.0 - Support new authentication types: Digest Auth and Bearer Token | Add a workaround to encrypt a secret key when used in custom HTTP headers | Add built-in authentication for services: Insight Platform, Pendo and OpsGenie
 * 3.0.5 - Fix issue where a null body return on a successful request would crash the plugin
 * 3.0.4 - Update REST plugin title to HTTP Requests

--- a/rest/komand_rest/connection/connection.py
+++ b/rest/komand_rest/connection/connection.py
@@ -2,7 +2,7 @@ import komand
 from .schema import ConnectionSchema, Input
 from komand_rest.util.util import Common
 from komand.exceptions import PluginException, ConnectionTestException
-from urllib.parse import urlparse, urljoin
+from urllib.parse import urlparse
 
 # Custom imports below
 from requests.auth import HTTPDigestAuth, HTTPBasicAuth

--- a/rest/plugin.spec.yaml
+++ b/rest/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rest
 title: HTTP Requests
 description: The HTTP Requests plugin to make it easy to integrate with RESTful services
-version: 4.0.0
+version: 4.0.1
 vendor: rapid7
 support: community
 status: []

--- a/rest/setup.py
+++ b/rest/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rest-rapid7-plugin",
-      version="4.0.0",
+      version="4.0.1",
       description="The HTTP Requests plugin to make it easy to integrate with RESTful services",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP Requests:4.0.0. Step name: get\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:4.0.0 --debug test < tests/get_opsgenie.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "error": "Connection test failed!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"message\":\"Key format is not valid!\",\"took\":0.0,\"requestId\":\"42012b3d-5400-4c03-8227-f46a035ec439\"}",
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP Requests:4.0.0. Step name: get\nConnection test failed!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"message\":\"Key format is not valid!\",\"took\":0.0,\"requestId\":\"42012b3d-5400-4c03-8227-f46a035ec439\"}\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/rest_rapid7_plugin-4.0.0-py3.7.egg/komand_rest/connection/connection.py\", line 94, in test\n    auth=self.auth\n  File \"/usr/local/lib/python3.7/site-packages/rest_rapid7_plugin-4.0.0-py3.7.egg/komand_rest/util/util.py\", line 36, in call_api\n    raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)\nkomand.exceptions.PluginException: An error occurred during plugin execution!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"message\":\"Key format is not valid!\",\"took\":0.0,\"requestId\":\"42012b3d-5400-4c03-8227-f46a035ec439\"}\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 421, in start_step\n    output = func()\n  File \"/usr/local/lib/python3.7/site-packages/rest_rapid7_plugin-4.0.0-py3.7.egg/komand_rest/connection/connection.py\", line 97, in test\n    raise ConnectionTestException(cause=e.cause, assistance=e.assistance, data=e.data)\nkomand.exceptions.ConnectionTestException: Connection test failed!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"message\":\"Key format is not valid!\",\"took\":0.0,\"requestId\":\"42012b3d-5400-4c03-8227-f46a035ec439\"}\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:4.0.0 --debug test < tests/get_opsgenie_bad.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP Requests:4.0.0. Step name: get\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:4.0.0 --debug test < tests/get_opsgenie_with_path.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP Requests:4.0.0. Step name: get\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:4.0.0 --debug test < tests/get_opsgenie_with_port.json
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "error": "HTTPSConnectionPool(host='example.com', port=80): Max retries exceeded with url: /v2/users (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1056)')))",
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP Requests:4.0.0. Step name: get\nHTTPSConnectionPool(host='example.com', port=80): Max retries exceeded with url: /v2/users (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1056)')))\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py\", line 603, in urlopen\n    chunked=chunked)\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py\", line 344, in _make_request\n    self._validate_conn(conn)\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py\", line 843, in _validate_conn\n    conn.connect()\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connection.py\", line 370, in connect\n    ssl_context=context)\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/util/ssl_.py\", line 355, in ssl_wrap_socket\n    return context.wrap_socket(sock, server_hostname=server_hostname)\n  File \"/usr/local/lib/python3.7/ssl.py\", line 412, in wrap_socket\n    session=session\n  File \"/usr/local/lib/python3.7/ssl.py\", line 853, in _create\n    self.do_handshake()\n  File \"/usr/local/lib/python3.7/ssl.py\", line 1117, in do_handshake\n    self._sslobj.do_handshake()\nssl.SSLError: [SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1056)\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/requests/adapters.py\", line 449, in send\n    timeout=timeout\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/connectionpool.py\", line 641, in urlopen\n    _stacktrace=sys.exc_info()[2])\n  File \"/usr/local/lib/python3.7/site-packages/urllib3-1.25.3-py3.7.egg/urllib3/util/retry.py\", line 399, in increment\n    raise MaxRetryError(_pool, url, error or ResponseError(cause))\nurllib3.exceptions.MaxRetryError: HTTPSConnectionPool(host='example.com', port=80): Max retries exceeded with url: /v2/users (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1056)')))\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 311, in handle_step\n    output = self.start_step(input_message['body'], 'action', logger, log_stream, is_test, is_debug)\n  File \"/usr/local/lib/python3.7/site-packages/komand-1.0.1-py3.7.egg/komand/plugin.py\", line 421, in start_step\n    output = func()\n  File \"/usr/local/lib/python3.7/site-packages/rest_rapid7_plugin-4.0.0-py3.7.egg/komand_rest/connection/connection.py\", line 94, in test\n    auth=self.auth\n  File \"/usr/local/lib/python3.7/site-packages/rest_rapid7_plugin-4.0.0-py3.7.egg/komand_rest/util/util.py\", line 27, in call_api\n    response = requests.request(\"GET\", f\"{url}{path}\", headers=headers, verify=ssl_verify, auth=auth)\n  File \"/usr/local/lib/python3.7/site-packages/requests/api.py\", line 61, in request\n    return session.request(method=method, url=url, **kwargs)\n  File \"/usr/local/lib/python3.7/site-packages/requests/sessions.py\", line 542, in request\n    resp = self.send(prep, **send_kwargs)\n  File \"/usr/local/lib/python3.7/site-packages/requests/sessions.py\", line 655, in send\n    r = adapter.send(request, **kwargs)\n  File \"/usr/local/lib/python3.7/site-packages/requests/adapters.py\", line 514, in send\n    raise SSLError(e, request=request)\nrequests.exceptions.SSLError: HTTPSConnectionPool(host='example.com', port=80): Max retries exceeded with url: /v2/users (Caused by SSLError(SSLError(1, '[SSL: WRONG_VERSION_NUMBER] wrong version number (_ssl.c:1056)')))\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:4.0.0 --debug test < tests/get_opsgenie_with_port_bad.json
</summary>
</details>

### Validate
<details>

```

[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 1386.882ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
./komand_rest/actions/delete/action.py:36:24: E711 comparison to None should be 'if cond is None:'
./komand_rest/actions/get/action.py:30:24: E711 comparison to None should be 'if cond is None:'
./komand_rest/actions/patch/action.py:36:24: E711 comparison to None should be 'if cond is None:'
./komand_rest/actions/post/action.py:33:24: E711 comparison to None should be 'if cond is None:'
./komand_rest/actions/put/action.py:33:24: E711 comparison to None should be 'if cond is None:'
./unit_test/test_delete.py:6:1: E402 module level import not at top of file
./unit_test/test_delete.py:7:1: E402 module level import not at top of file
./unit_test/test_delete.py:8:1: E402 module level import not at top of file
./unit_test/test_delete.py:9:1: E402 module level import not at top of file
./unit_test/test_delete.py:10:1: E402 module level import not at top of file
./unit_test/test_delete.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_delete.py:43:1: W293 blank line contains whitespace
./unit_test/test_delete.py:44:110: W291 trailing whitespace
./unit_test/test_get.py:6:1: E402 module level import not at top of file
./unit_test/test_get.py:7:1: E402 module level import not at top of file
./unit_test/test_get.py:8:1: E402 module level import not at top of file
./unit_test/test_get.py:9:1: E402 module level import not at top of file
./unit_test/test_get.py:10:1: E402 module level import not at top of file
./unit_test/test_get.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_get.py:43:1: W293 blank line contains whitespace
./unit_test/test_get.py:44:110: W291 trailing whitespace
./unit_test/test_patch.py:6:1: E402 module level import not at top of file
./unit_test/test_patch.py:7:1: E402 module level import not at top of file
./unit_test/test_patch.py:8:1: E402 module level import not at top of file
./unit_test/test_patch.py:9:1: E402 module level import not at top of file
./unit_test/test_patch.py:10:1: E402 module level import not at top of file
./unit_test/test_patch.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_patch.py:43:1: W293 blank line contains whitespace
./unit_test/test_patch.py:44:110: W291 trailing whitespace
./unit_test/test_post.py:6:1: E402 module level import not at top of file
./unit_test/test_post.py:7:1: E402 module level import not at top of file
./unit_test/test_post.py:8:1: E402 module level import not at top of file
./unit_test/test_post.py:9:1: E402 module level import not at top of file
./unit_test/test_post.py:10:1: E402 module level import not at top of file
./unit_test/test_post.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_post.py:30:1: W293 blank line contains whitespace
./unit_test/test_post.py:31:110: W291 trailing whitespace
./unit_test/test_put.py:6:1: E402 module level import not at top of file
./unit_test/test_put.py:7:1: E402 module level import not at top of file
./unit_test/test_put.py:8:1: E402 module level import not at top of file
./unit_test/test_put.py:9:1: E402 module level import not at top of file
./unit_test/test_put.py:10:1: E402 module level import not at top of file
./unit_test/test_put.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_put.py:43:1: W293 blank line contains whitespace
./unit_test/test_put.py:44:110: W291 trailing whitespace
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2021-03-09 02:18:43.503318

Test results:
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'CUSTOM_SECRET_INPUT'
   Severity: Low   Confidence: Medium
   Location: ./komand_rest/connection/connection.py:12
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
11      class Connection(komand.Connection):
12          CUSTOM_SECRET_INPUT = "CUSTOM_SECRET_INPUT"
13
14          def __init__(self):

--------------------------------------------------
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'secret'
   Severity: Low   Confidence: Medium
   Location: ./komand_rest/connection/schema.py:11
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
10          DEFAULT_HEADERS = "default_headers"
11          SECRET = "secret"
12          SSL_VERIFY = "ssl_verify"

--------------------------------------------------

Code scanned:
        Total lines of code: 1067
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 2.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 2.0
                High: 0.0
Files skipped (0):
[FAIL] Fails bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check

```

<summary>
make validate
</summary>
</details>

<details>

```

[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: help.md[218]: https://httpbin.org/post
violation: help.md[220]: https://httpbin.org/post
violation: help.md[417]: https://httpbin.org/delete\
violation: help.md[292]: https://httpbin.org/patch\
violation: help.md[220]: https://httpbin.org/post\
violation: help.md[25]: https://httpbin.org/|
violation: help.md[143]: https://httpbin.org/put
violation: help.md[145]: https://httpbin.org/put
violation: help.md[145]: https://httpbin.org/put\
violation: help.md[25]: httpbin.org
violation: help.md[36]: httpbin.org
violation: help.md[53]: httpbin.org
violation: help.md[135]: httpbin.org
violation: help.md[143]: httpbin.org
violation: help.md[145]: httpbin.org
violation: help.md[210]: httpbin.org
violation: help.md[218]: httpbin.org
violation: help.md[220]: httpbin.org
violation: help.md[284]: httpbin.org
violation: help.md[290]: httpbin.org
violation: help.md[292]: httpbin.org
violation: help.md[409]: httpbin.org
violation: help.md[415]: httpbin.org
violation: help.md[417]: httpbin.org
violation: help.md[70]: https://us.api.insight.rapid7.com
violation: help.md[415]: https://httpbin.org/delete
violation: help.md[417]: https://httpbin.org/delete
violation: help.md[290]: https://httpbin.org/patch
violation: help.md[292]: https://httpbin.org/patch
[*] Plugin successfully validated!

----
[*] Total time elapsed: 41124.51ms

```

<summary>
icon-validate --all .
</summary>
</details>