### PR TITLE
Add PluginException when response is empty in Domain and Address action in Whois plugin

### DIFF
--- a/whois/.CHECKSUM
+++ b/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "7b398c0101e5a89aa28c593b8faf3676",
-	"manifest": "5908eae74e0536c98ac9dbe3e3852b16",
-	"setup": "d897f755530495fac3c761e1c4087ae7",
+	"spec": "f658825644f1e5169354b9760baf5b53",
+	"manifest": "b9be3f122f9cf4efb75ddb2c748a9cbd",
+	"setup": "32553895a500fa53c7be3721e25712a5",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/whois/bin/komand_whois
+++ b/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "3.0.2"
+Version = "3.0.3"
 Description = "The WHOIS plugin enables address and domain lookups in the WHOIS databases"
 
 

--- a/whois/help.md
+++ b/whois/help.md
@@ -165,7 +165,7 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
-* 3.0.2 - Support non-UTF-8 responses in the Address action
+* 3.0.3 - Add PluginException in Domain and Address action when response is empty* 3.0.2 - Support non-UTF-8 responses in the Address action
 * 3.0.1 - Clean up help.md formatting
 * 3.0.0 - Add input `registrar` for manual server selection to Address Lookup action
 * 2.0.3 - Upgrade to latest Python plugin runtime | Define `cloud_ready` in spec

--- a/whois/help.md
+++ b/whois/help.md
@@ -165,7 +165,8 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
-* 3.0.3 - Add PluginException in Domain and Address action when response is empty* 3.0.2 - Support non-UTF-8 responses in the Address action
+* 3.0.3 - Add PluginException in Domain and Address action when response is empty
+* 3.0.2 - Support non-UTF-8 responses in the Address action
 * 3.0.1 - Clean up help.md formatting
 * 3.0.0 - Add input `registrar` for manual server selection to Address Lookup action
 * 2.0.3 - Upgrade to latest Python plugin runtime | Define `cloud_ready` in spec

--- a/whois/komand_whois/actions/address/action.py
+++ b/whois/komand_whois/actions/address/action.py
@@ -1,6 +1,7 @@
 import insightconnect_plugin_runtime
 from .schema import AddressInput, AddressOutput, Input
 import re
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 
 class Address(insightconnect_plugin_runtime.Action):
@@ -87,7 +88,10 @@ class Address(insightconnect_plugin_runtime.Action):
         results = insightconnect_plugin_runtime.helper.clean_dict(results)
 
         if not results:
-            self.logger.error("Error: Request did not return any data")
+            raise PluginException(
+                cause="Error: Request did not return any data.",
+                assistance="Please check provided address and try again."
+            )
         return results
 
     def _get_stdout_pairs(self, stdout):

--- a/whois/komand_whois/actions/domain/action.py
+++ b/whois/komand_whois/actions/domain/action.py
@@ -29,7 +29,17 @@ class Domain(insightconnect_plugin_runtime.Action):
             lookup_results = whois.query(domain, ignore_returncode=1)  # ignore_returncode required for plugin
         except Exception as e:
             self.logger.error("Error occurred: %s" % e)
-            raise
+            raise PluginException(
+                preset=PluginException.Preset.UNKNOWN,
+                assistance="Error occurred: ",
+                data=e
+            )
+
+        if not lookup_results:
+            raise PluginException(
+                cause="Error: Request did not return any data.",
+                assistance="Please check provided domain and try again."
+            )
         else:
             serializable_results = lookup_results.get_json_serializable()
             serializable_results = insightconnect_plugin_runtime.helper.clean_dict(serializable_results)

--- a/whois/plugin.spec.yaml
+++ b/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: The WHOIS plugin enables address and domain lookups in the WHOIS databases
-version: 3.0.2
+version: 3.0.3
 vendor: rapid7
 support: community
 status: []

--- a/whois/setup.py
+++ b/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="3.0.2",
+      version="3.0.3",
       description="The WHOIS plugin enables address and domain lookups in the WHOIS databases",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Add PluginException when response is empty in Domain and Address action in Whois plugin

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.3. Step name: address\nInfo: Using registry: ripe\n",
    "meta": {},
    "output": {
      "address": "DE",
      "country": "DE",
      "netname": "DE-MEDIAWAYS-20120425",
      "netrange": "5.4.0.0 - 5.7.255.255",
      "nettype": "ALLOCATED PA",
      "org_abuse_email": "abuse.de@telefonica.com",
      "organization": "ORG-TDG4-RIPE",
      "orgname": "Telefonica Germany GmbH \u0026 Co. OHG",
      "regdate": "2018-08-08T09",
      "updated": "2018-08-08T09"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.3 --debug run < tests/address.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nError: Request did not return any data. Please check provided address and try again.",
    "log": "rapid7/WHOIS:3.0.3. Step name: address\nWarning: No WHOIS registry detected from stdout, defaulting to ARIN...\nInfo: Using registry: arin\nAn error occurred during plugin execution!\n\nError: Request did not return any data. Please check provided address and try again.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.2.0-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 326, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.2.0-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 476, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/whois_rapid7_plugin-3.0.3-py3.8.egg/komand_whois/actions/address/action.py\", line 91, in run\n    raise PluginException(\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nError: Request did not return any data. Please check provided address and try again.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.3 --debug run < tests/address_bad.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/WHOIS:3.0.3. Step name: domain\nGetting whois information for google.com\n",
    "meta": {},
    "output": {
      "creation_date": "1997-09-15T04:00:00",
      "dnssec": "unsigned",
      "domain_status": [
        "clientdeleteprohibited https://icann.org/epp#clientdeleteprohibited",
        "clienttransferprohibited https://icann.org/epp#clienttransferprohibited",
        "clientupdateprohibited https://icann.org/epp#clientupdateprohibited",
        "serverdeleteprohibited https://icann.org/epp#serverdeleteprohibited",
        "servertransferprohibited https://icann.org/epp#servertransferprohibited",
        "serverupdateprohibited https://icann.org/epp#serverupdateprohibited"
      ],
      "last_updated": "2019-09-09T15:39:04",
      "name": "google.com",
      "name_servers": [
        "ns4.google.com",
        "ns1.google.com",
        "ns3.google.com",
        "ns2.google.com"
      ],
      "registrar": "MarkMonitor Inc.",
      "registrar_abuse_contact_email": "abusecomplaints@markmonitor.com",
      "registrar_abuse_contact_phone": "+1.2083895740",
      "registrar_iana_id": "292",
      "registrar_url": "http://www.markmonitor.com",
      "registrar_whois_server": "whois.markmonitor.com",
      "registry_domain_id": "2138514_domain_com-vrsn"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.3 --debug run < tests/domain.json
</summary>
</details>

<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nError: Request did not return any data. Please check provided domain and try again.",
    "log": "rapid7/WHOIS:3.0.3. Step name: domain\nGetting whois information for awesdrftgyhujik.com\nAn error occurred during plugin execution!\n\nError: Request did not return any data. Please check provided domain and try again.\nTraceback (most recent call last):\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.2.0-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 326, in handle_step\n    output = self.start_step(\n  File \"/usr/local/lib/python3.8/site-packages/insightconnect_plugin_runtime-4.2.0-py3.8.egg/insightconnect_plugin_runtime/plugin.py\", line 476, in start_step\n    output = func(params)\n  File \"/usr/local/lib/python3.8/site-packages/whois_rapid7_plugin-3.0.3-py3.8.egg/komand_whois/actions/domain/action.py\", line 39, in run\n    raise PluginException(\ninsightconnect_plugin_runtime.exceptions.PluginException: An error occurred during plugin execution!\n\nError: Request did not return any data. Please check provided domain and try again.\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/whois:3.0.3 --debug run < tests/domain_bad.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator

[*] Plugin successfully validated!

----
[*] Total time elapsed: 71720.406ms

```

<summary>
icon-validate --all . 
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 3030.583ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
[SUCCESS] Passes markdown linting

[*] Validating python files for style...
./unit_test/test_address.py:6:1: E402 module level import not at top of file
./unit_test/test_address.py:7:1: E402 module level import not at top of file
./unit_test/test_address.py:8:1: E402 module level import not at top of file
./unit_test/test_address.py:9:1: E402 module level import not at top of file
./unit_test/test_address.py:10:1: E402 module level import not at top of file
./unit_test/test_address.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_address.py:43:1: W293 blank line contains whitespace
./unit_test/test_address.py:44:110: W291 trailing whitespace
./unit_test/test_domain.py:6:1: E402 module level import not at top of file
./unit_test/test_domain.py:7:1: E402 module level import not at top of file
./unit_test/test_domain.py:8:1: E402 module level import not at top of file
./unit_test/test_domain.py:9:1: E402 module level import not at top of file
./unit_test/test_domain.py:10:1: E402 module level import not at top of file
./unit_test/test_domain.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_domain.py:30:1: W293 blank line contains whitespace
./unit_test/test_domain.py:31:110: W291 trailing whitespace
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
Run started:2021-03-14 23:29:30.334924

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 632
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] Checking for typos with Misspell...
[FAIL] Fails Misspell check
whois.conf:491:2: "immobilien" is a misspelling of "immobile"

```

<summary>
make validate
</summary>
</details>


