### PR TITLE
MC-348 - Service Now - Add Incident URL output to Create Incident Action

### DIFF
--- a/servicenow/.CHECKSUM
+++ b/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e292c15b372f3eed454c46a3b7d8f5f0",
-	"manifest": "f809b50e78aec388eeb58789f4b682a3",
-	"setup": "2de9bab1d43915d0c9d06a07bc4dab8e",
+	"spec": "fba1eb34f20f5f406a5261ebf41509d1",
+	"manifest": "5996d60a9a8ffa5aa390edea705c7e1d",
+	"setup": "7cdf61b231e7f14196bbf3f888585433",
 	"schemas": [
 		{
 			"identifier": "create_ci/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "create_incident/schema.py",
-			"hash": "857d374dc2286b344e04bc91e3503bfa"
+			"hash": "c2a75828d0b14226e9741de8832196cf"
 		},
 		{
 			"identifier": "delete_incident/schema.py",

--- a/servicenow/bin/icon_servicenow
+++ b/servicenow/bin/icon_servicenow
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ServiceNow"
 Vendor = "rapid7"
-Version = "5.0.1"
+Version = "5.1.0"
 Description = "ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes"
 
 

--- a/servicenow/help.md
+++ b/servicenow/help.md
@@ -124,6 +124,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
+|incident_url|string|True|URL to newly created incident|
 |number|string|True|Incident ticket number|
 |system_id|string|True|System ID of the new Incident created|
 
@@ -757,6 +758,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 5.1.0 - Add new Incident URL output for Create Incident action
 * 5.0.1 - Add new Additional Fields input for Create Incident and Update Incident actions
 * 5.0.0 - Add input fields to Create Incident and Update Incident action instead of JSON object
 * 4.1.2 - Fix input parameter in Incident Created trigger

--- a/servicenow/icon_servicenow/actions/create_incident/action.py
+++ b/servicenow/icon_servicenow/actions/create_incident/action.py
@@ -52,4 +52,8 @@ class CreateIncident(insightconnect_plugin_runtime.Action):
                 cause="Error: Create Incident failed - no system_id returned.", assistance=f"Response: {response.text}"
             )
 
-        return {Output.SYSTEM_ID: sys_id, Output.NUMBER: number}
+        return {
+            Output.SYSTEM_ID: sys_id,
+            Output.NUMBER: number,
+            Output.INCIDENT_URL: f"{self.connection.base_url}task.do?sys_id={sys_id}",
+        }

--- a/servicenow/icon_servicenow/actions/create_incident/schema.py
+++ b/servicenow/icon_servicenow/actions/create_incident/schema.py
@@ -26,6 +26,7 @@ class Input:
     
 
 class Output:
+    INCIDENT_URL = "incident_url"
     NUMBER = "number"
     SYSTEM_ID = "system_id"
     
@@ -140,6 +141,12 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "incident_url": {
+      "type": "string",
+      "title": "Incident URL",
+      "description": "URL to newly created incident",
+      "order": 3
+    },
     "number": {
       "type": "string",
       "title": "Incident Number",
@@ -154,6 +161,7 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
     }
   },
   "required": [
+    "incident_url",
     "number",
     "system_id"
   ]

--- a/servicenow/icon_servicenow/connection/connection.py
+++ b/servicenow/icon_servicenow/connection/connection.py
@@ -18,10 +18,10 @@ class Connection(insightconnect_plugin_runtime.Connection):
         api_route = "api/now/"
         incident_table = "incident"
 
-        base_url = params.get(Input.URL, "")
+        self.base_url = params.get(Input.URL, "")
 
-        if not base_url.endswith("/"):
-            base_url = f"{base_url}/"
+        if not self.base_url.endswith("/"):
+            self.base_url = f"{self.base_url}/"
 
         username = params[Input.CLIENT_LOGIN].get("username", "")
         password = params[Input.CLIENT_LOGIN].get("password", "")
@@ -30,9 +30,9 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.session.auth = HTTPBasicAuth(username, password)
         self.request = RequestHelper(self.session, self.logger)
 
-        self.table_url = f"{base_url}{api_route}table/"
+        self.table_url = f"{self.base_url}{api_route}table/"
         self.incident_url = f"{self.table_url}{incident_table}"
-        self.attachment_url = f"{base_url}{api_route}attachment"
+        self.attachment_url = f"{self.base_url}{api_route}attachment"
         self.timeout = params.get("timeout", 30)
 
     def test(self):

--- a/servicenow/plugin.spec.yaml
+++ b/servicenow/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: ["insightconnect"]
 name: servicenow
 title: ServiceNow
 description: ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes
-version: 5.0.1
+version: 5.1.0
 vendor: rapid7
 support: rapid7
 status: []
@@ -186,6 +186,11 @@ actions:
       number:
         title: Incident Number
         description: Incident ticket number
+        type: string
+        required: true
+      incident_url:
+        title: Incident URL
+        description: URL to newly created incident
         type: string
         required: true
   search_incident:

--- a/servicenow/setup.py
+++ b/servicenow/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="servicenow-rapid7-plugin",
-      version="5.0.1",
+      version="5.1.0",
       description="ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

Added `incident_url` output to Create Incident action, that will return a URL pointing to the newly created ticket.

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment
#### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/ServiceNow:5.1.0. Step name: create_incident\n",
    "meta": {},
    "output": {
      "incident_url": "https://ven01226.service-now.com/task.do?sys_id=0fe7a31b1bf26410cdd0a6c1604bcb9c",
      "number": "INC0010590",
      "system_id": "0fe7a31b1bf26410cdd0a6c1604bcb9c"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/servicenow:5.1.0 --debug run < tests/create_incident_1.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/ServiceNow:5.1.0. Step name: create_incident\n",
    "meta": {},
    "output": {
      "incident_url": "https://ven01226.service-now.com/task.do?sys_id=37e7e7931bb6e4d0c9768622dd4bcb6c",
      "number": "INC0010591",
      "system_id": "37e7e7931bb6e4d0c9768622dd4bcb6c"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/servicenow:5.1.0 --debug run < tests/create_incident_2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/ServiceNow:5.1.0. Step name: create_incident\n",
    "meta": {},
    "output": {
      "incident_url": "https://ven01226.service-now.com/task.do?sys_id=e4f7af931bb6e4d0c9768622dd4bcb02",
      "number": "INC0010592",
      "system_id": "e4f7af931bb6e4d0c9768622dd4bcb02"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/servicenow:5.1.0 --debug run < tests/create_incident_3.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/ServiceNow:5.1.0. Step name: create_incident\n",
    "meta": {},
    "output": {
      "incident_url": "https://ven01226.service-now.com/task.do?sys_id=d5f7a31b1bf26410cdd0a6c1604bcba0",
      "number": "INC0010593",
      "system_id": "d5f7a31b1bf26410cdd0a6c1604bcba0"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/servicenow:5.1.0 --debug run < tests/create_incident_4.json
</summary>
</details>

#### Plugin Validation

<details>

```
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed! 
        Cause: All inputs should have example field in plugin.spec. 
In action "search_incident": input "query", there is no example field.
In action "read_incident": input "system_id", there is no example field.
In action "read_incident": input "filtering_fields", there is no example field.
In action "delete_incident": input "system_id", there is no example field.
In action "put_incident_attachment": input "system_id", there is no example field.
In action "put_incident_attachment": input "attachment_name", there is no example field.
In action "put_incident_attachment": input "base64_content", there is no example field.
In action "put_incident_attachment": input "mime_type", there is no example field.
In action "put_incident_attachment": input "other_mime_type", there is no example field.
In action "search_incident_attachment": input "name", there is no example field.
In action "get_incident_attachment": input "attachment_id", there is no example field.
In action "delete_incident_attachment": input "attachment_id", there is no example field.
In action "get_ci": input "table", there is no example field.
In action "get_ci": input "system_id", there is no example field.
In action "search_ci": input "table", there is no example field.
In action "search_ci": input "query", there is no example field.
In action "create_ci": input "table", there is no example field.
In action "create_ci": input "create_data", there is no example field.
In action "update_ci": input "table", there is no example field.
In action "update_ci": input "system_id", there is no example field.
In action "update_ci": input "update_data", there is no example field.
In action "get_incident_comments_worknotes": input "system_id", there is no example field.
In action "get_incident_comments_worknotes": input "type", there is no example field.
In trigger "incident_changed": input "system_id", there is no example field.
In trigger "incident_changed": input "monitored_fields", there is no example field.
In trigger "incident_changed": input "interval", there is no example field.


----
[*] Total time elapsed: 2010.4419999999998ms
```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed! 
        Cause: All inputs should have example field in plugin.spec. 
In action "search_incident": input "query", there is no example field.
In action "read_incident": input "system_id", there is no example field.
In action "read_incident": input "filtering_fields", there is no example field.
In action "delete_incident": input "system_id", there is no example field.
In action "put_incident_attachment": input "system_id", there is no example field.
In action "put_incident_attachment": input "attachment_name", there is no example field.
In action "put_incident_attachment": input "base64_content", there is no example field.
In action "put_incident_attachment": input "mime_type", there is no example field.
In action "put_incident_attachment": input "other_mime_type", there is no example field.
In action "search_incident_attachment": input "name", there is no example field.
In action "get_incident_attachment": input "attachment_id", there is no example field.
In action "delete_incident_attachment": input "attachment_id", there is no example field.
In action "get_ci": input "table", there is no example field.
In action "get_ci": input "system_id", there is no example field.
In action "search_ci": input "table", there is no example field.
In action "search_ci": input "query", there is no example field.
In action "create_ci": input "table", there is no example field.
In action "create_ci": input "create_data", there is no example field.
In action "update_ci": input "table", there is no example field.
In action "update_ci": input "system_id", there is no example field.
In action "update_ci": input "update_data", there is no example field.
In action "get_incident_comments_worknotes": input "system_id", there is no example field.
In action "get_incident_comments_worknotes": input "type", there is no example field.
In trigger "incident_changed": input "system_id", there is no example field.
In trigger "incident_changed": input "monitored_fields", there is no example field.
In trigger "incident_changed": input "interval", there is no example field.


----
[*] Total time elapsed: 2436.916ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] For Markdown linting, install mdl: gem install mdl

[*] Validating python files for style...
./icon_servicenow/util/request_helper.py:4:1: F401 'insightconnect_plugin_runtime.exceptions.ConnectionTestException' imported but unused
./icon_servicenow/util/request_helper.py:45:23: F541 f-string is missing placeholders
./icon_servicenow/triggers/incident_created/trigger.py:64:29: F541 f-string is missing placeholders
./icon_servicenow/triggers/incident_created/trigger.py:69:29: F541 f-string is missing placeholders
./icon_servicenow/triggers/incident_created/trigger.py:75:21: F541 f-string is missing placeholders
./icon_servicenow/triggers/incident_changed/trigger.py:7:1: F811 redefinition of unused 'time' from line 2
./icon_servicenow/actions/create_ci/action.py:33:23: F541 f-string is missing placeholders
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
57 [0.. 50.. ]
Run started:2021-03-15 15:25:33.426718

Test results:
        No issues identified.

Code scanned:
        Total lines of code: 1878
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 0.0
Files skipped (0):
[SUCCESS] Passes bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check
```

<summary>
make validate
</summary>
</details>
