### PR TITLE
Remove extra Troubleshooting section from help.md in Palo Alto PanOS plugin

### DIFF
--- a/palo_alto_pan_os/.CHECKSUM
+++ b/palo_alto_pan_os/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e4baf5a2ad953ce337b418ff70ce8fe6",
-	"manifest": "de70de50f3a0e34d3f23e5fe3da19d01",
-	"setup": "8de5a405101601da1934833e29342e00",
+	"spec": "30c73ee195e628e53fca7b52fd4d704f",
+	"manifest": "3aa1c942c7701204f4831c632efb21da",
+	"setup": "54f88f704b2410ec6168daf964d2a89b",
 	"schemas": [
 		{
 			"identifier": "add_address_object_to_group/schema.py",

--- a/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Palo Alto Firewall"
 Vendor = "rapid7"
-Version = "6.1.0"
+Version = "6.1.1"
 Description = "Manage Palo Alto Networks firewall devices"
 
 

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -1066,7 +1066,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
-* 6.1.1 - Remove extra Troubleshooting section
+* 6.1.1 - Remove duplicate Troubleshooting section in documentation
 * 6.1.0 - Improve error handling for xpath elements and paths in `pa_os_request.py` | New action Get Addresses from Group | Support adding a list of address objects in Add Address Object to Group action
 * 6.0.4 - Update error handling in Add Address Object to Group, Check if Address in Group, Get Policy and Remove Address Object from Group actions
 * 6.0.3 - Add Input and Output examples

--- a/palo_alto_pan_os/help.md
+++ b/palo_alto_pan_os/help.md
@@ -1054,12 +1054,6 @@ Example output:
 
 _This plugin does not contain any triggers._
 
-### Troubleshooting
-
-For the URL, include `https://` e.g. `https://10.0.0.1` or `https://myfirewall`.
-
-When using the Add External Dynamic List action, a day and time must be chosen even if they are not used.
-
 ### Custom Output Types
 
 _This plugin does not contain any custom output types._
@@ -1072,6 +1066,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
+* 6.1.1 - Remove extra Troubleshooting section
 * 6.1.0 - Improve error handling for xpath elements and paths in `pa_os_request.py` | New action Get Addresses from Group | Support adding a list of address objects in Add Address Object to Group action
 * 6.0.4 - Update error handling in Add Address Object to Group, Check if Address in Group, Get Policy and Remove Address Object from Group actions
 * 6.0.3 - Add Input and Output examples

--- a/palo_alto_pan_os/plugin.spec.yaml
+++ b/palo_alto_pan_os/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto Firewall
 description: Manage Palo Alto Networks firewall devices
-version: 6.1.0
+version: 6.1.1
 vendor: rapid7
 support: rapid7
 status: []

--- a/palo_alto_pan_os/setup.py
+++ b/palo_alto_pan_os/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
-      version="6.1.0",
+      version="6.1.1",
       description="Manage Palo Alto Networks firewall devices",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Remove extra Troubleshooting section from help.md in Palo Alto PanOS plugin

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)


## Assessment
### Run

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpValidator" failed!
        Cause: Help section contains non-matching title in line: [PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama).

Validator "ExampleInputValidator" failed!
        Cause: All inputs should have example field in plugin.spec.
In action "set_security_policy_rule": input "disable_server_response_inspection", there is no example field.
In action "set_security_policy_rule": input "negate_source", there is no example field.
In action "set_security_policy_rule": input "negate_destination", there is no example field.
In action "set_security_policy_rule": input "disabled", there is no example field.
In action "set_security_policy_rule": input "log_start", there is no example field.
In action "set_security_policy_rule": input "log_end", there is no example field.
In action "retrieve_logs": input "skip", there is no example field.
In action "retrieve_logs": input "filter", there is no example field.
In action "check_if_address_object_in_group": input "enable_search", there is no example field.


----
[*] Total time elapsed: 3142.4249999999997ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] Validating markdown...
help.md:337: MD009 Trailing spaces
help.md:343: MD009 Trailing spaces
help.md:344: MD009 Trailing spaces
help.md:345: MD009 Trailing spaces
help.md:346: MD009 Trailing spaces
help.md:1080: MD009 Trailing spaces

A detailed description of the rules is available at https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md
[FAIL] Fails markdown linting

[*] Validating python files for style...
./komand_palo_alto_pan_os/actions/set_address_object/action.py:23:9: E722 do not use bare 'except'
./komand_palo_alto_pan_os/actions/set_address_object/action.py:95:1: W293 blank line contains whitespace
./komand_palo_alto_pan_os/actions/set_address_object/action.py:96:25: W291 trailing whitespace
./komand_palo_alto_pan_os/actions/set_address_object/action.py:100:15: W291 trailing whitespace
./unit_test/test_add_address_object_to_group.py:6:1: E402 module level import not at top of file
./unit_test/test_add_address_object_to_group.py:7:1: E402 module level import not at top of file
./unit_test/test_add_address_object_to_group.py:8:1: E402 module level import not at top of file
./unit_test/test_add_address_object_to_group.py:9:1: E402 module level import not at top of file
./unit_test/test_add_address_object_to_group.py:10:1: E402 module level import not at top of file
./unit_test/test_add_address_object_to_group.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_add_address_object_to_group.py:30:1: W293 blank line contains whitespace
./unit_test/test_add_address_object_to_group.py:31:110: W291 trailing whitespace
./unit_test/test_add_external_dynamic_list.py:6:1: E402 module level import not at top of file
./unit_test/test_add_external_dynamic_list.py:7:1: E402 module level import not at top of file
./unit_test/test_add_external_dynamic_list.py:8:1: E402 module level import not at top of file
./unit_test/test_add_external_dynamic_list.py:9:1: E402 module level import not at top of file
./unit_test/test_add_external_dynamic_list.py:10:1: E402 module level import not at top of file
./unit_test/test_add_external_dynamic_list.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_add_external_dynamic_list.py:43:1: W293 blank line contains whitespace
./unit_test/test_add_external_dynamic_list.py:44:110: W291 trailing whitespace
./unit_test/test_add_to_policy.py:6:1: E402 module level import not at top of file
./unit_test/test_add_to_policy.py:7:1: E402 module level import not at top of file
./unit_test/test_add_to_policy.py:8:1: E402 module level import not at top of file
./unit_test/test_add_to_policy.py:9:1: E402 module level import not at top of file
./unit_test/test_add_to_policy.py:10:1: E402 module level import not at top of file
./unit_test/test_add_to_policy.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_add_to_policy.py:43:1: W293 blank line contains whitespace
./unit_test/test_add_to_policy.py:44:110: W291 trailing whitespace
./unit_test/test_check_if_address_object_in_group.py:6:1: E402 module level import not at top of file
./unit_test/test_check_if_address_object_in_group.py:7:1: E402 module level import not at top of file
./unit_test/test_check_if_address_object_in_group.py:8:1: E402 module level import not at top of file
./unit_test/test_check_if_address_object_in_group.py:11:1: E402 module level import not at top of file
./unit_test/test_check_if_address_object_in_group.py:12:1: E402 module level import not at top of file
./unit_test/test_check_if_address_object_in_group.py:29:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_check_if_address_object_in_group.py:32:1: W293 blank line contains whitespace
./unit_test/test_check_if_address_object_in_group.py:33:110: W291 trailing whitespace
./unit_test/test_commit.py:6:1: E402 module level import not at top of file
./unit_test/test_commit.py:7:1: E402 module level import not at top of file
./unit_test/test_commit.py:8:1: E402 module level import not at top of file
./unit_test/test_commit.py:9:1: E402 module level import not at top of file
./unit_test/test_commit.py:10:1: E402 module level import not at top of file
./unit_test/test_commit.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_commit.py:43:1: W293 blank line contains whitespace
./unit_test/test_commit.py:44:110: W291 trailing whitespace
./unit_test/test_delete.py:6:1: E402 module level import not at top of file
./unit_test/test_delete.py:7:1: E402 module level import not at top of file
./unit_test/test_delete.py:8:1: E402 module level import not at top of file
./unit_test/test_delete.py:9:1: E402 module level import not at top of file
./unit_test/test_delete.py:10:1: E402 module level import not at top of file
./unit_test/test_delete.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_delete.py:43:1: W293 blank line contains whitespace
./unit_test/test_delete.py:44:110: W291 trailing whitespace
./unit_test/test_edit.py:6:1: E402 module level import not at top of file
./unit_test/test_edit.py:7:1: E402 module level import not at top of file
./unit_test/test_edit.py:8:1: E402 module level import not at top of file
./unit_test/test_edit.py:9:1: E402 module level import not at top of file
./unit_test/test_edit.py:10:1: E402 module level import not at top of file
./unit_test/test_edit.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_edit.py:43:1: W293 blank line contains whitespace
./unit_test/test_edit.py:44:110: W291 trailing whitespace
./unit_test/test_get.py:6:1: E402 module level import not at top of file
./unit_test/test_get.py:7:1: E402 module level import not at top of file
./unit_test/test_get.py:8:1: E402 module level import not at top of file
./unit_test/test_get.py:9:1: E402 module level import not at top of file
./unit_test/test_get.py:10:1: E402 module level import not at top of file
./unit_test/test_get.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_get.py:43:1: W293 blank line contains whitespace
./unit_test/test_get.py:44:110: W291 trailing whitespace
./unit_test/test_get_policy.py:6:1: E402 module level import not at top of file
./unit_test/test_get_policy.py:7:1: E402 module level import not at top of file
./unit_test/test_get_policy.py:8:1: E402 module level import not at top of file
./unit_test/test_get_policy.py:9:1: E402 module level import not at top of file
./unit_test/test_get_policy.py:10:1: E402 module level import not at top of file
./unit_test/test_get_policy.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_get_policy.py:30:1: W293 blank line contains whitespace
./unit_test/test_get_policy.py:31:110: W291 trailing whitespace
./unit_test/test_op.py:6:1: E402 module level import not at top of file
./unit_test/test_op.py:7:1: E402 module level import not at top of file
./unit_test/test_op.py:8:1: E402 module level import not at top of file
./unit_test/test_op.py:9:1: E402 module level import not at top of file
./unit_test/test_op.py:10:1: E402 module level import not at top of file
./unit_test/test_op.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_op.py:43:1: W293 blank line contains whitespace
./unit_test/test_op.py:44:110: W291 trailing whitespace
./unit_test/test_remove_address_object_from_group.py:6:1: E402 module level import not at top of file
./unit_test/test_remove_address_object_from_group.py:7:1: E402 module level import not at top of file
./unit_test/test_remove_address_object_from_group.py:8:1: E402 module level import not at top of file
./unit_test/test_remove_address_object_from_group.py:11:1: E402 module level import not at top of file
./unit_test/test_remove_address_object_from_group.py:12:1: E402 module level import not at top of file
./unit_test/test_remove_address_object_from_group.py:29:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_remove_address_object_from_group.py:32:1: W293 blank line contains whitespace
./unit_test/test_remove_address_object_from_group.py:33:110: W291 trailing whitespace
./unit_test/test_remove_from_policy.py:6:1: E402 module level import not at top of file
./unit_test/test_remove_from_policy.py:7:1: E402 module level import not at top of file
./unit_test/test_remove_from_policy.py:8:1: E402 module level import not at top of file
./unit_test/test_remove_from_policy.py:9:1: E402 module level import not at top of file
./unit_test/test_remove_from_policy.py:10:1: E402 module level import not at top of file
./unit_test/test_remove_from_policy.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_remove_from_policy.py:43:1: W293 blank line contains whitespace
./unit_test/test_remove_from_policy.py:44:110: W291 trailing whitespace
./unit_test/test_retrieve_logs.py:6:1: E402 module level import not at top of file
./unit_test/test_retrieve_logs.py:7:1: E402 module level import not at top of file
./unit_test/test_retrieve_logs.py:8:1: E402 module level import not at top of file
./unit_test/test_retrieve_logs.py:9:1: E402 module level import not at top of file
./unit_test/test_retrieve_logs.py:10:1: E402 module level import not at top of file
./unit_test/test_retrieve_logs.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_retrieve_logs.py:43:1: W293 blank line contains whitespace
./unit_test/test_retrieve_logs.py:44:110: W291 trailing whitespace
./unit_test/test_set.py:6:1: E402 module level import not at top of file
./unit_test/test_set.py:7:1: E402 module level import not at top of file
./unit_test/test_set.py:8:1: E402 module level import not at top of file
./unit_test/test_set.py:9:1: E402 module level import not at top of file
./unit_test/test_set.py:10:1: E402 module level import not at top of file
./unit_test/test_set.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_set.py:43:1: W293 blank line contains whitespace
./unit_test/test_set.py:44:110: W291 trailing whitespace
./unit_test/test_set_address_object.py:6:1: E402 module level import not at top of file
./unit_test/test_set_address_object.py:7:1: E402 module level import not at top of file
./unit_test/test_set_address_object.py:8:1: E402 module level import not at top of file
./unit_test/test_set_address_object.py:9:1: E402 module level import not at top of file
./unit_test/test_set_address_object.py:10:1: E402 module level import not at top of file
./unit_test/test_set_address_object.py:27:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_set_address_object.py:31:110: W291 trailing whitespace
./unit_test/test_set_security_policy_rule.py:6:1: E402 module level import not at top of file
./unit_test/test_set_security_policy_rule.py:7:1: E402 module level import not at top of file
./unit_test/test_set_security_policy_rule.py:8:1: E402 module level import not at top of file
./unit_test/test_set_security_policy_rule.py:9:1: E402 module level import not at top of file
./unit_test/test_set_security_policy_rule.py:10:1: E402 module level import not at top of file
./unit_test/test_set_security_policy_rule.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_set_security_policy_rule.py:43:1: W293 blank line contains whitespace
./unit_test/test_set_security_policy_rule.py:44:110: W291 trailing whitespace
./unit_test/test_show.py:6:1: E402 module level import not at top of file
./unit_test/test_show.py:7:1: E402 module level import not at top of file
./unit_test/test_show.py:8:1: E402 module level import not at top of file
./unit_test/test_show.py:9:1: E402 module level import not at top of file
./unit_test/test_show.py:10:1: E402 module level import not at top of file
./unit_test/test_show.py:40:9: F841 local variable 'e' is assigned to but never used
./unit_test/test_show.py:43:1: W293 blank line contains whitespace
./unit_test/test_show.py:44:110: W291 trailing whitespace
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
84 [0.. 50.. ]
Run started:2021-03-23 19:06:41.082309

Test results:
>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
   Severity: Low   Confidence: High
   Location: ./komand_palo_alto_pan_os/actions/set_address_object/action.py:23
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html
22                  return "ip-netmask"
23              except:
24                  pass

--------------------------------------------------
>> Issue: [B110:try_except_pass] Try, Except, Pass detected.
   Severity: Low   Confidence: High
   Location: ./komand_palo_alto_pan_os/actions/set_address_object/action.py:70
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b110_try_except_pass.html
69                      return True
70              except Exception:  # This was a domain name
71                  pass

--------------------------------------------------

Code scanned:
        Total lines of code: 4174
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 2.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 0.0
                High: 2.0
Files skipped (0):
[FAIL] Fails bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check

```

<summary>
make validate
</summary>
</details>
<details>

```

[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[594]: https://www.example.com/test.txt
violation: plugin.spec.yaml[597]: https://www.example.com/test.txt
violation: help.md[1018]: https://www.example.com/test.txt|None|https://www.example.com/test.txt|
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpValidator" failed!
        Cause: Help section contains non-matching title in line: [PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama).

Validator "ExampleInputValidator" failed!
        Cause: All inputs should have example field in plugin.spec.
In action "set_security_policy_rule": input "disable_server_response_inspection", there is no example field.
In action "set_security_policy_rule": input "negate_source", there is no example field.
In action "set_security_policy_rule": input "negate_destination", there is no example field.
In action "set_security_policy_rule": input "disabled", there is no example field.
In action "set_security_policy_rule": input "log_start", there is no example field.
In action "set_security_policy_rule": input "log_end", there is no example field.
In action "retrieve_logs": input "skip", there is no example field.
In action "retrieve_logs": input "filter", there is no example field.
In action "check_if_address_object_in_group": input "enable_search", there is no example field.



----
[*] Total time elapsed: 92691.969ms
```

<summary>
icon-validate --all .
</summary>
</details>
