### PR TITLE
[No ticket] - Fix microsoft teams for team name with bracket

### DIFF
--- a/microsoft_teams/.CHECKSUM
+++ b/microsoft_teams/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "47a3f674be32273a39b008c0d4267db9",
+	"spec": "b8cbbcfc4ce625f4f0bc84a03ed25415",
 	"manifest": "7b795c145e3ecb0b22b6b1937bee9c55",
 	"setup": "90fcf7e835240d7d800af06bee72c72f",
 	"schemas": [

--- a/microsoft_teams/.CHECKSUM
+++ b/microsoft_teams/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d42efdd553b8401e81553d2b72fb29d5",
-	"manifest": "20dabe67754497fa35e3db688343d801",
-	"setup": "01246d19bfb69c6b3fbedaa30e1246a9",
+	"spec": "47a3f674be32273a39b008c0d4267db9",
+	"manifest": "7b795c145e3ecb0b22b6b1937bee9c55",
+	"setup": "90fcf7e835240d7d800af06bee72c72f",
 	"schemas": [
 		{
 			"identifier": "add_channel_to_team/schema.py",

--- a/microsoft_teams/bin/icon_microsoft_teams
+++ b/microsoft_teams/bin/icon_microsoft_teams
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Teams"
 Vendor = "rapid7"
-Version = "3.1.1"
+Version = "3.1.2"
 Description = "The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users"
 
 

--- a/microsoft_teams/help.md
+++ b/microsoft_teams/help.md
@@ -873,6 +873,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 3.1.2 - Fix issue where a name with a bracket could crash the plugin
 * 3.1.1 - Correct spelling in help.md
 * 3.1.0 - New actions Add Group Owner and Add Member to Channel
 * 3.0.1 - Fix import error in New Message Received trigger

--- a/microsoft_teams/help.md
+++ b/microsoft_teams/help.md
@@ -247,7 +247,7 @@ This action sends a message using the GUID for the team and channel. This is mor
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |channel_guid|string|None|True|Channel GUID|None|xxxxx-xxxxx-xxxx-xxxx|
-|is_html|boolean|None|True|Is the message HTML|None|False|
+|is_html|boolean|None|True|Is the message HTML|None|True|
 |message|string|None|True|Message to send|None|Hello!|
 |team_guid|string|None|True|Team GUID|None|xxxxx-xxxxx-xxxx-xxxx|
 
@@ -576,7 +576,7 @@ This action is used to create a group in Azure and enable it for Microsoft Teams
 |----|----|-------|--------|-----------|----|-------|
 |group_description|string|None|True|Group description|None|A test group|
 |group_name|string|None|True|Team name|None|test_group|
-|mail_enabled|boolean|None|True|Should e-mail should be enabled for this group|None|False|
+|mail_enabled|boolean|None|True|Should e-mail should be enabled for this group|None|True|
 |mail_nickname|string|None|True|The nickname for the email address of this group in Outlook|None|TestGroup|
 |members|string[]|None|False|A list of usernames to set as members|None|["user@example.com"]|
 |owners|string[]|None|False|A list of usernames to set as owners|None|["user@example.com"]|

--- a/microsoft_teams/icon_microsoft_teams/util/teams_utils.py
+++ b/microsoft_teams/icon_microsoft_teams/util/teams_utils.py
@@ -16,8 +16,8 @@ def get_teams_from_microsoft(logger: Logger, connection: komand.connection, team
     :param explicit: boolean
     :return: array of teams
     """
-    compiled_team_name = None
-    if team_name:
+    compiled_team_name = re.compile("")
+    if team_name and not explicit:
         try:
             compiled_team_name = re.compile(team_name)
         except Exception as e:
@@ -37,6 +37,7 @@ def get_teams_from_microsoft(logger: Logger, connection: komand.connection, team
         teams_result.raise_for_status()
     except Exception as e:
         raise PluginException(cause="Attempt to get teams failed.", assistance=teams_result.text) from e
+
     try:
         teams = teams_result.json().get("value")
     except Exception as e:

--- a/microsoft_teams/plugin.spec.yaml
+++ b/microsoft_teams/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
 description: The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users
-version: 3.1.1
+version: 3.1.2
 vendor: rapid7
 support: community
 status: []

--- a/microsoft_teams/plugin.spec.yaml
+++ b/microsoft_teams/plugin.spec.yaml
@@ -421,7 +421,7 @@ actions:
         type: boolean
         required: true
         order: 3
-        example: false
+        example: true
       message:
         title: Message
         description: Message to send
@@ -607,7 +607,7 @@ actions:
         type: boolean
         required: true
         order: 4
-        example: false
+        example: true
       owners:
         title: Owners
         description: A list of usernames to set as owners

--- a/microsoft_teams/setup.py
+++ b/microsoft_teams/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="microsoft_teams-rapid7-plugin",
-      version="3.1.1",
+      version="3.1.2",
       description="The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users",
       author="rapid7",
       author_email="",

--- a/microsoft_teams/unit_test/test_teams_utils.py
+++ b/microsoft_teams/unit_test/test_teams_utils.py
@@ -1,4 +1,7 @@
 from unittest import TestCase
+
+from komand.exceptions import PluginException
+
 from icon_microsoft_teams.connection.connection import Connection
 from icon_microsoft_teams.util.teams_utils import (
     create_channel,
@@ -92,3 +95,22 @@ class TestTeamsUtils(TestCase):
         expected = "Komand-Test-Everyone"
         teams = get_teams_from_microsoft(log, test_connection, expected, True)
         self.assertEquals(teams[0].get("displayName"), expected)
+
+    def test_integration_negative_get_blank_team(self):
+            log = logging.getLogger("Test")
+            test_connection = Connection()
+            test_connection.logger = log
+
+            with open("../tests/send_message.json") as file:
+                data = json.load(file)
+                connection_params = data.get("body").get("connection")
+
+            test_connection.connect(connection_params)
+            expected = ""
+            with self.assertRaises(PluginException):
+                teams = get_teams_from_microsoft(log, test_connection, expected, True)
+
+
+
+
+

--- a/microsoft_teams/unit_test/test_teams_utils.py
+++ b/microsoft_teams/unit_test/test_teams_utils.py
@@ -4,6 +4,7 @@ from icon_microsoft_teams.util.teams_utils import (
     create_channel,
     delete_channel,
     get_channels_from_microsoft,
+    get_teams_from_microsoft
 )
 
 import logging
@@ -16,7 +17,7 @@ TEST_CHANNEL_NAME = "test_channel_delete_me_2"
 
 
 class TestTeamsUtils(TestCase):
-    def test_create_channel(self):
+    def test_integraion_create_channel(self):
         log = logging.getLogger("Test")
         test_connection = Connection()
         test_connection.logger = log
@@ -38,7 +39,7 @@ class TestTeamsUtils(TestCase):
 
         self.assertTrue(result)
 
-    def test_delete_channel(self):
+    def test_integration_delete_channel(self):
         log = logging.getLogger("Test")
         test_connection = Connection()
         test_connection.logger = log
@@ -64,3 +65,30 @@ class TestTeamsUtils(TestCase):
         #     time.sleep(1)
 
         self.assertTrue(result)
+
+    def test_integration_get_team(self):
+        log = logging.getLogger("Test")
+        test_connection = Connection()
+        test_connection.logger = log
+
+        with open("../tests/send_message.json") as file:
+            data = json.load(file)
+            connection_params = data.get("body").get("connection")
+
+        test_connection.connect(connection_params)
+
+        expected = "[Test] for customer"
+        teams = get_teams_from_microsoft(log, test_connection, expected, True)
+        self.assertEquals(teams[0].get("displayName"), expected)
+
+        expected = "Dream Team"
+        teams = get_teams_from_microsoft(log, test_connection, expected, True)
+        self.assertEquals(teams[0].get("displayName"), expected)
+
+        expected = "change_me"
+        teams = get_teams_from_microsoft(log, test_connection, expected, True)
+        self.assertEquals(teams[0].get("displayName"), expected)
+
+        expected = "Komand-Test-Everyone"
+        teams = get_teams_from_microsoft(log, test_connection, expected, True)
+        self.assertEquals(teams[0].get("displayName"), expected)

--- a/microsoft_teams/unit_test/test_teams_utils.py
+++ b/microsoft_teams/unit_test/test_teams_utils.py
@@ -110,6 +110,10 @@ class TestTeamsUtils(TestCase):
             with self.assertRaises(PluginException):
                 teams = get_teams_from_microsoft(log, test_connection, expected, True)
 
+            expected = "DONT FIND THIS"
+            with self.assertRaises(PluginException):
+                teams = get_teams_from_microsoft(log, test_connection, expected, True)
+
 
 
 


### PR DESCRIPTION
## Proposed Changes
This PR fixes an issue in Microsoft Teams where the trigger would fail if the team name had a bracket in it. 

## Valdiation: 
```
RMT-MBP-5357:microsoft_teams jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "ExampleInputValidator" failed!
	Cause: All inputs should have example field in plugin.spec.
In action "send_message_by_guid": input "is_html", there is no example field.
In action "create_teams_enabled_group": input "mail_enabled", there is no example field.


----
[*] Total time elapsed: 1192.3120000000001ms
```

## Testing: 
```
RMT-MBP-5357:microsoft_teams jmcadams$ ./run.sh -R tests/new_message_received.json
Running: cat tests/new_message_received.json | docker run --rm   -i rapid7/microsoft_teams:3.1.2 --debug run
This is a trigger ^C to continue
Time Now: 1616691167.1702363
Time Ago: 0
Refreshing auth token
Updating Auth Token...
Getting token from: https://login.microsoftonline.com/5c824599-dc8c-4d31-96fb-3b886d4f8f10/oauth2/token
Starting new HTTPS connection (1): login.microsoftonline.com:443
https://login.microsoftonline.com:443 "POST /5c824599-dc8c-4d31-96fb-3b886d4f8f10/oauth2/token HTTP/1.1" 200 3478
Authentication was successful, token is: ******************TfoTA
Detected Permissions: Directory.ReadWrite.All Group.ReadWrite.All
rapid7/Microsoft Teams:3.1.2. Step name: new_message_received
Time Now: 1616691167.7867827
Time Ago: 1616691167.7848923
Token is valid, not refreshing.
Starting new HTTPS connection (1): graph.microsoft.com:443
https://graph.microsoft.com:443 "GET /beta/groups?$filter=resourceProvisioningOptions/Any(x:x%20eq%20'Team')%20and%20displayName%20eq%20'%5BTest%5D%20for%20customer' HTTP/1.1" 200 None
Team name: [Test] for customer
Checking team: [Test] for customer
Time Now: 1616691168.383542
Time Ago: 1616691167.7848923
Token is valid, not refreshing.
Starting new HTTPS connection (1): graph.microsoft.com:443
https://graph.microsoft.com:443 "GET /beta/5c824599-dc8c-4d31-96fb-3b886d4f8f10/teams/c5b1bc9b-8477-42f8-9ccc-71235185a7cf/channels HTTP/1.1" 200 None
Channel name: General
Checking channel: General
Time Now: 1616691169.5627475
Time Ago: 1616691167.7848923
Token is valid, not refreshing.
Starting new HTTPS connection (1): graph.microsoft.com:443
https://graph.microsoft.com:443 "GET /beta/teams/c5b1bc9b-8477-42f8-9ccc-71235185a7cf/channels/19:d5f96cbaad8f47fcb110f5b532599db9@thread.tacv2/messages HTTP/1.1" 200 None
Time Now: 1616691171.237148
Time Ago: 1616691167.7848923
Token is valid, not refreshing.
Starting new HTTPS connection (1): graph.microsoft.com:443
https://graph.microsoft.com:443 "GET /beta/teams/c5b1bc9b-8477-42f8-9ccc-71235185a7cf/channels/19:d5f96cbaad8f47fcb110f5b532599db9@thread.tacv2/messages HTTP/1.1" 200 None
No new messages found...


Time Now: 1616691182.3144903
Time Ago: 1616691167.7848923
Token is valid, not refreshing.
Starting new HTTPS connection (1): graph.microsoft.com:443
https://graph.microsoft.com:443 "GET /beta/teams/c5b1bc9b-8477-42f8-9ccc-71235185a7cf/channels/19:d5f96cbaad8f47fcb110f5b532599db9@thread.tacv2/messages HTTP/1.1" 200 None
No new messages found...

```