### PR TITLE
MC-394 - Jira - Adding Attachments Bug Fix

### DIFF
--- a/jira/.CHECKSUM
+++ b/jira/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "04dacad5816ff5214019a92b5aed3f03",
-	"manifest": "216e416c6ae9ab54fd1c270d4d7fc96f",
-	"setup": "1c40f20ba35263a770cb8b7a9180e6fc",
+	"spec": "238f9727493554b78c907152565a99c3",
+	"manifest": "e2f8c84f562c14c6604d2f9bd56610da",
+	"setup": "42b6443e3b4ecfb4af1e797e1687dcee",
 	"schemas": [
 		{
 			"identifier": "assign_issue/schema.py",

--- a/jira/bin/komand_jira
+++ b/jira/bin/komand_jira
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Jira"
 Vendor = "rapid7"
-Version = "6.0.6"
+Version = "6.0.7"
 Description = "Automate the creation, search and management of issues, users, and alerting for Jira Software, Jira Server, and Jira ServiceDesk"
 
 

--- a/jira/help.md
+++ b/jira/help.md
@@ -1143,6 +1143,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 6.0.7 - Fix issue in Create Issue and Attach Issue actions where adding attachments failed
 * 6.0.6 - Fix build issue
 * 6.0.5 - Add more documentation on authentication
 * 6.0.4 - Update to v4 Python plugin runtime

--- a/jira/komand_jira/actions/assign_issue/action.py
+++ b/jira/komand_jira/actions/assign_issue/action.py
@@ -21,7 +21,8 @@ class AssignIssue(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {id_}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {id_}.",
+                assistance="Please provide a valid issue ID.",
             )
 
         result = self.connection.client.assign_issue(issue=issue, assignee=params[Input.ASSIGNEE])

--- a/jira/komand_jira/actions/attach_issue/action.py
+++ b/jira/komand_jira/actions/attach_issue/action.py
@@ -21,11 +21,12 @@ class AttachIssue(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {id_}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {id_}.",
+                assistance="Please provide a valid issue ID.",
             )
 
-        return {Output.ID: self.connection.rest_client.add_attachment(
-            issue.key,
-            params.get(Input.ATTACHMENT_FILENAME),
-            params.get(Input.ATTACHMENT_BYTES)
-        )}
+        return {
+            Output.ID: self.connection.rest_client.add_attachment(
+                issue.key, params.get(Input.ATTACHMENT_FILENAME), params.get(Input.ATTACHMENT_BYTES)
+            )
+        }

--- a/jira/komand_jira/actions/attach_issue/action.py
+++ b/jira/komand_jira/actions/attach_issue/action.py
@@ -1,6 +1,5 @@
 import insightconnect_plugin_runtime
 from .schema import AttachIssueInput, AttachIssueOutput, Input, Output, Component
-from komand_jira.util.util import add_attachment
 
 # Custom imports below
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -25,12 +24,8 @@ class AttachIssue(insightconnect_plugin_runtime.Action):
                 cause=f"No issue found with ID: {id_}.", assistance="Please provide a valid issue ID.",
             )
 
-        output = add_attachment(
-            self.connection,
-            self.logger,
-            issue,
+        return {Output.ID: self.connection.rest_client.add_attachment(
+            issue.key,
             params.get(Input.ATTACHMENT_FILENAME),
-            params.get(Input.ATTACHMENT_BYTES),
-        )
-
-        return {Output.ID: output.id}
+            params.get(Input.ATTACHMENT_BYTES)
+        )}

--- a/jira/komand_jira/actions/comment_issue/action.py
+++ b/jira/komand_jira/actions/comment_issue/action.py
@@ -21,7 +21,8 @@ class CommentIssue(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {id_}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {id_}.",
+                assistance="Please provide a valid issue ID.",
             )
 
         comment = self.connection.client.add_comment(issue=issue, body=params[Input.COMMENT])

--- a/jira/komand_jira/actions/create_issue/action.py
+++ b/jira/komand_jira/actions/create_issue/action.py
@@ -2,7 +2,7 @@ import insightconnect_plugin_runtime
 from .schema import CreateIssueInput, CreateIssueOutput, Input, Output, Component
 
 # Custom imports below
-from komand_jira.util.util import look_up_project, normalize_issue, add_attachment
+from komand_jira.util.util import look_up_project, normalize_issue
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException, PluginException
 
 
@@ -75,10 +75,8 @@ class CreateIssue(insightconnect_plugin_runtime.Action):
             )
 
         if params.get(Input.ATTACHMENT_BYTES) and params.get(Input.ATTACHMENT_FILENAME):
-            add_attachment(
-                self.connection,
-                self.logger,
-                issue,
+            self.connection.rest_client.add_attachment(
+                issue.key,
                 params.get(Input.ATTACHMENT_FILENAME),
                 params.get(Input.ATTACHMENT_BYTES),
             )

--- a/jira/komand_jira/actions/create_user/action.py
+++ b/jira/komand_jira/actions/create_user/action.py
@@ -7,7 +7,10 @@ from .schema import CreateUserInput, CreateUserOutput, Input, Output, Component
 class CreateUser(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="create_user", description=Component.DESCRIPTION, input=CreateUserInput(), output=CreateUserOutput(),
+            name="create_user",
+            description=Component.DESCRIPTION,
+            input=CreateUserInput(),
+            output=CreateUserOutput(),
         )
 
     def run(self, params={}):

--- a/jira/komand_jira/actions/delete_user/action.py
+++ b/jira/komand_jira/actions/delete_user/action.py
@@ -17,14 +17,14 @@ class DeleteUser(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         if self.connection.is_cloud and not params.get(Input.ACCOUNT_ID):
             raise PluginException(
-                preset=PluginException.Preset.USERNAME_PASSWORD,
-                assistance="Jira cloud server need account ID to be set",
+                cause="Account ID not provided",
+                assistance="Jira cloud server needs account ID to be set",
             )
 
         if not self.connection.is_cloud and not params.get(Input.USERNAME):
             raise PluginException(
-                preset=PluginException.Preset.USERNAME_PASSWORD,
-                assistance="Jira server need username to be set",
+                cause="Username not provided",
+                assistance="Jira server needs username to be set",
             )
 
         if self.connection.is_cloud:

--- a/jira/komand_jira/actions/delete_user/action.py
+++ b/jira/komand_jira/actions/delete_user/action.py
@@ -8,7 +8,10 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 class DeleteUser(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="delete_user", description=Component.DESCRIPTION, input=DeleteUserInput(), output=DeleteUserOutput(),
+            name="delete_user",
+            description=Component.DESCRIPTION,
+            input=DeleteUserInput(),
+            output=DeleteUserOutput(),
         )
 
     def run(self, params={}):
@@ -20,7 +23,8 @@ class DeleteUser(insightconnect_plugin_runtime.Action):
 
         if not self.connection.is_cloud and not params.get(Input.USERNAME):
             raise PluginException(
-                preset=PluginException.Preset.USERNAME_PASSWORD, assistance="Jira server need username to be set",
+                preset=PluginException.Preset.USERNAME_PASSWORD,
+                assistance="Jira server need username to be set",
             )
 
         if self.connection.is_cloud:

--- a/jira/komand_jira/actions/edit_issue/action.py
+++ b/jira/komand_jira/actions/edit_issue/action.py
@@ -8,7 +8,10 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 class EditIssue(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="edit_issue", description=Component.DESCRIPTION, input=EditIssueInput(), output=EditIssueOutput(),
+            name="edit_issue",
+            description=Component.DESCRIPTION,
+            input=EditIssueInput(),
+            output=EditIssueOutput(),
         )
 
     def run(self, params={}):

--- a/jira/komand_jira/actions/find_issues/action.py
+++ b/jira/komand_jira/actions/find_issues/action.py
@@ -8,7 +8,10 @@ from komand_jira.util.util import normalize_issue
 class FindIssues(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="find_issues", description=Component.DESCRIPTION, input=FindIssuesInput(), output=FindIssuesOutput(),
+            name="find_issues",
+            description=Component.DESCRIPTION,
+            input=FindIssuesInput(),
+            output=FindIssuesOutput(),
         )
 
     def run(self, params={}):

--- a/jira/komand_jira/actions/find_users/action.py
+++ b/jira/komand_jira/actions/find_users/action.py
@@ -8,7 +8,10 @@ from komand_jira.util.util import normalize_user
 class FindUsers(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="find_users", description=Component.DESCRIPTION, input=FindUsersInput(), output=FindUsersOutput(),
+            name="find_users",
+            description=Component.DESCRIPTION,
+            input=FindUsersInput(),
+            output=FindUsersOutput(),
         )
 
     def run(self, params={}):

--- a/jira/komand_jira/actions/get_comments/action.py
+++ b/jira/komand_jira/actions/get_comments/action.py
@@ -21,7 +21,8 @@ class GetComments(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {params[Input.ID]}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {params[Input.ID]}.",
+                assistance="Please provide a valid issue ID.",
             )
 
         comments = issue.fields.comment.comments or []

--- a/jira/komand_jira/actions/get_issue/action.py
+++ b/jira/komand_jira/actions/get_issue/action.py
@@ -9,7 +9,10 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 class GetIssue(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="get_issue", description=Component.DESCRIPTION, input=GetIssueInput(), output=GetIssueOutput(),
+            name="get_issue",
+            description=Component.DESCRIPTION,
+            input=GetIssueInput(),
+            output=GetIssueOutput(),
         )
 
     def run(self, params={}):
@@ -19,11 +22,15 @@ class GetIssue(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {params[Input.ID]}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {params[Input.ID]}.",
+                assistance="Please provide a valid issue ID.",
             )
 
         output = normalize_issue(
-            issue=issue, get_attachments=get_attachments, include_raw_fields=True, logger=self.logger,
+            issue=issue,
+            get_attachments=get_attachments,
+            include_raw_fields=True,
+            logger=self.logger,
         )
 
         clean_output = insightconnect_plugin_runtime.helper.clean(output)

--- a/jira/komand_jira/actions/label_issue/action.py
+++ b/jira/komand_jira/actions/label_issue/action.py
@@ -8,7 +8,10 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 class LabelIssue(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(
-            name="label_issue", description=Component.DESCRIPTION, input=LabelIssueInput(), output=LabelIssueOutput(),
+            name="label_issue",
+            description=Component.DESCRIPTION,
+            input=LabelIssueInput(),
+            output=LabelIssueOutput(),
         )
 
     def run(self, params={}):
@@ -18,7 +21,8 @@ class LabelIssue(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {params[Input.ID]}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {params[Input.ID]}.",
+                assistance="Please provide a valid issue ID.",
             )
 
         labels = params[Input.LABEL].split(",")

--- a/jira/komand_jira/actions/transition_issue/action.py
+++ b/jira/komand_jira/actions/transition_issue/action.py
@@ -22,7 +22,8 @@ class TransitionIssue(insightconnect_plugin_runtime.Action):
 
         if not issue:
             raise PluginException(
-                cause=f"No issue found with ID: {params[Input.ID]}.", assistance="Please provide a valid issue ID.",
+                cause=f"No issue found with ID: {params[Input.ID]}.",
+                assistance="Please provide a valid issue ID.",
             )
 
         try:

--- a/jira/komand_jira/util/api.py
+++ b/jira/komand_jira/util/api.py
@@ -42,10 +42,18 @@ class JiraApi:
             "POST",
             f"/rest/api/latest/issue/{issue}/attachments",
             files={"file": (filename, attachment, "application/octet-stream")},
-            headers={"content-type": None, "X-Atlassian-Token": "nocheck"}
-        )[0].get('id')
-        
-    def call_api(self, method: str, path: str, files: dict = None, headers: dict = None, params: dict = None, payload: dict = None) -> dict:
+            headers={"content-type": None, "X-Atlassian-Token": "nocheck"},
+        )[0].get("id")
+
+    def call_api(
+        self,
+        method: str,
+        path: str,
+        files: dict = None,
+        headers: dict = None,
+        params: dict = None,
+        payload: dict = None,
+    ) -> dict:
         try:
             response = self.session.request(
                 method.upper(),
@@ -57,9 +65,7 @@ class JiraApi:
             )
 
             if response.status_code == 401:
-                raise PluginException(
-                    preset=PluginException.Preset.USERNAME_PASSWORD, data=response.text
-                )
+                raise PluginException(preset=PluginException.Preset.USERNAME_PASSWORD, data=response.text)
             if response.status_code == 403:
                 raise PluginException(preset=PluginException.Preset.API_KEY, data=response.text)
             if response.status_code == 404:
@@ -70,9 +76,7 @@ class JiraApi:
                     data=response.text,
                 )
             if response.status_code >= 500:
-                raise PluginException(
-                    preset=PluginException.Preset.SERVER_ERROR, data=response.text
-                )
+                raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
 
             if 200 <= response.status_code < 300:
                 return response.json()

--- a/jira/komand_jira/util/api.py
+++ b/jira/komand_jira/util/api.py
@@ -1,3 +1,7 @@
+import base64
+import json
+from io import BytesIO
+from insightconnect_plugin_runtime.exceptions import PluginException
 from jira.resources import User
 
 
@@ -6,6 +10,8 @@ class JiraApi:
         self.jira_client = jira_client
         self.is_cloud = is_cloud
         self.logger = logger
+        self.session = jira_client._session
+        self.base_url = jira_client._options["server"]
 
     def delete_user(self, accountId):
         url = self.jira_client._options["server"] + "/rest/api/latest/user/?accountId=%s" % accountId
@@ -19,3 +25,58 @@ class JiraApi:
 
     def find_users(self, query, max_results=10):
         return self.jira_client._fetch_pages(User, None, "user/search", 0, max_results, {"query": query})
+
+    def add_attachment(self, issue, filename, file_bytes):
+        try:
+            data = base64.b64decode(file_bytes)
+        except Exception as e:
+            raise PluginException(
+                cause="Unable to decode attachment bytes.",
+                assistance=f"Please provide a valid attachment bytes. Error: {str(e)}",
+            )
+
+        attachment = BytesIO()
+        attachment.write(data)
+
+        return self.call_api(
+            "POST",
+            f"/rest/api/latest/issue/{issue}/attachments",
+            files={"file": (filename, attachment, "application/octet-stream")},
+            headers={"content-type": None, "X-Atlassian-Token": "nocheck"}
+        )[0].get('id')
+        
+    def call_api(self, method: str, path: str, files: dict = None, headers: dict = None, params: dict = None, payload: dict = None) -> dict:
+        try:
+            response = self.session.request(
+                method.upper(),
+                self.base_url + path,
+                params=params,
+                json=payload,
+                headers=headers,
+                files=files,
+            )
+
+            if response.status_code == 401:
+                raise PluginException(
+                    preset=PluginException.Preset.USERNAME_PASSWORD, data=response.text
+                )
+            if response.status_code == 403:
+                raise PluginException(preset=PluginException.Preset.API_KEY, data=response.text)
+            if response.status_code == 404:
+                raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response.text)
+            if 400 <= response.status_code < 500:
+                raise PluginException(
+                    preset=PluginException.Preset.UNKNOWN,
+                    data=response.text,
+                )
+            if response.status_code >= 500:
+                raise PluginException(
+                    preset=PluginException.Preset.SERVER_ERROR, data=response.text
+                )
+
+            if 200 <= response.status_code < 300:
+                return response.json()
+
+            raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
+        except json.decoder.JSONDecodeError as e:
+            raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=e)

--- a/jira/komand_jira/util/util.py
+++ b/jira/komand_jira/util/util.py
@@ -1,6 +1,5 @@
 import logging
 import base64
-from io import BytesIO
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 
@@ -101,18 +100,3 @@ def look_up_project(_id, client, logger=logging.getLogger()):
         logger.debug("Project %s exists", project_id_name)
         return True
     return False
-
-
-def add_attachment(connection, logger, issue, filename, file_bytes):
-    try:
-        data = base64.b64decode(file_bytes)
-    except Exception as e:
-        raise PluginException(
-            cause="Unable to decode attachment bytes.",
-            assistance=f"Please provide a valid attachment bytes. Error: {str(e)}",
-        )
-    attachment = BytesIO()
-    attachment.write(data)
-    output = connection.client.add_attachment(issue=issue, attachment=attachment, filename=filename)
-    logger.debug("Attach issue has returned: %s", output)
-    return output

--- a/jira/plugin.spec.yaml
+++ b/jira/plugin.spec.yaml
@@ -8,7 +8,7 @@ support: rapid7
 cloud_ready: true
 status: []
 description: Automate the creation, search and management of issues, users, and alerting for Jira Software, Jira Server, and Jira ServiceDesk
-version: 6.0.6
+version: 6.0.7
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/jira
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE

--- a/jira/setup.py
+++ b/jira/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="jira-rapid7-plugin",
-      version="6.0.6",
+      version="6.0.7",
       description="Automate the creation, search and management of issues, users, and alerting for Jira Software, Jira Server, and Jira ServiceDesk",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

Fixed the issue, where attaching a file or creating an issue with a new file would fail.

### Description

Describe the proposed changes:

  -

### Testing

Any testing information goes here.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment
#### Run

<details>

```
{
  "body": {
    "log": "rapid7/Jira:6.0.7. Step name: attach_issue\n",
    "meta": {},
    "output": {
      "id": "10022"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/jira:6.0.7 --debug run < tests/attach_issue_1.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Jira:6.0.7. Step name: attach_issue\n",
    "meta": {},
    "output": {
      "id": "10023"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/jira:6.0.7 --debug run < tests/attach_issue_2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Jira:6.0.7. Step name: attach_issue\n",
    "meta": {},
    "output": {
      "id": "10024"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/jira:6.0.7 --debug run < tests/attach_issue_3.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Jira:6.0.7. Step name: create_issue\n",
    "status": "ok",
    "meta": {},
    "output": {
      "issue": {
        "attachments": [],
        "id": "10106",
        "key": "IP-12",
        "url": "https://dm-rapid-test.atlassian.net/browse/IP-12",
        "summary": "Test Issue",
        "description": "Test issue created using InsightConnect",
        "status": "Open",
        "resolution": "",
        "reporter": "Dawid Mandyna",
        "assignee": "",
        "created_at": "2021-04-11T20:49:02.974+0100",
        "updated_at": "2021-04-11T20:49:02.974+0100",
        "resolved_at": "",
        "labels": [],
        "fields": {}
      }
    }
  },
  "version": "v1",
  "type": "action_event"
}

```

<summary>
docker run --rm -i rapid7/jira:6.0.7 --debug run < tests/create_issue_1.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Jira:6.0.7. Step name: create_issue\n",
    "status": "ok",
    "meta": {},
    "output": {
      "issue": {
        "attachments": [],
        "id": "10107",
        "key": "IP-13",
        "url": "https://dm-rapid-test.atlassian.net/browse/IP-13",
        "summary": "Test Issue",
        "description": "Test issue created using InsightConnect",
        "status": "Open",
        "resolution": "",
        "reporter": "Dawid Mandyna",
        "assignee": "",
        "created_at": "2021-04-11T20:49:35.772+0100",
        "updated_at": "2021-04-11T20:49:35.772+0100",
        "resolved_at": "",
        "labels": [],
        "fields": {}
      }
    }
  },
  "version": "v1",
  "type": "action_event"
}

```

<summary>
docker run --rm -i rapid7/jira:6.0.7 --debug run < tests/create_issue_2.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Jira:6.0.7. Step name: create_issue\n",
    "status": "ok",
    "meta": {},
    "output": {
      "issue": {
        "attachments": [],
        "id": "10108",
        "key": "IP-14",
        "url": "https://dm-rapid-test.atlassian.net/browse/IP-14",
        "summary": "Test Issue",
        "description": "Test issue created using InsightConnect",
        "status": "Open",
        "resolution": "",
        "reporter": "Dawid Mandyna",
        "assignee": "",
        "created_at": "2021-04-11T20:50:08.450+0100",
        "updated_at": "2021-04-11T20:50:08.450+0100",
        "resolved_at": "",
        "labels": [],
        "fields": {}
      }
    }
  },
  "version": "v1",
  "type": "action_event"
}

```

<summary>
docker run --rm -i rapid7/jira:6.0.7 --debug run < tests/create_issue_3.json
</summary>
</details>

#### Plugin Validation

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 17335.109ms
```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../tools/Makefiles/Helpers.mk ../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 2343.807ms

[*] Validating spec with js-yaml
[SUCCESS] Passes js-yaml spec check


[*] For Markdown linting, install mdl: gem install mdl

[*] Validating python files for style...
./komand_jira/connection/connection.py:55:49: F541 f-string is missing placeholders
./komand_jira/util/util.py:3:1: F401 'insightconnect_plugin_runtime.exceptions.PluginException' imported but unused
./komand_jira/util/api.py:47:1: W293 blank line contains whitespace
[FAIL] Fails flake8 linting

[*] Validating python files for security vulnerabilities...
[main]  INFO    profile include tests: None
[main]  INFO    profile exclude tests: None
[main]  INFO    cli include tests: None
[main]  INFO    cli exclude tests: None
[main]  INFO    running on Python 3.7.3
52 [0.. 50.. ]
Run started:2021-04-11 19:52:09.735949

Test results:
>> Issue: [B105:hardcoded_password_string] Possible hardcoded password: 'password'
   Severity: Low   Confidence: Medium
   Location: ./komand_jira/actions/create_user/schema.py:13
   More Info: https://bandit.readthedocs.io/en/latest/plugins/b105_hardcoded_password_string.html
12          NOTIFY = "notify"
13          PASSWORD = "password"
14          USERNAME = "username"

--------------------------------------------------

Code scanned:
        Total lines of code: 2299
        Total lines skipped (#nosec): 0

Run metrics:
        Total issues (by severity):
                Undefined: 0.0
                Low: 1.0
                Medium: 0.0
                High: 0.0
        Total issues (by confidence):
                Undefined: 0.0
                Low: 0.0
                Medium: 1.0
                High: 0.0
Files skipped (0):
[FAIL] Fails bandit security checks

[*] Checking for typos with Misspell...
[SUCCESS] Passes Misspell check
```

<summary>
make validate
</summary>
</details>
