### PR TITLE
[SOAR-5251] - Remove unused SSL code from the Rest plugin

### DIFF
--- a/rest/Dockerfile
+++ b/rest/Dockerfile
@@ -25,4 +25,5 @@ RUN python setup.py build && python setup.py install
 # needed for SSL Verify
 USER root
 
+# Entrypoint
 ENTRYPOINT ["/usr/local/bin/komand_rest"]

--- a/rest/komand_rest/util/util.py
+++ b/rest/komand_rest/util/util.py
@@ -70,10 +70,6 @@ class RestAPI(object):
         self.auth = None
         self.default_headers = default_headers
 
-        if not ssl_verify:
-            ssl._create_default_https_context = ssl._create_unverified_context
-
-
     def with_credentials(
             self, authentication_type: str, username: str = None, password: str = None, secret_key: str = None
     ):


### PR DESCRIPTION


### Description

Remove unused SSL code from the Rest plugin

### Testing: 
``` 
Tested locally, had mike watch me, it works
```

NOTE: Correcting for accidental change to master. 