### PR TITLE
[SOAR-5270] - Rest Plugin Fix non object return

### DIFF
--- a/rest/.CHECKSUM
+++ b/rest/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "c62a578ea0e445a775fbee229ef1a524",
-	"manifest": "409ed1b9a16205b56eb7548081339b04",
-	"setup": "74c0b0093d2711087b53eff85f3b6951",
+	"spec": "263fcd892213892f301df024c7019400",
+	"manifest": "2f727ec0622d3400ebacb57c31ed6e48",
+	"setup": "aa125f411e96bfbcc1ab37e4ef28f16f",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",

--- a/rest/bin/komand_rest
+++ b/rest/bin/komand_rest
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "HTTP Requests"
 Vendor = "rapid7"
-Version = "4.0.4"
+Version = "4.0.5"
 Description = "The HTTP Requests plugin to make it easy to integrate with RESTful services"
 
 

--- a/rest/help.md
+++ b/rest/help.md
@@ -445,6 +445,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
+* 4.0.5 - Fix issue where non json return would crash the plugin
 * 4.0.4 - Fix issue with SSL Verify
 * 4.0.3 - Update `requests` to the latest version | Update python version to `python-3-38-plugin:4` | Add `USER` in Dockerfile | Use input and output constants | Code refactor | Strip leading and trailing whitespace from route
 * 4.0.2 - Updated `docs_url` to [HTTP Requests - Plugin Connection Guide](https://docs.rapid7.com/insightconnect/http-requests)

--- a/rest/help.md
+++ b/rest/help.md
@@ -445,7 +445,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
-* 4.0.5 - Fix issue where non json return would crash the plugin
+* 4.0.5 - Fix issue where if an API returned a list it would crash the plugin
 * 4.0.4 - Fix issue with SSL Verify
 * 4.0.3 - Update `requests` to the latest version | Update python version to `python-3-38-plugin:4` | Add `USER` in Dockerfile | Use input and output constants | Code refactor | Strip leading and trailing whitespace from route
 * 4.0.2 - Updated `docs_url` to [HTTP Requests - Plugin Connection Guide](https://docs.rapid7.com/insightconnect/http-requests)

--- a/rest/komand_rest/util/util.py
+++ b/rest/komand_rest/util/util.py
@@ -142,7 +142,7 @@ class RestAPI(object):
             if response.status_code >= 500:
                 raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
 
-            if 200 <= response.status_code and response.status_code < 300:
+            if 200 <= response.status_code < 300:
                 return response
 
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)

--- a/rest/komand_rest/util/util.py
+++ b/rest/komand_rest/util/util.py
@@ -5,7 +5,6 @@ from urllib.parse import urlparse, urlsplit, urlunsplit
 from logging import Logger
 from requests.auth import HTTPDigestAuth, HTTPBasicAuth
 import json
-import ssl
 
 
 class Common:
@@ -40,7 +39,12 @@ class Common:
         if body_object is None:
             body_object = {}
 
-        return body_object
+        if isinstance(body_object, dict):
+            return body_object
+        else:
+            # Convert to object
+            return {"object": body_object}
+
 
 
 def url_path_join(*parts):
@@ -138,7 +142,7 @@ class RestAPI(object):
             if response.status_code >= 500:
                 raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
 
-            if 200 <= response.status_code < 300:
+            if 200 <= response.status_code and response.status_code < 300:
                 return response
 
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)

--- a/rest/plugin.spec.yaml
+++ b/rest/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rest
 title: HTTP Requests
 description: The HTTP Requests plugin to make it easy to integrate with RESTful services
-version: 4.0.4
+version: 4.0.5
 vendor: rapid7
 support: community
 status: []

--- a/rest/setup.py
+++ b/rest/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rest-rapid7-plugin",
-      version="4.0.4",
+      version="4.0.5",
       description="The HTTP Requests plugin to make it easy to integrate with RESTful services",
       author="rapid7",
       author_email="",

--- a/rest/unit_test/test_get.py
+++ b/rest/unit_test/test_get.py
@@ -50,12 +50,7 @@ class TestGet(TestCase):
         test_action.connection = test_conn
         results = test_action.run(action_params)
 
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
+        self.AssertIsNotNone({}, results)
 
     def test_get(self):
         """

--- a/rest/unit_test/test_get.py
+++ b/rest/unit_test/test_get.py
@@ -12,19 +12,6 @@ import logging
 
 class TestGet(TestCase):
     def test_integration_get(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
         log = logging.getLogger("Test")
         test_conn = Connection()
         test_action = Get()
@@ -50,18 +37,4 @@ class TestGet(TestCase):
         test_action.connection = test_conn
         results = test_action.run(action_params)
 
-        self.AssertIsNotNone({}, results)
-
-    def test_get(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+        self.assertIsNotNone(results)

--- a/rest/unit_test/test_utils.py
+++ b/rest/unit_test/test_utils.py
@@ -1,0 +1,51 @@
+import sys
+import os
+from komand_rest.util.util import *
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
+import logging
+
+
+class MockResponse():
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.text = "This is some error text"
+
+    def json(self):
+        return json.loads(json.dumps(self.json_data))
+
+# This method will be used by the mock to replace requests.get
+def mocked_requests_get(*args, **kwargs):
+    payload = [{"key":"value"}]
+
+    if args[0] == 'get':
+        if args[1] == 'www.google.com/':
+            return MockResponse(payload, 200)
+
+    print(f"mocked_requests_get failed looking for: {args[0]}")
+    return MockResponse(None, 404)
+
+class TestUtil(TestCase):
+
+    @mock.patch('requests.request', side_effect=mocked_requests_get)
+    def test_get_non_object(self, mock_get):
+        log = logging.getLogger("Test")
+        api = RestAPI("www.google.com", log, False, {})
+
+        actual = api.call_api("get", "/", None, None, None)
+        expected = [{'key': 'value'}]
+        self.assertEqual(actual.json(), expected)
+
+    def test_body_object(self):
+        common = Common()
+
+        test_response = MockResponse([{"key":"value"}], 200)
+        actual = common.body_object(test_response)
+        expected = {"object":[{"key":"value"}]}
+
+        self.assertEqual(actual, expected)
+
+


### PR DESCRIPTION
## Proposed Changes
This PR fixes an issue where the Rest plugin would fail if a list was returned by a successful API call 

## Validation: 
```
RMT-MBP-5357:rest jmcadams$ icon-validate .
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator LoggingValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Plugin successfully validated!

----
[*] Total time elapsed: 770.178ms
```

## Testing: 
```
RMT-MBP-5357:rest jmcadams$ ./run.sh -R tests/get.json -j
Running: cat tests/get.json | docker run --rm   -i rapid7/rest:4.0.5  run | grep -- ^\{ | jq -r '.body | try(.log | split("\n") | .[]),.output'
Connect: Configuring REST details
Connect: Connecting..
rapid7/HTTP Requests:4.0.5. Step name: get
Starting new HTTP connection (1): elast-alert.vuln.lax.rapid7.com:9200
http://elast-alert.vuln.lax.rapid7.com:9200 "GET /_mapping HTTP/1.1" 200 2011
Connect: Configuring REST details
Connect: Connecting..
rapid7/HTTP Requests:4.0.5. Step name: get

{
  "body_object": {
    "account": {
      "mappings": {
        "doc": {
          "properties": {
            "account_number": {
              "type": "long"
            },
            "address": {
              "type": "text",
              "fields": {
                "keyword": {
                  "type": "keyword",
                  "ignore_above": 256
                }
              }
            },
            "age": {
              "type": "long"
            },
            "balance": {
              "type": "long"
            },
            "city": {
              "type": "text",
              "fields": {
                "keyword": {
                  "type": "keyword",
                  "ignore_above": 256
                }
              }
            },
...<omitted for size>,
  "body_string": "{\"account\":{\"mappings\":{\"doc\":{\"properties\":{\"account_number\":{\"type\":\"long\"},\"address\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"age\":{\"type\":\"long\"},\"balance\":{\"type\":\"long\"},\"city\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"email\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"employer\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"firstname\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"gender\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"lastname\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}},\"state\":{\"type\":\"text\",\"fields\":{\"keyword\":{\"type\":\"keyword\",\"ignore_above\":256}}}}}}},\".tasks\":{\"mappings\":{\"task\":{\"dynamic\":\"strict\",\"_meta\":{\"version\":2},\"properties\":{\"completed\":{\"type\":\"boolean\"},\"error\":{\"type\":\"object\",\"enabled\":false},\"response\":{\"type\":\"object\",\"enabled\":false},\"task\":{\"properties\":{\"action\":{\"type\":\"keyword\"},\"cancellable\":{\"type\":\"boolean\"},\"description\":{\"type\":\"text\"},\"headers\":{\"type\":\"object\",\"enabled\":false},\"id\":{\"type\":\"long\"},\"node\":{\"type\":\"keyword\"},\"parent_id\":{\"type\":\"keyword\"},\"running_time_in_nanos\":{\"type\":\"long\"},\"start_time_in_millis\":{\"type\":\"long\"},\"status\":{\"type\":\"object\",\"enabled\":false},
... <omitted for size>",
  "status": 200,
  "headers": {
    "Warning": "299 Elasticsearch-6.8.15-c9a8c60 \"[types removal] The parameter include_type_name should be explicitly specified in get mapping requests to prepare for 7.0. In 7.0 include_type_name will default to 'false', which means responses will omit the type name in mapping definitions.\"",
    "content-type": "application/json; charset=UTF-8",
    "content-encoding": "gzip",
    "content-length": "2011"
  }
}
```