### PR TITLE
Update labels in output in InsightIDR plugin

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "857f4c9c3a03dc5135c7f8f0e82e3835",
-	"manifest": "1429256a3a10ddf8ca003ed88b6f7e94",
-	"setup": "c0936d8a3a6342746cbad617c2ee3496",
+	"spec": "e5b33327dbb43f7fef41e61259a1e0de",
+	"manifest": "fe1b50335e50285ea4bdae5d38a0133b",
+	"setup": "64fa3074c06cf73c3871714e18198fe7",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/Dockerfile
+++ b/plugins/rapid7_insightidr/Dockerfile
@@ -7,6 +7,8 @@ LABEL sdk=python
 # Add any custom package dependencies here
 # NOTE: Add pip packages to requirements.txt
 
+RUN apk add gcc musl-dev
+
 # End package dependencies
 
 # Add source code

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "3.1.4"
+Version = "3.1.5"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -14,7 +14,7 @@ Do more with Investigations in [InsightIDR](https://www.rapid7.com/products/insi
 
 # Supported Product Versions
 
-_There are no supported product versions listed._
+* Latest release successfully tested on 2022-05-05.
 
 # Documentation
 
@@ -25,7 +25,7 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |api_key|credential_secret_key|None|True|InsightIDR API key|None|4472f2g7-991z-4w70-li11-7552w8qm0266|
-|url|string|https://us.api.insight.rapid7.com|True|The URL endpoint for InsightIDR. e.g. https://<REGION_CODE>.api.insight.rapid7.com|None|https://us.api.insight.rapid7.com|
+|url|string|https://example.com|True|The URL endpoint for InsightIDR. e.g. https://<REGION_CODE>.api.insight.rapid7.com|None|https://example.com|
 
 Example input:
 
@@ -108,7 +108,7 @@ Example input:
 
 ```
 {
-  "log_set": "Firewall Activity",
+  "log": "Firewall Activity",
   "query": "where(user=adagentadmin, loose)",
   "relative_time": "Last 5 Minutes",
   "time_from": "01-01-2020T00:00:00",
@@ -413,9 +413,6 @@ This action is used to get a specific log from an account.
 Example input:
 
 ```
-{
-  "id": "174e4f99-2ac7-4481-9301-4d24c34baf06"
-}
 ```
 
 ##### Output
@@ -805,6 +802,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 3.1.5 - Patch issue parsing labels in Advanced Query on Log and Advanced Query on Log Set actions
 * 3.1.4 - Add `docs_url` to plugin spec with a link to [InsightIDR plugin setup guide](https://docs.rapid7.com/insightconnect/rapid7-insightidr)
 * 3.1.3 - Fix issue where Get a Log and Get All Logs would either fail in workflow or in connection test
 * 3.1.2 - Send plugin name and version in the User-Agent string to vendor

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -4,8 +4,8 @@ from komand.exceptions import PluginException
 
 # Custom imports below
 import time
-import json
 from komand_rapid7_insightidr.util.parse_dates import parse_dates
+from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 
 
 class AdvancedQueryOnLog(komand.Action):
@@ -42,15 +42,15 @@ class AdvancedQueryOnLog(komand.Action):
         # It will return results if it gets them. If not, we'll get a call back URL to work on
         callback_url, log_entries = self.maybe_get_log_entries(log_id, query, time_from, time_to)
 
-        if not log_entries:
+        if callback_url and not log_entries:
             log_entries = self.get_results_from_callback(callback_url, timeout)
 
-        log_entries = komand.helper.clean(log_entries)
+        if log_entries:
+            log_entries = ResourceHelper.get_log_entries_with_new_labels(
+                self.connection, komand.helper.clean(log_entries)
+            )
 
-        for log_entry in log_entries:
-            log_entry["message"] = json.loads(log_entry.get("message", "{}"))
-
-        self.logger.info(f"Sending results to orchestrator.")
+        self.logger.info("Sending results to orchestrator.")
         return {Output.RESULTS: log_entries, Output.COUNT: len(log_entries)}
 
     def get_results_from_callback(self, callback_url: str, timeout: int) -> [object]:
@@ -154,7 +154,7 @@ class AdvancedQueryOnLog(komand.Action):
             return None, potential_results
         else:
             self.logger.info("Got a callback url. Polling results...")
-            return results_object.get("links")[0].get("href"), None
+            return results_object.get("links", [{}])[0].get("href"), []
 
     def get_log_id(self, log_name: str) -> str:
         """
@@ -178,19 +178,19 @@ class AdvancedQueryOnLog(komand.Action):
 
         logs = response.json().get("logs")
 
-        id = ""
+        log_id = ""
 
         for log in logs:
             name = log.get("name")
             self.logger.info(f"Checking {log_name} against {name}")
             if name == log_name:
                 self.logger.info("Log found.")
-                id = log.get("id")
+                log_id = log.get("id")
                 break
 
-        if id:
-            self.logger.info(f"Found log with name {log_name} and ID: {id}")
-            return id
+        if log_id:
+            self.logger.info(f"Found log with name {log_name} and ID: {log_id}")
+            return log_id
 
         self.logger.error(f"Could not find log with name {log_name}")
         raise PluginException(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -4,7 +4,7 @@ from .schema import AdvancedQueryOnLogSetInput, AdvancedQueryOnLogSetOutput, Inp
 
 # Custom imports below
 import time
-import json
+from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from komand.exceptions import PluginException
 from komand_rapid7_insightidr.util.parse_dates import parse_dates
 
@@ -43,15 +43,15 @@ class AdvancedQueryOnLogSet(komand.Action):
         # It will return results if it gets them. If not, we'll get a call back URL to work on
         callback_url, log_entries = self.maybe_get_log_entries(log_set_id, query, time_from, time_to)
 
-        if not log_entries:
+        if callback_url and not log_entries:
             log_entries = self.get_results_from_callback(callback_url, timeout)
 
-        log_entries = komand.helper.clean(log_entries)
+        if log_entries:
+            log_entries = ResourceHelper.get_log_entries_with_new_labels(
+                self.connection, komand.helper.clean(log_entries)
+            )
 
-        for log_entry in log_entries:
-            log_entry["message"] = json.loads(log_entry.get("message", "{}"))
-
-        self.logger.info(f"Sending results to orchestrator.")
+        self.logger.info("Sending results to orchestrator.")
         return {Output.RESULTS: log_entries, Output.COUNT: len(log_entries)}
 
     def get_results_from_callback(self, callback_url: str, timeout: int) -> [object]:
@@ -155,7 +155,7 @@ class AdvancedQueryOnLogSet(komand.Action):
             return None, potential_results
         else:
             self.logger.info("Got a callback url. Polling results...")
-            return results_object.get("links")[0].get("href"), None
+            return results_object.get("links", [{}])[0].get("href"), []
 
     def get_log_set_id(self, log_name: str) -> str:
         """
@@ -179,19 +179,19 @@ class AdvancedQueryOnLogSet(komand.Action):
 
         log_sets = response.json().get("logsets")
 
-        id = ""
+        log_id = ""
 
         for log_set in log_sets:
             name = log_set.get("name")
             self.logger.info(f"Checking {log_name} against {name}")
             if name == log_name:
                 self.logger.info("Log set found.")
-                id = log_set.get("id")
+                log_id = log_set.get("id")
                 break
 
-        if id:
-            self.logger.info(f"Found log set with name {log_name} and ID: {id}")
-            return id
+        if log_id:
+            self.logger.info(f"Found log set with name {log_name} and ID: {log_id}")
+            return log_id
 
         self.logger.error(f"Could not find log set with name {log_name}")
         raise PluginException(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -4,13 +4,14 @@ from komand.exceptions import ConnectionTestException
 
 # Custom imports below
 import requests
+from typing import Optional
 
 
 class Connection(komand.Connection):
     def __init__(self):
         super(self.__class__, self).__init__(input=ConnectionSchema())
         self.url = None
-        self.session = None
+        self.session: Optional[requests.Session] = None
 
     def connect(self, params={}):
         api_key = params.get(Input.API_KEY).get("secretKey")
@@ -28,9 +29,9 @@ class Connection(komand.Connection):
         response = self.session.get(f"{self.url}validate")
         if response.status_code == 401:
             raise ConnectionTestException(preset=ConnectionTestException.Preset.UNAUTHORIZED)
-        elif response.status_code in range(500, 599):
+        if response.status_code in range(500, 599):
             raise ConnectionTestException(preset=ConnectionTestException.Preset.SERVICE_UNAVAILABLE)
-        elif response.status_code == 200:
+        if response.status_code == 200:
             return response.json()
         else:
             self.logger.error(response.text)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -86,7 +86,6 @@ class ResourceHelper(object):
             try:
                 error = response.json()["message"]
             except KeyError:
-                self.logger.error(f"Code: {response.status_code}, message: {error}")
                 error = "Unknown error occurred. Please contact support or try again later."
 
             status_code_message = self._ERRORS.get(response.status_code, self._ERRORS[000])

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -1,6 +1,34 @@
 from komand.exceptions import PluginException
 import requests
 
+import aiohttp
+import asyncio
+import json
+from typing import Optional
+
+from komand_rapid7_insightidr.connection import Connection
+
+
+def _get_async_session(headers) -> aiohttp.ClientSession:
+    """
+    Create and return a new aiohttp ClientSession
+    :return: aiohttp ClientSession
+    """
+
+    return aiohttp.ClientSession(connector=aiohttp.TCPConnector(verify_ssl=False), headers=headers)
+
+
+async def get_label_for_id(label_id: str, url: str, session: aiohttp.ClientSession) -> dict:
+    response = await session.get(f"{url}log_search/management/labels/{label_id}")
+    if response.status == 200:
+        try:
+            resp_json = await response.json()
+            return {"id": label_id, "name": resp_json.get("label", {}).get("name")}
+        except json.JSONDecodeError:
+            return {}
+
+    return {}
+
 
 class ResourceHelper(object):
     """
@@ -64,3 +92,44 @@ class ResourceHelper(object):
             status_code_message = self._ERRORS.get(response.status_code, self._ERRORS[000])
             self.logger.error(f"{status_code_message} ({response.status_code}): {error}")
             raise PluginException(f"InsightIDR returned a status code of {response.status_code}: {status_code_message}")
+
+    @staticmethod
+    async def _get_log_entries_with_labels(connection: Connection, log_entries: [dict]) -> [dict]:
+        label_ids = set()
+        for log_entry in log_entries:
+            for label in log_entry.get("labels", []):
+                label_ids.add(label.get("id"))
+
+        async with _get_async_session(connection.session.headers) as async_session:
+            tasks: [asyncio.Future] = []
+            for label_id in label_ids:
+                tasks.append(
+                    asyncio.ensure_future(
+                        get_label_for_id(label_id=label_id, url=connection.url, session=async_session)
+                    )
+                )
+
+            labels = await asyncio.gather(*tasks)
+
+        labels_by_id = {}
+        for label in labels:
+            if label:
+                labels_by_id[label.get("id")] = label.get("name")
+
+        new_log_entries: [dict] = []
+        for log_entry in log_entries:
+            new_log_entry = dict(log_entry)
+            new_log_entry["message"] = json.loads(log_entry.get("message", "{}"))
+            entry_labels = []
+            for label in log_entry.get("labels", []):
+                label_id = label.get("id")
+                if label_id and labels_by_id.get(label_id):
+                    entry_labels.append(labels_by_id[label_id])
+            new_log_entry["labels"] = entry_labels
+            new_log_entries.append(new_log_entry)
+
+        return new_log_entries
+
+    @staticmethod
+    def get_log_entries_with_new_labels(connection: Connection, log_entries: [dict]) -> [dict]:
+        return asyncio.run(ResourceHelper._get_log_entries_with_labels(connection=connection, log_entries=log_entries))

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,8 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 3.1.4
+version: 3.1.5
+supported_versions: ["Latest release successfully tested on 2022-05-05."]
 vendor: rapid7
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/rapid7_insightidr

--- a/plugins/rapid7_insightidr/requirements.txt
+++ b/plugins/rapid7_insightidr/requirements.txt
@@ -3,3 +3,4 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 python-dateutil==2.8.1
 validators == 0.18.2
+aiohttp==3.7.4.post0

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="3.1.4",
+      version="3.1.5",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/payloads/label_006.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/label_006.json.resp
@@ -1,0 +1,9 @@
+{
+  "label": {
+    "id": "00000000-0000-0000-0000-000000000006",
+    "sn": 6,
+    "name": "Out of order entry",
+    "color": "ffab04",
+    "reserved": true
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/label_007.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/label_007.json.resp
@@ -1,0 +1,9 @@
+{
+  "label": {
+    "id": "00000000-0000-0000-0000-000000000007",
+    "sn": 7,
+    "name": "Out of events",
+    "color": "ffab04",
+    "reserved": true
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/label_404.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/label_404.json.resp
@@ -1,0 +1,1 @@
+{"code":404,"message":"HTTP 404 Not Found"}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id.json.resp
@@ -1,0 +1,16 @@
+{
+  "events": [{
+    "links": [
+        {
+          "href": "https://us.api.insight.rapid7.com/log_search/query/context/3235937417370673152?per_page=50\u0026timestamp=1617235238436\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
+          "rel": "Context"
+        }
+      ],
+    "log_id": "5c6cc7cb-25bb-4423-8e43-7b2543489bbe",
+    "message": "{\"destination_account\": \"ibot\",\"destination_account_sid\": \"S-1-5-21-2677061338-3577197041-828036409-1608\",\"destination_asset\": \"unknown\",\"destination_asset_address\": \"10.4.20.11\",\"destination_domain\": \"soarcerrors\",\"logon_type\": \"NETWORK\",\"result\": \"SUCCESS\",\"service\": \"ntlmssp\",      \"source_asset_address\": \"10.4.20.11\",      \"source_json\": {        \"computerName\": \"iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com\",        \"eventCode\": 4624,        \"insertionStrings\": [          \"S-1-0-0\",          \"-\",          \"-\",          \"0x0\",          \"S-1-5-21-2677061338-3577197041-828036409-1608\",          \"ibot\",          \"SOARCERRORS\",          \"0x343967d4\",          \"3\",          \"NtLmSsp \",          \"NTLM\",          \"500e75420764\",          \"{00000000-0000-0000-0000-000000000000}\",          \"-\",          \"NTLM V2\",          \"0\",          \"0x0\",          \"-\",          \"10.4.20.11\",          \"59603\",          \"%1833\"        ],        \"timeGenerated\": \"20210401000023.939620-000\"      },      \"timestamp\": \"2021-04-01T00:00:23.939Z\"}",
+    "labels":[{"id":"00000000-0000-0000-0000-000000000006"}],
+    "sequence_number": 3235937417370673000,
+    "sequence_number_str": "3235937417370673152",
+    "timestamp": 1617235238436
+  }]
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id2.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id2.json.resp
@@ -1,0 +1,16 @@
+{
+  "events": [{
+    "links": [
+        {
+          "href": "https://us.api.insight.rapid7.com/log_search/query/context/3235937417370673152?per_page=50\u0026timestamp=1617235238436\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
+          "rel": "Context"
+        }
+      ],
+    "log_id": "5c6cc7cb-25bb-4423-8e43-7b2543489bbe",
+    "message": "{\"destination_account\": \"ibot\",\"destination_account_sid\": \"S-1-5-21-2677061338-3577197041-828036409-1608\",\"destination_asset\": \"unknown\",\"destination_asset_address\": \"10.4.20.11\",\"destination_domain\": \"soarcerrors\",\"logon_type\": \"NETWORK\",\"result\": \"SUCCESS\",\"service\": \"ntlmssp\",      \"source_asset_address\": \"10.4.20.11\",      \"source_json\": {        \"computerName\": \"iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com\",        \"eventCode\": 4624,        \"insertionStrings\": [          \"S-1-0-0\",          \"-\",          \"-\",          \"0x0\",          \"S-1-5-21-2677061338-3577197041-828036409-1608\",          \"ibot\",          \"SOARCERRORS\",          \"0x343967d4\",          \"3\",          \"NtLmSsp \",          \"NTLM\",          \"500e75420764\",          \"{00000000-0000-0000-0000-000000000000}\",          \"-\",          \"NTLM V2\",          \"0\",          \"0x0\",          \"-\",          \"10.4.20.11\",          \"59603\",          \"%1833\"        ],        \"timeGenerated\": \"20210401000023.939620-000\"      },      \"timestamp\": \"2021-04-01T00:00:23.939Z\"}",
+    "labels":[{"id":"00000000-0000-0000-0000-000000000006"}, {"id":"00000000-0000-0000-0000-000000000007"}],
+    "sequence_number": 3235937417370673000,
+    "sequence_number_str": "3235937417370673152",
+    "timestamp": 1617235238436
+  }]
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id3.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id3.json.resp
@@ -1,0 +1,15 @@
+{
+  "events": [{
+    "links": [
+        {
+          "href": "https://us.api.insight.rapid7.com/log_search/query/context/3235937417370673152?per_page=50\u0026timestamp=1617235238436\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
+          "rel": "Context"
+        }
+      ],
+    "log_id": "5c6cc7cb-25bb-4423-8e43-7b2543489bbe",
+    "message": "{\"destination_account\": \"ibot\",\"destination_account_sid\": \"S-1-5-21-2677061338-3577197041-828036409-1608\",\"destination_asset\": \"unknown\",\"destination_asset_address\": \"10.4.20.11\",\"destination_domain\": \"soarcerrors\",\"logon_type\": \"NETWORK\",\"result\": \"SUCCESS\",\"service\": \"ntlmssp\",      \"source_asset_address\": \"10.4.20.11\",      \"source_json\": {        \"computerName\": \"iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com\",        \"eventCode\": 4624,        \"insertionStrings\": [          \"S-1-0-0\",          \"-\",          \"-\",          \"0x0\",          \"S-1-5-21-2677061338-3577197041-828036409-1608\",          \"ibot\",          \"SOARCERRORS\",          \"0x343967d4\",          \"3\",          \"NtLmSsp \",          \"NTLM\",          \"500e75420764\",          \"{00000000-0000-0000-0000-000000000000}\",          \"-\",          \"NTLM V2\",          \"0\",          \"0x0\",          \"-\",          \"10.4.20.11\",          \"59603\",          \"%1833\"        ],        \"timeGenerated\": \"20210401000023.939620-000\"      },      \"timestamp\": \"2021-04-01T00:00:23.939Z\"}",
+    "sequence_number": 3235937417370673000,
+    "sequence_number_str": "3235937417370673152",
+    "timestamp": 1617235238436
+  }]
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id4.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id4.json.resp
@@ -1,0 +1,16 @@
+{
+  "events": [{
+    "links": [
+        {
+          "href": "https://us.api.insight.rapid7.com/log_search/query/context/3235937417370673152?per_page=50\u0026timestamp=1617235238436\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
+          "rel": "Context"
+        }
+      ],
+    "log_id": "5c6cc7cb-25bb-4423-8e43-7b2543489bbe",
+    "labels":[{"id":"not exist label - 404"}],
+    "message": "{\"destination_account\": \"ibot\",\"destination_account_sid\": \"S-1-5-21-2677061338-3577197041-828036409-1608\",\"destination_asset\": \"unknown\",\"destination_asset_address\": \"10.4.20.11\",\"destination_domain\": \"soarcerrors\",\"logon_type\": \"NETWORK\",\"result\": \"SUCCESS\",\"service\": \"ntlmssp\",      \"source_asset_address\": \"10.4.20.11\",      \"source_json\": {        \"computerName\": \"iagent5-dcwin12.soarcerrors.vuln.lax.rapid7.com\",        \"eventCode\": 4624,        \"insertionStrings\": [          \"S-1-0-0\",          \"-\",          \"-\",          \"0x0\",          \"S-1-5-21-2677061338-3577197041-828036409-1608\",          \"ibot\",          \"SOARCERRORS\",          \"0x343967d4\",          \"3\",          \"NtLmSsp \",          \"NTLM\",          \"500e75420764\",          \"{00000000-0000-0000-0000-000000000000}\",          \"-\",          \"NTLM V2\",          \"0\",          \"0x0\",          \"-\",          \"10.4.20.11\",          \"59603\",          \"%1833\"        ],        \"timeGenerated\": \"20210401000023.939620-000\"      },      \"timestamp\": \"2021-04-01T00:00:23.939Z\"}",
+    "sequence_number": 3235937417370673000,
+    "sequence_number_str": "3235937417370673152",
+    "timestamp": 1617235238436
+  }]
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/logs.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logs.json.resp
@@ -1,0 +1,20 @@
+{
+  "logs": [
+    {
+      "name": "example_log1",
+      "id": "log_id"
+    },
+    {
+      "name": "example_log2",
+      "id": "log_id2"
+    },
+    {
+      "name": "example_log3",
+      "id": "log_id3"
+    },
+    {
+      "name": "example_log4",
+      "id": "log_id4"
+    }
+  ]
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
@@ -1,0 +1,20 @@
+{
+  "logsets": [
+    {
+      "name": "log_set",
+      "id": "log_id"
+    },
+    {
+      "name": "log_set2",
+      "id": "log_id2"
+    },
+    {
+      "name": "log_set3",
+      "id": "log_id3"
+    },
+    {
+      "name": "log_set4",
+      "id": "log_id4"
+    }
+  ]
+}

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -1,0 +1,66 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from komand_rapid7_insightidr.actions.advanced_query_on_log_set import AdvancedQueryOnLogSet
+from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+
+
+@patch("requests.Session.get", side_effect=Util.mocked_requests)
+@patch("aiohttp.ClientSession.get", side_effect=Util.mocked_async_requests)
+class TestAdvancedQueryOnLogSet(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(AdvancedQueryOnLogSet())
+
+    def test_advanced_query_on_log_set_one_label(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG_SET: "log_set",
+            }
+        )
+        expected = ["Out of order entry"]
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_set_two_label(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG_SET: "log_set2",
+            }
+        )
+        expected = ["Out of order entry", "Out of events"]
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_set_without_label(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG_SET: "log_set3",
+            }
+        )
+        expected = []
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_set_wrong_label(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG_SET: "log_set4",
+            }
+        )
+        expected = []
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
@@ -1,0 +1,62 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from komand_rapid7_insightidr.actions.advanced_query_on_log import AdvancedQueryOnLog
+from komand_rapid7_insightidr.actions.advanced_query_on_log.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+
+
+@patch("requests.Session.get", side_effect=Util.mocked_requests)
+@patch("aiohttp.ClientSession.get", side_effect=Util.mocked_async_requests)
+class TestAdvancedQueryOnLog(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(AdvancedQueryOnLog())
+
+    def test_advanced_query_on_log_one_label(self, mock_get, mock_async_get):
+        actual = self.action.run({Input.QUERY: "", Input.LOG: "example_log1"})
+        self.maxDiff = None
+        expected = ["Out of order entry"]
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_two_labels(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG: "example_log2",
+            }
+        )
+        expected = ["Out of order entry", "Out of events"]
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_without_label(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG: "example_log3",
+            }
+        )
+        expected = []
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_wrong_label(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "",
+                Input.LOG: "example_log4",
+            }
+        )
+        expected = []
+
+        self.assertEqual(actual.get(Output.COUNT), 1)
+        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -1,0 +1,121 @@
+import asyncio
+import json
+import logging
+import os
+
+from komand.exceptions import PluginException
+from komand_rapid7_insightidr.connection import Connection
+from komand_rapid7_insightidr.connection.schema import Input
+from requests.models import HTTPError
+
+
+class Meta:
+    version = "0.0.0"
+
+
+class Util:
+    @staticmethod
+    def default_connector(action, connect_params: object = None):
+        default_connection = Connection()
+        default_connection.meta = Meta()
+        default_connection.logger = logging.getLogger("connection logger")
+        if connect_params:
+            params = connect_params
+        else:
+            params = {
+                Input.URL: "https://rapid7.com",
+                Input.API_KEY: {"secretKey": "4472f2g7-991z-4w70-li11-7552w8qm0266"},
+            }
+        default_connection.connect(params)
+        action.connection = default_connection
+        action.logger = logging.getLogger("action logger")
+        return action
+
+    @staticmethod
+    def read_file_to_string(filename):
+        with open(filename) as my_file:
+            return my_file.read()
+
+    @staticmethod
+    async def mocked_async_requests(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, filename, status_code):
+                self.filename = filename
+                self.status = status_code
+                self.text = "This is some error text"
+
+            def raise_for_status(self):
+                if self.status == 404:
+                    raise HTTPError("Not found", response=self)
+
+            async def json(self):
+                if self.filename == "error":
+                    raise PluginException(preset=PluginException.Preset.SERVER_ERROR)
+                if self.filename == "empty":
+                    return {}
+
+                return json.loads(
+                    Util.read_file_to_string(
+                        os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{self.filename}.json.resp")
+                    )
+                )
+
+        if args[0] == "https://rapid7.com/log_search/management/labels/00000000-0000-0000-0000-000000000006":
+            return MockResponse("label_006", 200)
+        elif args[0] == "https://rapid7.com/log_search/management/labels/00000000-0000-0000-0000-000000000007":
+            return MockResponse("label_007", 200)
+        elif args[0] == "https://rapid7.com/log_search/management/labels/not exist label - 404":
+            return MockResponse("label_404", 404)
+
+        raise Exception("Not implemented")
+
+    @staticmethod
+    def mocked_requests(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, filename, status_code):
+                self.filename = filename
+                self.status_code = status_code
+                self.text = "This is some error text"
+
+            def raise_for_status(self):
+                if self.status_code == 404:
+                    raise HTTPError("Not found", response=self)
+
+            def json(self):
+                if self.filename == "error":
+                    raise PluginException(preset=PluginException.Preset.SERVER_ERROR)
+                if self.filename == "empty":
+                    return {}
+
+                return json.loads(
+                    Util.read_file_to_string(
+                        os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{self.filename}.json.resp")
+                    )
+                )
+
+        if args[0] == "https://rapid7.com/log_search/management/logs":
+            return MockResponse("logs", 200)
+        elif (
+            args[0] == "https://rapid7.com/log_search/query/logs/log_id"
+            or args[0] == "https://rapid7.com/log_search/query/logsets/log_id"
+        ):
+            return MockResponse("log_id", 200)
+        elif (
+            args[0] == "https://rapid7.com/log_search/query/logs/log_id2"
+            or args[0] == "https://rapid7.com/log_search/query/logsets/log_id2"
+        ):
+            return MockResponse("log_id2", 200)
+        elif (
+            args[0] == "https://rapid7.com/log_search/query/logs/log_id3"
+            or args[0] == "https://rapid7.com/log_search/query/logsets/log_id3"
+        ):
+            return MockResponse("log_id3", 200)
+        elif (
+            args[0] == "https://rapid7.com/log_search/query/logs/log_id4"
+            or args[0] == "https://rapid7.com/log_search/query/logsets/log_id4"
+        ):
+            return MockResponse("log_id4", 200)
+        elif args[0] == "https://rapid7.com/log_search/management/logsets":
+            return MockResponse("logsets", 200)
+
+        raise Exception("Not implemented")


### PR DESCRIPTION
## Proposed Changes

### Description

Change object `labels` to `[]string` in Advanced Query on Log and Advanced Query on Log Set actions and add unit tests for this case
Tickets: MC-525 and MC-595

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/Rapid7 https://example.com Step name: advanced_query_on_log\nGetting log entries from: https://example.com\nChecking Active Directory against Endpoint Agents\nChecking Active Directory against Alert Audit Log\nChecking Active Directory against Log Updates\nChecking Active Directory against Windows Defender\nChecking Active Directory against Active Directory\nLog found.\nFound log with name Active Directory and ID: 5c6cc7cb-25bb-4423-8e43-7b2543489bbe\nGetting logs from: https://example.com\nUsing parameters: {'query': 'where(destination_asset=\"unknown\")', 'from': 1617235201000, 'to': 1617249600000}\nGot a callback url. Polling results...\nTrying to get results from callback URL: https://example.com\nSending results to orchestrator.\n",
    "meta": {},
    "output": {
      "count": 43,
      "results": [
        {
          "labels": [],
          "links": [
            {
              "href": "https://example.com\u0026timestamp=1617235238436\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
              "rel": "Context"
            }
          ],
          "log_id": "5c6cc7cb-25bb-4423-8e43-7b2543489bbe",
          "message": {
            "destination_account": "ibot",
            "destination_account_sid": "S-1-5-21-26770677197041-82409-1608",
            "destination_asset": "unknown",
            "destination_asset_address": "https://example.com",
            "destination_domain": "soarcerrors",
            "logon_type": "NETWORK",
            "result": "SUCCESS",
            "service": "ntlmssp",
            "source_asset_address": "https://example.com",
            "source_json": {
              "computerName": "https://example.com",
              "eventCode": 4624,
              "insertionStrings": [
                "S-1-0-0",
                "-",
                "-",
                "0x0",
                "S-1-5-21-2677338-357041-82809-1608",
                "ibot",
                "SOARCERRORS",
                "0x343967d4",
                "3",
                "NtLmSsp ",
                "NTLM",
                "500e75420764",
                "{00000000-0000-0000-0000-000000000000}",
                "-",
                "NTLM V2",
                "0",
                "0x0",
                "-",
                "https://example.com",
                "59603",
                "%1833"
              ],
              "timeGenerated": "https://example.com"
            },
            "timestamp": "https://example.com"
          },
          "sequence_number": 32359374173000,
          "sequence_number_str": "32359374173152",
          "timestamp": 1617235238436
        },
        {
          "labels": [],
          "links": [
            {
              "href": "https://example.com\u0026timestamp=1617236158628\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
              "rel": "Context"
            }
          ],
          "log_id": "5c6cc7cb-25bb-4423-8e43-7b2543489bbe",
          "message": {
            "destination_account": "ibot",
            "destination_account_sid": "S-1-5-21-2677068-3577141-8280309-1608",
            "destination_asset": "unknown",
            "destination_asset_address": "https://example.com",
            "destination_domain": "soarcerrors",
            "logon_type": "NETWORK",
            "result": "SUCCESS",
            "service": "ntlmssp",
            "source_asset_address": "https://example.com",
            "source_json": {
              "computerName": "https://example.com",
              "eventCode": 4624,
              "insertionStrings": [
                "S-1-0-0",
                "-",
                "-",
                "0x0",
                "S-1-5-21-267738-35-8280-1608",
                "ibot",
                "SOARCERRORS",
                "0x34404c02",
                "3",
                "NtLmSsp ",
                "NTLM",
                "500e7540764",
                "{00000000-0000-0000-0000-000000000000}",
                "-",
                "NTLM V2",
                "0",
                "0x0",
                "-",
                "https://example.com",
                "44942",
                "%1833"
              ],
              "timeGenerated": "https://example.com"
            },
            "timestamp": "https://example.com"
          },
          "sequence_number": 32359660628700,
          "sequence_number_str": "323596606028736",
          "timestamp": 1617236158628
        },
        {
          "labels": [],
          "links": [
            {
              "href": "https://example.com\u0026timestamp=1617237079212\u0026log_keys=5c6cc7cb-25bb-4423-8e43-7b2543489bbe\u0026context_type=SURROUND",
              "rel": "Context"
            }
          ]
      ]
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rapid7_insightidr:3.1.2 --debug run < tests/advanced_query_on_log.json
</summary>
</details>

<details>

```
{
  "output": {
    "results": [
      {
        "labels": [],
        "sequence_number": 3235933152,
        "timestamp": 1617235238436,
        "log_id": "5c6cb-25bb-23-8e43-7bbe",
        "message": {
          "timestamp": "2021-04-01T00:00:23.939Z",
          "destination_asset": "unknown",
          "source_asset_address": "10.0.0.0",
          "destination_asset_address": "10.0.0.0",
          "destination_account": "ibot",
          "destination_domain": "soarcerrors",
          "destination_account_sid": "S-1-5-21-611-8209-1608",
          "logon_type": "NETWORK",
          "result": "SUCCESS",
          "service": "ntlmssp",
          "source_json": {
            "eventCode": 44,
            "computerName": "examplerapid7.com",
            "insertionStrings": [
              "S-1-0-0",
              "-",
              "-",
              "0x0",
              "S-1-5-21-2638-3041-8409-1608",
              "ibot",
              "RRORS",
              "0x343967d4",
              "3",
              "NtLmSsp ",
              "NTLM",
              "500e20764",
              "{00000000-0000-0000-0000-000000000000}",
              "-",
              "NTLM V2",
              "0",
              "0x0",
              "-",
              "10.0.0.0",
              "59603",
              "%%1833"
            ],
            "timeGenerated": "20210401000023.939620-000"
          }
        },
        "links": [
          {
            "rel": "Context",
            "href": "https://example.com"
          }
        ],
        "sequence_number_str": "32359373152"
      },
      {
        "labels": [],
        "sequence_number": 32356,
        "timestamp": 161723,
        "log_id": "5c7b-25b-43-83-7b29bbe",
        "message": {
          "timestamp": "2021-04-01T00:15:24.045Z",
          "destination_asset": "unknown",
          "source_asset_address": "10.0.0.0",
          "destination_asset_address": "10.0.0.0",
          "destination_account": "ibot",
          "destination_domain": "soarcerrors",
          "destination_account_sid": "S-1-5-21-2638-357-8289-108",
          "logon_type": "NETWORK",
          "result": "SUCCESS",
          "service": "ntlmssp",
          "source_json": {
            "eventCode": 464,
            "computerName": "example.rapid7.com",
            "insertionStrings": [
              "S-1-0-0",
              "-",
              "-",
              "0x0",
              "S-1-5-21-2357041-80649-08",
              "ibot",
              "SOCERRORS",
              "0x34404c02",
              "3",
              "NtLmSsp ",
              "NTLM",
              "500e75420764",
              "{00000000-0000-0000-0000-000000000000}",
              "-",
              "NTLM V2",
              "0",
              "0x0",
              "-",
              "10.0.0.0",
              "44942",
              "%%1833"
            ],
            "timeGenerated": "20210401001524.045453-000"
          }
        },
        "links": [
          {
            "rel": "Context",
            "href": "https://example.com"
          }
        ],
        "sequence_number_str": "32359668736"
      }
      }
```

<summary>
docker run --rm -i rapid7/rapid7_insightidr:3.1.2 --debug run < tests/advanced_query_on_log_set.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator UnapprovedKeywordsValidator
318
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[366]: https://us.api.insight.rapid7.com
violation: plugin.spec.yaml[367]: https://us.api.insight.rapid7.com
violation: help.md[204]: https://us.api.insight.rapid7.com/log_search/query/context/xxxx
violation: help.md[331]: https://us.api.insight.rapid7.com/log_search/query/context/xxxx
violation: help.md[389]: https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85
violation: help.md[458]: https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85
[*] Plugin successfully validated!

----
[*] Total time elapsed: 62050.704000000005ms

```

<summary>
icon-validate --all . 
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../../tools/Makefiles/Helpers.mk ../../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator UnapprovedKeywordsValidator
318
[*] Plugin successfully validated!

----
[*] Total time elapsed: 3204.17ms

```

<summary>
make validate
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/Rapid7 https://example.com Step name: advanced_query_on_log\n",
    "meta": {},
    "output": {
      "message": "Authorized"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rapid7_insightidr:3.1.3 --debug test < tests/advanced_query_on_log.json
</summary>
</details>
