### PR TITLE
[SOAR-6617] Fix Get Incident Attachment response type bug

### DIFF
--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "fba1eb34f20f5f406a5261ebf41509d1",
-	"manifest": "5996d60a9a8ffa5aa390edea705c7e1d",
-	"setup": "7cdf61b231e7f14196bbf3f888585433",
+	"spec": "5a2f7df389559f9c27218d8da4d1673d",
+	"manifest": "6c3b265433250bb5e1fe41f963bef414",
+	"setup": "b387b9bde71ac3cf896378493777e1f0",
 	"schemas": [
 		{
 			"identifier": "create_ci/schema.py",

--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "5a2f7df389559f9c27218d8da4d1673d",
-	"manifest": "6c3b265433250bb5e1fe41f963bef414",
-	"setup": "b387b9bde71ac3cf896378493777e1f0",
+	"spec": "2b48e07b27612bbaef51fa855f52886e",
+	"manifest": "29bec59f83a73c20955fb53e75562ebe",
+	"setup": "1c6b5e6c291acead7b01f496a98dc987",
 	"schemas": [
 		{
 			"identifier": "create_ci/schema.py",
@@ -25,7 +25,7 @@
 		},
 		{
 			"identifier": "get_incident_attachment/schema.py",
-			"hash": "a8a5c2ba32d4004cb0dfe73179dfdcac"
+			"hash": "4fca400a3ae657aae2ffd2440abee413"
 		},
 		{
 			"identifier": "get_incident_comments_worknotes/schema.py",

--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2b48e07b27612bbaef51fa855f52886e",
-	"manifest": "29bec59f83a73c20955fb53e75562ebe",
-	"setup": "1c6b5e6c291acead7b01f496a98dc987",
+	"spec": "d11249019776d28f7ac19ceb595ab700",
+	"manifest": "6c3b265433250bb5e1fe41f963bef414",
+	"setup": "b387b9bde71ac3cf896378493777e1f0",
 	"schemas": [
 		{
 			"identifier": "create_ci/schema.py",

--- a/plugins/servicenow/bin/icon_servicenow
+++ b/plugins/servicenow/bin/icon_servicenow
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ServiceNow"
 Vendor = "rapid7"
-Version = "5.1.0"
+Version = "5.1.1"
 Description = "ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes"
 
 

--- a/plugins/servicenow/help.md
+++ b/plugins/servicenow/help.md
@@ -289,7 +289,7 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
-|attachment_contents|string|True|The Base64-encoded contents of the downloaded attachment|
+|attachment_contents|bytes|True|The Base64-encoded contents of the downloaded attachment|
 
 Example output:
 

--- a/plugins/servicenow/help.md
+++ b/plugins/servicenow/help.md
@@ -758,6 +758,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 5.1.1 - Fix output parsing bug in Get Incident Attachment action
 * 5.1.0 - Add new Incident URL output for Create Incident action
 * 5.0.1 - Add new Additional Fields input for Create Incident and Update Incident actions
 * 5.0.0 - Add input fields to Create Incident and Update Incident action instead of JSON object

--- a/plugins/servicenow/icon_servicenow/actions/get_incident_attachment/action.py
+++ b/plugins/servicenow/icon_servicenow/actions/get_incident_attachment/action.py
@@ -8,7 +8,10 @@ from .schema import (
 )
 
 # Custom imports below
+from insightconnect_plugin_runtime.exceptions import PluginException
+
 import base64
+import json
 
 
 class GetIncidentAttachment(insightconnect_plugin_runtime.Action):
@@ -26,4 +29,17 @@ class GetIncidentAttachment(insightconnect_plugin_runtime.Action):
 
         response = self.connection.request.make_request(url, method)
 
-        return {Output.ATTACHMENT_CONTENTS: str(base64.b64encode(response.get("resource")), "utf-8")}
+        resource = response.get("resource")
+        result = b""
+        if resource is not None:
+            if isinstance(resource, bytes):
+                result = resource
+            elif isinstance(resource, dict):
+                try:
+                    result = json.dumps(resource).encode("utf-8")
+                except TypeError:
+                    raise PluginException(PluginException.Preset.INVALID_JSON, data=resource)
+            else:
+                raise PluginException(PluginException.Preset.UNKNOWN, data=resource)
+
+        return {Output.ATTACHMENT_CONTENTS: str(base64.b64encode(result), "utf-8")}

--- a/plugins/servicenow/icon_servicenow/actions/get_incident_attachment/action.py
+++ b/plugins/servicenow/icon_servicenow/actions/get_incident_attachment/action.py
@@ -8,6 +8,7 @@ from .schema import (
 )
 
 # Custom imports below
+import base64
 
 
 class GetIncidentAttachment(insightconnect_plugin_runtime.Action):
@@ -25,4 +26,4 @@ class GetIncidentAttachment(insightconnect_plugin_runtime.Action):
 
         response = self.connection.request.make_request(url, method)
 
-        return {Output.ATTACHMENT_CONTENTS: response.get("resource")}
+        return {Output.ATTACHMENT_CONTENTS: str(base64.b64encode(response.get("resource")), "utf-8")}

--- a/plugins/servicenow/icon_servicenow/actions/get_incident_attachment/schema.py
+++ b/plugins/servicenow/icon_servicenow/actions/get_incident_attachment/schema.py
@@ -47,7 +47,9 @@ class GetIncidentAttachmentOutput(insightconnect_plugin_runtime.Output):
     "attachment_contents": {
       "type": "string",
       "title": "Attachment Contents",
+      "displayType": "bytes",
       "description": "The Base64-encoded contents of the downloaded attachment",
+      "format": "bytes",
       "order": 1
     }
   },

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -33,7 +33,10 @@ class RequestHelper(object):
                 if response.status_code == 204:
                     resource = None
                 else:
-                    resource = response.json()
+                    if response.headers['Content-Type'] == "application/json":
+                        resource = response.json()
+                    else:
+                        resource = response.content
             except json.decoder.JSONDecodeError:
                 raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
 

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -28,6 +28,7 @@ class RequestHelper(object):
             self.logger.error(e)
             raise
 
+        # pylint: disable=no-else-return
         if response.status_code in range(200, 299):
             content_type = response.headers['Content-Type']
 
@@ -50,6 +51,6 @@ class RequestHelper(object):
                 raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
 
             raise PluginException(
-                cause=f"Error in API request to ServiceNow. ",
+                cause="Error in API request to ServiceNow. ",
                 assistance=f"Status code: {response.status_code}, Error: {error}",
             )

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -28,9 +28,8 @@ class RequestHelper(object):
             self.logger.error(e)
             raise
 
-        # pylint: disable=no-else-return
         if response.status_code in range(200, 299):
-            content_type = response.headers["Content-Type"] if "Content-Type" in response.headers else ""
+            content_type = response.headers.get("Content-Type", "")
 
             if response.status_code == 204:
                 resource = None
@@ -44,13 +43,13 @@ class RequestHelper(object):
                     resource = response.content
 
             return {"resource": resource, "status": response.status_code, "content-type": content_type}
-        else:
-            try:
-                error = response.json()
-            except json.decoder.JSONDecodeError:
-                raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
 
-            raise PluginException(
-                cause="Error in API request to ServiceNow. ",
-                assistance=f"Status code: {response.status_code}, Error: {error}",
-            )
+        try:
+            error = response.json()
+        except json.decoder.JSONDecodeError:
+            raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
+
+        raise PluginException(
+            cause="Error in API request to ServiceNow. ",
+            assistance=f"Status code: {response.status_code}, Error: {error}",
+        )

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -30,7 +30,10 @@ class RequestHelper(object):
 
         if response.status_code in range(200, 299):
             try:
-                resource = None if response.status_code == 204 else response.json()
+                if response.status_code == 204:
+                    resource = None
+                else:
+                    resource = response.json()
             except json.decoder.JSONDecodeError:
                 raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
 

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -29,10 +29,12 @@ class RequestHelper(object):
             raise
 
         if response.status_code in range(200, 299):
+            content_type = response.headers['Content-Type']
+
             if response.status_code == 204:
                 resource = None
             else:
-                if response.headers['Content-Type'] == "application/json":
+                if content_type == "application/json":
                     try:
                         resource = response.json()
                     except json.decoder.JSONDecodeError:
@@ -40,7 +42,7 @@ class RequestHelper(object):
                 else:
                     resource = response.content
 
-            return {"resource": resource, "status": response.status_code}
+            return {"resource": resource, "status": response.status_code, "content-type": content_type}
         else:
             try:
                 error = response.json()

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -30,7 +30,7 @@ class RequestHelper(object):
 
         # pylint: disable=no-else-return
         if response.status_code in range(200, 299):
-            content_type = response.headers["Content-Type"]
+            content_type = response.headers["Content-Type"] if "Content-Type" in response.headers else ""
 
             if response.status_code == 204:
                 resource = None

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -29,16 +29,16 @@ class RequestHelper(object):
             raise
 
         if response.status_code in range(200, 299):
-            try:
-                if response.status_code == 204:
-                    resource = None
-                else:
-                    if response.headers['Content-Type'] == "application/json":
+            if response.status_code == 204:
+                resource = None
+            else:
+                if response.headers['Content-Type'] == "application/json":
+                    try:
                         resource = response.json()
-                    else:
-                        resource = response.content
-            except json.decoder.JSONDecodeError:
-                raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
+                    except json.decoder.JSONDecodeError:
+                        raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
+                else:
+                    resource = response.content
 
             return {"resource": resource, "status": response.status_code}
         else:

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -35,7 +35,7 @@ class RequestHelper(object):
             if response.status_code == 204:
                 resource = None
             else:
-                if content_type.contains("application/json"):
+                if "application/json" in content_type:
                     try:
                         resource = response.json()
                     except json.decoder.JSONDecodeError:

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -35,7 +35,7 @@ class RequestHelper(object):
             if response.status_code == 204:
                 resource = None
             else:
-                if content_type == "application/json":
+                if content_type.contains("application/json"):
                     try:
                         resource = response.json()
                     except json.decoder.JSONDecodeError:

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -30,7 +30,7 @@ class RequestHelper(object):
 
         # pylint: disable=no-else-return
         if response.status_code in range(200, 299):
-            content_type = response.headers['Content-Type']
+            content_type = response.headers["Content-Type"]
 
             if response.status_code == 204:
                 resource = None

--- a/plugins/servicenow/plugin.spec.yaml
+++ b/plugins/servicenow/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: ["insightconnect"]
 name: servicenow
 title: ServiceNow
 description: ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes
-version: 5.1.0
+version: 5.1.1
 vendor: rapid7
 support: rapid7
 status: []

--- a/plugins/servicenow/plugin.spec.yaml
+++ b/plugins/servicenow/plugin.spec.yaml
@@ -428,7 +428,7 @@ actions:
       attachment_contents:
         title: Attachment Contents
         description: The Base64-encoded contents of the downloaded attachment
-        type: string
+        type: bytes
         required: true
   delete_incident_attachment:
     title: Delete Incident Attachment

--- a/plugins/servicenow/setup.py
+++ b/plugins/servicenow/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="servicenow-rapid7-plugin",
-      version="5.1.0",
+      version="5.1.1",
       description="ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - This PR fixes a reported issue that the Get Incident Attachment action incorrectly parses a returned attachment type (as raw bytes) as a string.
  - JIRA: https://issues.corp.rapid7.com/browse/SOAR-6617

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

Successfully decoded file attachment from ServiceNow by passing the attachment contents to the base64 plugin for decoding.

![Screen Shot 2021-08-13 at 1 25 46 PM](https://user-images.githubusercontent.com/52976633/129397060-deaf7e4d-54eb-43b3-8c29-17a93e42d139.png)

This proves that actions whose response content is in fact JSON gets parsed correctly.

![Screen Shot 2021-08-13 at 3 33 10 PM](https://user-images.githubusercontent.com/52976633/129409923-047dab39-6053-431c-ba25-33797ecd8b93.png)

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
