### PR TITLE
Add default PORT in SQL plugin and add unit test

### DIFF
--- a/plugins/sql/.CHECKSUM
+++ b/plugins/sql/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "607bed64de93bcf183577b5e593c3bbe",
-	"manifest": "be7ae0a934540f8203c836d4baf3966e",
-	"setup": "41d318dbfdbff00ca2d07424a286a5bd",
+	"spec": "31b216bdd7c5a867655bacde0d1b4957",
+	"manifest": "99ab330346beb71308eebe741ddd5299",
+	"setup": "db0ced5a0d973c0914f2f4a208384f17",
 	"schemas": [
 		{
 			"identifier": "query/schema.py",

--- a/plugins/sql/bin/komand_sql
+++ b/plugins/sql/bin/komand_sql
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "SQL"
 Vendor = "rapid7"
-Version = "3.0.1"
+Version = "3.0.2"
 Description = "The SQL plugin allows you to run SQL queries"
 
 

--- a/plugins/sql/help.md
+++ b/plugins/sql/help.md
@@ -14,6 +14,10 @@ This plugin allows users to run and execute queries against a SQL database.
 * Name of your SQL database
 * Credentials (username and password) for your SQL database
 
+# Supported Product Versions
+
+_There are no supported product versions listed._
+
 # Documentation
 
 ## Setup
@@ -113,6 +117,7 @@ For the SQL query action, be sure that your query is valid SQL.
 
 # Version History
 
+* 3.0.2 - Add default PORT for MSSQL and MySQL connection
 * 3.0.1 - Close database connection after use
 * 3.0.0 - Add example input and title in connection and Query action | Update python version to `python-3-37-plugin:3` | Add `USER` in Dockerfile | Update `psycopg2` and `mysqlclient` version | Code refactor in connection.py, util.py and Query action.py
 * 2.0.7 - Add supported databases as a drop-down list | Add example inputs

--- a/plugins/sql/komand_sql/connection/connection.py
+++ b/plugins/sql/komand_sql/connection/connection.py
@@ -39,12 +39,14 @@ class Connection(komand.Connection):
 
     def mssql_conn_string(self, params):
         self.logger.info("Using MSSQL connection string...")
+        params[Input.PORT] = params.get(Input.PORT) or 1433
         return (
             f"mssql+pymssql://{self.user}:{self.password}@{params[Input.HOST]}:{params[Input.PORT]}/{params[Input.DB]}"
         )
 
     def default_conn_string(self, params):
         self.logger.info("Using MySQL connection string...")
+        params[Input.PORT] = params.get(Input.PORT) or 3306
         return (
             f"mysql+mysqldb://{self.user}:{self.password}@{params[Input.HOST]}:{params[Input.PORT]}/{params[Input.DB]}"
         )

--- a/plugins/sql/plugin.spec.yaml
+++ b/plugins/sql/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: sql
 title: SQL
 description: The SQL plugin allows you to run SQL queries
-version: 3.0.1
+version: 3.0.2
 vendor: rapid7
 support: community
 status: []

--- a/plugins/sql/setup.py
+++ b/plugins/sql/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="sql-rapid7-plugin",
-      version="3.0.1",
+      version="3.0.2",
       description="The SQL plugin allows you to run SQL queries",
       author="rapid7",
       author_email="",

--- a/plugins/sql/unit_test/test_connection.py
+++ b/plugins/sql/unit_test/test_connection.py
@@ -1,0 +1,100 @@
+import unittest
+from dataclasses import dataclass
+from typing import Optional
+
+from komand_sql.connection.connection import Connection
+import logging
+
+from komand_sql.connection.schema import Input
+
+
+@dataclass
+class TestCase:
+    name: str
+    input_type: str
+    input_port: Optional[str]
+    expected: str
+
+
+testcases = [
+    TestCase(
+        name="mssql_connect",
+        input_type="MSSQL",
+        input_port="1433",
+        expected="mssql+pymssql://username:password@198.51.100.1:1433/database_name",
+    ),
+    TestCase(
+        name="postgres_connect",
+        input_type="PostgreSQL",
+        input_port="1433",
+        expected="postgres://username:password@198.51.100.1:1433/database_name",
+    ),
+    TestCase(
+        name="mysql_connect",
+        input_type="MySQL",
+        input_port="1433",
+        expected="mysql+mysqldb://username:password@198.51.100.1:1433/database_name",
+    ),
+    TestCase(
+        name="mssql_connect_without_port",
+        input_type="MSSQL",
+        input_port=None,
+        expected="mssql+pymssql://username:password@198.51.100.1:1433/database_name",
+    ),
+    TestCase(
+        name="postgres_connect_without_port",
+        input_type="PostgreSQL",
+        input_port=None,
+        expected="postgres://username:password@198.51.100.1:5432/database_name",
+    ),
+    TestCase(
+        name="mysql_connect_without_port",
+        input_type="MySQL",
+        input_port=None,
+        expected="mysql+mysqldb://username:password@198.51.100.1:3306/database_name",
+    ),
+    TestCase(
+        name="mssql_connect_different_port",
+        input_type="MSSQL",
+        input_port="1111",
+        expected="mssql+pymssql://username:password@198.51.100.1:1111/database_name",
+    ),
+    TestCase(
+        name="postgres_connect_different_port",
+        input_type="PostgreSQL",
+        input_port="1111",
+        expected="postgres://username:password@198.51.100.1:1111/database_name",
+    ),
+    TestCase(
+        name="mysql_connect_different_port",
+        input_type="MySQL",
+        input_port="1111",
+        expected="mysql+mysqldb://username:password@198.51.100.1:1111/database_name",
+    ),
+]
+
+
+class TestConnection(unittest.TestCase):
+    @staticmethod
+    def configure_connection(type_: str, port: Optional[str]):
+        default_connection = Connection()
+        default_connection.logger = logging.getLogger("connection logger")
+        params = {
+            Input.CREDENTIALS: {"username": "username", "password": "password"},
+            Input.PORT: port,
+            Input.TYPE: type_,
+            Input.HOST: "198.51.100.1",
+            Input.DB: "database_name",
+        }
+        default_connection.connect(params)
+
+        return default_connection
+
+    def test_connect(self):
+        for case in testcases:
+            with self.subTest(case.name):
+                actual = TestConnection.configure_connection(case.input_type, case.input_port).conn_str
+                self.assertEqual(
+                    case.expected,
+                    actual,
+                )


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:
Add default PORT for MySQL and MSSQL connection
Add unit test for Query action

Tickets: [MC-566][MC-705] 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)


## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Using MSSQL connection string...\nrapid7/SQL:3.0.2. Step name: query\n",
    "meta": {},
    "output": {
      "header": [
        "name",
        "id"
      ],
      "results": [
        {
          "id": "1",
          "name": "bob"
        },
        {
          "id": "2",
          "name": "paul"
        },
        {
          "id": "3",
          "name": "sully"
        }
      ],
      "status": "operation success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/sql:3.0.2 --debug run < tests/query.json
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../../tools/Makefiles/Colors.mk ../../tools/Makefiles/Helpers.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed! 
	Cause: Invalid JSON example identified in Example input of action titled Query. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 1910.875ms

```

<summary>
make validate
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed! 
	Cause: Invalid JSON example identified in Example input of action titled Query. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 80722.672ms
```

<summary>
icon-validate --all .
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Using MSSQL connection string...\nrapid7/SQL:3.0.2. Step name: query\n",
    "meta": {},
    "output": {
      "status": "Success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/sql:3.0.2 --debug test < tests/query.json
</summary>
</details>



