### PR TITLE
Update Palo Alto Cortex XDR help.md

### DIFF
--- a/plugins/palo_alto_cortex_xdr/help.md
+++ b/plugins/palo_alto_cortex_xdr/help.md
@@ -511,6 +511,8 @@ Example output:
 
 ### Tasks
 
+Plugin Tasks are currently in development! This new plugin capability will collect and deliver events to Insight products for search and use in automation workflows.
+
 #### Monitor Incident Events
 
 This task is used to monitor incident events.


### PR DESCRIPTION
As per Slack:

Jon Schipp:  18 hours ago
This is great. Nice work guys! One thought about this is customers can’t use tasks yet so we should create standard note in plugins docs that this is for a future feature, or hide that section until we launch Cloud Events (edited) 

Spencer Engleson  15 hours ago
@jdevlin @sdevlin @jprice could we put a very low-lift notice on "Tasks" documentation in the library? We just want users to know this is a new plugin capability that is not yet available in-product. Something along the lines of, "Plugin Tasks are currently in development! This new plugin capability will collect and deliver events to Insight products for search and use in automation workflows."