### PR TITLE
Update Prospector to Ignore 'inconsistent-return-statements'

### DIFF
--- a/prospector.yaml
+++ b/prospector.yaml
@@ -11,6 +11,7 @@ pylint:
     - raise-missing-from
     - no-else-return
     - no-else-raise
+    - inconsistent-return-statements
 
 pyflakes:
   disable:


### PR DESCRIPTION
Updates prospector rules to ignore the 'inconsistent-return-statements' rule. It flags on the following code which is perfectly fine as far as I can tell (as all logic branches are exhausted/defaulted):
```
            if response.status_code == 401:
                raise PluginException(preset=PluginException.Preset.USERNAME_PASSWORD, data=response.text)
            if response.status_code == 403:
                raise PluginException(preset=PluginException.Preset.API_KEY, data=response.text)
            if response.status_code == 404:
                raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response.text)
            if 400 <= response.status_code < 500:
                raise PluginException(
                    preset=PluginException.Preset.UNKNOWN,
                    data=response.text,
                )
            if response.status_code >= 500:
                raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)

            if 200 <= response.status_code < 300:
                return response.json()

            raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
        except json.decoder.JSONDecodeError as e:
            raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=e)
```