### PR TITLE
[MC-801] Fix Set Address Object action in Palo Alto PAN-OS plugin

### DIFF
--- a/plugins/palo_alto_pan_os/.CHECKSUM
+++ b/plugins/palo_alto_pan_os/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "fd1d01ec53cbee3c38b694fd4ad97ba0",
-	"manifest": "ee4584f15437585cd498cacb82900b7e",
-	"setup": "20ab78f505d983c4b5d583baec528f1d",
+	"spec": "8fe143f1accc9f0a16769a7525cccbbf",
+	"manifest": "beb2a53fe866e1b7f2736aa706ebae6b",
+	"setup": "f54c55e105cdee39ef885aa56961f727",
 	"schemas": [
 		{
 			"identifier": "add_address_object_to_group/schema.py",
@@ -65,7 +65,7 @@
 		},
 		{
 			"identifier": "set_address_object/schema.py",
-			"hash": "6c1d5d5c991071d49eb5614234e29189"
+			"hash": "ae16f4a2f4b748ff474278b15cb02423"
 		},
 		{
 			"identifier": "set_security_policy_rule/schema.py",

--- a/plugins/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/plugins/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Palo Alto Firewall"
 Vendor = "rapid7"
-Version = "6.1.2"
+Version = "6.1.3"
 Description = "Manage Palo Alto Networks firewall devices"
 
 

--- a/plugins/palo_alto_pan_os/help.md
+++ b/plugins/palo_alto_pan_os/help.md
@@ -1,6 +1,6 @@
 # Description
 
-[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama).
+[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto Firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama).
 
 # Key Features
 
@@ -17,6 +17,10 @@
 
 * Access to Palo Alto Next Generation firewall or Palo Alto Panorama device
 
+# Supported Product Versions
+
+* 9.0.3
+
 # Documentation
 
 ## Setup
@@ -26,7 +30,7 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |credentials|credential_username_password|None|True|Username and password|None|{"username":"username", "password":"password"}|
-|server|string|None|True|URL pointing to instance of Panorama or an individual Palo Alto firewall|None|http://www.example.com|
+|server|string|None|True|URL pointing to instance of Panorama or an individual Palo Alto Firewall|None|http://www.example.com|
 |verify_cert|boolean|None|True|If true, validate the server's TLS certificate when contacting the firewall over HTTPS|None|True|
 
 Example input:
@@ -350,7 +354,7 @@ In this case, we will strip the /32 from the end and check the IP against the wh
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|address|string|None|True|The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com google.com|None|1.1.1.1|
+|address|string|None|True|The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com|None|1.1.1.1|
 |address_object|string|None|True|The name of the address object|None|Blocked host|
 |description|string|None|False|A description for the address object|None|Blocked host from Insight Connect|
 |skip_rfc1918|boolean|False|True|Skip private IP addresses as defined in RFC 1918|None|True|
@@ -699,7 +703,7 @@ This action is used to query firewall logs.
 |----|----|-------|--------|-----------|----|-------|
 |count|integer|20|False|Number of logs to retrieve (Max: 500, Default: 20)|None|20|
 |direction|string|None|False|Order in which to return the logs|['backward', 'forward']|backward|
-|filter|string|None|False|Search query. Format as a log filter expression|None|None|
+|filter|string|None|False|Search query. Format as a log filter expression|None|receive_time geq '2021/12/22 08:00:00'|
 |interval|float|0.5|False|Time interval in seconds to wait between queries for commit job completion (Default: 0.5)|None|0.5|
 |log_type|string|None|False|Type of log to retrieve|['config', 'hipmatch', 'system', 'threat', 'traffic', 'url', 'wildfire']|config|
 |max_tries|integer|25|False|Maximum number of times to poll for job completion before timing out (Default: 25)|None|25|
@@ -711,6 +715,7 @@ Example input:
 {
   "count": 20,
   "direction": "backward",
+  "filter": "receive_time geq '2021/12/22 08:00:00'",
   "interval": 0.5,
   "log_type": "config",
   "max_tries": 25,
@@ -1066,6 +1071,7 @@ When using the Add External Dynamic List action, a day and time must be chosen e
 
 # Version History
 
+* 6.1.3 - Fix `check_if_private` method in Set Address Object action | Improve `determine_address_type` method in Set Address Object action | Fix issue where Add External Dynamic List action fails when `repeat` input has been set to retrieve updates from list weekly | Add example for `filter` input for Retrieve Logs action
 * 6.1.2 - Add `docs_url` in plugin spec | Update `source_url` in plugin spec
 * 6.1.1 - Remove duplicate Troubleshooting section in documentation
 * 6.1.0 - Improve error handling for xpath elements and paths in `pa_os_request.py` | New action Get Addresses from Group | Support adding a list of address objects in Add Address Object to Group action

--- a/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_external_dynamic_list/action.py
+++ b/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_external_dynamic_list/action.py
@@ -39,7 +39,7 @@ class AddExternalDynamicList(komand.Action):
         time = params.get("time")
         day = params.get("day")
 
-        xpath = "/config/devices/entry/vsys/entry/external-list/entry[@name='{}']".format(name)
+        xpath = f"/config/devices/entry/vsys/entry/external-list/entry[@name='{name}']"
         element = add.element_for_create_external_list(
             self._LIST_TYPE_KEY[list_type],
             description,

--- a/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_external_dynamic_list/action.py
+++ b/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_external_dynamic_list/action.py
@@ -46,7 +46,7 @@ class AddExternalDynamicList(komand.Action):
             source,
             self._REPEAT_KEY[repeat],
             time,
-            day.lower,
+            day.lower(),
         )
 
         output = self.connection.request.set_(xpath=xpath, element=element)

--- a/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
+++ b/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
@@ -43,8 +43,7 @@ class SetAddressObject(komand.Action):
             if address in whitelist:
                 self.logger.info(f" Whitelist matched\n{address} was found in whitelist")
                 return True
-            else:
-                return False
+            return False
 
         # if 1.1.1.1/32 - remove /32
         trimmed_address = re.sub(r"/32$", "", address)
@@ -54,13 +53,13 @@ class SetAddressObject(komand.Action):
             return address in whitelist
 
         # IP is in CIDR - Give the user a log message
-        for object in whitelist:
-            type = self.determine_address_type(object)
-            if type == "ip-netmask":
-                net = ip_network(object, False)  # False means ignore the masked bits, otherwise they need to be 0
+        for address_object in whitelist:
+            address_type = self.determine_address_type(address_object)
+            if address_type == "ip-netmask":
+                net = ip_network(address_object, False)  # False means ignore the masked bits, otherwise they need to be 0
                 ip = ip_address(trimmed_address)
                 if ip in net:
-                    self.logger.info(f" Whitelist matched\nIP {address} was found in {object}")
+                    self.logger.info(f" Whitelist matched\nIP {address} was found in {address_object}")
                     return True
 
         return False
@@ -73,8 +72,8 @@ class SetAddressObject(komand.Action):
         if re.search("-", address):  # IP Range
             split_ = address.split("-")
             return IP(split_[0]).iptype() in ip_types and IP(split_[1]).iptype() in ip_types
-        else:  # Other
-            return IP(address).iptype() in ip_types
+        # Other
+        return IP(address).iptype() in ip_types
 
     def run(self, params={}):
         address = params.get(Input.ADDRESS)
@@ -94,15 +93,7 @@ class SetAddressObject(komand.Action):
             for item in tag_list:
                 tag = tag + f"<member>{item}</member>"
 
-        """
-        create object type XML
-        
-        supported types: 
-
-        - ip-netmask
-        - ip-range
-        - fqdn        
-        """
+        # create object type XML, supported types: ip-netmask, ip-range, fqdn
         # object_type = object_type.lower()
         if skip_private:
             if object_type != "fqdn":

--- a/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
+++ b/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/action.py
@@ -56,7 +56,9 @@ class SetAddressObject(komand.Action):
         for address_object in whitelist:
             address_type = self.determine_address_type(address_object)
             if address_type == "ip-netmask":
-                net = ip_network(address_object, False)  # False means ignore the masked bits, otherwise they need to be 0
+                net = ip_network(
+                    address_object, False
+                )  # False means ignore the masked bits, otherwise they need to be 0
                 ip = ip_address(trimmed_address)
                 if ip in net:
                     self.logger.info(f" Whitelist matched\nIP {address} was found in {address_object}")

--- a/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
+++ b/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/set_address_object/schema.py
@@ -31,7 +31,7 @@ class SetAddressObjectInput(komand.Input):
     "address": {
       "type": "string",
       "title": "Address",
-      "description": "The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com google.com",
+      "description": "The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com",
       "order": 1
     },
     "address_object": {

--- a/plugins/palo_alto_pan_os/plugin.spec.yaml
+++ b/plugins/palo_alto_pan_os/plugin.spec.yaml
@@ -4,7 +4,8 @@ products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto Firewall
 description: Manage Palo Alto Networks firewall devices
-version: 6.1.2
+version: 6.1.3
+supported_versions: ["9.0.3"]
 vendor: rapid7
 support: rapid7
 status: []
@@ -329,7 +330,7 @@ actions:
         type: string
         description: Search query. Format as a log filter expression
         required: false
-        example:
+        example: "receive_time geq '2021/12/22 08:00:00'"
       interval:
         title: Interval
         type: float
@@ -680,7 +681,6 @@ actions:
       address:
         title: Address
         description: The IP address, network CIDR, or FQDN e.g. 192.168.1.1, 192.168.1.0/24, google.com
-          google.com
         type: string
         example: 1.1.1.1
         required: true
@@ -698,8 +698,7 @@ actions:
         required: false
       tags:
         title: Tags
-        description: Tags for the address object. Use commas to separate multiple
-          tags
+        description: Tags for the address object. Use commas to separate multiple tags
         type: string
         example: malware
         required: false

--- a/plugins/palo_alto_pan_os/requirements.txt
+++ b/plugins/palo_alto_pan_os/requirements.txt
@@ -5,3 +5,5 @@ gunicorn==19.9.0
 xmltodict==0.12.0
 dicttoxml==1.7.4
 validators==0.14.2
+IPy==1.01
+parameterized==0.8.1

--- a/plugins/palo_alto_pan_os/setup.py
+++ b/plugins/palo_alto_pan_os/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
-      version="6.1.2",
+      version="6.1.3",
       description="Manage Palo Alto Networks firewall devices",
       author="rapid7",
       author_email="",

--- a/plugins/palo_alto_pan_os/unit_test/payloads/commit.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/commit.resp
@@ -1,0 +1,5 @@
+<response status="success" code="19">
+  <result>
+    <msg>There are no changes to commit.</msg>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/commit2.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/commit2.resp
@@ -1,0 +1,8 @@
+<response status="success" code="19">
+  <result>
+    <msg>
+      <line>Commit job enqueued with jobid 10</line>
+    </msg>
+    <job>10</job>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_config_logs.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_config_logs.resp
@@ -1,0 +1,51 @@
+<response status="success"><result>
+  <job>
+    <tenq>04:46:20</tenq>
+    <tdeq>04:46:20</tdeq>
+    <tlast>04:46:20</tlast>
+    <status>FIN</status>
+    <id>1</id>
+  </job>
+  <log>
+    <logs count="1" progress="100">
+      <entry logid="7044309865149235243">
+        <domain>1</domain>
+        <receive_time>2021/12/22 08:54:51</receive_time>
+        <serial>0000000000000001</serial>
+        <seqno>1550</seqno>
+        <actionflags>0x0</actionflags>
+        <is-logging-service>no</is-logging-service>
+        <type>CONFIG</type>
+        <subtype>0</subtype>
+        <config_ver>0</config_ver>
+        <time_generated>2021/12/22 08:54:51</time_generated>
+        <dg_hier_level_1>0</dg_hier_level_1>
+        <dg_hier_level_2>0</dg_hier_level_2>
+        <dg_hier_level_3>0</dg_hier_level_3>
+        <dg_hier_level_4>0</dg_hier_level_4>
+        <device_name>TEST</device_name>
+        <vsys_id>0</vsys_id>
+        <host>198.51.100.100</host>
+        <cmd>delete</cmd>
+        <admin>admin</admin>
+        <client>Web</client>
+        <result>Succeeded</result>
+        <path> vsys  vsys1 external-list  Test Domain List</path>
+        <dg_id>0</dg_id>
+        <full-path>/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/external-list/entry[@name='Test Domain List']</full-path>
+      </entry>
+    </logs>
+  </log>
+  <meta>
+    <devices>
+      <entry name="localhost.localdomain">
+        <hostname>localhost.localdomain</hostname>
+        <vsys>
+          <entry name="vsys1">
+            <display-name>vsys1</display-name>
+          </entry>
+        </vsys>
+      </entry>
+    </devices>
+  </meta>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id.resp
@@ -1,0 +1,8 @@
+<response status="success" code="19">
+  <result>
+    <msg>
+      <line>query job enqueued with jobid 1</line>
+    </msg>
+    <job>1</job>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id2.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id2.resp
@@ -1,0 +1,8 @@
+<response status="success" code="19">
+  <result>
+    <msg>
+      <line>query job enqueued with jobid 2</line>
+    </msg>
+    <job>2</job>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id3.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id3.resp
@@ -1,0 +1,8 @@
+<response status="success" code="19">
+  <result>
+    <msg>
+      <line>query job enqueued with jobid 3</line>
+    </msg>
+    <job>3</job>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id4.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_job_id4.resp
@@ -1,0 +1,8 @@
+<response status="success" code="19">
+  <result>
+    <msg>
+      <line>query job enqueued with jobid 4</line>
+    </msg>
+    <job>4</job>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_object_domain.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_object_domain.resp
@@ -1,0 +1,6 @@
+<response status="success" code="19"><result total-count="1" count="1">
+ <entry name="test.com">
+  <fqdn>test.com</fqdn>
+  <description>Example Description</description>
+ </entry>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_object_ipv4.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_object_ipv4.resp
@@ -1,0 +1,6 @@
+<response status="success" code="19"><result total-count="1" count="1">
+ <entry name="1.1.1.1">
+  <ip-netmask>1.1.1.1</ip-netmask>
+  <description>Example Description</description>
+ </entry>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_object_ipv6.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_object_ipv6.resp
@@ -1,0 +1,6 @@
+<response status="success" code="19"><result total-count="1" count="1">
+ <entry name="IPv6">
+  <ip-netmask>abcd:123::1</ip-netmask>
+  <description>Example Description</description>
+ </entry>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_objects_from_group.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_objects_from_group.resp
@@ -1,0 +1,9 @@
+<response status="success" code="19"><result total-count="1" count="1">
+ <entry name="Test Group" admin="admin" dirtyId="144" time="2021/12/14 09:43:15">
+  <static admin="admin" dirtyId="144" time="2021/12/14 09:43:15">
+   <member admin="admin" dirtyId="144" time="2021/12/14 09:43:15">1.1.1.1</member>
+   <member admin="admin" dirtyId="144" time="2021/12/14 09:43:15">test.com</member>
+   <member admin="admin" dirtyId="144" time="2021/12/14 09:43:15">IPv6</member>
+  </static>
+ </entry>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_objects_from_group_bad.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_objects_from_group_bad.resp
@@ -1,0 +1,2 @@
+<response status="success" code="7"><result>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_policy.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_policy.resp
@@ -1,0 +1,34 @@
+<response status="success"><result>
+ <entry name="Test Policy" uuid="290ba776-4bd0-49b2-8c20-a35467b22c11">
+  <to>
+   <member>any</member>
+  </to>
+  <from>
+   <member>any</member>
+  </from>
+  <source>
+   <member>any</member>
+  </source>
+  <destination>
+   <member>any</member>
+  </destination>
+  <service>
+   <member>application-default</member>
+   <member>any</member>
+  </service>
+  <application>
+   <member>any</member>
+  </application>
+  <category>
+   <member>adult</member>
+   <member>abused-drugs</member>
+  </category>
+  <hip-profiles>
+   <member>any</member>
+  </hip-profiles>
+  <source-user>
+   <member>Joe Smith</member>
+  </source-user>
+  <action>drop</action>
+ </entry>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_policy2.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_policy2.resp
@@ -1,0 +1,32 @@
+<response status="success" code="19"><result total-count="1" count="1">
+  <entry name="Test Rule" admin="admin" dirtyId="145" time="2021/12/17 08:10:05" uuid="6783a432-c27a-4bc7-9535-7652ab5a4987">
+    <to admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </to>
+    <from admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </from>
+    <source admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </source>
+    <destination admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </destination>
+    <source-user admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </source-user>
+    <category admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </category>
+    <application admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </application>
+    <service admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">application-default</member>
+    </service>
+    <hip-profiles admin="admin" dirtyId="145" time="2021/12/17 08:10:05">
+      <member admin="admin" dirtyId="145" time="2021/12/17 08:10:05">any</member>
+    </hip-profiles>
+    <action admin="admin" dirtyId="145" time="2021/12/17 08:10:05">drop</action>
+  </entry>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_policy_bad.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_policy_bad.resp
@@ -1,0 +1,2 @@
+<response status="success" code="7"><result>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_system_logs.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_system_logs.resp
@@ -1,0 +1,49 @@
+<response status="success"><result>
+  <job>
+    <tenq>05:45:27</tenq>
+    <tdeq>05:45:27</tdeq>
+    <tlast>05:45:27</tlast>
+    <status>FIN</status>
+    <id>2</id>
+  </job>
+  <log>
+    <logs count="1" progress="100">
+      <entry logid="7044309865149247490">
+        <domain>1</domain>
+        <receive_time>2021/12/22 08:00:12</receive_time>
+        <serial>000000000000002</serial>
+        <seqno>8144908</seqno>
+        <actionflags>0x0</actionflags>
+        <is-logging-service>no</is-logging-service>
+        <type>SYSTEM</type>
+        <subtype>syslog</subtype>
+        <config_ver>0</config_ver>
+        <time_generated>2021/12/22 08:00:12</time_generated>
+        <dg_hier_level_1>0</dg_hier_level_1>
+        <dg_hier_level_2>0</dg_hier_level_2>
+        <dg_hier_level_3>0</dg_hier_level_3>
+        <dg_hier_level_4>0</dg_hier_level_4>
+        <device_name>TEST</device_name>
+        <vsys_id>0</vsys_id>
+        <eventid>syslog-conn-status</eventid>
+        <fmt>0</fmt>
+        <id>0</id>
+        <module>mgmt</module>
+        <severity>high</severity>
+        <opaque>Syslog connection failed to server['TEST']</opaque>
+      </entry>
+    </logs>
+  </log>
+  <meta>
+    <devices>
+      <entry name="localhost.localdomain">
+        <hostname>localhost.localdomain</hostname>
+        <vsys>
+          <entry name="vsys1">
+            <display-name>vsys1</display-name>
+          </entry>
+        </vsys>
+      </entry>
+    </devices>
+  </meta>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_threat_logs.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_threat_logs.resp
@@ -1,0 +1,66 @@
+<response status="success"><result>
+  <job>
+    <tenq>05:45:27</tenq>
+    <tdeq>05:45:27</tdeq>
+    <tlast>05:45:27</tlast>
+    <status>FIN</status>
+    <id>3</id>
+  </job>
+  <log>
+    <logs count="1" progress="100">
+      <entry logid="191242123113213">
+        <domain>1</domain>
+        <receive_time>2021/12/22 12:50:24</receive_time>
+        <serial>000000000000003</serial>
+        <seqno>8210416</seqno>
+        <actionflags>0x0</actionflags>
+        <type>THREAT</type>
+        <subtype>vulnerability</subtype>
+        <config_ver>1</config_ver>
+        <time_generated>2021/12/22 10:50:24</time_generated>
+        <src>xxx.xxx.xxx.xxx</src>
+        <dst>xxx.xxx.xxx.xxx</dst>
+        <rule>CorporationHQ</rule>
+        <srcloc>United States</srcloc>
+        <dstloc>xxx.xxx.xxx.xxx-xxx.xxx.xxx.xxx</dstloc>
+        <app>smtp</app>
+        <vsys>vsys1</vsys>
+        <from>trust</from>
+        <to>trust</to>
+        <inbound_if>ethernet1/5</inbound_if>
+        <outbound_if>ethernet1/6</outbound_if>
+        <logset>Logs</logset>
+        <time_received>2021/12/22 12:50:24</time_received>
+        <sessionid>135193</sessionid>
+        <repeatcnt>1</repeatcnt>
+        <sport>52252</sport>
+        <dport>25</dport>
+        <action>reset-both</action>
+        <dg_hier_level_1>11</dg_hier_level_1>
+        <dg_hier_level_2>0</dg_hier_level_2>
+        <dg_hier_level_3>0</dg_hier_level_3>
+        <dg_hier_level_4>0</dg_hier_level_4>
+        <device_name>TEST</device_name>
+        <vsys_id>1</vsys_id>
+        <threatid>User Login Brute Force Attempt</threatid>
+        <tid>0</tid>
+        <reportid>0</reportid>
+        <category>any</category>
+        <severity>high</severity>
+        <direction>client-to-server</direction>
+      </entry>
+    </logs>
+  </log>
+  <meta>
+    <devices>
+      <entry name="localhost.localdomain">
+        <hostname>localhost.localdomain</hostname>
+        <vsys>
+          <entry name="vsys1">
+            <display-name>vsys1</display-name>
+          </entry>
+        </vsys>
+      </entry>
+    </devices>
+  </meta>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/get_traffic_logs.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/get_traffic_logs.resp
@@ -1,0 +1,24 @@
+<response status="success"><result>
+  <job>
+    <tenq>06:37:53</tenq>
+    <tdeq>06:37:53</tdeq>
+    <tlast>06:37:53</tlast>
+    <status>FIN</status>
+    <id>4</id>
+  </job>
+  <log>
+    <logs count="0" progress="100"/>
+  </log>
+  <meta>
+    <devices>
+      <entry name="localhost.localdomain">
+        <hostname>localhost.localdomain</hostname>
+        <vsys>
+          <entry name="vsys1">
+            <display-name>vsys1</display-name>
+          </entry>
+        </vsys>
+      </entry>
+    </devices>
+  </meta>
+</result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/invalid_rule_name.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/invalid_rule_name.resp
@@ -1,0 +1,1 @@
+<response status="error" code=""><msg><line>No such node</line></msg></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/invalid_url_category_parameter.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/invalid_url_category_parameter.resp
@@ -1,0 +1,7 @@
+<response status="error" code="12">
+  <msg>
+    <line><![CDATA[ ICON Block Rule -> category 'hacking1' is not an allowed keyword]]></line>
+    <line><![CDATA[ ICON Block Rule -> category 'hacking1' is not a valid reference]]></line>
+    <line><![CDATA[ ICON Block Rule -> category is invalid]]></line>
+  </msg>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/key.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/key.resp
@@ -1,0 +1,1 @@
+<response status = 'success'><result><key>test_key</key></result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/op.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/op.resp
@@ -1,0 +1,18 @@
+<response status="success">
+  <result>
+    <job>
+      <tenq>2021/12/22 10:41:44</tenq>
+      <id>1</id>
+      <type>Commit</type>
+      <status>FIN</status>
+      <stoppable>no</stoppable>
+      <result>OK</result>
+      <tfin>10:42:22</tfin>
+      <progress>100</progress>
+      <details>
+        <line>Configuration committed successfully</line>
+      </details>
+      <warnings/>
+    </job>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/op2.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/op2.resp
@@ -1,0 +1,5 @@
+<response status="success">
+  <result>
+    <commit-locks></commit-locks>
+  </result>
+</response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/show_group.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/show_group.resp
@@ -1,0 +1,7 @@
+<response status="success"><result><entry name="Test Group">
+  <static>
+    <member>example.com</member>
+    <member>1.1.1.1</member>
+    <member>IPv6</member>
+  </static>
+</entry></result></response>

--- a/plugins/palo_alto_pan_os/unit_test/payloads/successful.resp
+++ b/plugins/palo_alto_pan_os/unit_test/payloads/successful.resp
@@ -1,0 +1,1 @@
+<response status="success" code="20"><msg>command succeeded</msg></response>

--- a/plugins/palo_alto_pan_os/unit_test/test_add_external_dynamic_list.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_add_external_dynamic_list.py
@@ -1,72 +1,79 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.add_external_dynamic_list import AddExternalDynamicList
+from komand_palo_alto_pan_os.actions.add_external_dynamic_list.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.add_external_dynamic_list import AddExternalDynamicList
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestAddExternalDynamicList(TestCase):
-    def test_integration_add_external_dynamic_list(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = AddExternalDynamicList()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/add_external_dynamic_list.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_add_external_dynamic_list(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "ip_list",
+                "IP List",
+                "IP List",
+                "List of IPs",
+                "https://www.example.com/test.txt",
+                "Five Minute",
+                "00",
+                "Monday",
+                {"status": "success", "code": "20", "message": "command succeeded"},
+            ],
+            [
+                "url_list",
+                "URL List",
+                "URL List",
+                "List of URLs",
+                "https://www.example.com/test.txt",
+                "Hourly",
+                "01",
+                "Wednesday",
+                {"status": "success", "code": "20", "message": "command succeeded"},
+            ],
+            [
+                "domain_list",
+                "Domain List",
+                "Domain List",
+                "List of domains",
+                "https://www.example.com/test.txt",
+                "Daily",
+                "08",
+                "Tuesday",
+                {"status": "success", "code": "20", "message": "command succeeded"},
+            ],
+            [
+                "url_list_weekly",
+                "URL List",
+                "URL List",
+                "List of URLs",
+                "https://www.example.com/test.txt",
+                "Weekly",
+                "12",
+                "Thursday",
+                {"status": "success", "code": "20", "message": "command succeeded"},
+            ],
+        ]
+    )
+    def test_add_external_dynamic_list(
+        self, mock_get, mock_post, name, list_name, list_type, description, source, repeat, time, day, expected
+    ):
+        action = Util.default_connector(AddExternalDynamicList())
+        actual = action.run(
+            {
+                Input.NAME: list_name,
+                Input.LIST_TYPE: list_type,
+                Input.DESCRIPTION: description,
+                Input.SOURCE: source,
+                Input.REPEAT: repeat,
+                Input.TIME: time,
+                Input.DAY: day,
+            }
+        )
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_add_to_policy.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_add_to_policy.py
@@ -1,72 +1,192 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.add_to_policy import AddToPolicy
+from komand_palo_alto_pan_os.actions.add_to_policy.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
+from komand.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.add_to_policy import AddToPolicy
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestAddToPolicy(TestCase):
-    def test_integration_add_to_policy(self):
-        """
-        TODO: Implement assertions at the end of this test case
+    @parameterized.expand(
+        [
+            [
+                "update_active_configuration",
+                "Test Policy",
+                "active",
+                "any",
+                "any",
+                "any",
+                "any",
+                "Example User",
+                "any",
+                "any",
+                "adult",
+                "any",
+                "drop",
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "update_candidate_configuration",
+                "Test Policy",
+                "candidate",
+                "any",
+                "any",
+                "any",
+                "any",
+                "Example User",
+                "any",
+                "any",
+                "adult",
+                "any",
+                "drop",
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "update_candidate_configuration",
+                "Test Policy",
+                "active",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+        ]
+    )
+    def test_add_to_policy(
+        self,
+        mock_get,
+        mock_post,
+        name,
+        rule_name,
+        update_active_or_candidate_configuration,
+        source,
+        destination,
+        service,
+        application,
+        source_user,
+        src_zone,
+        dst_zone,
+        url_category,
+        hip_profiles,
+        new_action,
+        expected,
+    ):
+        action = Util.default_connector(AddToPolicy())
+        actual = action.run(
+            {
+                Input.RULE_NAME: rule_name,
+                Input.UPDATE_ACTIVE_OR_CANDIDATE_CONFIGURATION: update_active_or_candidate_configuration,
+                Input.SOURCE: source,
+                Input.DESTINATION: destination,
+                Input.SERVICE: service,
+                Input.APPLICATION: application,
+                Input.SOURCE_USER: source_user,
+                Input.SRC_ZONE: src_zone,
+                Input.DST_ZONE: dst_zone,
+                Input.URL_CATEGORY: url_category,
+                Input.HIP_PROFILES: hip_profiles,
+                Input.ACTION: new_action,
+            }
+        )
+        self.assertEqual(actual, expected)
 
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = AddToPolicy()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/add_to_policy.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_add_to_policy(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "invalid_rule_name",
+                "Invalid Rule Name",
+                "active",
+                "any",
+                "any",
+                "any",
+                "any",
+                "Example User",
+                "any",
+                "any",
+                "adult",
+                "any",
+                "drop",
+                "PAN-OS returned an error in response to the request.",
+                "Double-check that inputs are valid. Contact support if this issue persists.",
+                '{"line": "No such node"}',
+            ],
+            [
+                "invalid_url_category_parameter",
+                "Test Policy",
+                "candidate",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                "test1",
+                None,
+                None,
+                "PAN-OS returned an error in response to the request.",
+                'This is likely because the provided element <entry name="Test Policy"><to><member>any</member></to><from><member>any</member></from><source><member>any</member></source><destination><member>any</member></destination><service><member>application-default</member><member>any</member></service><application><member>any</member></application><category><member>adult</member><member>abused-drugs</member><member>test1</member></category><hip-profiles><member>any</member></hip-profiles><source-user><member>Joe Smith</member></source-user><action>drop</action></entry> does not exist or the xpath is not correct. Please verify the element name and xpath and try again.',
+                [
+                    "ICON Block Rule -> category 'hacking1' is not an allowed keyword",
+                    "ICON Block Rule -> category 'hacking1' is not a valid reference",
+                    "ICON Block Rule -> category is invalid",
+                ],
+            ],
+        ]
+    )
+    def test_add_to_policy_bad(
+        self,
+        mock_get,
+        mock_post,
+        name,
+        rule_name,
+        update_active_or_candidate_configuration,
+        source,
+        destination,
+        service,
+        application,
+        source_user,
+        src_zone,
+        dst_zone,
+        url_category,
+        hip_profiles,
+        new_action,
+        cause,
+        assistance,
+        data,
+    ):
+        action = Util.default_connector(AddToPolicy())
+        with self.assertRaises(PluginException) as e:
+            action.run(
+                {
+                    Input.RULE_NAME: rule_name,
+                    Input.UPDATE_ACTIVE_OR_CANDIDATE_CONFIGURATION: update_active_or_candidate_configuration,
+                    Input.SOURCE: source,
+                    Input.DESTINATION: destination,
+                    Input.SERVICE: service,
+                    Input.APPLICATION: application,
+                    Input.SOURCE_USER: source_user,
+                    Input.SRC_ZONE: src_zone,
+                    Input.DST_ZONE: dst_zone,
+                    Input.URL_CATEGORY: url_category,
+                    Input.HIP_PROFILES: hip_profiles,
+                    Input.ACTION: new_action,
+                }
+            )
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(e.exception.data, data)

--- a/plugins/palo_alto_pan_os/unit_test/test_commit.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_commit.py
@@ -1,72 +1,47 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.commit import Commit
+from komand_palo_alto_pan_os.actions.commit.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.commit import Commit
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.get", side_effect=Util.mocked_requests)
 class TestCommit(TestCase):
-    def test_integration_commit(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = Commit()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/commit.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_commit(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "no_changes",
+                None,
+                "<commit></commit>",
+                {
+                    "response": {
+                        "@status": "success",
+                        "@code": "19",
+                        "result": {"msg": "There are no changes to commit."},
+                    }
+                },
+            ],
+            [
+                "partial",
+                "partial",
+                "<commit><partial><admin><member>admin-name</member></admin></partial></commit>",
+                {
+                    "response": {
+                        "@status": "success",
+                        "@code": "19",
+                        "result": {"msg": {"line": "Commit job enqueued with jobid 10"}, "job": "10"},
+                    }
+                },
+            ],
+        ]
+    )
+    def test_commit(self, mock_get, mock_get2, name, commit_action, cmd, expected):
+        action = Util.default_connector(Commit())
+        actual = action.run({Input.ACTION: commit_action, Input.CMD: cmd})
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_edit.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_edit.py
@@ -1,72 +1,41 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.edit import Edit
+from komand_palo_alto_pan_os.actions.edit.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.edit import Edit
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestEdit(TestCase):
-    def test_integration_edit(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = Edit()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/edit.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_edit(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "policy",
+                "/config/devices/entry/vsys/entry/rulebase/security/rules/entry[@name='Test Rule']/action",
+                "<action>drop</action>",
+                {"response": {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}}},
+            ],
+            [
+                "address_object",
+                "/config/devices/entry/vsys/entry/address/entry[@name='example.com']/tag",
+                "<tag><member>test</member></tag>",
+                {"response": {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}}},
+            ],
+            [
+                "address_group",
+                "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Test Group']",
+                "<entry name='Test Group'><static><member>example.com</member><member>IPv6</member></static></entry>",
+                {"response": {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}}},
+            ],
+        ]
+    )
+    def test_edit(self, mock_get, mock_post, name, xpath, element, expected):
+        action = Util.default_connector(Edit())
+        actual = action.run({Input.XPATH: xpath, Input.ELEMENT: element})
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_get.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_get.py
@@ -1,72 +1,212 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.get import Get
+from komand_palo_alto_pan_os.actions.get.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.get import Get
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
 class TestGet(TestCase):
-    def test_integration_get(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = Get()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/get.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_get(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "address_object",
+                "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address/entry[@name='1.1.1.1']",
+                {
+                    "response": {
+                        "@status": "success",
+                        "@code": "19",
+                        "result": {
+                            "@total-count": "1",
+                            "@count": "1",
+                            "entry": {
+                                "@name": "1.1.1.1",
+                                "ip-netmask": "1.1.1.1",
+                                "description": "Example Description",
+                            },
+                        },
+                    }
+                },
+            ],
+            [
+                "address_group",
+                "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Test Group']",
+                {
+                    "response": {
+                        "@status": "success",
+                        "@code": "19",
+                        "result": {
+                            "@total-count": "1",
+                            "@count": "1",
+                            "entry": {
+                                "@name": "Test Group",
+                                "@admin": "admin",
+                                "@dirtyId": "144",
+                                "@time": "2021/12/14 09:43:15",
+                                "static": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "144",
+                                    "@time": "2021/12/14 09:43:15",
+                                    "member": [
+                                        {
+                                            "@admin": "admin",
+                                            "@dirtyId": "144",
+                                            "@time": "2021/12/14 09:43:15",
+                                            "#text": "1.1.1.1",
+                                        },
+                                        {
+                                            "@admin": "admin",
+                                            "@dirtyId": "144",
+                                            "@time": "2021/12/14 09:43:15",
+                                            "#text": "test.com",
+                                        },
+                                        {
+                                            "@admin": "admin",
+                                            "@dirtyId": "144",
+                                            "@time": "2021/12/14 09:43:15",
+                                            "#text": "IPv6",
+                                        },
+                                    ],
+                                },
+                            },
+                        },
+                    }
+                },
+            ],
+            [
+                "policy",
+                "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='Test Rule']",
+                {
+                    "response": {
+                        "@status": "success",
+                        "@code": "19",
+                        "result": {
+                            "@total-count": "1",
+                            "@count": "1",
+                            "entry": {
+                                "@name": "Test Rule",
+                                "@admin": "admin",
+                                "@dirtyId": "145",
+                                "@time": "2021/12/17 08:10:05",
+                                "@uuid": "6783a432-c27a-4bc7-9535-7652ab5a4987",
+                                "to": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "from": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "source": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "destination": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "source-user": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "category": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "application": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "service": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "application-default",
+                                    },
+                                },
+                                "hip-profiles": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "member": {
+                                        "@admin": "admin",
+                                        "@dirtyId": "145",
+                                        "@time": "2021/12/17 08:10:05",
+                                        "#text": "any",
+                                    },
+                                },
+                                "action": {
+                                    "@admin": "admin",
+                                    "@dirtyId": "145",
+                                    "@time": "2021/12/17 08:10:05",
+                                    "#text": "drop",
+                                },
+                            },
+                        },
+                    }
+                },
+            ],
+        ]
+    )
+    def test_get(self, mock_get, name, xpath, expected):
+        action = Util.default_connector(Get())
+        actual = action.run({Input.XPATH: xpath})
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_get_addresses_from_group.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_get_addresses_from_group.py
@@ -1,0 +1,55 @@
+import sys
+import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.get_addresses_from_group import GetAddressesFromGroup
+from komand_palo_alto_pan_os.actions.get_addresses_from_group.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
+from komand.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+class TestGetAddressesFromGroup(TestCase):
+    @parameterized.expand(
+        [
+            [
+                "success",
+                "Test Group",
+                "localhost.localdomain",
+                "vsys1",
+                {
+                    "success": True,
+                    "fqdn_addresses": ["test.com"],
+                    "ipv4_addresses": ["1.1.1.1"],
+                    "ipv6_addresses": ["abcd:123::1"],
+                    "all_addresses": ["1.1.1.1", "test.com", "abcd:123::1"],
+                },
+            ]
+        ]
+    )
+    def test_get_addresses_from_group(self, mock_get, name, group, device_name, virtual_system, expected):
+        action = Util.default_connector(GetAddressesFromGroup())
+        actual = action.run({Input.GROUP: group, Input.DEVICE_NAME: device_name, Input.VIRTUAL_SYSTEM: virtual_system})
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                "invalid_group",
+                "Invalid Group",
+                "localhost.localdomain",
+                "vsys1",
+                "PAN OS returned an unexpected response.",
+                "Could not find group 'Invalid Group', or group was empty. Check the name, virtual system name, and device name.\nDevice name: localhost.localdomain\nVirtual system: vsys1\n",
+            ]
+        ]
+    )
+    def test_get_addresses_from_group_bad(self, mock_get, name, group, device_name, virtual_system, cause, assistance):
+        action = Util.default_connector(GetAddressesFromGroup())
+        with self.assertRaises(PluginException) as e:
+            action.run({Input.GROUP: group, Input.DEVICE_NAME: device_name, Input.VIRTUAL_SYSTEM: virtual_system})
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)

--- a/plugins/palo_alto_pan_os/unit_test/test_get_policy.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_get_policy.py
@@ -1,67 +1,64 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.get_policy import GetPolicy
+from komand_palo_alto_pan_os.actions.get_policy.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
+from komand.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.get_policy import GetPolicy
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
 class TestGetPolicy(TestCase):
-    def test_integration_get_policy(self):
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = GetPolicy()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/get_policy.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        keys = [
-            "to",
-            "from",
-            "source",
-            "destination",
-            "source_user",
-            "category",
-            "application",
-            "service",
-            "hip_profiles",
-            "action",
+    @parameterized.expand(
+        [
+            [
+                "success",
+                "Test Policy",
+                "localhost.localdomain",
+                "vsys1",
+                {
+                    "to": ["any"],
+                    "from": ["any"],
+                    "source": ["any"],
+                    "destination": ["any"],
+                    "source_user": ["Joe Smith"],
+                    "category": ["adult", "abused-drugs"],
+                    "application": ["any"],
+                    "service": ["application-default", "any"],
+                    "hip_profiles": ["any"],
+                    "action": "drop",
+                },
+            ]
         ]
+    )
+    def test_get_policy(self, mock_get, name, policy_name, device_name, virtual_system, expected):
+        action = Util.default_connector(GetPolicy())
+        actual = action.run(
+            {Input.POLICY_NAME: policy_name, Input.DEVICE_NAME: device_name, Input.VIRTUAL_SYSTEM: virtual_system}
+        )
+        self.assertEqual(actual, expected)
 
-        self.assertEquals(list(results.keys()), keys)
-
-    def test_get_policy(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "invalid_policy_name",
+                "Invalid Policy",
+                "localhost.localdomain",
+                "vsys1",
+                "PAN OS returned an unexpected response.",
+                "Could not find policy 'Invalid Policy'. Check the name, virtual system name, and device name.\ndevice name: localhost.localdomain\nvirtual system: vsys1",
+            ]
+        ]
+    )
+    def test_get_policy_bad(self, mock_get, name, policy_name, device_name, virtual_system, cause, assistance):
+        action = Util.default_connector(GetPolicy())
+        with self.assertRaises(PluginException) as e:
+            action.run(
+                {Input.POLICY_NAME: policy_name, Input.DEVICE_NAME: device_name, Input.VIRTUAL_SYSTEM: virtual_system}
+            )
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)

--- a/plugins/palo_alto_pan_os/unit_test/test_op.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_op.py
@@ -1,72 +1,50 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.op import Op
+from komand_palo_alto_pan_os.actions.op.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.op import Op
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
 class TestOp(TestCase):
-    def test_integration_op(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = Op()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/op.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_op(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "show_job",
+                "<show><jobs><id>1</id></jobs></show>",
+                {
+                    "response": {
+                        "@status": "success",
+                        "result": {
+                            "job": {
+                                "tenq": "2021/12/22 10:41:44",
+                                "id": "1",
+                                "type": "Commit",
+                                "status": "FIN",
+                                "stoppable": "no",
+                                "result": "OK",
+                                "tfin": "10:42:22",
+                                "progress": "100",
+                                "details": {"line": "Configuration committed successfully"},
+                                "warnings": None,
+                            }
+                        },
+                    }
+                },
+            ],
+            [
+                "show_commit_locks",
+                "<show><commit-locks/></show>",
+                {"response": {"@status": "success", "result": {"commit-locks": None}}},
+            ],
+        ]
+    )
+    def test_op(self, mock_get, name, cmd, expected):
+        action = Util.default_connector(Op())
+        actual = action.run({Input.CMD: cmd})
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_remove_from_policy.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_remove_from_policy.py
@@ -1,72 +1,170 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.remove_from_policy import RemoveFromPolicy
+from komand_palo_alto_pan_os.actions.remove_from_policy.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
+from komand.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.remove_from_policy import RemoveFromPolicy
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestRemoveFromPolicy(TestCase):
-    def test_integration_remove_from_policy(self):
-        """
-        TODO: Implement assertions at the end of this test case
+    @parameterized.expand(
+        [
+            [
+                "update_active_configuration",
+                "Test Policy",
+                "active",
+                "any",
+                "any",
+                "any",
+                "any",
+                "Example User",
+                "any",
+                "any",
+                "adult",
+                "any",
+                "drop",
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "update_candidate_configuration",
+                "Test Policy",
+                "candidate",
+                "any",
+                "any",
+                "any",
+                "any",
+                "Example User",
+                "any",
+                "any",
+                "adult",
+                "any",
+                "drop",
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "update_candidate_configuration",
+                "Test Policy",
+                "active",
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                None,
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+        ]
+    )
+    def test_remove_from_policy(
+        self,
+        mock_get,
+        mock_post,
+        name,
+        rule_name,
+        update_active_or_candidate_configuration,
+        source,
+        destination,
+        service,
+        application,
+        source_user,
+        src_zone,
+        dst_zone,
+        url_category,
+        hip_profiles,
+        new_action,
+        expected,
+    ):
+        action = Util.default_connector(RemoveFromPolicy())
+        actual = action.run(
+            {
+                Input.RULE_NAME: rule_name,
+                Input.UPDATE_ACTIVE_OR_CANDIDATE_CONFIGURATION: update_active_or_candidate_configuration,
+                Input.SOURCE: source,
+                Input.DESTINATION: destination,
+                Input.SERVICE: service,
+                Input.APPLICATION: application,
+                Input.SOURCE_USER: source_user,
+                Input.SRC_ZONE: src_zone,
+                Input.DST_ZONE: dst_zone,
+                Input.URL_CATEGORY: url_category,
+                Input.HIP_PROFILES: hip_profiles,
+                Input.ACTION: new_action,
+            }
+        )
+        self.assertEqual(actual, expected)
 
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = RemoveFromPolicy()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/remove_from_policy.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_remove_from_policy(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "invalid_rule_name",
+                "Invalid Rule Name",
+                "active",
+                "any",
+                "any",
+                "any",
+                "any",
+                "Example User",
+                "any",
+                "any",
+                "adult",
+                "any",
+                "drop",
+                "PAN-OS returned an error in response to the request.",
+                "Double-check that inputs are valid. Contact support if this issue persists.",
+                '{"line": "No such node"}',
+            ]
+        ]
+    )
+    def test_remove_from_policy_bad(
+        self,
+        mock_get,
+        mock_post,
+        name,
+        rule_name,
+        update_active_or_candidate_configuration,
+        source,
+        destination,
+        service,
+        application,
+        source_user,
+        src_zone,
+        dst_zone,
+        url_category,
+        hip_profiles,
+        new_action,
+        cause,
+        assistance,
+        data,
+    ):
+        action = Util.default_connector(RemoveFromPolicy())
+        with self.assertRaises(PluginException) as e:
+            action.run(
+                {
+                    Input.RULE_NAME: rule_name,
+                    Input.UPDATE_ACTIVE_OR_CANDIDATE_CONFIGURATION: update_active_or_candidate_configuration,
+                    Input.SOURCE: source,
+                    Input.DESTINATION: destination,
+                    Input.SERVICE: service,
+                    Input.APPLICATION: application,
+                    Input.SOURCE_USER: source_user,
+                    Input.SRC_ZONE: src_zone,
+                    Input.DST_ZONE: dst_zone,
+                    Input.URL_CATEGORY: url_category,
+                    Input.HIP_PROFILES: hip_profiles,
+                    Input.ACTION: new_action,
+                }
+            )
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(e.exception.data, data)

--- a/plugins/palo_alto_pan_os/unit_test/test_retrieve_logs.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_retrieve_logs.py
@@ -1,72 +1,194 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.retrieve_logs import RetrieveLogs
+from komand_palo_alto_pan_os.actions.retrieve_logs.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.retrieve_logs import RetrieveLogs
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.get", side_effect=Util.mocked_requests)
 class TestRetrieveLogs(TestCase):
-    def test_integration_retrieve_logs(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = RetrieveLogs()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/retrieve_logs.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_retrieve_logs(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "config",
+                "config",
+                1,
+                0,
+                "receive_time geq '2021/12/22 08:00:00'",
+                0.5,
+                25,
+                "backward",
+                {
+                    "response": {
+                        "logs": {
+                            "@count": "1",
+                            "@progress": "100",
+                            "entry": {
+                                "@logid": "7044309865149235243",
+                                "domain": "1",
+                                "receive_time": "2021/12/22 08:54:51",
+                                "serial": "0000000000000001",
+                                "seqno": "1550",
+                                "actionflags": "0x0",
+                                "is-logging-service": "no",
+                                "type": "CONFIG",
+                                "subtype": "0",
+                                "config_ver": "0",
+                                "time_generated": "2021/12/22 08:54:51",
+                                "dg_hier_level_1": "0",
+                                "dg_hier_level_2": "0",
+                                "dg_hier_level_3": "0",
+                                "dg_hier_level_4": "0",
+                                "device_name": "TEST",
+                                "vsys_id": "0",
+                                "host": "198.51.100.100",
+                                "cmd": "delete",
+                                "admin": "admin",
+                                "client": "Web",
+                                "result": "Succeeded",
+                                "path": "vsys  vsys1 external-list  Test Domain List",
+                                "dg_id": "0",
+                                "full-path": "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/external-list/entry[@name='Test Domain List']",
+                            },
+                        }
+                    }
+                },
+            ],
+            [
+                "system",
+                "system",
+                1,
+                0,
+                "receive_time geq '2021/12/22 08:00:00'",
+                0.5,
+                25,
+                "forward",
+                {
+                    "response": {
+                        "logs": {
+                            "@count": "1",
+                            "@progress": "100",
+                            "entry": {
+                                "@logid": "7044309865149247490",
+                                "domain": "1",
+                                "receive_time": "2021/12/22 08:00:12",
+                                "serial": "000000000000002",
+                                "seqno": "8144908",
+                                "actionflags": "0x0",
+                                "is-logging-service": "no",
+                                "type": "SYSTEM",
+                                "subtype": "syslog",
+                                "config_ver": "0",
+                                "time_generated": "2021/12/22 08:00:12",
+                                "dg_hier_level_1": "0",
+                                "dg_hier_level_2": "0",
+                                "dg_hier_level_3": "0",
+                                "dg_hier_level_4": "0",
+                                "device_name": "TEST",
+                                "vsys_id": "0",
+                                "eventid": "syslog-conn-status",
+                                "fmt": "0",
+                                "id": "0",
+                                "module": "mgmt",
+                                "severity": "high",
+                                "opaque": "Syslog connection failed to server['TEST']",
+                            },
+                        }
+                    }
+                },
+            ],
+            [
+                "threat",
+                "threat",
+                1,
+                0,
+                "receive_time geq '2021/12/22 08:00:00'",
+                0.5,
+                25,
+                "forward",
+                {
+                    "response": {
+                        "logs": {
+                            "@count": "1",
+                            "@progress": "100",
+                            "entry": {
+                                "@logid": "191242123113213",
+                                "domain": "1",
+                                "receive_time": "2021/12/22 12:50:24",
+                                "serial": "000000000000003",
+                                "seqno": "8210416",
+                                "actionflags": "0x0",
+                                "type": "THREAT",
+                                "subtype": "vulnerability",
+                                "config_ver": "1",
+                                "time_generated": "2021/12/22 10:50:24",
+                                "src": "xxx.xxx.xxx.xxx",
+                                "dst": "xxx.xxx.xxx.xxx",
+                                "rule": "CorporationHQ",
+                                "srcloc": "United States",
+                                "dstloc": "xxx.xxx.xxx.xxx-xxx.xxx.xxx.xxx",
+                                "app": "smtp",
+                                "vsys": "vsys1",
+                                "from": "trust",
+                                "to": "trust",
+                                "inbound_if": "ethernet1/5",
+                                "outbound_if": "ethernet1/6",
+                                "logset": "Logs",
+                                "time_received": "2021/12/22 12:50:24",
+                                "sessionid": "135193",
+                                "repeatcnt": "1",
+                                "sport": "52252",
+                                "dport": "25",
+                                "action": "reset-both",
+                                "dg_hier_level_1": "11",
+                                "dg_hier_level_2": "0",
+                                "dg_hier_level_3": "0",
+                                "dg_hier_level_4": "0",
+                                "device_name": "TEST",
+                                "vsys_id": "1",
+                                "threatid": "User Login Brute Force Attempt",
+                                "tid": "0",
+                                "reportid": "0",
+                                "category": "any",
+                                "severity": "high",
+                                "direction": "client-to-server",
+                            },
+                        }
+                    }
+                },
+            ],
+            [
+                "traffic_empty",
+                "traffic",
+                1,
+                None,
+                None,
+                None,
+                10,
+                None,
+                {"response": {"logs": {"@count": "0", "@progress": "100"}}},
+            ],
+        ]
+    )
+    def test_retrieve_logs(
+        self, mock_get, mock_get2, name, log_type, count, skip, query_filter, interval, max_tries, direction, expected
+    ):
+        action = Util.default_connector(RetrieveLogs())
+        actual = action.run(
+            {
+                Input.LOG_TYPE: log_type,
+                Input.COUNT: count,
+                Input.SKIP: skip,
+                Input.FILTER: query_filter,
+                Input.INTERVAL: interval,
+                Input.MAX_TRIES: max_tries,
+                Input.DIRECTION: direction,
+            }
+        )
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_set.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_set.py
@@ -1,72 +1,41 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.set import Set
+from komand_palo_alto_pan_os.actions.set.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.set import Set
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestSet(TestCase):
-    def test_integration_set(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = Set()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/set.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_set(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "policy",
+                "/config/devices/entry/vsys/entry/rulebase/security/rules/entry[@name='Test Rule']",
+                "<category><member>adult</member></category><action>drop</action>",
+                {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}},
+            ],
+            [
+                "address_object",
+                "/config/devices/entry/vsys/entry/address/entry[@name='example.com']",
+                "<fqdn>example.com</fqdn><description>Test</description><tag><member>test</member></tag>",
+                {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}},
+            ],
+            [
+                "address_group",
+                "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Test Group']",
+                "<static><member>example.com</member></static>",
+                {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}},
+            ],
+        ]
+    )
+    def test_set(self, mock_get, mock_post, name, xpath, element, expected):
+        action = Util.default_connector(Set())
+        actual = action.run({Input.XPATH: xpath, Input.ELEMENT: element})
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_set_address_object.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_set_address_object.py
@@ -1,48 +1,215 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.set_address_object import SetAddressObject
+from komand_palo_alto_pan_os.actions.set_address_object.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
+from komand.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.set_address_object import SetAddressObject
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestSetAddressObject(TestCase):
-    def test_integration_set_address_object(self):
-        log = logging.getLogger("Test")
-        test_conn = Connection()
+    @parameterized.expand(
+        [
+            [
+                "domain",
+                "example.com",
+                "Domain",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "domain_whitelisted",
+                "example.com",
+                "Domain Whitelisted",
+                "Test",
+                "test",
+                False,
+                ["example.com"],
+                {"message": "Address object matched whitelist.", "status": "error", "code": ""},
+            ],
+            [
+                "ipv4",
+                "198.51.100.1",
+                "IPv4",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "ipv4_cidr",
+                "198.51.100.1/32",
+                "IPv4 CIDR",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "ipv4_range",
+                "198.51.100.1-198.51.100.2",
+                "IPv4 Range",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "ipv4_private",
+                "192.168.0.0",
+                "IPv4 Private",
+                "Test",
+                "test",
+                True,
+                [],
+                {"message": "Address object was RFC 1918 (private).", "status": "error", "code": ""},
+            ],
+            [
+                "ipv4_whitelisted",
+                "198.51.100.1",
+                "IPv4 Whitelisted",
+                "Test",
+                "test",
+                False,
+                ["198.51.100.1"],
+                {"message": "Address object matched whitelist.", "status": "error", "code": ""},
+            ],
+            [
+                "ipv6",
+                "abcd:123:4::1",
+                "IPv6",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "ipv6_cidr",
+                "abcd:123:4::1/128",
+                "IPv6 CIDR",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "ipv6_range",
+                "abcd:123:4::1-abcd:123:4::2",
+                "IPv6 Range",
+                "Test",
+                "test",
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+            [
+                "ipv6_private",
+                "fd12:3456:789a:1::1",
+                "IPv6 Private",
+                "Test",
+                "test",
+                True,
+                [],
+                {"message": "Address object was RFC 1918 (private).", "status": "error", "code": ""},
+            ],
+            [
+                "ipv6_whitelisted",
+                "abcd:123:4::1",
+                "IPv6 Whitelisted",
+                "Test",
+                "test",
+                False,
+                ["abcd:123:4::1"],
+                {"message": "Address object matched whitelist.", "status": "error", "code": ""},
+            ],
+            [
+                "without_description_and_tags",
+                "example.com",
+                "Domain",
+                None,
+                None,
+                False,
+                [],
+                {"message": "command succeeded", "status": "success", "code": "20"},
+            ],
+        ]
+    )
+    def test_set_address_object(
+        self, mock_get, mock_post, name, address, address_object, description, tags, skip_rfc1918, whitelist, expected
+    ):
+        action = Util.default_connector(SetAddressObject())
+        actual = action.run(
+            {
+                Input.ADDRESS: address,
+                Input.ADDRESS_OBJECT: address_object,
+                Input.DESCRIPTION: description,
+                Input.TAGS: tags,
+                Input.SKIP_RFC1918: skip_rfc1918,
+                Input.WHITELIST: whitelist,
+            }
+        )
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                "invalid_address",
+                "test",
+                "Invalid Address",
+                "Test",
+                "test",
+                False,
+                [],
+                "Unable to determine type for the given address: test.",
+                "Please provide a valid address.",
+            ],
+        ]
+    )
+    def test_set_address_object_bad(
+        self,
+        mock_get,
+        mock_post,
+        name,
+        address,
+        address_object,
+        description,
+        tags,
+        skip_rfc1918,
+        whitelist,
+        cause,
+        assistance,
+    ):
+        action = Util.default_connector(SetAddressObject())
+        with self.assertRaises(PluginException) as e:
+            action.run(
+                {
+                    Input.ADDRESS: address,
+                    Input.ADDRESS_OBJECT: address_object,
+                    Input.DESCRIPTION: description,
+                    Input.TAGS: tags,
+                    Input.SKIP_RFC1918: skip_rfc1918,
+                    Input.WHITELIST: whitelist,
+                }
+            )
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+
+    def test_in_whitelist(self, mock_get, mock_post):
         test_action = SetAddressObject()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/set_address_object.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        self.assertIsNotNone(results)
-        self.assertEquals({"code": "20", "message": "command succeeded", "status": "success"}, results)
-
-    def test_in_whitelist(self):
-        test_action = SetAddressObject()
-        test_action.logger = logging.getLogger("test")
 
         self.assertTrue(test_action.match_whitelist("1.1.1.1", ["1.1.1.1/32"], "ip-netmask"))
         self.assertTrue(test_action.match_whitelist("1.1.1.1/32", ["1.1.1.1/32"], "ip-netmask"))
@@ -59,35 +226,31 @@ class TestSetAddressObject(TestCase):
         self.assertTrue(test_action.match_whitelist("1.1.1.1", ["1.1.1.1"], "ip-range"))
         self.assertFalse(test_action.match_whitelist("1.1.1.1/24", ["1.1.1.1"], "ip-range"))
 
-    def test_cidr_vs_cidr_in_whitelis(self):
+    def test_cidr_vs_cidr_in_whitelist(self, mock_get, mock_post):
         test_action = SetAddressObject()
-        test_action.logger = logging.getLogger("test")
 
         self.assertTrue(test_action.match_whitelist("1.1.1.1/24", ["1.1.1.1", "1.1.1.1/24"], "ip-netmask"))
         self.assertTrue(test_action.match_whitelist("1.1.1.1", ["1.1.1.1/24"], "ip-netmask"))
         self.assertFalse(test_action.match_whitelist("1.1.1.1/24", ["1.1.1.1", "1.1.1.1/32"], "ip-netmask"))
 
-    def test_get_address_type(self):
+    def test_get_address_type(self, mock_get, mock_post):
         test_action = SetAddressObject()
-        test_action.logger = logging.getLogger("test")
 
-        self.assertEquals(test_action.determine_address_type("1.1.1.1"), "ip-netmask")
-        self.assertEquals(test_action.determine_address_type("1.1.1.1/32"), "ip-netmask")
-        self.assertEquals(test_action.determine_address_type("www.google.com"), "fqdn")
-        self.assertEquals(test_action.determine_address_type("10.1.1.1-10.1.1.255"), "ip-range")
-        self.assertEquals(test_action.determine_address_type("1:2:3:4:5:6:7:8"), "ip-netmask")
-        self.assertEquals(
+        self.assertEqual(test_action.determine_address_type("1.1.1.1"), "ip-netmask")
+        self.assertEqual(test_action.determine_address_type("1.1.1.1/32"), "ip-netmask")
+        self.assertEqual(test_action.determine_address_type("www.google.com"), "fqdn")
+        self.assertEqual(test_action.determine_address_type("10.1.1.1-10.1.1.255"), "ip-range")
+        self.assertEqual(test_action.determine_address_type("1:2:3:4:5:6:7:8"), "ip-netmask")
+        self.assertEqual(
             test_action.determine_address_type("2001:0db8:85a3:0000:0000:8a2e:0370:7334"),
             "ip-netmask",
         )
 
-    def test_check_if_private(self):
+    def test_check_if_private(self, mock_get, mock_post):
         test_action = SetAddressObject()
-        test_action.logger = logging.getLogger("test")
 
         self.assertTrue(test_action.check_if_private("192.168.1.1"))
         self.assertTrue(test_action.check_if_private("192.168.1.1/32"))
-        self.assertTrue(test_action.check_if_private("FE80::903A:1C1A:E802:11E4"))
-        self.assertFalse(test_action.check_if_private("www.google.com"))
+        self.assertTrue(test_action.check_if_private("fd12:3456:789a:1aa2:22b::1"))
+        self.assertTrue(test_action.check_if_private("192.168.1.1-192.168.1.100"))
         self.assertFalse(test_action.check_if_private("1.1.1.1"))
-        self.assertFalse(test_action.check_if_private("192.168.1.1-192.168.1.100"))

--- a/plugins/palo_alto_pan_os/unit_test/test_set_security_policy_rule.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_set_security_policy_rule.py
@@ -1,72 +1,104 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.set_security_policy_rule import SetSecurityPolicyRule
+from komand_palo_alto_pan_os.actions.set_security_policy_rule.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.set_security_policy_rule import SetSecurityPolicyRule
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
 class TestSetSecurityPolicyRule(TestCase):
-    def test_integration_set_security_policy_rule(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = SetSecurityPolicyRule()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/set_security_policy_rule.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_set_security_policy_rule(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "test_policy_1",
+                "Test Policy 1",
+                "any",
+                "any",
+                "any",
+                "any",
+                "drop",
+                "Example User",
+                False,
+                False,
+                False,
+                False,
+                False,
+                False,
+                "Test Rule",
+                "any",
+                "any",
+                {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}},
+            ],
+            [
+                "test_policy_2",
+                "Test Policy 2",
+                "198.51.100.1",
+                "198.51.100.2",
+                "any",
+                "8x8",
+                "deny",
+                "Example User",
+                True,
+                True,
+                True,
+                True,
+                True,
+                True,
+                "Test Rule",
+                "any",
+                "any",
+                {"response": {"@status": "success", "@code": "20", "msg": "command succeeded"}},
+            ],
+        ]
+    )
+    def test_set_security_policy_rule(
+        self,
+        mock_get,
+        mock_post,
+        name,
+        rule_name,
+        source,
+        destination,
+        service,
+        application,
+        policy_action,
+        source_user,
+        disable_server_response_inspection,
+        negate_source,
+        negate_destination,
+        disabled,
+        log_start,
+        log_end,
+        description,
+        src_zone,
+        dst_zone,
+        expected,
+    ):
+        action = Util.default_connector(SetSecurityPolicyRule())
+        actual = action.run(
+            {
+                Input.RULE_NAME: rule_name,
+                Input.SOURCE: source,
+                Input.DESTINATION: destination,
+                Input.SERVICE: service,
+                Input.APPLICATION: application,
+                Input.ACTION: policy_action,
+                Input.SOURCE_USER: source_user,
+                Input.DISABLE_SERVER_RESPONSE_INSPECTION: disable_server_response_inspection,
+                Input.NEGATE_SOURCE: negate_source,
+                Input.NEGATE_DESTINATION: negate_destination,
+                Input.DISABLED: disabled,
+                Input.LOG_START: log_start,
+                Input.LOG_END: log_end,
+                Input.DESCRIPTION: description,
+                Input.SRC_ZONE: src_zone,
+                Input.DST_ZONE: dst_zone,
+            }
+        )
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/test_show.py
+++ b/plugins/palo_alto_pan_os/unit_test/test_show.py
@@ -1,72 +1,59 @@
 import sys
 import os
+from unittest import TestCase
+from komand_palo_alto_pan_os.actions.show import Show
+from komand_palo_alto_pan_os.actions.show.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase
-from komand_palo_alto_pan_os.connection.connection import Connection
-from komand_palo_alto_pan_os.actions.show import Show
-import json
-import logging
 
-
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
 class TestShow(TestCase):
-    def test_integration_show(self):
-        """
-        TODO: Implement assertions at the end of this test case
-
-        This is an integration test that will connect to the services your plugin uses. It should be used
-        as the basis for tests below that can run independent of a "live" connection.
-
-        This test assumes a normal plugin structure with a /tests directory. In that /tests directory should
-        be json samples that contain all the data needed to run this test. To generate samples run:
-
-        icon-plugin generate samples
-
-        """
-
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = Show()
-
-        test_conn.logger = log
-        test_action.logger = log
-
-        try:
-            with open("../tests/show.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = """
-            Could not find or read sample tests from /tests directory
-            
-            An exception here likely means you didn't fill out your samples correctly in the /tests directory 
-            Please use 'icon-plugin generate samples', and fill out the resulting test files in the /tests directory
-            """
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-
-        # TODO: Remove this line
-        self.fail("Unimplemented test case")
-
-        # TODO: The following assert should be updated to look for data from your action
-        # For example: self.assertEquals({"success": True}, results)
-        self.assertEquals({}, results)
-
-    def test_show(self):
-        """
-        TODO: Implement test cases here
-
-        Here you can mock the connection with data returned from the above integration test.
-        For information on mocking and unit testing please go here:
-
-        https://docs.google.com/document/d/1PifePDG1-mBcmNYE8dULwGxJimiRBrax5BIDG_0TFQI/edit?usp=sharing
-
-        You can either create a formal Mock for this, or you can create a fake connection class to pass to your
-        action for testing.
-        """
-        self.fail("Unimplemented Test Case")
+    @parameterized.expand(
+        [
+            [
+                "address_group",
+                "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Test Group']",
+                {
+                    "response": {
+                        "@status": "success",
+                        "result": {
+                            "entry": {"@name": "Test Group", "static": {"member": ["example.com", "1.1.1.1", "IPv6"]}}
+                        },
+                    }
+                },
+            ],
+            [
+                "policy",
+                "/config/devices/entry/vsys/entry/rulebase/security/rules/entry[@name='Test Policy']",
+                {
+                    "response": {
+                        "@status": "success",
+                        "result": {
+                            "entry": {
+                                "@name": "Test Policy",
+                                "@uuid": "290ba776-4bd0-49b2-8c20-a35467b22c11",
+                                "to": {"member": "any"},
+                                "from": {"member": "any"},
+                                "source": {"member": "any"},
+                                "destination": {"member": "any"},
+                                "service": {"member": ["application-default", "any"]},
+                                "application": {"member": "any"},
+                                "category": {"member": ["adult", "abused-drugs"]},
+                                "hip-profiles": {"member": "any"},
+                                "source-user": {"member": "Joe Smith"},
+                                "action": "drop",
+                            }
+                        },
+                    }
+                },
+            ],
+        ]
+    )
+    def test_show(self, mock_get, name, xpath, expected):
+        action = Util.default_connector(Show())
+        actual = action.run({Input.XPATH: xpath})
+        self.assertEqual(actual, expected)

--- a/plugins/palo_alto_pan_os/unit_test/util.py
+++ b/plugins/palo_alto_pan_os/unit_test/util.py
@@ -1,0 +1,150 @@
+import logging
+import os
+from komand_palo_alto_pan_os.connection.connection import Connection
+from komand_palo_alto_pan_os.connection.schema import Input
+
+
+class Util:
+    @staticmethod
+    def default_connector(action, connect_params: object = None):
+        default_connection = Connection()
+        default_connection.logger = logging.getLogger("connection logger")
+        if connect_params:
+            params = connect_params
+        else:
+            params = {
+                Input.SERVER: "https://example.com",
+                Input.CREDENTIALS: {"password": "password", "username": "user"},
+                Input.VERIFY_CERT: True,
+            }
+        default_connection.connect(params)
+        action.connection = default_connection
+        action.logger = logging.getLogger("action logger")
+        return action
+
+    @staticmethod
+    def read_file_to_string(filename):
+        with open(filename) as my_file:
+            return my_file.read()
+
+    @staticmethod
+    def mocked_requests(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, filename, status_code):
+                self.filename = filename
+                self.status_code = status_code
+                self.text = self.load_data()
+
+            def load_data(self):
+                return Util.read_file_to_string(
+                    os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{self.filename}.resp")
+                )
+
+        params = kwargs.get("params", {})
+        job_id = params.get("job-id")
+        log_type = params.get("log-type")
+        element = params.get("element")
+        action = params.get("action")
+        xpath = params.get("xpath")
+        cmd = params.get("cmd")
+
+        if params == {"type": "keygen", "user": "user", "password": "password"}:
+            return MockResponse("key", 200)
+        if log_type == "config":
+            return MockResponse("get_job_id", 200)
+        if log_type == "system":
+            return MockResponse("get_job_id2", 200)
+        if log_type == "threat":
+            return MockResponse("get_job_id3", 200)
+        if log_type == "traffic":
+            return MockResponse("get_job_id4", 200)
+        if job_id == "1":
+            return MockResponse("get_config_logs", 200)
+        if job_id == "2":
+            return MockResponse("get_system_logs", 200)
+        if job_id == "3":
+            return MockResponse("get_threat_logs", 200)
+        if job_id == "4":
+            return MockResponse("get_traffic_logs", 200)
+        if cmd == "<commit></commit>":
+            return MockResponse("commit", 200)
+        if cmd == "<commit><partial><admin><member>admin-name</member></admin></partial></commit>":
+            return MockResponse("commit2", 200)
+        if cmd == "<show><jobs><id>1</id></jobs></show>":
+            return MockResponse("op", 200)
+        if cmd == "<show><commit-locks/></show>":
+            return MockResponse("op2", 200)
+        if (
+            action == "get"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address/entry[@name='1.1.1.1']"
+        ):
+            return MockResponse("get_object_ipv4", 200)
+        if (
+            action == "get"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address/entry[@name='IPv6']"
+        ):
+            return MockResponse("get_object_ipv6", 200)
+        if (
+            action == "get"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address/entry[@name='test.com']"
+        ):
+            return MockResponse("get_object_domain", 200)
+        if (
+            action == "get"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Test Group']"
+        ):
+            return MockResponse("get_objects_from_group", 200)
+        if (
+            action == "get"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Invalid Group']"
+        ):
+            return MockResponse("get_objects_from_group_bad", 200)
+        if (
+            action == "show"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/address-group/entry[@name='Test Group']"
+        ):
+            return MockResponse("show_group", 200)
+        if (
+            action == "get"
+            and xpath
+            == '/config/devices/entry[@name="localhost.localdomain"]/vsys/entry[@name="vsys1"]/rulebase/security/rules/entry[@name="Test Policy"]'
+        ):
+            return MockResponse("get_policy", 200)
+        if (
+            action == "get"
+            and xpath
+            == "/config/devices/entry[@name='localhost.localdomain']/vsys/entry[@name='vsys1']/rulebase/security/rules/entry[@name='Test Rule']"
+        ):
+            return MockResponse("get_policy2", 200)
+        if (
+            action == "get"
+            and xpath
+            == '/config/devices/entry[@name="localhost.localdomain"]/vsys/entry[@name="vsys1"]/rulebase/security/rules/entry[@name="Invalid Policy"]'
+        ):
+            return MockResponse("get_policy_bad", 200)
+        if (
+            action in ["get", "show"]
+            and xpath == "/config/devices/entry/vsys/entry/rulebase/security/rules/entry[@name='Test Policy']"
+        ):
+            return MockResponse("get_policy", 200)
+        if (
+            action in ["get", "show"]
+            and xpath == "/config/devices/entry/vsys/entry/rulebase/security/rules/entry[@name='Invalid Rule Name']"
+        ):
+            return MockResponse("invalid_rule_name", 200)
+        if (
+            action == "edit"
+            and element
+            == '<entry name="Test Policy"><to><member>any</member></to><from><member>any</member></from><source><member>any</member></source><destination><member>any</member></destination><service><member>application-default</member><member>any</member></service><application><member>any</member></application><category><member>adult</member><member>abused-drugs</member><member>test1</member></category><hip-profiles><member>any</member></hip-profiles><source-user><member>Joe Smith</member></source-user><action>drop</action></entry>'
+        ):
+            return MockResponse("invalid_url_category_parameter", 200)
+        if action in ["edit", "set", "delete"]:
+            return MockResponse("successful", 200)
+
+        raise Exception("Not implemented")

--- a/plugins/palo_alto_pan_os/unit_test/util.py
+++ b/plugins/palo_alto_pan_os/unit_test/util.py
@@ -1,22 +1,22 @@
 import logging
+import sys
 import os
 from komand_palo_alto_pan_os.connection.connection import Connection
 from komand_palo_alto_pan_os.connection.schema import Input
 
+sys.path.append(os.path.abspath("../"))
+
 
 class Util:
     @staticmethod
-    def default_connector(action, connect_params: object = None):
+    def default_connector(action):
         default_connection = Connection()
         default_connection.logger = logging.getLogger("connection logger")
-        if connect_params:
-            params = connect_params
-        else:
-            params = {
-                Input.SERVER: "https://example.com",
-                Input.CREDENTIALS: {"password": "password", "username": "user"},
-                Input.VERIFY_CERT: True,
-            }
+        params = {
+            Input.SERVER: "https://example.com",
+            Input.CREDENTIALS: {"password": "password", "username": "user"},
+            Input.VERIFY_CERT: True,
+        }
         default_connection.connect(params)
         action.connection = default_connection
         action.logger = logging.getLogger("action logger")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix `check_if_private` method in Set Address Object action
  - Improve `determine_address_type` method in Set Address Object action
  - Fix issue where Add External Dynamic List action fails when `repeat` input has been set to retrieve updates from list weekly
  - Add example for `filter` input for Retrieve Logs action

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_domain.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv4.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv4_cidr.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "",
      "message": "Address object was RFC 1918 (private).",
      "status": "error"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv4_private.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv4_range.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv6.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv6_cidr.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "",
      "message": "Address object was RFC 1918 (private).",
      "status": "error"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv6_private.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "code": "20",
      "message": "command succeeded",
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug run < tests/set_address_object_ipv6_range.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[596]: https://www.example.com/test.txt
violation: plugin.spec.yaml[599]: https://www.example.com/test.txt
violation: help.md[1023]: https://www.example.com/test.txt|None|https://www.example.com/test.txt|
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed! 
	Cause: Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 146993.53300000002ms
```

<summary>
icon-validate --all .
</summary>
</details>

Autogenerate with:
<details>

```
{
  "body": {
    "log": "Connect: Connecting..\nKey obtained\nrapid7/Palo Alto https://example.com Step name: set_address_object\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_pan_os:6.1.3 --debug test < tests/set_address_object_domain.json
</summary>
</details>

