### PR TITLE
Fix Workflow Validator GitHub Action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
       env: 
         PACKAGE_CLOUD_TOKEN: ${{ secrets.CI_PACKAGECLOUD_TOKEN }}
       run: |
-        python -m pip install --upgrade pip setuptools
+        python -m pip install --upgrade pip setuptools wheel
         curl -s "https://${PACKAGE_CLOUD_TOKEN}@packagecloud.io/install/repositories/rapid7/insightconnect_internal_python_tooling/script.python.sh" | bash
         python -m pip install --user icon-integrations-ci --no-warn-script-location
         export ICON_INTEGRATIONS_RELEASES_SLACK_WEBHOOK=${{ secrets.ICON_INTEGRATIONS_RELEASES_SLACK_WEBHOOK }}


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Installs/upgrades `wheel` as part of the GitHub Action for plugin validation where it could fail with certain package dependencies. 

- Fixes issues like this one: https://github.com/rapid7/insightconnect-plugins/runs/4599365700?check_suite_focus=true