### PR TITLE
[MC-650] Add Quarantine Host action in FireEye HX plugin

### DIFF
--- a/plugins/fireeye_hx/icon_fireeye_hx/actions/quarantine_host/action.py
+++ b/plugins/fireeye_hx/icon_fireeye_hx/actions/quarantine_host/action.py
@@ -14,5 +14,4 @@ class QuarantineHost(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        # TODO: Implement run function
-        return {}
+        return {Output.SUCCESS: self.connection.api.quarantine_host(params.get(Input.AGENT_ID))}

--- a/plugins/fireeye_hx/unit_test/payloads/get_containment_state.json.resp
+++ b/plugins/fireeye_hx/unit_test/payloads/get_containment_state.json.resp
@@ -1,0 +1,26 @@
+{
+  "details": [],
+  "route": "/hx/api/v3/hosts/agent_id/containment",
+  "data": {
+    "_id": "1111111111",
+    "last_sysinfo": "2022-01-05T04:14:47.419Z",
+    "requested_by_actor": {
+      "_id": 1000,
+      "username": "admin"
+    },
+    "requested_on": "2022-01-05T16:56:52.718Z",
+    "contained_by_actor": {
+      "_id": 1000,
+      "username": "admin"
+    },
+    "contained_on": "2022-01-05T16:56:52.718Z",
+    "queued": true,
+    "excluded": false,
+    "missing_software": false,
+    "reported_clone": false,
+    "state": "uncontaining",
+    "state_update_time": "2022-01-05T17:11:03.276Z",
+    "url": "/hx/api/v3/hosts/1111111111"
+  },
+  "message": "OK"
+}

--- a/plugins/fireeye_hx/unit_test/test_quarantine_host.py
+++ b/plugins/fireeye_hx/unit_test/test_quarantine_host.py
@@ -1,0 +1,58 @@
+import sys
+import os
+
+from unittest import TestCase
+from icon_fireeye_hx.actions.quarantine_host import QuarantineHost
+from icon_fireeye_hx.actions.quarantine_host.schema import Input, Output
+from unit_test.util import Util
+from unittest.mock import patch
+from parameterized import parameterized
+from komand.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+
+@patch("requests.sessions.Session.request", side_effect=Util.mocked_requests)
+class TestQuarantineHost(TestCase):
+    @classmethod
+    def setUp(cls) -> None:
+        cls.action = Util.default_connector(QuarantineHost())
+
+    @parameterized.expand(
+        [
+            [
+                "success",
+                "1111111111",
+                {"success": True},
+            ]
+        ]
+    )
+    def test_quarantine_host(self, mock_request, name, host_id, expected):
+        actual = self.action.run(
+            {
+                Input.AGENT_ID: host_id,
+            }
+        )
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                "host_not_found",
+                "invalid_host_id",
+                "Invalid or unreachable endpoint provided.",
+                "Verify the endpoint/URL/hostname configured in your plugin connection is correct.",
+                '{"message": "Not Found"}',
+            ]
+        ]
+    )
+    def test_quarantine_host_bad(self, mock_request, name, host_id, cause, assistance, data):
+        with self.assertRaises(PluginException) as e:
+            self.action.run(
+                {
+                    Input.AGENT_ID: host_id,
+                }
+            )
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(e.exception.data, data)

--- a/plugins/fireeye_hx/unit_test/test_quarantine_host.py
+++ b/plugins/fireeye_hx/unit_test/test_quarantine_host.py
@@ -7,7 +7,7 @@ from icon_fireeye_hx.actions.quarantine_host.schema import Input, Output
 from unit_test.util import Util
 from unittest.mock import patch
 from parameterized import parameterized
-from komand.exceptions import PluginException
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Add Quarantine Host action

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)


## Assessment
### Run

<details>

```
{
  "body": {
    "log": "rapid7/FireEye https://example.com Step name: get_host_id_from_hostname\n",
    "meta": {},
    "output": {
      "host_id": "44d88612fea8a8f36de82e",
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/fireeye_hx:2.0.0 --debug run < tests/get_host_id_from_hostname.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/FireEye https://example.com Step name: quarantine_host\n",
    "meta": {},
    "output": {
      "success": true
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/fireeye_hx:2.0.0 --debug run < tests/quarantine_host.json
</summary>
</details>

### Test

Autogenerate with:
<details>

```
{
  "body": {
    "log": "rapid7/FireEye https://example.com Step name: get_host_id_from_hostname\n",
    "meta": {},
    "output": {
      "status": "success"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/fireeye_hx:2.0.0 --debug test < tests/get_host_id_from_hostname.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
WARNING: Use of 'PluginException' or 'ConnectionTestException' is recommended when raising an exception.
violation: icon_fireeye_hx/actions/get_alerts_by_host_id/action.py: line,  38
violation: icon_fireeye_hx/actions/get_alerts_by_host_id/action.py: line,  41
violation: icon_fireeye_hx/actions/get_alerts_by_host_id/action.py: line,  45
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[400]: https://test.fireeye.com
[*] Plugin successfully validated!

----
[*] Total time elapsed: 40115.912000000004ms
```

<summary>
icon-validate --all .
</summary>
</details>

