### PR TITLE
[MC-524] Add credentials to script in Powershell and Python plugins

### DIFF
--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -1,19 +1,19 @@
 {
-	"spec": "327aa50d8347ef72119c2986125f5ed6",
-	"manifest": "07b7e11a627119d17569c37eb00e9a08",
-	"setup": "69826c42ba677f33dfbf58644f40327b",
+	"spec": "803fff66054e06f6fe30a7a0112c1ebe",
+	"manifest": "d728b40297c6a9ce7677dd860be93016",
+	"setup": "6745c5a358f87740a30482c288a72455",
 	"schemas": [
 		{
 			"identifier": "execute_script/schema.py",
-			"hash": "ab4ddf237c0f067c6286c132fc66ad30"
+			"hash": "c7d92bc1c6d1b32ad7070d9df86f66a3"
 		},
 		{
 			"identifier": "powershell_string/schema.py",
-			"hash": "cec583283bf674c8fc00fc330009a330"
+			"hash": "d00cd36eaa511852447c41aa12a82579"
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "aa968abc2a0dd02d075c5602bc245108"
+			"hash": "49d9a7433894f9f67fb7ce9e4e0f0458"
 		}
 	]
 }

--- a/plugins/powershell/Dockerfile
+++ b/plugins/powershell/Dockerfile
@@ -1,4 +1,4 @@
-FROM komand/python-3-plugin:2
+FROM komand/python-3-37-plugin:3.2
 LABEL organization=komand
 LABEL sdk=python
 LABEL type=plugin
@@ -14,20 +14,39 @@ WORKDIR /python/src
 # Add any package dependencies here
 ENV DEBIAN_FRONTEND noninteractive
 # Kerberos dependencies
-RUN apt-get update && apt-get install -y libffi6 libffi-dev \
+RUN apt-get update && apt-get install -y \
+    apt-transport-https \
+    curl \
     gcc python-dev libkrb5-dev \
-    realmd \
+    git \
+    gnupg \
+    krb5-user \
+    libffi6 libffi-dev \
+    libssl1.1 \
     ntp adcli sssd \
     samba-common \
-    krb5-user
+    software-properties-common \
+    sudo \
+    realmd \
+    wget
+
 # Local PowerShell dependencies
-RUN apt-get install -y apt-transport-https
-RUN curl https://packages.microsoft.com/keys/microsoft.asc | apt-key add -
-RUN echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-debian-jessie-prod jessie main" > /etc/apt/sources.list.d/microsoft.list
-RUN apt-get update && apt-get install -y powershell
-RUN python setup.py build && python setup.py install
+RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" | sudo tee -a /etc/apt/sources.list.d/bionic.list && \
+    apt-cache policy libssl1.0-dev && \
+    sudo apt-get install libssl1.0-dev && \
+    wget http://mirrors.kernel.org/ubuntu/pool/main/i/icu/libicu52_52.1-3ubuntu0.8_amd64.deb && \
+    sudo apt install -y ./libicu52_52.1-3ubuntu0.8_amd64.deb && \
+    rm ./libicu52_52.1-3ubuntu0.8_amd64.deb && \
+    wget https://github.com/PowerShell/PowerShell/releases/download/v7.1.5/powershell_7.1.5-1.debian.9_amd64.deb && \
+    sudo apt install -y ./powershell_7.1.5-1.debian.9_amd64.deb && \
+    rm ./powershell_7.1.5-1.debian.9_amd64.deb
+
+
 # End package dependencies
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 RUN python setup.py build && python setup.py install
+
+# User to run plugin code. The two supported users are: root, nobody
+USER root
 
 ENTRYPOINT ["/usr/local/bin/komand_powershell"]

--- a/plugins/powershell/bin/komand_powershell
+++ b/plugins/powershell/bin/komand_powershell
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "PowerShell"
 Vendor = "rapid7"
-Version = "2.1.4"
+Version = "2.2.0"
 Description = "Run a PowerShell script"
 
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -11,20 +11,39 @@
 * For local Orchestrator execution, ensure connectivity to any network resources the script will use
 * For remote server execution, a PowerShell-enabled server and administrative credentials
 
+# Supported Product Versions
+
+* PowerShell 6.1.2
+
 # Documentation
 
 ## Setup
 
-Check out the [plugin guide](https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/) for more details on how to configure this plugin.
-
 The connection configuration accepts the following parameters:
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|credentials|credential_username_password|None|False|Username and password|None|
-|kerberos|kerberos|None|False|Connection information required for Kerberos|None|
-|port|integer|5986|False|Port number, defaults are 5986 for SSL and 5985 for unencrypted|None|
-|auth|string|None|True|Authentication type|['NTLM', 'Kerberos', 'None', 'CredSSP']|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|auth|string|None|True|Authentication type|['NTLM', 'Kerberos', 'CredSSP', 'None']|Kerberos|
+|credentials|credential_username_password|None|False|Username and password|None|{"username": "user", "password": "mypassword"}|
+|kerberos|kerberos|None|False|Connection information required for Kerberos|None| {"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}|
+|port|integer|5986|False|Port number, defaults are 5986 for SSL and 5985 for unencrypted|None|5986|
+
+Example input:
+
+```
+{
+  "auth": "Kerberos",
+  "credentials": {
+    "username": "user",
+    "password": "mypassword"
+  },
+  "kerberos": {
+    "kdc": "10.0.1.11",
+    "domain": "EXAMPLE.domain"
+  },
+  "port": 5986
+}
+```
 
 ## Technical Details
 
@@ -32,62 +51,172 @@ The connection configuration accepts the following parameters:
 
 #### PowerShell String
 
-This action is used to execute a PowerShell script in the form of a string on a remote host or locally on the Komand host.
+This action is used to execute PowerShell script in the form of a string.
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|script|string|None|True|PowerShell script as a string|None|
-|host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|
-|address|string|None|True|IP address of the remote host e.g. 192.168.1.1|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
+|host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|string|None|True|PowerShell script as a string|None|Get-Date|
+|secret_key|credential_secret_key|None|False|Credential secret key available in script as PowerShell variable (`$secret_key`)|None|{"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"}|
+|username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}|
+
+Example input:
+
+```
+{
+  "address": "10.0.1.17",
+  "host_name": "windows",
+  "script": "Get-Date",
+  "secret_key": {
+    "secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"
+  },
+  "username_and_password": {
+    "username": "user",
+    "password": "mypassword"
+  }
+}
+```
 
 ##### Output
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|stderr|string|False|PowerShell standard error|
-|stdout|string|False|PowerShell standard output|
+|Name|Type|Required|Description|Example|
+|----|----|--------|-----------|--------|
+|stderr|string|False|PowerShell standard error|#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>|
+|stdout|string|False|PowerShell standard output|Tuesday, January 11, 2022 5:05:42 AM|
+
 
 Example output:
 
 ```
-
 {
-  "stdout": "Mr $test  $test2\r\nMr bob  said hello\r\nbob \n  said hello\r\n5\r\ntesting chars in lit string \\ / \\r /r // \\\\ ! @ ## $ %\r\ntesting chars in interpreted string // \\\\ /r/n ! @ ## $\r\n\r\nPath            \r\n----            \r\nC:\\Users\\mhofert\r\nC:\\Users        \r\nC:\\             \r\n\r\n\r\n",
-  "stderr": "#< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><Obj S=\"progress\" RefId=\"0\"><TN RefId=\"0\"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S=\"progress\" RefId=\"1\"><TNRef RefId=\"0\" /><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>"
+  "stdout": "Tuesday, January 11, 2022 5:05:42 AM",
+  "stderr": "#< CLIXML
+            <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+                <Obj S="progress" RefId="0">
+                    <TN RefId="0">
+                        <T>System.Management.Automation.PSCustomObject</T>
+                        <T>System.Object</T>
+                    </TN>
+                    <MS>
+                        <I64 N="SourceId">1</I64>
+                        <PR N="Record">
+                            <AV>Preparing modules for first use.</AV>
+                            <AI>0</AI>
+                            <Nil/>
+                            <PI>-1</PI>
+                            <PC>-1</PC>
+                            <T>Completed</T>
+                            <SR>-1</SR>
+                            <SD> </SD>
+                        </PR>
+                    </MS>
+                </Obj>
+                <Obj S="progress" RefId="1">
+                    <TNRef RefId="0"/>
+                    <MS>
+                        <I64 N="SourceId">1</I64>
+                        <PR N="Record">
+                            <AV>Preparing modules for first use.</AV>
+                            <AI>0</AI>
+                            <Nil/>
+                            <PI>-1</PI>
+                            <PC>-1</PC>
+                            <T>Completed</T>
+                            <SR>-1</SR>
+                            <SD> </SD>
+                        </PR>
+                    </MS>
+                </Obj>
+            </Objs>"
 }
-
 ```
 
 #### Execute Script
 
-This action is used to execute a PowerShell script on a remote host or locally on the Komand host.
+This action is used to execute PowerShell script encoded as a base64 file on a remote host.
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|script|bytes|None|True|PowerShell script as base64|None|
-|host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|
-|address|string|None|True|IP address of the remote host e.g. 192.168.1.1|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
+|host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|bytes|None|True|PowerShell script as base64|None|R2V0LURhdGU=|
+|secret_key|credential_secret_key|None|False|Credential secret key available in script as PowerShell variable (`$secret_key`)|None|{"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"}|
+|username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}|
+
+Example input:
+
+```
+{
+  "address": "10.0.1.15",
+  "host_name": "windows",
+  "script": "R2V0LURhdGU=",
+  "secret_key": {
+    "secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"
+  },
+  "username_and_password": {
+    "username": "user",
+    "password": "mypassword"
+  }
+}
+```
 
 ##### Output
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|stderr|string|False|PowerShell standard error|
-|stdout|string|False|PowerShell standard output|
+|Name|Type|Required|Description|Example|
+|----|----|--------|-----------|--------|
+|stderr|string|False|PowerShell standard error|#< CLIXML\r\n<Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04"><Obj S="progress" RefId="0"><TN RefId="0"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S="progress" RefId="1"><TNRef RefId="0" /><MS><I64 N="SourceId">1</I64><PR N="Record"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>|
+|stdout|string|False|PowerShell standard output|Tuesday, January 11, 2022 5:05:42 AM|
+
 
 Example output:
 
 ```
-
 {
-  "stdout": "Mr $test  $test2\r\nMr bob  said hello\r\nbob \n  said hello\r\n5\r\ntesting chars in lit string \\ / \\r /r // \\\\ ! @ ## $ %\r\ntesting chars in interpreted string // \\\\ /r/n ! @ ## $\r\n\r\nPath            \r\n----            \r\nC:\\Users\\mhofert\r\nC:\\Users        \r\nC:\\             \r\n\r\n\r\n",
-  "stderr": "#< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/PowerShell/2004/04\"><Obj S=\"progress\" RefId=\"0\"><TN RefId=\"0\"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S=\"progress\" RefId=\"1\"><TNRef RefId=\"0\" /><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>"
+  "stdout": "Tuesday, January 11, 2022 5:05:42 AM",
+  "stderr": "#< CLIXML
+            <Objs Version="1.1.0.1" xmlns="http://schemas.microsoft.com/powershell/2004/04">
+                <Obj S="progress" RefId="0">
+                    <TN RefId="0">
+                        <T>System.Management.Automation.PSCustomObject</T>
+                        <T>System.Object</T>
+                    </TN>
+                    <MS>
+                        <I64 N="SourceId">1</I64>
+                        <PR N="Record">
+                            <AV>Preparing modules for first use.</AV>
+                            <AI>0</AI>
+                            <Nil/>
+                            <PI>-1</PI>
+                            <PC>-1</PC>
+                            <T>Completed</T>
+                            <SR>-1</SR>
+                            <SD> </SD>
+                        </PR>
+                    </MS>
+                </Obj>
+                <Obj S="progress" RefId="1">
+                    <TNRef RefId="0"/>
+                    <MS>
+                        <I64 N="SourceId">1</I64>
+                        <PR N="Record">
+                            <AV>Preparing modules for first use.</AV>
+                            <AI>0</AI>
+                            <Nil/>
+                            <PI>-1</PI>
+                            <PC>-1</PC>
+                            <T>Completed</T>
+                            <SR>-1</SR>
+                            <SD> </SD>
+                        </PR>
+                    </MS>
+                </Obj>
+            </Objs>"
 }
-
 ```
 
 ### Triggers
@@ -144,6 +273,7 @@ Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw
 
 # Version History
 
+* 2.2.0 - Add custom credentials in Execute Script and PowerShell String actions
 * 2.1.4 - Update `docs_url` in plugin spec with a new link to [plugin setup guide](https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/)
 * 2.1.3 - Correct spelling in help.md
 * 2.1.2 - Add `docs_url` to plugin spec with link to [plugin setup guide](https://insightconnect.help.rapid7.com/docs/mass-delete-with-powershell)
@@ -167,4 +297,4 @@ Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw
 * [samba-common](https://packages.debian.org/sid/samba-common)
 * [krb5-user](https://packages.debian.org/search?keywords=krb5-user)
 * [realmd](https://packages.debian.org/jessie/admin/realmd)
-* [InsightConnect Powershell Plugin Guide](https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/)
+* [InsightConnect Powershell Plugin Guide](https://docs.rapid7.com/insightconnect/mass-delete-with-PowerShell/)

--- a/plugins/powershell/komand_powershell/actions/execute_script/schema.py
+++ b/plugins/powershell/komand_powershell/actions/execute_script/schema.py
@@ -11,6 +11,8 @@ class Input:
     ADDRESS = "address"
     HOST_NAME = "host_name"
     SCRIPT = "script"
+    SECRET_KEY = "secret_key"
+    USERNAME_AND_PASSWORD = "username_and_password"
     
 
 class Output:
@@ -43,11 +45,69 @@ class ExecuteScriptInput(komand.Input):
       "description": "PowerShell script as base64",
       "format": "bytes",
       "order": 1
+    },
+    "secret_key": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "Secret Key",
+      "description": "Credential secret key available in script as PowerShell variable (`$secret_key`)",
+      "order": 4
+    },
+    "username_and_password": {
+      "$ref": "#/definitions/credential_username_password",
+      "title": "Username and Password",
+      "description": "Username and password available in script as PowerShell variables (`$username`, `$password`)",
+      "order": 5
     }
   },
   "required": [
     "script"
-  ]
+  ],
+  "definitions": {
+    "credential_secret_key": {
+      "id": "credential_secret_key",
+      "type": "object",
+      "title": "Credential: Secret Key",
+      "description": "A shared secret key",
+      "properties": {
+        "secretKey": {
+          "type": "string",
+          "title": "Secret Key",
+          "displayType": "password",
+          "description": "The shared secret key",
+          "format": "password"
+        }
+      },
+      "required": [
+        "secretKey"
+      ]
+    },
+    "credential_username_password": {
+      "id": "credential_username_password",
+      "type": "object",
+      "title": "Credential: Username and Password",
+      "description": "A username and password combination",
+      "properties": {
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "displayType": "password",
+          "description": "The password",
+          "format": "password",
+          "order": 2
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username to log in with",
+          "order": 1
+        }
+      },
+      "required": [
+        "username",
+        "password"
+      ]
+    }
+  }
 }
     """)
 

--- a/plugins/powershell/komand_powershell/actions/powershell_string/schema.py
+++ b/plugins/powershell/komand_powershell/actions/powershell_string/schema.py
@@ -11,6 +11,8 @@ class Input:
     ADDRESS = "address"
     HOST_NAME = "host_name"
     SCRIPT = "script"
+    SECRET_KEY = "secret_key"
+    USERNAME_AND_PASSWORD = "username_and_password"
     
 
 class Output:
@@ -41,11 +43,69 @@ class PowershellStringInput(komand.Input):
       "title": "Script",
       "description": "PowerShell script as a string",
       "order": 1
+    },
+    "secret_key": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "Secret Key",
+      "description": "Credential secret key available in script as PowerShell variable (`$secret_key`)",
+      "order": 4
+    },
+    "username_and_password": {
+      "$ref": "#/definitions/credential_username_password",
+      "title": "Username and Password",
+      "description": "Username and password available in script as PowerShell variables (`$username`, `$password`)",
+      "order": 5
     }
   },
   "required": [
     "script"
-  ]
+  ],
+  "definitions": {
+    "credential_secret_key": {
+      "id": "credential_secret_key",
+      "type": "object",
+      "title": "Credential: Secret Key",
+      "description": "A shared secret key",
+      "properties": {
+        "secretKey": {
+          "type": "string",
+          "title": "Secret Key",
+          "displayType": "password",
+          "description": "The shared secret key",
+          "format": "password"
+        }
+      },
+      "required": [
+        "secretKey"
+      ]
+    },
+    "credential_username_password": {
+      "id": "credential_username_password",
+      "type": "object",
+      "title": "Credential: Username and Password",
+      "description": "A username and password combination",
+      "properties": {
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "displayType": "password",
+          "description": "The password",
+          "format": "password",
+          "order": 2
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username to log in with",
+          "order": 1
+        }
+      },
+      "required": [
+        "username",
+        "password"
+      ]
+    }
+  }
 }
     """)
 

--- a/plugins/powershell/komand_powershell/connection/connection.py
+++ b/plugins/powershell/komand_powershell/connection/connection.py
@@ -1,17 +1,23 @@
 import komand
-from .schema import ConnectionSchema
+from .schema import ConnectionSchema, Input
 
 
 class Connection(komand.Connection):
     def __init__(self):
         super(self.__class__, self).__init__(input=ConnectionSchema())
+        self.username = None
+        self.password = None
+        self.auth_type = None
+        self.port = None
+        self.domain = None
+        self.kdc = None
 
-    def connect(self, params):
-        self.username = params.get("credentials").get("username")
-        self.password = params.get("credentials").get("password")
-        self.auth_type = params.get("auth")
-        self.port = params.get("port")
-        self.domain = params.get("kerberos").get("domain_name")
-        self.kdc = params.get("kerberos").get("kdc")
+    def connect(self, params={}):
+        self.username = params.get(Input.CREDENTIALS, {}).get("username")
+        self.password = params.get(Input.CREDENTIALS, {}).get("password")
+        self.auth_type = params.get(Input.AUTH, "None")
+        self.port = params.get(Input.PORT, 5986)
+        self.domain = params.get(Input.KERBEROS, {}).get("domain_name")
+        self.kdc = params.get(Input.KERBEROS, {}).get("kdc")
 
         self.logger.info("Connect: Connecting..")

--- a/plugins/powershell/komand_powershell/connection/schema.py
+++ b/plugins/powershell/komand_powershell/connection/schema.py
@@ -20,6 +20,7 @@ class ConnectionSchema(komand.Input):
       "type": "string",
       "title": "Auth Type",
       "description": "Authentication type",
+      "default": "None",
       "enum": [
         "NTLM",
         "Kerberos",

--- a/plugins/powershell/komand_powershell/util/util.py
+++ b/plugins/powershell/komand_powershell/util/util.py
@@ -2,51 +2,121 @@ import winrm
 import base64
 import subprocess  # noqa: B404
 
+import komand
+from komand.exceptions import PluginException
 
-def fix_run_ps(self, script):  # Fixes string bug in python 3 for NTLM connection
-    encoded_ps = base64.b64encode(script.encode("utf_16_le")).decode("ascii")
-    rs = self.run_cmd("powershell -encodedcommand {0}".format(encoded_ps))
-    if len(rs.std_err):
-        rs.std_err = self._clean_error_msg(rs.std_err.decode("utf-8"))
-    return rs
+DECODING_TYPE = "utf-8"
 
 
-winrm.Session.run_ps = fix_run_ps
+class FixWinrmSession(winrm.Session):
+    def run_ps(self, script: str) -> winrm.Response:  # Fixes string bug in python 3 for NTLM connection
+        encoded_ps = base64.b64encode(script.encode("utf_16_le")).decode("ascii")
+        rs = self.run_cmd(f"powershell -encodedcommand {encoded_ps}")
+        if len(rs.std_err):
+            rs.std_err = self._clean_error_msg(rs.std_err.decode(DECODING_TYPE))
+        return rs
 
 
-def local(action, powershell_script):
+def run_powershell_script(
+    auth: str,
+    action: komand.Action,
+    host_ip: str,
+    kdc: str,
+    domain: str,
+    host_name: str,
+    powershell_script: str,
+    password: str,
+    username: str,
+    port: int,
+) -> dict:
+    if auth == "None" or not host_ip:
+        data = run_script_locally(action=action, powershell_script=powershell_script)
+
+    elif auth == "NTLM":
+        data = run_script_using_ntlm(
+            action=action,
+            host_ip=host_ip,
+            powershell_script=powershell_script,
+            username=username,
+            password=password,
+            port=port,
+        )
+
+    elif auth == "Kerberos":
+        data = run_script_using_kerberos(
+            action=action,
+            host_ip=host_ip,
+            kdc=kdc,
+            domain=domain,
+            host_name=host_name,
+            powershell_script=powershell_script,
+            password=password,
+            username=username,
+            port=port,
+        )
+
+    elif auth == "CredSSP":
+        data = run_script_using_credssp(
+            action=action,
+            host_ip=host_ip,
+            powershell_script=powershell_script,
+            username=username,
+            password=password,
+            port=port,
+        )
+
+    else:
+        raise PluginException(
+            cause="No valid Authentication type was chosen.",
+            assistance="Make sure that you choose a correct Authentication type based on documentation.",
+        )
+
+    stdout = data.get("stdout")
+    stderr = data.get("stderr")
+
+    if stdout:
+        stdout = action.safe_encode(stdout)
+    if stderr:
+        stderr = action.safe_encode(stderr)
+
+    return {"stdout": stdout, "stderr": stderr}
+
+
+def run_script_locally(action: komand.Action, powershell_script: str) -> dict:
     action.logger.info("Running on local VM")
     action.logger.debug("PowerShell script: " + powershell_script)
-    process = subprocess.Popen(
+    with subprocess.Popen(
         powershell_script,
         shell="true",  # noqa: B602
         executable="pwsh",
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
-    )
-    output, error = process.communicate()
-    try:
-        output = output.decode("utf-8")
-    except AttributeError:
-        pass
-    try:
-        error = error.decode("utf-8")
-    except AttributeError:
-        pass
+    ) as process:
+        stdout, error = process.communicate()
+        try:
+            stdout = stdout.decode(DECODING_TYPE)
+        except AttributeError:
+            pass
+        try:
+            error = error.decode(DECODING_TYPE)
+        except AttributeError:
+            pass
 
-    return {"output": output, "stderr": error}
+        return {"stdout": stdout, "stderr": error}
 
 
-def ntlm(action, host_ip, powershell_script, username, password, port):
+def run_script_using_ntlm(
+    action: komand.Action, host_ip: str, powershell_script: str, username: str, password: str, port: int
+) -> dict:
     # Adds needed https and port number to host IP
     action.logger.info("Running a NTLM connection")
-    host_connection = "https://{host_ip}:{port}/wsman".format(host_ip=host_ip, port=port)
+    host_connection = f"https://{host_ip}:{port}/wsman"
     action.logger.debug("Host Connection: " + host_connection)
     action.logger.debug("PowerShell script: " + powershell_script)
 
-    powershell_session = winrm.Session(host_connection, auth=(username, password), transport="ntlm")
+    powershell_session = FixWinrmSession(host_connection, auth=(username, password), transport="ntlm")
     # Forces the Protocol to not fail with self signed certs
-    p = winrm.Protocol(
+    powershell_session.protocol = winrm.Protocol(
         endpoint=host_connection,
         transport="ntlm",
         username=username,
@@ -54,123 +124,24 @@ def ntlm(action, host_ip, powershell_script, username, password, port):
         server_cert_validation="ignore",
         message_encryption="auto",
     )
-    powershell_session.protocol = p
-    run_script = powershell_session.run_ps(powershell_script)
-    exit_code = run_script.status_code
-    error_value = run_script.std_err
-    output = run_script.std_out
 
-    try:
-        error_value = error_value.decode("utf-8")
-    except AttributeError:
-        pass
-    output = output.decode("utf-8")
+    error_value, stdout = run_powershell_session(action, powershell_script, powershell_session)
 
-    if exit_code != 0:
-        action.logger.error(error_value)
-        raise Exception("An error occurred in the PowerShell script, see logging for more info")
-
-    return {"output": output, "stderr": error_value}
+    return {"stdout": stdout, "stderr": error_value}
 
 
-def kerberos(action, host_ip, kdc, domain, host_name, powershell_script, password, username, port):
-    action.logger.info("Running Kerberos connection")
-    # Adds needed https and port number to host IP
-    host_connection = "https://{host_ip}:{port}/wsman".format(host_ip=host_ip, port=port)
-    action.logger.debug("PowerShell script: " + powershell_script)
-
-    udomain = domain.upper()
-    # Config for krb5 file to the domain
-    krb_config = """[libdefaults]
-default_realm = {udomain}
-forwardable = true
-proxiable = true
-
-[realms]
-{udomain} = {{
-kdc = {kdc}
-admin_server = {kdc}
-default_domain = {udomain}
-}}
-
-[domain_realm]
-.{domain} = {udomain}
-{domain} = {udomain}""".format(
-        udomain=udomain, domain=domain, kdc=kdc
-    )
-    action.logger.debug(krb_config)
-    # Config for DNS
-    dns = "search %s\r\nnameserver %s" % (domain, kdc)
-    action.logger.debug(dns)
-    # Sends output from stdout on shell commands to logging. Preventing errors
-    subprocess.call("mkdir -p /var/lib/samba/private", shell="true")  # noqa: B607,B602
-    subprocess.call("systemctl enable sssd", shell="true")  # noqa: B607,B602
-    # Setup realm to join the domain
-    with open("/etc/krb5.conf", "w") as f:
-        f.write(krb_config)
-    # Creates a Kerberos ticket
-    kinit = """echo '%s' | kinit %s@%s""" % (password, username, domain.upper())
-    response = subprocess.Popen(kinit, shell="true", stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: B602
-    (stdout, stderr) = response.communicate()
-    stdout = stdout.decode("utf-8")
-    stderr = stderr.decode("utf-8")
-    action.logger.info("Attempt to make Kerberos ticket stdout: " + stdout)
-    action.logger.info("Attempt to make Kerberos ticket stderr: " + stderr)
-    # DNS info so the plugin knows where to find the domain
-    with open("/etc/resolv.conf", "w") as f:
-        f.write(dns)
-    # Joins Komand to domain
-    realm = """echo '%s' | realm --install=/ join --user=%s %s""" % (password, username, domain)
-    response = subprocess.Popen(realm, shell="true", stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: B602
-    (stdout, stderr) = response.communicate()
-    stdout = stdout.decode("utf-8")
-    stderr = stderr.decode("utf-8")
-    action.logger.info("Attempt to join domain stdout: " + stdout)
-    action.logger.info("Attempt to join domain stderr: " + stderr)
-    # Allows resolution if A name not set for host
-    with open("/etc/hosts", "a") as f:
-        f.write("\r\n" + host_ip + " " + host_name)
-
-    # Runs the script on the host
-    powershell_session = winrm.Session(host_connection, auth=(username, password), transport="kerberos")
-
-    # Forces the protocol to not fail with self signed certs
-    p = winrm.Protocol(
-        endpoint=host_connection,
-        transport="kerberos",
-        username=username,
-        password=password,
-        server_cert_validation="ignore",
-    )
-    powershell_session.protocol = p
-    run_script = powershell_session.run_ps(powershell_script)
-    exit_code = run_script.status_code
-    error_value = run_script.std_err
-    output = run_script.std_out
-
-    try:
-        error_value = error_value.decode("utf-8")
-    except AttributeError:
-        pass
-    output = output.decode("utf-8")
-
-    if exit_code != 0:
-        action.logger.error(error_value)
-        raise Exception("An error occurred in the PowerShell script, see logging for more info")
-
-    return {"output": output, "stderr": error_value}
-
-
-def credssp(action, host_ip, powershell_script, username, password, port):
+def run_script_using_credssp(
+    action: komand.Action, host_ip: str, powershell_script: str, username: str, password: str, port: int
+) -> dict:
     # Adds needed https and port number to host IP
     action.logger.info("Running a CredSSP connection")
-    host_connection = "https://{host_ip}:{port}/wsman".format(host_ip=host_ip, port=port)
+    host_connection = f"https://{host_ip}:{port}/wsman"
     action.logger.debug("Host Connection: " + host_connection)
     action.logger.debug("PowerShell script: " + powershell_script)
 
-    powershell_session = winrm.Session(host_connection, auth=(username, password), transport="credssp")
+    powershell_session = FixWinrmSession(host_connection, auth=(username, password), transport="credssp")
     # Forces the Protocol to not fail with self signed certs
-    p = winrm.Protocol(
+    powershell_session.protocol = winrm.Protocol(
         endpoint=host_connection,
         transport="credssp",
         username=username,
@@ -178,20 +149,134 @@ def credssp(action, host_ip, powershell_script, username, password, port):
         server_cert_validation="ignore",
         message_encryption="auto",
     )
-    powershell_session.protocol = p
+
+    error_value, stdout = run_powershell_session(action, powershell_script, powershell_session)
+
+    return {"stdout": stdout, "stderr": error_value}
+
+
+def run_script_using_kerberos(
+    action: komand.Action,
+    host_ip: str,
+    kdc: str,
+    domain: str,
+    host_name: str,
+    powershell_script: str,
+    password: str,
+    username: str,
+    port: int,
+) -> dict:
+    action.logger.info("Running Kerberos connection")
+    # Adds needed https and port number to host IP
+    host_address = f"https://{host_ip}:{port}/wsman"
+    configure_machine_for_kerberos_connection(
+        action, domain, host_ip, host_name, kdc, password, powershell_script, username
+    )
+
+    # Runs the script on the host
+    powershell_session = FixWinrmSession(host_address, auth=(username, password), transport="kerberos")
+
+    # Forces the protocol to not fail with self signed certs
+    powershell_session.protocol = winrm.Protocol(
+        endpoint=host_address,
+        transport="kerberos",
+        username=username,
+        password=password,
+        server_cert_validation="ignore",
+    )
+    error_value, stdout = run_powershell_session(action, powershell_script, powershell_session)
+
+    return {"stdout": stdout, "stderr": error_value}
+
+
+def configure_machine_for_kerberos_connection(
+    action: komand.Action,
+    domain: str,
+    host_ip: str,
+    host_name: str,
+    kdc: str,
+    password: str,
+    powershell_script: str,
+    username: str,
+):
+    action.logger.debug("PowerShell script: " + powershell_script)
+    udomain = domain.upper()
+    # Config for krb5 file to the domain
+    krb_config = (
+        f"[libdefaults]\n"
+        f"default_realm = {udomain}\n"
+        f"forwardable = true\n"
+        f"proxiable = true\n"
+        f"\n"
+        f"[realms]\n"
+        f"{udomain} = {{\n"
+        f"kdc = {kdc}\n"
+        f"admin_server = {kdc}\n"
+        f"default_domain = {udomain}\n"
+        f"}}\n"
+        f"\n"
+        f"[domain_realm]\n"
+        f".{domain} = {udomain}\n"
+        f"{domain} = {udomain}\n"
+    )
+
+    action.logger.debug(krb_config)
+    # Config for DNS
+    dns = f"search {domain}\r\nnameserver {kdc}"
+    action.logger.debug(dns)
+    # Sends output from stdout on shell commands to logging. Preventing errors
+    subprocess.call("mkdir -p /var/lib/samba/private", shell="true")  # noqa: B607,B602
+    subprocess.call("systemctl enable sssd", shell="true")  # noqa: B607,B602
+    # Setup realm to join the domain
+    with open("/etc/krb5.conf", "w", encoding="utf-8") as f:
+        f.write(krb_config)
+
+    # Creates a Kerberos ticket
+    kinit = f"""echo '{password}' | kinit {username}@{domain.upper()}"""
+    response = subprocess.Popen(kinit, shell="true", stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: B602
+    (stdout, stderr) = response.communicate()
+    stdout = stdout.decode(DECODING_TYPE)
+    stderr = stderr.decode(DECODING_TYPE)
+    action.logger.info("Attempt to make Kerberos ticket stdout: " + stdout)
+    action.logger.info("Attempt to make Kerberos ticket stderr: " + stderr)
+    # DNS info so the plugin knows where to find the domain
+    with open("/etc/resolv.conf", "w", encoding="utf-8") as f:
+        f.write(dns)
+    # Joins Komand to domain
+    realm = f"""echo '{password}' | realm --install=/ join --user={username} {domain}"""
+    response = subprocess.Popen(realm, shell="true", stdout=subprocess.PIPE, stderr=subprocess.PIPE)  # noqa: B602
+    (stdout, stderr) = response.communicate()
+    stdout = stdout.decode(DECODING_TYPE)
+    stderr = stderr.decode(DECODING_TYPE)
+    action.logger.info("Attempt to join domain stdout: " + stdout)
+    action.logger.info("Attempt to join domain stderr: " + stderr)
+    # Allows resolution if A name not set for host
+    with open("/etc/hosts", "a", encoding="utf-8") as f:
+        f.write("\r\n" + host_ip + " " + host_name)
+
+
+def run_powershell_session(action: komand.Action, powershell_script: str, powershell_session: winrm.Session) -> tuple:
     run_script = powershell_session.run_ps(powershell_script)
     exit_code = run_script.status_code
     error_value = run_script.std_err
     output = run_script.std_out
-
     try:
-        error_value = error_value.decode("utf-8")
+        error_value = error_value.decode(DECODING_TYPE)
     except AttributeError:
         pass
-    output = output.decode("utf-8")
-
+    output = output.decode(DECODING_TYPE)
     if exit_code != 0:
         action.logger.error(error_value)
-        raise Exception("An error occurred in the PowerShell script, see logging for more info")
+        raise PluginException(
+            cause="An error occurred in the PowerShell script.", assistance="See logging for more info."
+        )
+    return error_value, output
 
-    return {"output": output, "stderr": error_value}
+
+def add_credentials_to_script(powershell_script: str, params: dict) -> dict:
+    powershell_credentials = (
+        f"$username = '{params.get('username_and_password', {}).get('username')}'\n"
+        f"$password = '{params.get('username_and_password', {}).get('password')}' | ConvertTo-SecureString -asPlainText -Force\n"
+        f"$secret_key = '{params.get('secret_key', {}).get('secretKey')}'\n"
+    )
+    return powershell_credentials + powershell_script

--- a/plugins/powershell/plugin.spec.yaml
+++ b/plugins/powershell/plugin.spec.yaml
@@ -4,7 +4,8 @@ products: [insightconnect]
 name: powershell
 title: PowerShell
 description: Run a PowerShell script
-version: 2.1.4
+version: 2.2.0
+supported_versions: ["PowerShell 6.1.2"]
 vendor: rapid7
 support: community
 status: []
@@ -42,12 +43,14 @@ connection:
     title: Credentials
     description: Username and password
     required: false
+    example: '{"username": "user", "password": "mypassword"}'
   port:
     title: Port
     description: Port number, defaults are 5986 for SSL and 5985 for unencrypted
     type: integer
     default: 5986
     required: false
+    example: 5986
   auth:
     title: Auth Type
     description: Authentication type
@@ -57,12 +60,15 @@ connection:
     - Kerberos
     - CredSSP
     - None
+    default: None
     required: true
+    example: Kerberos
   kerberos:
     title: Kerberos
     description: Connection information required for Kerberos
     type: kerberos
     required: false
+    example: '{"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}'
 actions:
   execute_script:
     title: Execute Script
@@ -73,29 +79,46 @@ actions:
         description: PowerShell script as base64
         type: bytes
         required: true
+        example: R2V0LURhdGU=
       address:
         title: Address
         description: IP address of the remote host e.g. 192.168.1.1. If address is
           left blank PowerShell will run locally
         type: string
         required: false
+        example: 10.0.1.15
       host_name:
         title: Host Name
         description: Case-sensitive name of the remote host, eg. MyComputer for Kerberos
           connection only
         type: string
         required: false
+        example: windows
+      secret_key:
+        title: Secret Key
+        description: Credential secret key available in script as PowerShell variable (`$secret_key`)
+        type: credential_secret_key
+        required: false
+        example: '{"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"}'
+      username_and_password:
+        title: Username and Password
+        description: Username and password available in script as PowerShell variables (`$username`, `$password`)
+        type: credential_username_password
+        required: false
+        example: '{"username": "user", "password": "mypassword"}'
     output:
       stdout:
         title: PowerShell Standard Output
         description: PowerShell standard output
         type: string
         required: false
+        example: Tuesday, January 11, 2022 5:05:42 AM
       stderr:
         title: PowerShell Standard Error
         description: PowerShell standard error
         type: string
         required: false
+        example: #< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><Obj S=\"progress\" RefId=\"0\"><TN RefId=\"0\"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S=\"progress\" RefId=\"1\"><TNRef RefId=\"0\" /><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>
   powershell_string:
     title: PowerShell String
     description: Execute PowerShell script in the form of a string
@@ -105,26 +128,44 @@ actions:
         description: PowerShell script as a string
         type: string
         required: true
+        example: Get-Date
       address:
         title: Address
         description: IP address of the remote host e.g. 192.168.1.1. If address is
           left blank PowerShell will run locally
         type: string
         required: false
+        example: 10.0.1.17
       host_name:
         title: Host Name
         description: Case-sensitive name of the remote host, eg. MyComputer for Kerberos
           connection only
         type: string
         required: false
+        example: windows
+      secret_key:
+        title: Secret Key
+        description: Credential secret key available in script as PowerShell variable (`$secret_key`)
+        type: credential_secret_key
+        required: false
+        example: '{"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"}'
+      username_and_password:
+        title: Username and Password
+        description: Username and password available in script as PowerShell variables (`$username`, `$password`)
+        type: credential_username_password
+        required: false
+        example: '{"username": "user", "password": "mypassword"}'
     output:
       stdout:
         title: PowerShell Standard Output
         description: PowerShell standard output
         type: string
         required: false
+        example: Tuesday, January 11, 2022 5:05:42 AM
       stderr:
         title: PowerShell Standard Error
         description: PowerShell standard error
         type: string
         required: false
+        example: #< CLIXML\r\n<Objs Version=\"1.1.0.1\" xmlns=\"http://schemas.microsoft.com/powershell/2004/04\"><Obj S=\"progress\" RefId=\"0\"><TN RefId=\"0\"><T>System.Management.Automation.PSCustomObject</T><T>System.Object</T></TN><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj><Obj S=\"progress\" RefId=\"1\"><TNRef RefId=\"0\" /><MS><I64 N=\"SourceId\">1</I64><PR N=\"Record\"><AV>Preparing modules for first use.</AV><AI>0</AI><Nil /><PI>-1</PI><PC>-1</PC><T>Completed</T><SR>-1</SR><SD> </SD></PR></MS></Obj></Objs>
+

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -1,8 +1,6 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-
 git+https://github.com/komand/pywinrm.git@v0.3.1dev0#pywinrm
-pykerberos==1.2.1
 requests-kerberos==0.12.0
 requests-credssp==1.1.0

--- a/plugins/powershell/setup.py
+++ b/plugins/powershell/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="powershell-rapid7-plugin",
-      version="2.1.4",
+      version="2.2.0",
       description="Run a PowerShell script",
       author="rapid7",
       author_email="",

--- a/plugins/powershell/unit_test/expecteds/credssp_connection.json.resp
+++ b/plugins/powershell/unit_test/expecteds/credssp_connection.json.resp
@@ -1,0 +1,4 @@
+{
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/expecteds/kerberos_connection.json.resp
+++ b/plugins/powershell/unit_test/expecteds/kerberos_connection.json.resp
@@ -1,0 +1,4 @@
+{
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/expecteds/local_connection.json.resp
+++ b/plugins/powershell/unit_test/expecteds/local_connection.json.resp
@@ -1,0 +1,4 @@
+{
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/expecteds/ntlm_connection.json.resp
+++ b/plugins/powershell/unit_test/expecteds/ntlm_connection.json.resp
@@ -1,0 +1,4 @@
+{
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/inputs/credssp_connection.json.resp
+++ b/plugins/powershell/unit_test/inputs/credssp_connection.json.resp
@@ -1,0 +1,12 @@
+{
+  "credentials": {
+    "username": "user",
+    "password": "passw"
+  },
+  "auth": "CredSSP",
+  "port": "5986",
+  "kerberos": {
+    "domain_name": "",
+    "kdc": ""
+  }
+}

--- a/plugins/powershell/unit_test/inputs/kerberos_connection.json.resp
+++ b/plugins/powershell/unit_test/inputs/kerberos_connection.json.resp
@@ -1,0 +1,12 @@
+{
+  "credentials": {
+    "username": "user",
+    "password": "passw"
+  },
+  "auth": "Kerberos",
+  "port": "5986",
+  "kerberos": {
+    "domain_name": "EXAMPLE.domain",
+    "kdc": "10.0.1.11"
+  }
+}

--- a/plugins/powershell/unit_test/inputs/local_connection.json.resp
+++ b/plugins/powershell/unit_test/inputs/local_connection.json.resp
@@ -1,0 +1,12 @@
+{
+  "credentials": {
+    "username": "user",
+    "password": "passw"
+  },
+  "auth": "None",
+  "port": "",
+  "kerberos": {
+    "domain_name": "",
+    "kdc": ""
+  }
+}

--- a/plugins/powershell/unit_test/inputs/ntlm_connection.json.resp
+++ b/plugins/powershell/unit_test/inputs/ntlm_connection.json.resp
@@ -1,0 +1,12 @@
+{
+  "credentials": {
+    "username": "user",
+    "password": "passw"
+  },
+  "auth": "NTLM",
+  "port": "5986",
+  "kerberos": {
+    "domain_name": "",
+    "kdc": ""
+  }
+}

--- a/plugins/powershell/unit_test/payloads/execute_script_credssp.json.resp
+++ b/plugins/powershell/unit_test/payloads/execute_script_credssp.json.resp
@@ -1,0 +1,5 @@
+{
+  "status_code": 0,
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/execute_script_kerberos.json.resp
+++ b/plugins/powershell/unit_test/payloads/execute_script_kerberos.json.resp
@@ -1,0 +1,5 @@
+{
+  "status_code": 0,
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/execute_script_local.json.resp
+++ b/plugins/powershell/unit_test/payloads/execute_script_local.json.resp
@@ -1,0 +1,4 @@
+{
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/execute_script_ntlm.json.resp
+++ b/plugins/powershell/unit_test/payloads/execute_script_ntlm.json.resp
@@ -1,0 +1,5 @@
+{
+  "status_code": 0,
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/powershell_string_credssp.json.resp
+++ b/plugins/powershell/unit_test/payloads/powershell_string_credssp.json.resp
@@ -1,0 +1,5 @@
+{
+  "status_code": 0,
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/powershell_string_kerberos.json.resp
+++ b/plugins/powershell/unit_test/payloads/powershell_string_kerberos.json.resp
@@ -1,0 +1,5 @@
+{
+  "status_code": 0,
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/powershell_string_local.json.resp
+++ b/plugins/powershell/unit_test/payloads/powershell_string_local.json.resp
@@ -1,0 +1,4 @@
+{
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/payloads/powershell_string_ntlm.json.resp
+++ b/plugins/powershell/unit_test/payloads/powershell_string_ntlm.json.resp
@@ -1,0 +1,5 @@
+{
+  "status_code": 0,
+  "stdout": "Thursday, January 13, 2022 3:18:12 AM",
+  "stderr": ""
+}

--- a/plugins/powershell/unit_test/test_execute_script.py
+++ b/plugins/powershell/unit_test/test_execute_script.py
@@ -1,0 +1,54 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from unittest.mock import patch
+from parameterized import parameterized
+
+from unit_test.util import Util
+from komand_powershell.actions.execute_script import ExecuteScript
+
+
+class TestExecuteScript(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.params = {
+            "address": "10.0.1.11",
+            "username_and_password": {"password": "example_password", "username": "example_user"},
+            "host_name": "windows",
+            "script": "R2V0LURhdGU=",
+            "secret_key": {"secretKey": "s1e2c3r4e5t67k8e9y"},
+        }
+
+    @parameterized.expand(
+        [
+            ("ntlm", "inputs/ntlm_connection.json.resp", "expecteds/ntlm_connection.json.resp"),
+            ("cred_ssp", "inputs/credssp_connection.json.resp", "expecteds/credssp_connection.json.resp"),
+        ]
+    )
+    @patch("komand_powershell.util.util.FixWinrmSession", side_effect=Util.mock_powershell)
+    def test_powershell_string_ntlm_credssp(self, name: str, input_path: str, expected_path: str, mock_powershell):
+        params = Util.read_file_to_dict(input_path)
+        action = Util.default_connector(ExecuteScript(), params)
+        actual = action.run(params=self.params)
+        expected = Util.read_file_to_dict(expected_path)
+        self.assertEqual(actual, expected)
+
+    @patch("subprocess.Popen", side_effect=Util.mock_powershell)
+    def test_powershell_string_local(self, mock_powershell):
+        params = Util.read_file_to_dict("inputs/local_connection.json.resp")
+        action = Util.default_connector(ExecuteScript(), params)
+        actual = action.run(params=self.params)
+        expected = Util.read_file_to_dict("expecteds/local_connection.json.resp")
+        self.assertEqual(actual, expected)
+
+    @patch("komand_powershell.util.util.FixWinrmSession", side_effect=Util.mock_powershell)
+    @patch("komand_powershell.util.util.configure_machine_for_kerberos_connection")
+    def test_powershell_string_kerberos(self, mock_configure_kerberos, mock_powershell):
+        params = Util.read_file_to_dict("inputs/kerberos_connection.json.resp")
+        action = Util.default_connector(ExecuteScript(), params)
+        actual = action.run(params=self.params)
+        expected = Util.read_file_to_dict("expecteds/kerberos_connection.json.resp")
+        self.assertEqual(actual, expected)

--- a/plugins/powershell/unit_test/test_powershell_string.py
+++ b/plugins/powershell/unit_test/test_powershell_string.py
@@ -1,0 +1,54 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from unittest.mock import patch
+from parameterized import parameterized
+
+from unit_test.util import Util
+from komand_powershell.actions.powershell_string import PowershellString
+
+
+class TestPowershellString(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.params = {
+            "address": "10.0.1.11",
+            "username_and_password": {"password": "example_password", "username": "example_user"},
+            "host_name": "windows",
+            "script": "Get-Date",
+            "secret_key": {"secretKey": "s1e2c3r4e5t67k8e9y"},
+        }
+
+    @parameterized.expand(
+        [
+            ("ntlm", "inputs/ntlm_connection.json.resp", "expecteds/ntlm_connection.json.resp"),
+            ("cred_ssp", "inputs/credssp_connection.json.resp", "expecteds/credssp_connection.json.resp"),
+        ]
+    )
+    @patch("komand_powershell.util.util.FixWinrmSession", side_effect=Util.mock_powershell)
+    def test_powershell_string_ntlm_credssp(self, name: str, input_path: str, expected_path: str, mock_powershell):
+        params = Util.read_file_to_dict(input_path)
+        action = Util.default_connector(PowershellString(), params)
+        actual = action.run(params=self.params)
+        expected = Util.read_file_to_dict(expected_path)
+        self.assertEqual(actual, expected)
+
+    @patch("subprocess.Popen", side_effect=Util.mock_powershell)
+    def test_powershell_string_local(self, mock_powershell):
+        params = Util.read_file_to_dict("inputs/local_connection.json.resp")
+        action = Util.default_connector(PowershellString(), params)
+        actual = action.run(params=self.params)
+        expected = Util.read_file_to_dict("expecteds/local_connection.json.resp")
+        self.assertEqual(actual, expected)
+
+    @patch("komand_powershell.util.util.FixWinrmSession", side_effect=Util.mock_powershell)
+    @patch("komand_powershell.util.util.configure_machine_for_kerberos_connection")
+    def test_powershell_string_kerberos(self, mock_configure_kerberos, mock_powershell):
+        params = Util.read_file_to_dict("inputs/kerberos_connection.json.resp")
+        action = Util.default_connector(PowershellString(), params)
+        actual = action.run(params=self.params)
+        expected = Util.read_file_to_dict("expecteds/kerberos_connection.json.resp")
+        self.assertEqual(actual, expected)

--- a/plugins/powershell/unit_test/util.py
+++ b/plugins/powershell/unit_test/util.py
@@ -1,0 +1,62 @@
+import json
+import logging
+import os
+
+from unittest.mock import Mock
+
+from komand_powershell.connection import Connection
+from komand_powershell.actions.execute_script.schema import Output
+
+
+class Util:
+    @staticmethod
+    def default_connector(action, connect_params: object = None):
+        default_connection = Connection()
+        default_connection.logger = logging.getLogger("connection logger")
+
+        default_connection.connect(connect_params)
+        action.connection = default_connection
+        action.logger = logging.getLogger("action logger")
+        return action
+
+    @staticmethod
+    def read_file_to_string(filename, directory_path=os.path.dirname(os.path.realpath(__file__))):
+        with open(os.path.join(directory_path, filename)) as my_file:
+            return my_file.read()
+
+    @staticmethod
+    def read_file_to_dict(filename, directory_path=os.path.dirname(os.path.realpath(__file__))):
+        return json.loads(Util.read_file_to_string(filename, directory_path))
+
+    @staticmethod
+    def mock_powershell(*args, **kwargs):
+        class MockProcess:
+            def __init__(self, filename):
+                self.response_text = Util.read_file_to_string(f"payloads/{filename}.json.resp")
+
+            def __enter__(self, *args, **kwargs):
+                return self
+
+            def __exit__(self, *args, **kwargs):
+                pass
+
+            def communicate(self):
+                response_dict = json.loads(self.response_text)
+                return response_dict.get(Output.STDOUT), response_dict.get(Output.STDERR)
+
+            def run_ps(self, *args, **kwargs):
+                response_dict = json.loads(self.response_text)
+                mock = Mock()
+                mock.status_code = response_dict.get("status_code")
+                mock.std_err = bytes(response_dict.get(Output.STDERR), "utf-8")
+                mock.std_out = bytes(response_dict.get(Output.STDOUT), "utf-8")
+                return mock
+
+        if kwargs.get("transport") == "ntlm":
+            return MockProcess("powershell_string_ntlm")
+        if kwargs.get("transport") == "credssp":
+            return MockProcess("powershell_string_credssp")
+        if kwargs.get("transport") == "kerberos":
+            return MockProcess("powershell_string_kerberos")
+
+        return MockProcess("powershell_string_local")

--- a/plugins/python_3_script/.CHECKSUM
+++ b/plugins/python_3_script/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "55e972c98c91adf4cfe7a1192018944b",
-	"manifest": "3b194eb7a01f0432f32adb08b8c86672",
-	"setup": "6554be0153f2f752a7c42c1ddb73ea9f",
+	"spec": "c474d77cee8af63110a5b7c85a010b3b",
+	"manifest": "20dd3c9d2ad113c08744fca8e2678d70",
+	"setup": "c3d625e43a27e24b74b6082083b0a35b",
 	"schemas": [
 		{
 			"identifier": "run/schema.py",
-			"hash": "14ea1ea56dda5693dcc0d5b93bc43892"
+			"hash": "c3cf785fc129ffc567d578a3f5a8b0f3"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/plugins/python_3_script/Dockerfile
+++ b/plugins/python_3_script/Dockerfile
@@ -23,4 +23,7 @@ ENV PYTHONUSERBASE=/var/cache/python_dependencies \
 RUN if [ -f requirements.txt ]; then pip install --no-cache-dir -r requirements.txt; fi
 RUN python setup.py build && python setup.py install
 
+# User to run plugin code. The two supported users are: root, nobody
+USER nobody
+
 ENTRYPOINT ["/usr/local/bin/komand_python_3_script"]

--- a/plugins/python_3_script/bin/komand_python_3_script
+++ b/plugins/python_3_script/bin/komand_python_3_script
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Python 3 Script"
 Vendor = "rapid7"
-Version = "2.0.4"
+Version = "3.0.0"
 Description = "Run a Python 3 script"
 
 

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -13,22 +13,38 @@ The Python 3 Script plugin also allows you to load custom modules via its connec
 
 # Key Features
 
-* Run a Python 3 script to securely orchestrate, automate, and respond to (almost) anything
+* Run a Python 3 Script to securely orchestrate, automate, and respond to (almost) anything
 
 # Requirements
 
 _This plugin does not contain any requirements._
 
+# Supported Product Versions
+
+* Python 3.7.2
+
 # Documentation
 
 ## Setup
 
-Check out the [plugin guide](https://docs.rapid7.com/insightconnect/python-2-or-3-script/) for more details on how to configure this plugin.
+The connection configuration accepts the following parameters:
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|modules|[]string|None|False|List of third-party modules to install for use in the supplied Python script|None|
-|timeout|integer|60|True|Timeout (in seconds) for installing third-party modules|None|
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|modules|[]string|None|False|List of third-party modules to install for use in the supplied Python script|None|["pandas", "numpy"]|
+|timeout|integer|60|True|Timeout (in seconds) for installing third-party modules|None|120|
+
+Example input:
+
+```
+{
+  "modules": [
+    "pandas",
+    "numpy"
+  ],
+  "timeout": 120
+}
+```
 
 ## Technical Details
 
@@ -43,45 +59,60 @@ It works the same way as the [Python Script 2 plugin](https://market.komand.com/
 
 An input object can be supplied as the `params={}` parameter for the function.
 
-The `run` function should return an object, whose fields gets added to the results object, e.g.
+The run function should return an object, whose fields gets added to the results object, e.g.
 
 ```
-
 def run(params={}):
   return { 'hello': 'world' }
-
 ```
 
 This returns a string with key `hello` on the output object accessible at `{{Step.hello}}`.
 
-Make sure you the edit the output variables so that they match the keys returned by the 'run()' function.
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|----------------------------------------------------------------------------------------------|
+|function|python|def run(params={}):\n    return {}|True|Function definition. Must be named `run`. Accepts the `input` object as params. Returns the dict as output|None|def run(params={}):\n\tprint(params.get('some_input'))\n\tprint(username, password)\n\treturn {}|
+|input|object|None|False|Input object to be passed as `params={}` to the `run` function|None|{"some_input": "example input"}|
+|secret_key|credential_secret_key|None|False|Credential secret key available in script as python variable (`secret_key`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|username_and_password|credential_username_password|None|False|Username and password available in script as python variables (`username`, `password`)|None|{"username": "user", "password": "mypassword"}|
 
-|Name|Type|Default|Required|Description|Enum|
-|----|----|-------|--------|-----------|----|
-|function|python|None|False|Function definition|None|
-|input|object|None|False|Input object to be passed as `params={}` to the `run` function|None|
+Example input:
+
+```
+{
+  "function": "def run(params={}):\n\tprint(params.get('some_input'))\n\tprint(username, password)\n\treturn {'result1': 'example output 1', 'result2': 'example output 2'}",
+  "input": {
+    "some_input": "example input"
+  },
+  "secret_key": {
+    "secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"
+  },
+  "username_and_password": {
+    "username": "user", 
+    "password": "mypassword"
+  }
+}
+```
+
+Note that `username` and `password` inputs are accessible directly in the script as variable, but arguments from `input` are stored in `params` dictionary.
 
 ##### Output
 
 The default output variables are `result1` and `result2`, both of type `string`. While these may work for you they're intended to be changed by the user to meet their naming and type needs.
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|result2|string|False|Sample output result2 (delete or edit)|
-|result1|string|False|Sample output result1 (delete or edit)|
+|Name|Type|Required|Description|Example|
+|----|----|--------|-----------|----------------|
+|result1|string|False|Sample output result1 (delete or edit)|example output 1|
+|result2|string|False|Sample output result2 (delete or edit)|example output 2|
 
-Make sure you the edit the output variables in the user interface so that they match the keys returned by the 'run()' function.
-This allows you to pass the variables to other steps using the names chosen by the user.
+Make sure you edit the output variables in the user interface so that they match the keys returned by the `run()` function. This allows you to pass the variables to other steps using the names chosen by the user.
 
-Example Output:
+Example output:
 
 ```
-
 {
-  "result1": "My result",
-  "result2": "My result2"
+  "result1": "example output 1", 
+  "result2": "example output 2"
 }
-
 ```
 
 ### Triggers
@@ -99,6 +130,7 @@ If installation fails, try increasing the `Timeout` connection input to `900` (1
 
 # Version History
 
+* 3.0.0 - Add custom credentials in Run action
 * 2.0.4 - Update help documentation for installing third-party modules
 * 2.0.3 - Update `docs_url` in plugin spec with a new link to [plugin setup guide](https://docs.rapid7.com/insightconnect/python-2-or-3-script/)
 * 2.0.2 - Add `docs_url` to plugin spec with link to [plugin setup guide](https://insightconnect.help.rapid7.com/docs/python-2-or-3-script)

--- a/plugins/python_3_script/komand_python_3_script/actions/run/action.py
+++ b/plugins/python_3_script/komand_python_3_script/actions/run/action.py
@@ -1,6 +1,9 @@
-import komand
-from .schema import RunOutput, RunInput, Component
 import sys
+
+import komand
+from komand.exceptions import PluginException
+
+from .schema import RunOutput, RunInput, Component, Input
 
 sys.path.append("/var/cache/python_dependencies/lib/python3.7/site-packages")
 
@@ -12,19 +15,42 @@ class Run(komand.Action):
         )
 
     def run(self, params={}):
-        self.logger.info("Input: (below)\n\n%s\n", params["input"])
-        self.logger.info("Function: (below)\n\n%s\n", params["function"])
+        self.logger.info(f"Input: (below)\n\n{params.get(Input.INPUT)}\n")
+        func = params.get(Input.FUNCTION)
+        self.logger.info(f"Function: (below)\n\n{func}\n")
+        func = self._add_credentials_to_function(func, params)
 
         try:
-            func = params["function"]
-            exec(func)  # noqa: B102
-            funcname = func.split(" ")[1].split("(")[0]
-            out = locals()[funcname](params["input"])
+            out = self._exec_python_function(func=func, params=params)
         except Exception as e:
-            raise Exception("Could not run supplied script. Error: " + str(e))
+            raise PluginException(cause="Could not run supplied script", data=str(e))
         try:
             if out is None:
-                raise Exception("Output type was None. Ensure that output has a non-None data type")
+                raise PluginException(
+                    cause="Output type was None", assistance="Ensure that output has a non-None data type"
+                )
             return out
         except UnboundLocalError:
-            raise Exception("No output was returned. Check supplied script to ensure that it returns output")
+            raise PluginException(
+                cause="No output was returned.", assistance="Check supplied script to ensure that it returns output"
+            )
+
+    @staticmethod
+    def _exec_python_function(func, params):
+        exec(func)  # noqa: B102
+        funcname = func.split(" ")[1].split("(")[0]
+        out = locals()[funcname](params.get(Input.INPUT))
+        return out
+
+    @staticmethod
+    def _add_credentials_to_function(func: str, params: dict):
+        credentials_definition = [
+            f"\tusername='{params.get(Input.USERNAME_AND_PASSWORD).get('username')}'",
+            f"\tpassword='{params.get(Input.USERNAME_AND_PASSWORD).get('password')}'",
+            f"\tsecret_key='{params.get(Input.SECRET_KEY).get('secretKey')}'",
+        ]
+
+        func_lines = func.split("\n")
+        func_lines = [func_lines[0]] + credentials_definition + func_lines[1:]
+
+        return "\n".join(func_lines)

--- a/plugins/python_3_script/komand_python_3_script/actions/run/schema.py
+++ b/plugins/python_3_script/komand_python_3_script/actions/run/schema.py
@@ -10,6 +10,8 @@ class Component:
 class Input:
     FUNCTION = "function"
     INPUT = "input"
+    SECRET_KEY = "secret_key"
+    USERNAME_AND_PASSWORD = "username_and_password"
     
 
 class Output:
@@ -37,6 +39,67 @@ class RunInput(komand.Input):
       "title": "Input",
       "description": "Input object to be passed as `params={}` to the `run` function",
       "order": 2
+    },
+    "secret_key": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "Secret Key",
+      "description": "Credential secret key available in script as python variable (`secret_key`)",
+      "order": 3
+    },
+    "username_and_password": {
+      "$ref": "#/definitions/credential_username_password",
+      "title": "Username and Password",
+      "description": "Username and password available in script as python variables (`username`, `password`)",
+      "order": 4
+    }
+  },
+  "required": [
+    "function"
+  ],
+  "definitions": {
+    "credential_secret_key": {
+      "id": "credential_secret_key",
+      "type": "object",
+      "title": "Credential: Secret Key",
+      "description": "A shared secret key",
+      "properties": {
+        "secretKey": {
+          "type": "string",
+          "title": "Secret Key",
+          "displayType": "password",
+          "description": "The shared secret key",
+          "format": "password"
+        }
+      },
+      "required": [
+        "secretKey"
+      ]
+    },
+    "credential_username_password": {
+      "id": "credential_username_password",
+      "type": "object",
+      "title": "Credential: Username and Password",
+      "description": "A username and password combination",
+      "properties": {
+        "password": {
+          "type": "string",
+          "title": "Password",
+          "displayType": "password",
+          "description": "The password",
+          "format": "password",
+          "order": 2
+        },
+        "username": {
+          "type": "string",
+          "title": "Username",
+          "description": "The username to log in with",
+          "order": 1
+        }
+      },
+      "required": [
+        "username",
+        "password"
+      ]
     }
   }
 }

--- a/plugins/python_3_script/plugin.spec.yaml
+++ b/plugins/python_3_script/plugin.spec.yaml
@@ -7,7 +7,8 @@ vendor: rapid7
 support: rapid7
 status: []
 description: Run a Python 3 script
-version: 2.0.4
+version: 3.0.0
+supported_versions: ["Python 3.7.2"]
 enable_cache: true
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/python_3_script
@@ -20,7 +21,7 @@ tags:
  - utilities
 hub_tags:
   use_cases: [data_utility]
-  keywords: [python, python3, scripting, utilities]
+  keywords: [python, scripting]
   features: []
 
 connection:
@@ -29,12 +30,14 @@ connection:
     description: "List of third-party modules to install for use in the supplied Python script"
     required: false
     type: "[]string"
+    example: ["pandas", "numpy"]
   timeout:
     title: "Timeout"
     description: "Timeout (in seconds) for installing third-party modules"
     required: true
     type: integer
     default: 60
+    example: 120
 
 actions:
   run:
@@ -46,17 +49,33 @@ actions:
           object as params. Returns the dict as output
         type: python
         default: def run(params={}):\n    return {}
-        required: false
+        required: true
+        example: def run(params={}):\n\tprint(params.get('some_input'))\n\tprint(username, password)\n\treturn {}
       input:
         description: Input object to be passed as `params={}` to the `run` function
         type: object
         required: false
+        example: '{"some_input": "example input"}'
+      secret_key:
+        title: Secret Key
+        description: Credential secret key available in script as python variable (`secret_key`)
+        type: credential_secret_key
+        required: false
+        example: 9de5069c5afe602b2ea0a04b66beb2c0
+      username_and_password:
+        title: Username and Password
+        description: Username and password available in script as python variables (`username`, `password`)
+        type: credential_username_password
+        required: false
+        example: '{"username": "user", "password": "mypassword"}'
     output:
       result1:
         description: Sample output result1 (delete or edit)
         type: string
         required: false
+        example: example output 1
       result2:
         description: Sample output result2 (delete or edit)
         type: string
         required: false
+        example: example output 2

--- a/plugins/python_3_script/setup.py
+++ b/plugins/python_3_script/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="python_3_script-rapid7-plugin",
-      version="2.0.4",
+      version="3.0.0",
       description="Run a Python 3 script",
       author="rapid7",
       author_email="",

--- a/plugins/python_3_script/unit_test/inputs/run.bad.json.resp
+++ b/plugins/python_3_script/unit_test/inputs/run.bad.json.resp
@@ -1,0 +1,13 @@
+{
+  "username_and_password": {
+    "password": "mypassword",
+    "username": "user"
+  },
+  "function": "def run(params={}):\n\treturn",
+  "input": {
+    "some_input": "example_param"
+  },
+  "secret_key": {
+    "secretKey": "1111243354"
+  }
+}

--- a/plugins/python_3_script/unit_test/inputs/run.json.resp
+++ b/plugins/python_3_script/unit_test/inputs/run.json.resp
@@ -1,0 +1,13 @@
+{
+  "username_and_password": {
+    "password": "mypassword",
+    "username": "user"
+  },
+  "function": "def run(params={}):\n\treturn {'some_output': params.get('some_input'), 'user_name': username, 'password': password, 'secret_key': secret_key}",
+  "input": {
+    "some_input": "example_param"
+  },
+  "secret_key": {
+    "secretKey": "1111243354"
+  }
+}

--- a/plugins/python_3_script/unit_test/payloads/run.json.resp
+++ b/plugins/python_3_script/unit_test/payloads/run.json.resp
@@ -1,0 +1,6 @@
+{
+  "some_output": "example_param",
+  "user_name": "user",
+  "password": "mypassword",
+  "secret_key": "1111243354"
+}

--- a/plugins/python_3_script/unit_test/test_run.py
+++ b/plugins/python_3_script/unit_test/test_run.py
@@ -1,0 +1,32 @@
+import sys
+import os
+from unittest import TestCase
+from unittest.mock import patch
+
+from komand.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+from unit_test.util import Util
+from komand_python_3_script.actions.run import Run
+
+
+class TestRun(TestCase):
+    @patch.object(Run, "_exec_python_function", side_effect=Util.mock_exec_python_function)
+    def test_run(self, mock_exec_python_function):
+        params = Util.read_file_to_dict(f"inputs/run.json.resp")
+        action = Util.default_connector(Run())
+        actual = action.run(params=params)
+
+        expected = Util.read_file_to_dict(f"payloads/run.json.resp")
+        self.assertEqual(actual, expected)
+
+    @patch.object(Run, "_exec_python_function", side_effect=Util.mock_exec_python_function)
+    def test_run_return_none(self, mock_exec_python_function):
+        params = Util.read_file_to_dict(f"inputs/run.bad.json.resp")
+        action = Util.default_connector(Run())
+        with self.assertRaises(PluginException) as e:
+            action.run(params=params)
+
+        self.assertEqual(e.exception.cause, "Output type was None")
+        self.assertEqual(e.exception.assistance, "Ensure that output has a non-None data type")

--- a/plugins/python_3_script/unit_test/util.py
+++ b/plugins/python_3_script/unit_test/util.py
@@ -1,0 +1,38 @@
+import json
+import logging
+import os
+
+from komand_python_3_script.connection import Connection
+from komand_python_3_script.actions.run.schema import Input
+
+
+class Util:
+    @staticmethod
+    def default_connector(action, connect_params: object = None):
+        default_connection = Connection()
+        default_connection.logger = logging.getLogger("connection logger")
+        if connect_params:
+            params = connect_params
+        else:
+            params = {"modules": [], "timeout": 60}
+
+        default_connection.connect(params)
+        action.connection = default_connection
+        action.logger = logging.getLogger("action logger")
+        return action
+
+    @staticmethod
+    def read_file_to_string(filename, directory_path=os.path.dirname(os.path.realpath(__file__))):
+        with open(os.path.join(directory_path, filename)) as my_file:
+            return my_file.read()
+
+    @staticmethod
+    def read_file_to_dict(filename, directory_path=os.path.dirname(os.path.realpath(__file__))):
+        return json.loads(Util.read_file_to_string(filename, directory_path))
+
+    @staticmethod
+    def mock_exec_python_function(*args, **kwargs):
+        function = kwargs.get("params", dict()).get(Input.FUNCTION, "").split("\n")
+        if "return {" in function[-1]:
+            return Util.read_file_to_dict(f"payloads/run.json.resp")
+        return None


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Add credential variables (username, password, secret_key) to python and powershell plugins
  - Small refactor of execute_script and powershell_string actions - moved much code to utils.py

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)



## Assessment
### Run

<details>

```
{
  "stderr": "#\u003c CLIXML\r\n\u003cObjs Version=\"https://example.com\" xmlns=\"https://example.com\"\u003e\u003cObj S=\"progress\" RefId=\"0\"\u003e\u003cTN RefId=\"0\"\u003e\u003cT\https://example.com\u003c/T\u003e\u003cT\https://example.com\u003c/T\u003e\u003c/TN\u003e\u003cMS\u003e\u003cI64 N=\"SourceId\"\u003e1\u003c/I64\u003e\u003cPR N=\"Record\"\u003e\u003cAV\u003ePreparing modules for first use.\u003c/AV\u003e\u003cAI\u003e0\u003c/AI\u003e\u003cNil /\u003e\u003cPI\u003e-1\u003c/PI\u003e\u003cPC\u003e-1\u003c/PC\u003e\u003cT\u003eCompleted\u003c/T\u003e\u003cSR\u003e-1\u003c/SR\u003e\u003cSD\u003e \u003c/SD\u003e\u003c/PR\u003e\u003c/MS\u003e\u003c/Obj\u003e\u003cObj S=\"progress\" RefId=\"1\"\u003e\u003cTNRef RefId=\"0\" /\u003e\u003cMS\u003e\u003cI64 N=\"SourceId\"\u003e1\u003c/I64\u003e\u003cPR N=\"Record\"\u003e\u003cAV\u003ePreparing modules for first use.\u003c/AV\u003e\u003cAI\u003e0\u003c/AI\u003e\u003cNil /\u003e\u003cPI\u003e-1\u003c/PI\u003e\u003cPC\u003e-1\u003c/PC\u003e\u003cT\u003eCompleted\u003c/T\u003e\u003cSR\u003e-1\u003c/SR\u003e\u003cSD\u003e \u003c/SD\u003e\u003c/PR\u003e\u003c/MS\u003e\u003c/Obj\u003e\u003c/Objs\u003e",
  "stdout": "\r\nMonday, January 17, 2022 10:46:45 AM\r\n\r\n\r\n"
}

```

<summary>
docker run --rm -i rapid7/powershell:2.2.0 --debug run < tests/execute_script.json
</summary>
</details>

<details>

```
{
  "stderr": "#\u003c CLIXML\r\n\u003cObjs Version=\"https://example.com\" xmlns=\"https://example.com\"\u003e\u003cObj S=\"progress\" RefId=\"0\"\u003e\u003cTN RefId=\"0\"\u003e\u003cT\https://example.com\u003c/T\u003e\u003cT\https://example.com\u003c/T\u003e\u003c/TN\u003e\u003cMS\u003e\u003cI64 N=\"SourceId\"\u003e1\u003c/I64\u003e\u003cPR N=\"Record\"\u003e\u003cAV\u003ePreparing modules for first use.\u003c/AV\u003e\u003cAI\u003e0\u003c/AI\u003e\u003cNil /\u003e\u003cPI\u003e-1\u003c/PI\u003e\u003cPC\u003e-1\u003c/PC\u003e\u003cT\u003eCompleted\u003c/T\u003e\u003cSR\u003e-1\u003c/SR\u003e\u003cSD\u003e \u003c/SD\u003e\u003c/PR\u003e\u003c/MS\u003e\u003c/Obj\u003e\u003cObj S=\"progress\" RefId=\"1\"\u003e\u003cTNRef RefId=\"0\" /\u003e\u003cMS\u003e\u003cI64 N=\"SourceId\"\u003e1\u003c/I64\u003e\u003cPR N=\"Record\"\u003e\u003cAV\u003ePreparing modules for first use.\u003c/AV\u003e\u003cAI\u003e0\u003c/AI\u003e\u003cNil /\u003e\u003cPI\u003e-1\u003c/PI\u003e\u003cPC\u003e-1\u003c/PC\u003e\u003cT\u003eCompleted\u003c/T\u003e\u003cSR\u003e-1\u003c/SR\u003e\u003cSD\u003e \u003c/SD\u003e\u003c/PR\u003e\u003c/MS\u003e\u003c/Obj\u003e\u003c/Objs\u003e",
  "stdout": "\r\nMonday, January 17, 2022 10:46:47 AM\r\n\r\n\r\n"
}

```

<summary>
docker run --rm -i rapid7/powershell:2.2.0 --debug run < tests/powershell_string.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[121]: http://schemas.microsoft.com/powershell/2004/04\
violation: plugin.spec.yaml[170]: http://schemas.microsoft.com/powershell/2004/04\
violation: help.md[87]: http://schemas.microsoft.com/powershell/2004/04
violation: help.md[97]: http://schemas.microsoft.com/powershell/2004/04
violation: help.md[172]: http://schemas.microsoft.com/powershell/2004/04
violation: help.md[182]: http://schemas.microsoft.com/powershell/2004/04
violation: help.md[243]: https://blogs.msdn.microsoft.com/PowerShell/2015/10/27/compromising-yourself-with-winrms-allowunencrypted-true/
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled PowerShell String. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled PowerShell String. Please updated the JSON example in help.md with 2 space indentation.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Input. Please updated the JSON example in help.md with 2 space indentation.

Validator "CredentialsValidator" failed!
        Cause: Remove credentials from the following files: ['tests/execute_script.json', 'tests/powershell_string.json'].


----
[*] Total time elapsed: 33686.709ms
```

<summary>
icon-validate --all .
</summary>
</details>


<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../../tools/Makefiles/Helpers.mk ../../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled PowerShell String. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled PowerShell String. Please updated the JSON example in help.md with 2 space indentation.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Input. Please updated the JSON example in help.md with 2 space indentation.


----
[*] Total time elapsed: 2542.991ms
make: *** [../../tools/Makefiles/Helpers.mk:15: validate] Error 1
```

<summary>
make validate
</summary>
</details>

<br />

<details>

```
{
  "result1": "example output 1",
  "result2": "example output 2"
}

```
   
<summary>
docker run --rm -i rapid7/python_3_script:2.1.0 --debug run < tests/run.json
</summary>
</details>


<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled Run Function. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Run Function. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Run Function. Please updated the JSON example in help.md with 2 space indentation.
        Improperly formatted JSON example identified in Example input of action titled Run Function. Please updated the JSON example in help.md with 2 space indentation.
        Improperly formatted JSON example identified in Example input of action titled Run Function. Please updated the JSON example in help.md with 2 space indentation.


----
[*] Total time elapsed: 21583.523ms
```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../../tools/Makefiles/Helpers.mk ../../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled Run Function. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Run Function. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Run Function. Please updated the JSON example in help.md with 2 space indentation.
        Improperly formatted JSON example identified in Example input of action titled Run Function. Please updated the JSON example in help.md with 2 space indentation.
        Improperly formatted JSON example identified in Example input of action titled Run Function. Please updated the JSON example in help.md with 2 space indentation.


----
[*] Total time elapsed: 2447.3250000000003ms
make: *** [../../tools/Makefiles/Helpers.mk:15: validate] Error 1
```

<summary>
make validate
</summary>
</details>