### PR TITLE
SOAR [8441] - Fix issue with REST/HTTP patch method

### DIFF
--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2bd0d11bee8d707ad601c025887895bb",
-	"manifest": "e6369f9c838f2cee46918ce514d4f5a0",
-	"setup": "d688002dc2257b5c40a6e428491c01a9",
+	"spec": "acf25eac81a091fe06f3e10f1c0579b2",
+	"manifest": "42b0bc6d85a6921bf0968b39038f2a77",
+	"setup": "1743f95b2348e36ebd544a1f671d89b5",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",

--- a/plugins/rest/bin/komand_rest
+++ b/plugins/rest/bin/komand_rest
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "HTTP Requests"
 Vendor = "rapid7"
-Version = "5.0.1"
+Version = "5.0.2"
 Description = "The HTTP Requests plugin to make it easy to integrate with RESTful services"
 
 

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -11,6 +11,10 @@ This plugin is often used to integrate with ad-hoc 3rd party API's in a workflow
 
 * A RESTFUL HTTP/HTTPS resource and supported authentication, if any
 
+# Supported Product Versions
+
+* 2022-02-22
+
 # Documentation
 
 ## Setup
@@ -449,6 +453,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
+* 5.0.2 - Fix issue with JSON data parser for PATCH request
 * 5.0.1 - Update to make 'No Authentication' the default connection type
 * 5.0.0 - Add ability for user to choose if the plugin should fail on standard HTTP error codes (4xx-5xx) | Add 'No Authentication' as another authentication type
 * 4.0.5 - Fix issue where if an API returned a list it would crash the plugin

--- a/plugins/rest/komand_rest/actions/patch/action.py
+++ b/plugins/rest/komand_rest/actions/patch/action.py
@@ -18,7 +18,7 @@ class Patch(insightconnect_plugin_runtime.Action):
         response = self.connection.api.call_api(
             method="PATCH",
             path=params.get(Input.ROUTE),
-            data=params.get(Input.BODY, {}),
+            json_data=params.get(Input.BODY, {}),
             headers=params.get(Input.HEADERS, {}),
         )
 

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -4,9 +4,10 @@ products: [insightconnect]
 name: rest
 title: HTTP Requests
 description: The HTTP Requests plugin to make it easy to integrate with RESTful services
-version: 5.0.1
+version: 5.0.2
 vendor: rapid7
 support: community
+supported_versions: ["2022-02-22"]
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/rest

--- a/plugins/rest/setup.py
+++ b/plugins/rest/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rest-rapid7-plugin",
-      version="5.0.1",
+      version="5.0.2",
       description="The HTTP Requests plugin to make it easy to integrate with RESTful services",
       author="rapid7",
       author_email="",

--- a/plugins/rest/unit_test/mockconnection.py
+++ b/plugins/rest/unit_test/mockconnection.py
@@ -1,9 +1,20 @@
-from requests import Response
-from komand_rest.util.util import Common
-from insightconnect_plugin_runtime.exceptions import PluginException
-import insightconnect_plugin_runtime
-import logging
 import json
+
+import insightconnect_plugin_runtime
+from requests import Response
+
+
+class MockResponse:
+    def __init__(self, json_data, status_code, text):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.text = text
+        self.headers = {}
+
+    def json(self):
+        if self.status_code == 418:
+            raise json.decoder.JSONDecodeError("I am a teapot", "NA", 0)
+        return json.loads(json.dumps(self.json_data))
 
 
 class MockConnection(insightconnect_plugin_runtime.Connection):
@@ -44,16 +55,3 @@ class MockConnectionApi:
             response = MockResponse({"SampleBodyError": "SampleVal"}, 404, "TRYGOOGLE for method " + method)
             response.headers = {"SampleError": "SampleVal"}
             return response
-
-
-class MockResponse:
-    def __init__(self, json_data, status_code, text):
-        self.json_data = json_data
-        self.status_code = status_code
-        self.text = text
-        self.headers = {}
-
-    def json(self):
-        if self.status_code == 418:
-            raise json.decoder.JSONDecodeError("I am a teapot", "NA", 0)
-        return json.loads(json.dumps(self.json_data))

--- a/plugins/rest/unit_test/test_delete.py
+++ b/plugins/rest/unit_test/test_delete.py
@@ -1,10 +1,12 @@
-import sys
 import os
-from unit_test.mockconnection import MockConnection
+import sys
+
+from mockconnection import MockConnection
 
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
+
 from komand_rest.actions.delete import Delete
 
 

--- a/plugins/rest/unit_test/test_get.py
+++ b/plugins/rest/unit_test/test_get.py
@@ -1,10 +1,12 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
-from unit_test.mockconnection import MockConnection
+
+from mockconnection import MockConnection
+
 from komand_rest.actions.get import Get
 
 

--- a/plugins/rest/unit_test/test_patch.py
+++ b/plugins/rest/unit_test/test_patch.py
@@ -1,7 +1,8 @@
-import sys
 import os
-from unit_test.mockconnection import MockConnection
+import sys
 from unittest import TestCase
+
+from mockconnection import MockConnection
 
 sys.path.append(os.path.abspath("../"))
 from komand_rest.actions.patch import Patch

--- a/plugins/rest/unit_test/test_post.py
+++ b/plugins/rest/unit_test/test_post.py
@@ -1,10 +1,12 @@
-import sys
 import os
-from unit_test.mockconnection import MockConnection
+import sys
+
+from mockconnection import MockConnection
 
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
+
 from komand_rest.actions.post import Post
 
 

--- a/plugins/rest/unit_test/test_put.py
+++ b/plugins/rest/unit_test/test_put.py
@@ -1,10 +1,12 @@
-import sys
 import os
-from unit_test.mockconnection import MockConnection
+import sys
+
+from mockconnection import MockConnection
 
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
+
 from komand_rest.actions.put import Put
 
 

--- a/plugins/rest/unit_test/test_utils.py
+++ b/plugins/rest/unit_test/test_utils.py
@@ -1,12 +1,12 @@
-import sys
 import os
+import sys
+
 from komand_rest.util.util import *
-import json
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
 import logging
+from unittest import TestCase, mock
 
 
 class MockResponse:


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix the issue with PATCH method in REST/HTTP plugin

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [x] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [x] Screenshot of job output with the plugin changes
- [x] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [x] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [x] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [x] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

### Validators

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
WARNING: Unsupported keywords found: request, rpc, microservices. The following keywords will not be searchable by the Extension Library. Please remove or update the invalid keywords from the keywords array in the plugin.spec.yaml file.
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: help.md[153]: https://httpbin.org/put\
violation: help.md[77]: https://us.api.insight.rapid7.com
violation: help.md[226]: https://httpbin.org/post
violation: help.md[228]: https://httpbin.org/post
violation: help.md[151]: https://httpbin.org/put
violation: help.md[153]: https://httpbin.org/put
violation: help.md[29]: https://httpbin.org/|
violation: help.md[423]: https://httpbin.org/delete
violation: help.md[425]: https://httpbin.org/delete
violation: help.md[298]: https://httpbin.org/patch
violation: help.md[300]: https://httpbin.org/patch
violation: help.md[29]: httpbin.org
violation: help.md[41]: httpbin.org
violation: help.md[59]: httpbin.org
violation: help.md[143]: httpbin.org
violation: help.md[151]: httpbin.org
violation: help.md[153]: httpbin.org
violation: help.md[218]: httpbin.org
violation: help.md[226]: httpbin.org
violation: help.md[228]: httpbin.org
violation: help.md[292]: httpbin.org
violation: help.md[298]: httpbin.org
violation: help.md[300]: httpbin.org
violation: help.md[417]: httpbin.org
violation: help.md[423]: httpbin.org
violation: help.md[425]: httpbin.org
violation: help.md[300]: https://httpbin.org/patch\
violation: help.md[425]: https://httpbin.org/delete\
violation: help.md[228]: https://httpbin.org/post\
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed! 
        Cause: Invalid JSON example identified in Example input of action titled PUT. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled PUT. Please updated the JSON example in help.md with 2 space indentation.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Input. Please updated the JSON example in help.md with 2 space indentation.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Input. Please updated the JSON example in help.md with 2 space indentation.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Improperly formatted JSON example identified in Example input of action titled Input. Please updated the JSON example in help.md with 2 space indentation.
```

<summary>
icon-validate --all .
</summary>
</details>

### Run (with same payload as JSON body and headers)
Without fix
<details>

```
{
  "body": {
    "error": "An error occurred during plugin execution!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"error\":{\"name\":\"badRequest\",\"message\":\"Request body has invalid format.\"}}",
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP https://example.com Step name: patch\nAn error occurred during plugin execution!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"error\":{\"name\":\"badRequest\",\"message\":\"Request body has invalid format.\"}}\nTraceback (most recent call last):\n  File \"/usr/local/lib/https://example.com\", line 326, in handle_step\n    output = https://example.com\n  File \"/usr/local/lib/https://example.com\", line 476, in start_step\n    output = func(params)\n  File \"/usr/local/lib/https://example.com\", line 18, in run\n    response = https://example.com\n  File \"/usr/local/lib/https://example.com\", line 147, in call_api\n    raise PluginException(\https://example.com An error occurred during plugin execution!\n\nSomething unexpected occurred. Check the logs and if the issue persists please contact support. Response was: {\"error\":{\"name\":\"badRequest\",\"message\":\"Request body has invalid format.\"}}\n",
    "meta": {},
    "status": "error"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:5.0.1 run < tests/patch.json
</summary>
</details>

With fix
<details>

```
{
  "body": {
    "log": "Connect: Configuring REST details\nConnect: Connecting..\nrapid7/HTTP https://example.com Step name: patch\n",
    "meta": {},
    "output": {
      "body_object": {
        "Hello": "World PATCH"
      },
      "body_string": "{\n    \"Hello\": \"World PATCH\"\n}",
      "headers": {
        "Access-Control-Allow-Origin": "*",
        "Connection": "keep-alive",
        "Content-Encoding": "gzip",
        "Content-Type": "text/html; charset=utf-8",
        "Date": "Thu, 24 Feb 2022 08:54:52 GMT",
        "ETag": "W/\"1e-ix4PLeG42si1zhX52zfBhiCG22E\"",
        "Server": "nginx",
        "Transfer-Encoding": "chunked",
        "Vary": "Accept-Encoding",
        "X-RateLimit-Limit": "120",
        "X-RateLimit-Remaining": "119",
        "X-RateLimit-Reset": "1645692952",
        "x-srv-span": "v=1;s=1f2f5b11a0051a0d",
        "x-srv-trace": "v=1;t=0e6359ac39b66c0c"
      },
      "status": 200
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/rest:5.0.2 run < tests/patch.json
</summary>
</details>

### UI

<details>

![RESTHTTP](https://user-images.githubusercontent.com/99184344/155728619-6b611407-0dd5-4cce-b95f-ad86a677aec1.png)
<summary>
PATCH Method on insightConnect Platform
</summary>
</details>