### PR TITLE
[MC-954] ServiceNow - Fix b64 decoding in put_incident_attachment action

### DIFF
--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e23584dc8ec1d9ffd6f301de6609b76a",
-	"manifest": "85a12a5377d2a993c6666fee3b2acd66",
-	"setup": "d62b866092d8128bde1fb2e858612947",
+	"spec": "10d53bdf82c37c0b290281136cbc0f88",
+	"manifest": "2f2a522675cee522c2242211dd17dfb4",
+	"setup": "8e0ff7a93fff897cc42a5c0b1eed36c7",
 	"schemas": [
 		{
 			"identifier": "create_ci/schema.py",

--- a/plugins/servicenow/bin/icon_servicenow
+++ b/plugins/servicenow/bin/icon_servicenow
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ServiceNow"
 Vendor = "rapid7"
-Version = "6.0.0"
+Version = "6.0.1"
 Description = "ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes"
 
 

--- a/plugins/servicenow/help.md
+++ b/plugins/servicenow/help.md
@@ -865,6 +865,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 6.0.1 - Fix base64 decoding in Put Incident Attachment action
 * 6.0.0 - Add additional file information in output for Get Attachments for an Incident
 * 5.2.0 - Add new action Get Attachments for an Incident | Add unit test for action Get Attachments for an Incident and Get Incident Attachment
 * 5.1.1 - Fix output parsing bug in Get Incident Attachment action

--- a/plugins/servicenow/icon_servicenow/actions/put_incident_attachment/action.py
+++ b/plugins/servicenow/icon_servicenow/actions/put_incident_attachment/action.py
@@ -1,3 +1,5 @@
+import base64
+
 import insightconnect_plugin_runtime
 from .schema import (
     PutIncidentAttachmentInput,
@@ -25,15 +27,16 @@ class PutIncidentAttachment(insightconnect_plugin_runtime.Action):
             f"{self.connection.attachment_url}/file?table_name=incident&table_sys_id={params.get(Input.SYSTEM_ID)}"
             f"&file_name={params.get(Input.ATTACHMENT_NAME)}"
         )
-        payload = params.get(Input.BASE64_CONTENT)
+
         content_type = (
             params.get(Input.MIME_TYPE)
             if params.get(Input.OTHER_MIME_TYPE) == ""
             else params.get(Input.OTHER_MIME_TYPE)
         )
-        method = "post"
 
-        response = self.connection.request.make_request(url, method, payload=payload, content_type=content_type)
+        response = self.connection.request.make_request(
+            url, "post", data=base64.b64decode(params.get(Input.BASE64_CONTENT)), content_type=content_type
+        )
 
         try:
             result = response["resource"].get("result")

--- a/plugins/servicenow/plugin.spec.yaml
+++ b/plugins/servicenow/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: ["insightconnect"]
 name: servicenow
 title: ServiceNow
 description: ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes
-version: 6.0.0
+version: 6.0.1
 supported_versions: ["2020-03-11 Orlando"]
 vendor: rapid7
 support: rapid7

--- a/plugins/servicenow/setup.py
+++ b/plugins/servicenow/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="servicenow-rapid7-plugin",
-      version="6.0.0",
+      version="6.0.1",
       description="ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix b64 decoding in put_incident_attachment action

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/https://example.com/ Step name: put_incident_attachment\n",
    "meta": {},
    "output": {
      "attachment_id": "9de5069c5afe602b2ea0a04b66beb2c0"
    },
    "status": "ok"
  },
  "type": "action_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/servicenow:6.0.1 run < tests/put_incident_attachment.json
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[86]: https://instance.servicenow.com/
violation: plugin.spec.yaml[89]: https://instance.servicenow.com/
violation: help.md[324]: https://example.service-now.com/api/now/table/cmn_location/US-East
violation: help.md[517]: https://example.service-now.com/api/now/table/cmn_location/US-East
violation: help.md[302]: https://example.service-now.com/api/now/table/sys_user_group/sysdomain
violation: help.md[494]: https://example.service-now.com/api/now/table/sys_user_group/sysdomain
violation: help.md[296]: https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6
violation: help.md[487]: https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6
violation: help.md[893]: http://wiki.servicenow.com/index.php?title=Operators_Available_for_Filters_and_Queries
violation: help.md[319]: https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949
violation: help.md[512]: https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 24123.054ms
```

<summary>
icon-validate --all .
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../../tools/Makefiles/Helpers.mk ../../tools/Makefiles/Colors.mk
--
[*] Running validators
icon-[*] Validating plugin at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
valida[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
t[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
e[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
 [*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
--all[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
 [*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 3204.266ms
```

<summary>
make validate
</summary>
</details>