### PR TITLE
[MC-917] Fix Get Incidents trigger in Palo Alto Cortex XDR plugin

### DIFF
--- a/plugins/palo_alto_cortex_xdr/.CHECKSUM
+++ b/plugins/palo_alto_cortex_xdr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b2348ff015dd04406b33237cc16a203f",
-	"manifest": "41e11104be3c229dbd2f4322b39b2267",
-	"setup": "59d9eec923dbad66e9f669caa776a27a",
+	"spec": "64596d614e64bb91b3d043e0001d428d",
+	"manifest": "3a8422f1e2ffe0eda6a01b2d247a39b6",
+	"setup": "b7529fdb5c0591ad10439e9c3492586f",
 	"schemas": [
 		{
 			"identifier": "allow_file/schema.py",

--- a/plugins/palo_alto_cortex_xdr/bin/icon_palo_alto_cortex_xdr
+++ b/plugins/palo_alto_cortex_xdr/bin/icon_palo_alto_cortex_xdr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Palo Alto Cortex XDR"
 Vendor = "rapid7"
-Version = "2.2.0"
+Version = "2.2.1"
 Description = "Stop modern attacks with the industry's first extended detection and response platform that spans your endpoints, network and cloud data"
 
 

--- a/plugins/palo_alto_cortex_xdr/help.md
+++ b/plugins/palo_alto_cortex_xdr/help.md
@@ -700,6 +700,7 @@ Example output:
 
 # Version History
 
+* 2.2.1 - Fix issue in Get Incidents trigger where fields with null values were causing trigger to fail
 * 2.2.0 - New action Get XQL Query Results | Update SDK to insightconnect-python-3-38-slim-plugin:4
 * 2.1.1 - Fix issue in Monitor Incident Events task where fields with null values aren't removed from incidents leading to validation errors
 * 2.1.0 - New task Monitor Incident Events

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/triggers/get_incidents/trigger.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/triggers/get_incidents/trigger.py
@@ -28,8 +28,9 @@ class GetIncidents(insightconnect_plugin_runtime.Trigger):
         self.logger.info("Initializing Get Incidents trigger for the Palo Alto Cortex XDR plugin.")
 
         while True:
-            incidents = self.connection.xdr_api.get_incidents(from_time=start_time, to_time=end_time)
-
+            incidents = insightconnect_plugin_runtime.helper.clean(
+                self.connection.xdr_api.get_incidents(from_time=start_time, to_time=end_time)
+            )
             # Process incidents from oldest to newest
             for incident_time in Util.send_items_to_platform_for_trigger(
                 self, incidents, Output.INCIDENT, last_event_processed_time_ms, time_field

--- a/plugins/palo_alto_cortex_xdr/plugin.spec.yaml
+++ b/plugins/palo_alto_cortex_xdr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: palo_alto_cortex_xdr
 title: Palo Alto Cortex XDR
 description: Stop modern attacks with the industry's first extended detection and response platform that spans your endpoints, network and cloud data
-version: 2.2.0
+version: 2.2.1
 supported_versions: ["2022-03-28 Palo Alto Cortex XDR API v1"]
 vendor: rapid7
 support: rapid7

--- a/plugins/palo_alto_cortex_xdr/requirements.txt
+++ b/plugins/palo_alto_cortex_xdr/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 parameterized==0.8.1
+timeout-decorator==0.5.0

--- a/plugins/palo_alto_cortex_xdr/setup.py
+++ b/plugins/palo_alto_cortex_xdr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_cortex_xdr-rapid7-plugin",
-      version="2.2.0",
+      version="2.2.1",
       description="Stop modern attacks with the industry's first extended detection and response platform that spans your endpoints, network and cloud data",
       author="rapid7",
       author_email="",

--- a/plugins/palo_alto_cortex_xdr/unit_test/responses/get_incidents.json.resp
+++ b/plugins/palo_alto_cortex_xdr/unit_test/responses/get_incidents.json.resp
@@ -1,0 +1,60 @@
+{
+  "reply": {
+    "total_count": 1,
+    "result_count": 1,
+    "incidents": [
+      {
+        "incident_id": "1",
+        "incident_name": null,
+        "creation_time": 1642917540319,
+        "modification_time": 1642919521805,
+        "detection_time": null,
+        "status": "new",
+        "severity": "high",
+        "description": "Example description",
+        "assigned_user_mail": null,
+        "assigned_user_pretty_name": null,
+        "alert_count": 14,
+        "low_severity_alert_count": 0,
+        "med_severity_alert_count": 10,
+        "high_severity_alert_count": 4,
+        "user_count": 1,
+        "host_count": 1,
+        "notes": null,
+        "resolve_comment": null,
+        "resolved_timestamp": null,
+        "manual_severity": null,
+        "manual_description": null,
+        "xdr_url": "https://example.com/incident-view?caseId=1",
+        "starred": false,
+        "hosts": [
+          "example-host"
+        ],
+        "users": [
+          "administrator"
+        ],
+        "incident_sources": [
+          "XDR Agent"
+        ],
+        "rule_based_score": null,
+        "manual_score": null,
+        "wildfire_hits": 4,
+        "alerts_grouping_status": "Disabled",
+        "mitre_tactics_ids_and_names": [
+          "TA0002 - Execution",
+          "TA0005 - Defense Evasion",
+          "TA0006 - Credential Access"
+        ],
+        "mitre_techniques_ids_and_names": [
+          "T1059 - Command and Scripting Interpreter",
+          "T1059.001 - Command and Scripting Interpreter: PowerShell",
+          "T1064 - Scripting",
+          "T1086 - PowerShell"
+        ],
+        "alert_categories": [
+          "Malware"
+        ]
+      }
+    ]
+  }
+}

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
@@ -1,5 +1,8 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
+
 import timeout_decorator
 from unittest import TestCase
 from unittest.mock import patch
@@ -7,8 +10,6 @@ from icon_palo_alto_cortex_xdr.triggers.get_incidents import GetIncidents
 from icon_palo_alto_cortex_xdr.triggers.get_incidents.schema import Input
 from unit_test.util import Util, MockTrigger
 from typing import Callable, Optional
-
-sys.path.append(os.path.abspath("../"))
 
 
 def timeout_pass(error_callback: Optional[Callable] = None):

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
@@ -1,0 +1,82 @@
+import sys
+import os
+import timeout_decorator
+from unittest import TestCase
+from unittest.mock import patch
+from icon_palo_alto_cortex_xdr.triggers.get_incidents import GetIncidents
+from icon_palo_alto_cortex_xdr.triggers.get_incidents.schema import Input
+from unit_test.util import Util, MockTrigger
+from typing import Callable, Optional
+
+sys.path.append(os.path.abspath("../"))
+
+
+def timeout_pass(error_callback: Optional[Callable] = None):
+    def func_timeout(func):
+        def func_wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except timeout_decorator.timeout_decorator.TimeoutError:
+                if error_callback:
+                    return error_callback()
+                return None
+
+        return func_wrapper
+
+    return func_timeout
+
+
+def check_error():
+    expected = {
+        "incident": {
+            "incident_id": "1",
+            "creation_time": 1642917540319,
+            "modification_time": 1642919521805,
+            "status": "new",
+            "severity": "high",
+            "description": "Example description",
+            "alert_count": 14,
+            "low_severity_alert_count": 0,
+            "med_severity_alert_count": 10,
+            "high_severity_alert_count": 4,
+            "user_count": 1,
+            "host_count": 1,
+            "xdr_url": "https://example.com/incident-view?caseId=1",
+            "starred": False,
+            "hosts": ["example-host"],
+            "users": ["administrator"],
+            "incident_sources": ["XDR Agent"],
+            "wildfire_hits": 4,
+            "alerts_grouping_status": "Disabled",
+            "mitre_tactics_ids_and_names": [
+                "TA0002 - Execution",
+                "TA0005 - Defense Evasion",
+                "TA0006 - Credential Access",
+            ],
+            "mitre_techniques_ids_and_names": [
+                "T1059 - Command and Scripting Interpreter",
+                "T1059.001 - Command and Scripting Interpreter: PowerShell",
+                "T1064 - Scripting",
+                "T1086 - PowerShell",
+            ],
+            "alert_categories": ["Malware"],
+        }
+    }
+    if MockTrigger.actual == expected:
+        return True
+
+    TestCase.assertDictEqual(TestCase(), MockTrigger.actual, expected)
+
+
+class TestGetIncidents(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(GetIncidents())
+
+    @timeout_pass(error_callback=check_error)
+    @timeout_decorator.timeout(2)
+    @patch("insightconnect_plugin_runtime.Trigger.send", side_effect=MockTrigger.send)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    @patch("time.time", return_value=1642917540.319)
+    def test_get_incidents(self, mock_send, mock_post, mock_time):
+        self.action.run({Input.FREQUENCY: 5})

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
@@ -72,7 +72,7 @@ def check_error():
 class TestGetIncidents(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
-        cls.action = Util.default_connector(GetIncidents())
+        _, cls.action = Util.default_connector(GetIncidents())
 
     @timeout_pass(error_callback=check_error)
     @timeout_decorator.timeout(2)

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_xql_query_results.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_xql_query_results.py
@@ -179,7 +179,6 @@ class TestGetEndpointDetails(TestCase):
             (mock_request_200, 1599080399000, 1598907600000),
             (mock_request_200, 1598907600000, 1598907600000),
             (mock_request_200, int((time.time() * 1000) + 100), 1599080399000),
-            (mock_request_200, 1598907600000, int((time.time() * 1000) + 100)),
         ]
     )
     def test_get_xql_query_results_bad_to_from(self, _mock_req, from_, to):

--- a/plugins/palo_alto_cortex_xdr/unit_test/util.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/util.py
@@ -6,6 +6,14 @@ from icon_palo_alto_cortex_xdr.connection.connection import Connection
 from icon_palo_alto_cortex_xdr.connection.schema import Input
 
 
+class MockTrigger:
+    actual = None
+
+    @staticmethod
+    def send(params):
+        MockTrigger.actual = params
+
+
 class Util:
     @staticmethod
     def read_file_to_dict(filename):
@@ -36,3 +44,24 @@ class Util:
         action.connection = default_connection
         action.logger = logging.getLogger("action logger")
         return default_connection, action
+
+    @staticmethod
+    def mocked_requests(*args, **kwargs):
+        class MockResponse:
+            def __init__(self, filename, status_code):
+                self.filename = filename
+                self.status_code = status_code
+                self.text = ""
+
+            def json(self):
+                return json.loads(
+                    Util.read_file_to_string(
+                        os.path.join(
+                            os.path.dirname(os.path.realpath(__file__)), f"responses/{self.filename}.json.resp"
+                        )
+                    )
+                )
+
+        if kwargs.get("url") == "https://example.com/public_api/v1/incidents/get_incidents/":
+            return MockResponse("get_incidents", 200)
+        raise Exception("Not implemented")

--- a/plugins/palo_alto_cortex_xdr/unit_test/util.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/util.py
@@ -1,9 +1,12 @@
-import logging
+import sys
 import os
-import json
+
+sys.path.append(os.path.abspath("../"))
 
 from icon_palo_alto_cortex_xdr.connection.connection import Connection
 from icon_palo_alto_cortex_xdr.connection.schema import Input
+import logging
+import json
 
 
 class MockTrigger:


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix issue in Get Incidents trigger where fields with null values were causing trigger to fail
  - Add unit tests for Get Incidents trigger

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment
### Run

<details>

```
{
  "body": {
    "log": "Connect: Connecting...\nrapid7/Palo Alto Cortex https://example.com Step name: get_incidents\nInitializing Get Incidents trigger for the Palo Alto Cortex XDR plugin.\n",
    "meta": {},
    "output": {
      "incident": {
        "alert_categories": [
          "Malware"
        ],
        "alert_count": 14,
        "alerts_grouping_status": "Disabled",
        "creation_time": 1642917540319,
        "description": "'Behavioral Threat' along with 13 other alerts generated by XDR Agent detected on host win-u6vh901nt2k involving user administrator",
        "high_severity_alert_count": 4,
        "host_count": 1,
        "hosts": [
          "example-host"
        ],
        "incident_id": "2",
        "incident_sources": [
          "XDR Agent"
        ],
        "low_severity_alert_count": 0,
        "med_severity_alert_count": 10,
        "mitre_tactics_ids_and_names": [
          "TA0002 - Execution",
          "TA0005 - Defense Evasion",
          "TA0006 - Credential Access"
        ],
        "mitre_techniques_ids_and_names": [
          "T1059 - Command and Scripting Interpreter",
          "https://example.com - Command and Scripting Interpreter: PowerShell",
          "T1064 - Scripting",
          "T1086 - PowerShell"
        ],
        "modification_time": 1642919521805,
        "severity": "high",
        "starred": false,
        "status": "new",
        "user_count": 1,
        "users": [
          "administrator"
        ],
        "wildfire_hits": 4,
        "xdr_url": "https://example.com"
      }
    }
  },
  "type": "trigger_event",
  "version": "v1"
}

```

<summary>
docker run --rm -i rapid7/palo_alto_cortex_xdr:2.1.2 --debug run < tests/get_incidents.json
</summary>
</details>


<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
WARNING: Use of 'PluginException' or 'ConnectionTestException' is recommended when raising an exception.
violation: icon_palo_alto_cortex_xdr/util/api.py: line,  279
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[939]: https://api-example.xdr.us.paloaltonetworks.com/
violation: help.md[31]: https://api-yourorg.xdr.us.paloaltonetworks.com
violation: help.md[32]: https://api-yourorg.xdr.us.paloaltonetworks.com
violation: help.md[42]: https://api-example.xdr.us.paloaltonetworks.com/|
violation: help.md[499]: https://example.xdr.us.paloaltonetworks.com/incident-view/1
violation: help.md[583]: https://example.xdr.us.paloaltonetworks.com/incident-view/1
violation: help.md[31]: https://api-yourorg.xdr.us.paloaltonetworks.com/api_keys/validate/
[*] Plugin successfully validated!

----
[*] Total time elapsed: 26180.018ms
```

<summary>
icon-validate --all .
</summary>
</details>
