### PR TITLE
[SOAR-9079] Fix Update URL List By ID Non-Required Fields

### DIFF
--- a/plugins/netskope/.CHECKSUM
+++ b/plugins/netskope/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "592f28d645dac331d657124638581d8e",
-	"manifest": "a0c9f2782e9d48b01f901b378f7f69b3",
-	"setup": "0a195349e5a0f094f0244eae9eca6763",
+	"spec": "fe934117f055bf8380ce04d0158a12b4",
+	"manifest": "f40dd8619fedb69c6861e25f61a4ea71",
+	"setup": "9965a2869343ac9bfd291027f0e3fd7b",
 	"schemas": [
 		{
 			"identifier": "apply_pending_url_list_changes/schema.py",
@@ -29,7 +29,7 @@
 		},
 		{
 			"identifier": "patch_url_list_by_id/schema.py",
-			"hash": "6408ea41afe88385002ffc0f14c5b590"
+			"hash": "ec30e9e11147f45318e958e76e534585"
 		},
 		{
 			"identifier": "replace_url_list_by_id/schema.py",

--- a/plugins/netskope/.CHECKSUM
+++ b/plugins/netskope/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2defd240782880fd9af1cff6a9543026",
-	"manifest": "f40dd8619fedb69c6861e25f61a4ea71",
-	"setup": "9965a2869343ac9bfd291027f0e3fd7b",
+	"spec": "592f28d645dac331d657124638581d8e",
+	"manifest": "a0c9f2782e9d48b01f901b378f7f69b3",
+	"setup": "0a195349e5a0f094f0244eae9eca6763",
 	"schemas": [
 		{
 			"identifier": "apply_pending_url_list_changes/schema.py",
@@ -29,7 +29,7 @@
 		},
 		{
 			"identifier": "patch_url_list_by_id/schema.py",
-			"hash": "63204cc88b1dfb05a2e82733b4852fa7"
+			"hash": "6408ea41afe88385002ffc0f14c5b590"
 		},
 		{
 			"identifier": "replace_url_list_by_id/schema.py",

--- a/plugins/netskope/.CHECKSUM
+++ b/plugins/netskope/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "5fb1119598a7fa2cd6390d4472cd26d3",
-	"manifest": "a0228e2da4330999a834aa56676febaf",
-	"setup": "bbaa07fd7250b5a5c535d90194b3509a",
+	"spec": "2defd240782880fd9af1cff6a9543026",
+	"manifest": "f40dd8619fedb69c6861e25f61a4ea71",
+	"setup": "9965a2869343ac9bfd291027f0e3fd7b",
 	"schemas": [
 		{
 			"identifier": "apply_pending_url_list_changes/schema.py",

--- a/plugins/netskope/bin/icon_netskope
+++ b/plugins/netskope/bin/icon_netskope
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Netskope"
 Vendor = "rapid7"
-Version = "2.0.0"
+Version = "1.0.1"
 Description = "This plugin allows users to create, read, update, and delete URL lists in their Netskope environment"
 
 

--- a/plugins/netskope/bin/icon_netskope
+++ b/plugins/netskope/bin/icon_netskope
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Netskope"
 Vendor = "rapid7"
-Version = "1.0.0"
+Version = "1.0.1"
 Description = "This plugin allows users to create, read, update, and delete URL lists in their Netskope environment"
 
 

--- a/plugins/netskope/bin/icon_netskope
+++ b/plugins/netskope/bin/icon_netskope
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Netskope"
 Vendor = "rapid7"
-Version = "1.0.1"
+Version = "2.0.0"
 Description = "This plugin allows users to create, read, update, and delete URL lists in their Netskope environment"
 
 

--- a/plugins/netskope/help.md
+++ b/plugins/netskope/help.md
@@ -22,7 +22,7 @@ This plugin allows users to create, read, update, and delete URL list
 
 # Supported Product Versions
 
-* 2022-02-11
+* 2022-04-26
 
 # Documentation
 
@@ -609,6 +609,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.0.1 - Fix bug where Update URL List by ID did not support empty non-required fields
 * 1.0.0 - Initial plugin (Actions: Apply Pending URL List Changes, Create a New URL List, Delete a URL List by ID, Get All URL Lists, Get Single User's Confidence Index, Get URL List by ID, Replace URL List Configuration by ID, Update URL List by ID, Update a File Hash List, Upload JSON File Configurations)
 
 # Links
@@ -618,4 +619,3 @@ _This plugin does not contain any troubleshooting information._
 * [Netskope](https://www.netskope.com/)
 * [Netskope API v1](https://docs.netskope.com/en/rest-api-v1-overview.html)
 * [Netskope API v2](https://docs.netskope.com/en/rest-api-v2-overview-312207.html)
-

--- a/plugins/netskope/help.md
+++ b/plugins/netskope/help.md
@@ -61,7 +61,7 @@ This action is used to update the name, URLs, and/or type of a URL list object.
 |action|string|None|True|Replace or append to current URLs|['replace', 'append']|append|
 |id|integer|None|True|ID of the URL list|None|1|
 |name|string|None|False|Name of replaced URL list|None|ExampleName|
-|type|string|None|False|Category of URL list|['', 'exact', 'regex']|exact|
+|type|string|None|True|Category of URL list|['', 'exact', 'regex']|exact|
 |urls|[]string|None|False|List of URLs|None|["https://example.com", "https://example.com"]|
 
 Example input (type exact):
@@ -609,7 +609,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 1.0.1 - Fix bug where Update URL List by ID did not support empty non-required fields
+* 2.0.0 - Fix bug where Update URL List by ID did not support empty non-required fields | URL List Category is now a required input for Update URL List by ID
 * 1.0.0 - Initial plugin (Actions: Apply Pending URL List Changes, Create a New URL List, Delete a URL List by ID, Get All URL Lists, Get Single User's Confidence Index, Get URL List by ID, Replace URL List Configuration by ID, Update URL List by ID, Update a File Hash List, Upload JSON File Configurations)
 
 # Links

--- a/plugins/netskope/help.md
+++ b/plugins/netskope/help.md
@@ -61,8 +61,8 @@ This action is used to update the name, URLs, and/or type of a URL list object.
 |action|string|None|True|Replace or append to current URLs|['replace', 'append']|append|
 |id|integer|None|True|ID of the URL list|None|1|
 |name|string|None|False|Name of replaced URL list|None|ExampleName|
-|type|string|None|True|Category of URL list|['', 'exact', 'regex']|exact|
-|urls|[]string|None|False|List of URLs|None|["https://example.com", "https://example.com"]|
+|type|string|None|True|Category of URL list (to update this value, URLs input must also be provided)|['', 'exact', 'regex']|exact|
+|urls|[]string|None|False|List of URLs (to update this value, URL List Category input must also be provided)|None|["https://example.com", "https://example.com"]|
 
 Example input (type exact):
 
@@ -609,7 +609,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.0.0 - Fix bug where Update URL List by ID did not support empty non-required fields | URL List Category is now a required input for Update URL List by ID
+* 1.0.1 - Fix bug where Update URL List by ID did not support empty non-required Name field | Update Update URL List by ID input descriptions
 * 1.0.0 - Initial plugin (Actions: Apply Pending URL List Changes, Create a New URL List, Delete a URL List by ID, Get All URL Lists, Get Single User's Confidence Index, Get URL List by ID, Replace URL List Configuration by ID, Update URL List by ID, Update a File Hash List, Upload JSON File Configurations)
 
 # Links

--- a/plugins/netskope/help.md
+++ b/plugins/netskope/help.md
@@ -61,7 +61,7 @@ This action is used to update the name, URLs, and/or type of a URL list object.
 |action|string|None|True|Replace or append to current URLs|['replace', 'append']|append|
 |id|integer|None|True|ID of the URL list|None|1|
 |name|string|None|False|Name of replaced URL list|None|ExampleName|
-|type|string|None|True|Category of URL list (to update this value, URLs input must also be provided)|['', 'exact', 'regex']|exact|
+|type|string|None|False|Category of URL list (to update this value, URLs input must also be provided)|['', 'exact', 'regex']|exact|
 |urls|[]string|None|False|List of URLs (to update this value, URL List Category input must also be provided)|None|["https://example.com", "https://example.com"]|
 
 Example input (type exact):

--- a/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/action.py
+++ b/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/action.py
@@ -13,9 +13,7 @@ class PatchUrlListById(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        data = {}
-        if params.get(Input.NAME):
-            data[Input.NAME] = params.get(Input.NAME)
+        data = {Input.NAME: params.get(Input.NAME)} if params.get(Input.NAME) else {}
         if all((params.get(Input.URLS), params.get(Input.TYPE))):
             data["data"] = {Input.URLS: params.get(Input.URLS), Input.TYPE: params.get(Input.TYPE)}
         return self.connection.client.patch_url_list_by_id(params.get(Input.ID), params.get(Input.ACTION), data)

--- a/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/action.py
+++ b/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/action.py
@@ -13,9 +13,9 @@ class PatchUrlListById(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        data = {
-            Input.NAME: params.get(Input.NAME),
-        }
+        data = {}
+        if params.get(Input.NAME):
+            data[Input.NAME] = params.get(Input.NAME)
         if all((params.get(Input.URLS), params.get(Input.TYPE))):
             data["data"] = {Input.URLS: params.get(Input.URLS), Input.TYPE: params.get(Input.TYPE)}
         return self.connection.client.patch_url_list_by_id(params.get(Input.ID), params.get(Input.ACTION), data)

--- a/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/schema.py
+++ b/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/schema.py
@@ -56,7 +56,7 @@ class PatchUrlListByIdInput(insightconnect_plugin_runtime.Input):
     "type": {
       "type": "string",
       "title": "URL List Category",
-      "description": "Category of URL list",
+      "description": "Category of URL list (to update this value, URLs input must also be provided)",
       "enum": [
         "",
         "exact",
@@ -67,7 +67,7 @@ class PatchUrlListByIdInput(insightconnect_plugin_runtime.Input):
     "urls": {
       "type": "array",
       "title": "URLs",
-      "description": "List of URLs",
+      "description": "List of URLs (to update this value, URL List Category input must also be provided)",
       "items": {
         "type": "string"
       },
@@ -76,8 +76,7 @@ class PatchUrlListByIdInput(insightconnect_plugin_runtime.Input):
   },
   "required": [
     "action",
-    "id",
-    "type"
+    "id"
   ]
 }
     """)

--- a/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/schema.py
+++ b/plugins/netskope/icon_netskope/actions/patch_url_list_by_id/schema.py
@@ -76,7 +76,8 @@ class PatchUrlListByIdInput(insightconnect_plugin_runtime.Input):
   },
   "required": [
     "action",
-    "id"
+    "id",
+    "type"
   ]
 }
     """)

--- a/plugins/netskope/plugin.spec.yaml
+++ b/plugins/netskope/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: netskope
 title: Netskope
 description: This plugin allows users to create, read, update, and delete URL lists in their Netskope environment
-version: 2.0.0
+version: 1.0.1
 vendor: rapid7
 support: rapid7
 supported_versions: ["2022-04-26"]
@@ -412,19 +412,19 @@ actions:
         example: ExampleName
       urls:
         title: URLs
-        description: List of URLs
+        description: List of URLs (to update this value, URL List Category input must also be provided)
         type: "[]string"
         required: false
         example: '["https://example.com", "https://example.com"]'
       type:
         title: URL List Category
-        description: Category of URL list
+        description: Category of URL list (to update this value, URLs input must also be provided)
         type: string
         enum:
           - ""
           - exact
           - regex
-        required: true
+        required: false
         example: exact
     output:
       id:

--- a/plugins/netskope/plugin.spec.yaml
+++ b/plugins/netskope/plugin.spec.yaml
@@ -4,10 +4,10 @@ products: [insightconnect]
 name: netskope
 title: Netskope
 description: This plugin allows users to create, read, update, and delete URL lists in their Netskope environment
-version: 1.0.0
+version: 1.0.1
 vendor: rapid7
 support: rapid7
-supported_versions: ["2022-02-11"]
+supported_versions: ["2022-04-26"]
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/netskope

--- a/plugins/netskope/plugin.spec.yaml
+++ b/plugins/netskope/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: netskope
 title: Netskope
 description: This plugin allows users to create, read, update, and delete URL lists in their Netskope environment
-version: 1.0.1
+version: 2.0.0
 vendor: rapid7
 support: rapid7
 supported_versions: ["2022-04-26"]
@@ -424,7 +424,7 @@ actions:
           - ""
           - exact
           - regex
-        required: false
+        required: true
         example: exact
     output:
       id:

--- a/plugins/netskope/setup.py
+++ b/plugins/netskope/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="netskope-rapid7-plugin",
-      version="1.0.1",
+      version="2.0.0",
       description="This plugin allows users to create, read, update, and delete URL lists in their Netskope environment",
       author="rapid7",
       author_email="",

--- a/plugins/netskope/setup.py
+++ b/plugins/netskope/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="netskope-rapid7-plugin",
-      version="2.0.0",
+      version="1.0.1",
       description="This plugin allows users to create, read, update, and delete URL lists in their Netskope environment",
       author="rapid7",
       author_email="",

--- a/plugins/netskope/setup.py
+++ b/plugins/netskope/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="netskope-rapid7-plugin",
-      version="1.0.0",
+      version="1.0.1",
       description="This plugin allows users to create, read, update, and delete URL lists in their Netskope environment",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Update the Update URL List By ID action to handle non-required field 'name' being empty. Previously, if left empty, the action would fail.
  - Update the Update URL List By ID action to successfully update URL list by setting 'type' input to required. If 'type' input was not provided previously, the passed URLs would not be appended to or replace the original URL list.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section

![Screenshot 2022-04-26 at 14 15 00](https://user-images.githubusercontent.com/96182471/165322054-2057b5a6-cb57-481e-bb78-0afafb1229ed.png)
![Screenshot 2022-04-26 at 14 10 43](https://user-images.githubusercontent.com/96182471/165322061-a972353e-492e-4eff-956e-45e9fc3d172b.png)

