### PR TITLE
[MC-1017] Insight vm incorrect types

### DIFF
--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,6 +1,6 @@
 {
-	"spec": "eeaa663d820ef433d71f05999f9b491f",
-	"manifest": "b13c487bdfb586d7e3ea25460009a5fd",
+	"spec": "9d42ec8a8fda7953796ef0cf62d59ba2",
+	"manifest": "6082c7c4e00032ab66b480688efa207f",
 	"setup": "363288e12cede27992f9d7ef4ab710f9",
 	"schemas": [
 		{

--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,6 +1,6 @@
 {
-	"spec": "9d42ec8a8fda7953796ef0cf62d59ba2",
-	"manifest": "6082c7c4e00032ab66b480688efa207f",
+	"spec": "eeaa663d820ef433d71f05999f9b491f",
+	"manifest": "b13c487bdfb586d7e3ea25460009a5fd",
 	"setup": "363288e12cede27992f9d7ef4ab710f9",
 	"schemas": [
 		{

--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "896bed8a75691e7d6f4e49e349ead4a2",
-	"manifest": "b096ea79dfff01bcf792179ceac75353",
-	"setup": "38efc26d64ac89fc85ee517206350f82",
+	"spec": "eeaa663d820ef433d71f05999f9b491f",
+	"manifest": "b13c487bdfb586d7e3ea25460009a5fd",
+	"setup": "363288e12cede27992f9d7ef4ab710f9",
 	"schemas": [
 		{
 			"identifier": "add_scan_engine_pool_engine/schema.py",
@@ -21,7 +21,7 @@
 		},
 		{
 			"identifier": "asset_vulnerability_solution/schema.py",
-			"hash": "5ae2202b33b66ec147a0033b78bf0569"
+			"hash": "7a789e0b1682910486c4f180a8bee983"
 		},
 		{
 			"identifier": "create_asset_group/schema.py",
@@ -105,7 +105,7 @@
 		},
 		{
 			"identifier": "get_asset/schema.py",
-			"hash": "76477ea46278b21c015886d6fc5b778a"
+			"hash": "360ceba6a8bf2ef6f98f2951dfa2b8d4"
 		},
 		{
 			"identifier": "get_asset_group/schema.py",
@@ -121,7 +121,7 @@
 		},
 		{
 			"identifier": "get_asset_software/schema.py",
-			"hash": "330b22d82a384886834452b4101e4da3"
+			"hash": "625301ffd22597dff7d8665e4753b631"
 		},
 		{
 			"identifier": "get_asset_tags/schema.py",
@@ -129,7 +129,7 @@
 		},
 		{
 			"identifier": "get_asset_vulnerabilities/schema.py",
-			"hash": "aef30c6698a25e93875fb2e26ee5b4ae"
+			"hash": "252860b202fa81722c24534f5675c049"
 		},
 		{
 			"identifier": "get_authentication_source/schema.py",

--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,6 +1,6 @@
 {
 	"spec": "eeaa663d820ef433d71f05999f9b491f",
-	"manifest": "6082c7c4e00032ab66b480688efa207f",
+	"manifest": "b13c487bdfb586d7e3ea25460009a5fd",
 	"setup": "363288e12cede27992f9d7ef4ab710f9",
 	"schemas": [
 		{

--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,6 +1,6 @@
 {
 	"spec": "eeaa663d820ef433d71f05999f9b491f",
-	"manifest": "b13c487bdfb586d7e3ea25460009a5fd",
+	"manifest": "6082c7c4e00032ab66b480688efa207f",
 	"setup": "363288e12cede27992f9d7ef4ab710f9",
 	"schemas": [
 		{

--- a/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
+++ b/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightVM Console"
 Vendor = "rapid7"
-Version = "4.10.0"
+Version = "5.0.0"
 Description = "InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans"
 
 

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -16,7 +16,7 @@ This plugin utilizes the [InsightVM API 3](https://help.rapid7.com/insightvm/en-
 
 # Supported Product Versions
 
-* Rapid7 InsightVM API v3 2022-05-18
+* Rapid7 InsightVM API v3 2022-05-25
 
 # Documentation
 
@@ -50,7 +50,7 @@ This action returns the highest-superceding rollup solutions for a list of vulne
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|asset_id|string|None|True|The identifier of the asset|None|423|
+|asset_id|integer|None|True|The identifier of the asset|None|423|
 |vulnerability_ids|[]string|None|True|A list of identifiers of the vulnerabilities|None|["flash_player-cve-2017-11305"]|
 
 Example input:
@@ -78,7 +78,7 @@ Example output:
     {
       "links": [
         {
-          "href": "https://ivm-console.rapid7.com:3780/api/3/assets/234/vulnerabilities/flash_player-cve-2017-11305/solution",
+          "href": "https://example.com/api/3/assets/234/vulnerabilities/flash_player-cve-2017-11305/solution",
           "rel": "self"
         }
       ],
@@ -90,15 +90,15 @@ Example output:
           "id": "adobe-flash-windows-upgrade-latest",
           "links": [
             {
-              "href": "https://ivm-consolelax.rapid7.com:3780/api/3/solutions/adobe-flash-windows-upgrade-latest",
+              "href": "https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest",
               "rel": "self"
             },
             {
-              "href": "https://ivm-console.rapid7.com:3780/api/3/solutions/adobe-flash-windows-upgrade-latest/prerequisites",
+              "href": "https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest/prerequisites",
               "rel": "Prerequisites"
             },
             {
-              "href": "https://ivm-console.rapid7.com:3780/api/3/solutions/adobe-flash-windows-upgrade-latest/supersedes",
+              "href": "https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest/supersedes",
               "rel": "Supersedes"
             }
           ],
@@ -114,7 +114,7 @@ Example output:
               },
               "links": [
                 {
-                  "href": "https://ivm-console.rapid7.com:3780/api/3/solutions/adobe-flash-upgrade-28-0-0-126-windows",
+                  "href": "https://example.com/api/3/solutions/adobe-flash-upgrade-28-0-0-126-windows",
                   "id": "adobe-flash-upgrade-28-0-0-126-windows",
                   "rel": "Solution"
                 }
@@ -472,13 +472,13 @@ This action gets an asset by ID.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|id|integer|None|True|Get an asset by ID|None|1234|
+|asset_id|integer|None|True|Identifier of asset|None|1234|
 
 Example input:
 
 ```
 {
-  "id": 1234
+  "asset_id": 1234
 }
 ```
 
@@ -756,7 +756,7 @@ This action is used to get vulnerabilities found on an asset. Can only be used i
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|asset_id|string|None|True|ID of the asset for which to find vulnerabilities|None|234|
+|asset_id|integer|None|True|ID of the asset for which to find vulnerabilities|None|234|
 |get_risk_score|boolean|None|False|Return risk score along with other vulnerability data|None|True|
 
 Example input:
@@ -830,7 +830,7 @@ This action is used to get software found on an asset. Can only be used if the a
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|asset_id|string|None|True|ID of the asset for which to find software|None|234|
+|asset_id|integer|None|True|ID of the asset for which to find software|None|234|
 
 Example input:
 
@@ -1282,11 +1282,11 @@ Example output:
     },
     "links": [
       {
-        "href": "https://ivm-console-test.vuln.lax.rapid7.com:3780/...",
+        "href": "https://example.com/...",
         "rel": "self"
       },
       {
-        "href": "https://ivm-console-test.vuln.lax.rapid7.com:3780/...",
+        "href": "https://example.com/...",
         "rel": "Vulnerability Checks"
       }
     ],
@@ -5662,6 +5662,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 5.0.0 - Fix parameters type, input examples and description for `Get Asset Vulnerability Solutions`, `Get Asset Vulnerabilities`, `Get Asset Software` and `Get Asset` actions
 * 4.10.0 - Add new action Tag Assets
 * 4.9.2 - Add expiration date conversion to ISO8601 in Create Vulnerability Exception Submission and Update Vulnerability Exception Expiration Date actions | Fix issue with incorrect expiration date format in Get Expiring Vulnerability Exceptions action | Fix issue in List Reports action where first page of reports was not included | Fix issue in List Reports action where `found` output was returned as false even though list of reports was returned | Updated plugin SDK to latest version
 * 4.9.1 - Rename the plugin with "console" as there is a new cloud based plugin for InsightVM

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/asset_vulnerability_solution/schema.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/asset_vulnerability_solution/schema.py
@@ -23,7 +23,7 @@ class AssetVulnerabilitySolutionInput(insightconnect_plugin_runtime.Input):
   "title": "Variables",
   "properties": {
     "asset_id": {
-      "type": "string",
+      "type": "integer",
       "title": "Asset ID",
       "description": "The identifier of the asset",
       "order": 1

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset/action.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset/action.py
@@ -17,9 +17,7 @@ class GetAsset(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         resource_helper = ResourceRequests(self.connection.session, self.logger)
-        asset_id = params.get(Input.ID)
-        endpoint = endpoints.Asset.assets(self.connection.console_url, asset_id)
+        endpoint = endpoints.Asset.assets(self.connection.console_url, params.get(Input.ASSET_ID))
         self.logger.info(f"Using {endpoint}")
-        asset = resource_helper.resource_request(endpoint)
 
-        return {Output.ASSET: asset}
+        return {Output.ASSET: resource_helper.resource_request(endpoint)}

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset/schema.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset/schema.py
@@ -8,7 +8,7 @@ class Component:
 
 
 class Input:
-    ID = "id"
+    ASSET_ID = "asset_id"
     
 
 class Output:
@@ -21,15 +21,15 @@ class GetAssetInput(insightconnect_plugin_runtime.Input):
   "type": "object",
   "title": "Variables",
   "properties": {
-    "id": {
+    "asset_id": {
       "type": "integer",
-      "title": "ID",
-      "description": "Get an asset by ID",
+      "title": "Asset ID",
+      "description": "Identifier of asset",
       "order": 1
     }
   },
   "required": [
-    "id"
+    "asset_id"
   ]
 }
     """)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset_software/schema.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset_software/schema.py
@@ -22,7 +22,7 @@ class GetAssetSoftwareInput(insightconnect_plugin_runtime.Input):
   "title": "Variables",
   "properties": {
     "asset_id": {
-      "type": "string",
+      "type": "integer",
       "title": "Asset ID",
       "description": "ID of the asset for which to find software",
       "order": 1

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset_vulnerabilities/schema.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/get_asset_vulnerabilities/schema.py
@@ -23,7 +23,7 @@ class GetAssetVulnerabilitiesInput(insightconnect_plugin_runtime.Input):
   "title": "Variables",
   "properties": {
     "asset_id": {
-      "type": "string",
+      "type": "integer",
       "title": "Asset ID",
       "description": "ID of the asset for which to find vulnerabilities",
       "order": 1

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -4,8 +4,8 @@ products: [insightconnect]
 name: rapid7_insightvm
 title: Rapid7 InsightVM Console
 description: InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans
-version: 4.10.0
-supported_versions: ["Rapid7 InsightVM API v3 2022-05-18"]
+version: 5.0.0
+supported_versions: ["Rapid7 InsightVM API v3 2022-05-25"]
 vendor: rapid7
 support: rapid7
 status: []
@@ -1890,7 +1890,7 @@ actions:
       asset_id:
         title: Asset ID
         description: ID of the asset for which to find vulnerabilities
-        type: string
+        type: integer
         required: true
         example: 234
       get_risk_score:
@@ -1912,9 +1912,9 @@ actions:
       asset_id:
         title: Asset ID
         description: ID of the asset for which to find software
-        type: string
+        type: integer
         required: true
-        example: "234"
+        example: 234
     output:
       software:
         title: Software
@@ -2395,9 +2395,9 @@ actions:
     title: Get Asset
     description: Gets an asset by ID
     input:
-      id:
-        title: ID
-        description: Get an asset by ID
+      asset_id:
+        title: Asset ID
+        description: Identifier of asset
         type: integer
         example: 1234
         required: true
@@ -4047,7 +4047,7 @@ actions:
       asset_id:
         title: Asset ID
         description: The identifier of the asset
-        type: string
+        type: integer
         required: true
         example: 423
       vulnerability_ids:

--- a/plugins/rapid7_insightvm/requirements.txt
+++ b/plugins/rapid7_insightvm/requirements.txt
@@ -8,3 +8,4 @@ python-dateutil==2.8.2
 parameterized==0.8.1
 pytest==7.0.1
 freezegun==1.1.0
+asyncinit==0.2.4

--- a/plugins/rapid7_insightvm/requirements.txt
+++ b/plugins/rapid7_insightvm/requirements.txt
@@ -8,4 +8,3 @@ python-dateutil==2.8.2
 parameterized==0.8.1
 pytest==7.0.1
 freezegun==1.1.0
-asyncinit==0.2.4

--- a/plugins/rapid7_insightvm/setup.py
+++ b/plugins/rapid7_insightvm/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightvm-rapid7-plugin",
-      version="4.10.0",
+      version="5.0.0",
       description="InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightvm/unit_test/expected/asset_vulnerability_solution.json.exp
+++ b/plugins/rapid7_insightvm/unit_test/expected/asset_vulnerability_solution.json.exp
@@ -1,0 +1,54 @@
+{
+  "vulnerabilities_solution": [
+    {
+      "resources": [
+        {
+          "confidence": "exact",
+          "estimate": "PT1H",
+          "id": "ssl-beast-attack",
+          "links": [
+            {
+              "href": "https://example.com/api/3/solutions/ssl-beast-attack",
+              "rel": "self"
+            }
+          ],
+          "matches": [
+            {
+              "confidence": "exact",
+              "fingerprint": {
+                "description": "Apache HTTPD",
+                "family": "Apache",
+                "product": "HTTPD",
+                "vendor": "Apache"
+              },
+              "links": [
+                {
+                  "id": "ssl-beast-attack",
+                  "href": "https://example.com/api/3/solutions/ssl-beast-attack",
+                  "rel": "Solution"
+                }
+              ],
+              "solution": "ssl-beast-attack",
+              "type": "service"
+            }
+          ],
+          "steps": {
+            "html": "<p>\r\n<p>\n         There is no server-side mitigation available against the BEAST attack. The only option is to disable the affected\n         protocols (SSLv3 and TLS 1.0). The only fully safe configuration is to use Authenticated Encryption with Associated Data (AEAD),\n         e.g. AES-GCM, AES-CCM in TLS 1.2.\n      </p></p>",
+            "text": "There is no server-side mitigation available against the BEAST attack. The only option is to disable the affected protocols (SSLv3 and TLS 1.0). The only fully safe configuration is to use Authenticated Encryption with Associated Data (AEAD), e.g. AES-GCM, AES-CCM in TLS 1.2."
+          },
+          "summary": {
+            "html": "Disable SSLv2, SSLv3, and TLS 1.0. The best solution is to only have TLS 1.2 enabled",
+            "text": "Disable SSLv2, SSLv3, and TLS 1.0. The best solution is to only have TLS 1.2 enabled"
+          },
+          "type": "configuration"
+        }
+      ],
+      "links": [
+        {
+          "href": "https://example.com/api/3/assets/41/vulnerabilities/ssl-cve-2011-3389-beast/solution",
+          "rel": "self"
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/asset_vulnerability_solution.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/asset_vulnerability_solution.json.resp
@@ -1,0 +1,50 @@
+{
+  "resources": [
+    {
+      "confidence": "exact",
+      "estimate": "PT1H",
+      "id": "ssl-beast-attack",
+      "links": [
+        {
+          "href": "https://example.com/api/3/solutions/ssl-beast-attack",
+          "rel": "self"
+        }
+      ],
+      "matches": [
+        {
+          "confidence": "exact",
+          "fingerprint": {
+            "description": "Apache HTTPD",
+            "family": "Apache",
+            "product": "HTTPD",
+            "vendor": "Apache"
+          },
+          "links": [
+            {
+              "id": "ssl-beast-attack",
+              "href": "https://example.com/api/3/solutions/ssl-beast-attack",
+              "rel": "Solution"
+            }
+          ],
+          "solution": "ssl-beast-attack",
+          "type": "service"
+        }
+      ],
+      "steps": {
+        "html": "<p>\r\n<p>\n         There is no server-side mitigation available against the BEAST attack. The only option is to disable the affected\n         protocols (SSLv3 and TLS 1.0). The only fully safe configuration is to use Authenticated Encryption with Associated Data (AEAD),\n         e.g. AES-GCM, AES-CCM in TLS 1.2.\n      </p></p>",
+        "text": "There is no server-side mitigation available against the BEAST attack. The only option is to disable the affected protocols (SSLv3 and TLS 1.0). The only fully safe configuration is to use Authenticated Encryption with Associated Data (AEAD), e.g. AES-GCM, AES-CCM in TLS 1.2."
+      },
+      "summary": {
+        "html": "Disable SSLv2, SSLv3, and TLS 1.0. The best solution is to only have TLS 1.2 enabled",
+        "text": "Disable SSLv2, SSLv3, and TLS 1.0. The best solution is to only have TLS 1.2 enabled"
+      },
+      "type": "configuration"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/41/vulnerabilities/ssl-cve-2011-3389-beast/solution",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/asset_vulnerability_solution_invalid_asset_id.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/asset_vulnerability_solution_invalid_asset_id.json.resp
@@ -1,0 +1,10 @@
+{
+  "status": 404,
+  "message": "The resource does not exist or access is prohibited.",
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/415478561/vulnerabilities/ssl-cve-2011-3389-beast/solution",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/asset_vulnerability_solution_invalid_vulnerability_id.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/asset_vulnerability_solution_invalid_vulnerability_id.json.resp
@@ -1,0 +1,10 @@
+{
+  "status": 404,
+  "message": "The requested resource does not exist.",
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/41/vulnerabilities/ssl-ce-2011-3389-east/solution",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/get_asset_software.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/get_asset_software.json.resp
@@ -1,0 +1,19 @@
+{
+  "resources": [
+    {
+      "description": "Adobe Flash 18.0.0.209",
+      "family": "Flash",
+      "id": 31,
+      "product": "Flash",
+      "type": "Internet Client",
+      "vendor": "Adobe",
+      "version": "18.0.0.209"
+    }
+  ],
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/234/software",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/get_asset_software_invalid_id.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/get_asset_software_invalid_id.json.resp
@@ -1,0 +1,10 @@
+{
+  "status": 404,
+  "message": "The resource does not exist or access is prohibited.",
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/6",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/get_asset_vulnerabilities.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/get_asset_vulnerabilities.json.resp
@@ -1,0 +1,33 @@
+{
+  "resources": [
+    {
+      "id": "certificate-common-name-mismatch",
+      "instances": 1,
+      "links": [
+      ],
+      "results": [
+        {
+          "port": 443,
+          "proof": "<p><p>The subject common name found in the X.509 certificate does not seem to match the scan target:<ul><li>Subject CN observium does not match target name specified in the site.</li><li>Subject CN observium does not match DNS name specified in the site.</li><li>Subject CN observium could not be resolved to an IP address via DNS lookup</li><li>Subject Alternative Name observium does not match target name specified in the site.</li><li>Subject Alternative Name observium does not match DNS name specified in the site.</li></ul></p></p>",
+          "protocol": "tcp",
+          "since": "2020-08-18T20:39:17.369Z",
+          "status": "vulnerable"
+        }
+      ],
+      "since": "2020-08-18T20:39:17.369Z",
+      "status": "vulnerable"
+    }
+  ],
+  "page": {
+    "number": 0,
+    "size": 500,
+    "totalResources": 8,
+    "totalPages": 1
+  },
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/41/vulnerabilities?page=0&size=500&sort=id,asc",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/get_asset_vulnerabilities_invalid_id.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/get_asset_vulnerabilities_invalid_id.json.resp
@@ -1,0 +1,10 @@
+{
+  "status": 404,
+  "message": "The resource does not exist or access is prohibited.",
+  "links": [
+    {
+      "href": "https://example.com/api/3/assets/413424234234/vulnerabilities?size=500&page=0",
+      "rel": "self"
+    }
+  ]
+}

--- a/plugins/rapid7_insightvm/unit_test/payloads/get_asset_vulnerabilities_with_risk_score.json.resp
+++ b/plugins/rapid7_insightvm/unit_test/payloads/get_asset_vulnerabilities_with_risk_score.json.resp
@@ -1,0 +1,72 @@
+{
+  "added": "2018-02-21",
+  "categories": [
+    "CIFS"
+  ],
+  "cvss": {
+    "links": [
+      {
+        "href": "https://example.com/vuln-metrics/cvss/v2-calculator?vector=(AV:A/AC:H/Au:N/C:C/I:C/A:N)",
+        "rel": "CVSS v2 Calculator"
+      }
+    ],
+    "v2": {
+      "accessComplexity": "H",
+      "accessVector": "A",
+      "authentication": "N",
+      "availabilityImpact": "N",
+      "confidentialityImpact": "C",
+      "exploitScore": 3.1835,
+      "impactScore": 9.2066,
+      "integrityImpact": "C",
+      "score": 6.2,
+      "vector": "AV:A/AC:H/Au:N/C:C/I:C/A:N"
+    }
+  },
+  "denialOfService": false,
+  "description": {
+    "html": "<p>\n         This system enables, but does not require SMB signing. SMB signing\n         allows the recipient of SMB packets to confirm their authenticity and\n         helps prevent man in the middle attacks against SMB. SMB 2.x signing\n         can be configured in one of two ways: not required (least secure) and\n         required (most secure).\n      </p>",
+    "text": "This system enables, but does not require SMB signing. SMB signing allows the recipient of SMB packets to confirm their authenticity and helps prevent man in the middle attacks against SMB. SMB 2.x signing can be configured in one of two ways: not required (least secure) and required (most secure)."
+  },
+  "exploits": 0,
+  "id": "cifs-smb2-signing-not-required",
+  "links": [
+    {
+      "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required",
+      "rel": "self"
+    },
+    {
+      "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required/checks",
+      "rel": "Vulnerability Checks"
+    },
+    {
+      "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required/references",
+      "rel": "Vulnerability References"
+    },
+    {
+      "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required/malware_kits",
+      "rel": "Vulnerability Malware Kits"
+    },
+    {
+      "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required/exploits",
+      "rel": "Vulnerability Exploits"
+    },
+    {
+      "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required/solutions",
+      "rel": "Vulnerability Solutions"
+    }
+  ],
+  "malwareKits": 0,
+  "modified": "2018-02-21",
+  "pci": {
+    "adjustedCVSSScore": 6,
+    "adjustedSeverityScore": 4,
+    "fail": true,
+    "status": "Fail"
+  },
+  "published": "2004-11-01",
+  "riskScore": 849.0,
+  "severity": "Severe",
+  "severityScore": 6,
+  "title": "SMBv2 signing not required"
+}

--- a/plugins/rapid7_insightvm/unit_test/test_asset_vulnerability_solution.py
+++ b/plugins/rapid7_insightvm/unit_test/test_asset_vulnerability_solution.py
@@ -1,0 +1,62 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from unittest.mock import patch
+from unit_test.util import Util
+from komand_rapid7_insightvm.actions.asset_vulnerability_solution import AssetVulnerabilitySolution
+from komand_rapid7_insightvm.actions.asset_vulnerability_solution.schema import Input
+from parameterized import parameterized
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+
+@patch("aiohttp.client.ClientSession.request", side_effect=Util.mocked_async_requests)
+class TestAssetVulnerabilitySolution(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(AssetVulnerabilitySolution())
+
+    @parameterized.expand(
+        [
+            [
+                "found",
+                9,
+                ["ssl-cve-2011-3389-beast"],
+                Util.read_file_to_dict("expected/asset_vulnerability_solution.json.exp"),
+            ]
+        ]
+    )
+    def test_asset_vulnerability_solution(self, mock_get, name, asset_id, vulnerability_ids, expected):
+        actual = self.action.run({Input.ASSET_ID: asset_id, Input.VULNERABILITY_IDS: vulnerability_ids})
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                "not_found_software",
+                10,
+                ["sl-ve-211-339-beast"],
+                "InsightVM returned an error message. Not Found",
+                "Ensure that the requested resource exists.",
+                "The requested resource does not exist.",
+            ],
+            [
+                "not_found_asset",
+                11,
+                ["ssl-cve-2011-3389-beast"],
+                "InsightVM returned an error message. Not Found",
+                "Ensure that the requested resource exists.",
+                "The resource does not exist or access is prohibited.",
+            ],
+        ]
+    )
+    def test_asset_vulnerability_solution_bad(
+        self, mock_get, name, asset_id, vulnerability_ids, cause, assistance, data
+    ):
+        with self.assertRaises(PluginException) as e:
+            self.action.run({Input.ASSET_ID: asset_id, Input.VULNERABILITY_IDS: vulnerability_ids})
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(e.exception.data, data)

--- a/plugins/rapid7_insightvm/unit_test/test_async_requests.py
+++ b/plugins/rapid7_insightvm/unit_test/test_async_requests.py
@@ -27,7 +27,7 @@ class MockSession:
 
 class TestAsyncRequests(TestCase):
     def test_async_request(self):
-        loop = asyncio.get_event_loop()
+        loop = asyncio.new_event_loop()
 
         asyc_obj = async_requests.AsyncRequests("user", "pass")
         session = MockSession()

--- a/plugins/rapid7_insightvm/unit_test/test_get_asset.py
+++ b/plugins/rapid7_insightvm/unit_test/test_get_asset.py
@@ -54,7 +54,7 @@ class TestGetAsset(TestCase):
         ]
     )
     def test_get_asset(self, mock_get, name, asset_id, expected):
-        actual = self.action.run({Input.ID: asset_id})
+        actual = self.action.run({Input.ASSET_ID: asset_id})
         self.assertEqual(actual, expected)
 
     @parameterized.expand(
@@ -70,7 +70,7 @@ class TestGetAsset(TestCase):
     )
     def test_get_asset_bad(self, mock_get, name, asset_id, cause, assistance, data):
         with self.assertRaises(PluginException) as e:
-            self.action.run({Input.ID: asset_id})
+            self.action.run({Input.ASSET_ID: asset_id})
         self.assertEqual(e.exception.cause, cause)
         self.assertEqual(e.exception.assistance, assistance)
         self.assertEqual(e.exception.data, data)

--- a/plugins/rapid7_insightvm/unit_test/test_get_asset_software.py
+++ b/plugins/rapid7_insightvm/unit_test/test_get_asset_software.py
@@ -1,0 +1,62 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from unittest.mock import patch
+from unit_test.util import Util
+from komand_rapid7_insightvm.actions.get_asset_software import GetAssetSoftware
+from komand_rapid7_insightvm.actions.get_asset_software.schema import Input
+from parameterized import parameterized
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+class TestGetAssetSoftware(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(GetAssetSoftware())
+
+    @parameterized.expand(
+        [
+            [
+                "found",
+                5,
+                {
+                    "software": [
+                        {
+                            "description": "Adobe Flash 18.0.0.209",
+                            "family": "Flash",
+                            "id": 31,
+                            "product": "Flash",
+                            "type": "Internet Client",
+                            "vendor": "Adobe",
+                            "version": "18.0.0.209",
+                        }
+                    ]
+                },
+            ]
+        ]
+    )
+    def test_get_asset_software(self, mock_get, name, asset_id, expected):
+        actual = self.action.run({Input.ASSET_ID: asset_id})
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                "not_found",
+                6,
+                "InsightVM returned an error message. Not Found",
+                "Ensure that the requested resource exists.",
+                "The resource does not exist or access is prohibited.",
+            ]
+        ]
+    )
+    def test_get_asset_software_bad(self, mock_get, name, asset_id, cause, assistance, data):
+        with self.assertRaises(PluginException) as e:
+            self.action.run({Input.ASSET_ID: asset_id})
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(e.exception.data, data)

--- a/plugins/rapid7_insightvm/unit_test/test_get_asset_vulnerabilities.py
+++ b/plugins/rapid7_insightvm/unit_test/test_get_asset_vulnerabilities.py
@@ -1,0 +1,69 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+from unittest.mock import patch
+from unit_test.util import Util
+from komand_rapid7_insightvm.actions.get_asset_vulnerabilities import GetAssetVulnerabilities
+from komand_rapid7_insightvm.actions.get_asset_vulnerabilities.schema import Input
+from parameterized import parameterized
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+
+@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+class TestGetAssetVulnerabilities(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(GetAssetVulnerabilities())
+
+    @parameterized.expand(
+        [
+            [
+                "found",
+                7,
+                {
+                    "vulnerabilities": [
+                        {
+                            "id": "certificate-common-name-mismatch",
+                            "instances": 1,
+                            "links": [],
+                            "results": [
+                                {
+                                    "port": 443,
+                                    "proof": "<p><p>The subject common name found in the X.509 certificate does not seem to match the scan target:<ul><li>Subject CN observium does not match target name specified in the site.</li><li>Subject CN observium does not match DNS name specified in the site.</li><li>Subject CN observium could not be resolved to an IP address via DNS lookup</li><li>Subject Alternative Name observium does not match target name specified in the site.</li><li>Subject Alternative Name observium does not match DNS name specified in the site.</li></ul></p></p>",
+                                    "protocol": "tcp",
+                                    "since": "2020-08-18T20:39:17.369Z",
+                                    "status": "vulnerable",
+                                }
+                            ],
+                            "since": "2020-08-18T20:39:17.369Z",
+                            "status": "vulnerable",
+                        },
+                    ]
+                },
+            ]
+        ]
+    )
+    def test_get_asset(self, mock_get, name, asset_id, expected):
+        actual = self.action.run({Input.ASSET_ID: asset_id})
+        self.assertEqual(actual, expected)
+
+    @parameterized.expand(
+        [
+            [
+                "not_found",
+                8,
+                "InsightVM returned an error message. Not Found",
+                "Ensure that the requested resource exists.",
+                "The resource does not exist or access is prohibited.",
+            ]
+        ]
+    )
+    def test_get_asset_bad(self, mock_get, name, asset_id, cause, assistance, data):
+        with self.assertRaises(PluginException) as e:
+            self.action.run({Input.ASSET_ID: asset_id})
+        self.assertEqual(e.exception.cause, cause)
+        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(e.exception.data, data)

--- a/plugins/rapid7_insightvm/unit_test/util.py
+++ b/plugins/rapid7_insightvm/unit_test/util.py
@@ -7,7 +7,6 @@ sys.path.append(os.path.abspath("../"))
 from komand_rapid7_insightvm.connection.connection import Connection
 from komand_rapid7_insightvm.connection.schema import Input
 import json
-from asyncinit import asyncinit
 
 
 class Util:
@@ -123,10 +122,9 @@ class Util:
         raise Exception("Not implemented")
 
     @staticmethod
-    def mocked_async_requests(*args, **kwargs):
-        @asyncinit
+    async def mocked_async_requests(*args, **kwargs):
         class MockAsyncResponse:
-            async def __init__(self, filename, status_code):
+            def __init__(self, filename, status_code):
                 self.filename = filename
                 self.status = status_code
                 self.response_text = ""

--- a/plugins/rapid7_insightvm/unit_test/util.py
+++ b/plugins/rapid7_insightvm/unit_test/util.py
@@ -149,3 +149,5 @@ class Util:
             return MockAsyncResponse("asset_vulnerability_solution_invalid_vulnerability_id", 404)
         if kwargs.get("url") == "https://example.com/api/3/assets/11/vulnerabilities/ssl-cve-2011-3389-beast/solution":
             return MockAsyncResponse("asset_vulnerability_solution_invalid_asset_id", 404)
+        if kwargs.get("url") == "https://example.com/api/3/vulnerabilities/certificate-common-name-mismatch":
+            return MockAsyncResponse("get_asset_vulnerabilities_with_risk_score", 200)


### PR DESCRIPTION
## Proposed Changes
Fix parameters type, input examples, description
* Get Asset Vulnerability Solutions
* Get Asset Vulnerabilities
* Get Asset Software
* Get Asset

Create Unit tests for:
* Get Asset Vulnerability Solutions
* Get Asset Vulnerabilities
* Get Asset Software

### Description

Describe the proposed changes:

  -

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

## Assessment

### Run

<details>

```
{
  "body": {
    "log": "rapid7/Rapid7 InsightVM Console:5.0.0. Step name: asset_vulnerability_solution\n",
    "status": "ok",
    "meta": {},
    "output": {
      "vulnerabilities_solution": [
        {
          "resources": [
            {
              "confidence": "exact",
              "estimate": "PT1H",
              "id": "ssl-beast-attack",
              "links": [
                {
                  "href": "https://example.com/api/3/solutions/ssl-beast-attack",
                  "rel": "self"
                },
                {
                  "href": "https://example.com/api/3/solutions/ssl-beast-attack/prerequisites",
                  "rel": "Prerequisites"
                },
                {
                  "href": "https://example.com/api/3/solutions/ssl-beast-attack/supersedes",
                  "rel": "Supersedes"
                }
              ],
              "matches": [
                {
                  "confidence": "exact",
                  "fingerprint": {
                    "description": "Apache HTTPD",
                    "family": "Apache",
                    "product": "HTTPD",
                    "vendor": "Apache"
                  },
                  "links": [
                    {
                      "id": "ssl-beast-attack",
                      "href": "https://example.com/api/3/solutions/ssl-beast-attack",
                      "rel": "Solution"
                    }
                  ],
                  "solution": "ssl-beast-attack",
                  "type": "service"
                }
              ],
              "steps": {
                "html": "<p>\r\n<p>\n         There is no server-side mitigation available against the BEAST attack. The only option is to disable the affected\n         protocols (SSLv3 and TLS 1.0). The only fully safe configuration is to use Authenticated Encryption with Associated Data (AEAD),\n         e.g. AES-GCM, AES-CCM in TLS 1.2.\n      </p></p>",
                "text": "There is no server-side mitigation available against the BEAST attack. The only option is to disable the affected protocols (SSLv3 and TLS 1.0). The only fully safe configuration is to use Authenticated Encryption with Associated Data (AEAD), e.g. AES-GCM, AES-CCM in TLS 1.2."
              },
              "summary": {
                "html": "Disable SSLv2, SSLv3, and TLS 1.0. The best solution is to only have TLS 1.2 enabled",
                "text": "Disable SSLv2, SSLv3, and TLS 1.0. The best solution is to only have TLS 1.2 enabled"
              },
              "type": "configuration"
            }
          ],
          "links": [
            {
              "href": "https://example.com/api/3/assets/41/vulnerabilities/ssl-cve-2011-3389-beast/solution",
              "rel": "self"
            }
          ]
        }
      ]
    }
  },
  "version": "v1",
  "type": "action_event"
}
```

<summary>
docker run --rm -i rapid7/rapid7_insightvm:5.0.0 run < tests/asset_vulnerability_solution.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Rapid7 InsightVM Console:5.0.0. Step name: get_asset\nUsing [https://example.com//api/3/assets/249\n](https://example.com//api/3/assets/249%5Cn)",
    "status": "ok",
    "meta": {},
    "output": {
      "asset": {
        "addresses": [
          {
            "ip": "10.4.19.149",
            "mac": "08:00:27:36:EA:DA"
          }
        ],
        "assessedForPolicies": false,
        "assessedForVulnerabilities": true,
        "history": [
          {
            "date": "2020-08-18T22:16:53.298Z",
            "scanId": 3,
            "type": "SCAN",
            "version": 1
          }
        ],
        "hostName": "[example.com](http://example.com/)",
        "hostNames": [
          {
            "name": "[example.com](http://example.com/)",
            "source": "dns"
          }
        ],
        "id": 249,
        "ip": "10.4.19.149",
        "links": [
          {
            "href": "https://example.com/api/3/assets/249",
            "rel": "self"
          },
          {
            "href": "https://example.com/api/3/assets/249/software",
            "rel": "Software"
          },
          {
            "href": "https://example.com/api/3/assets/249/files",
            "rel": "Files"
          },
          {
            "href": "https://example.com/api/3/assets/249/users",
            "rel": "Users"
          },
          {
            "href": "https://example.com/api/3/assets/249/user_groups",
            "rel": "User Groups"
          },
          {
            "href": "https://example.com/api/3/assets/249/databases",
            "rel": "Databases"
          },
          {
            "href": "https://example.com/api/3/assets/249/services",
            "rel": "Services"
          },
          {
            "href": "https://example.com/api/3/assets/249/tags",
            "rel": "Tags"
          }
        ],
        "mac": "08:00:27:36:EA:DA",
        "os": "Linux 3.2",
        "osFingerprint": {
          "cpe": {
            "part": "o",
            "product": "linux_kernel",
            "targetHW": "x86",
            "v2.2": "cpe:/o:linux:linux_kernel:3.2::~~~~x86~",
            "v2.3": "cpe:2.3:o:linux:linux_kernel:3.2:*:*:*:*:*:x86:*",
            "vendor": "linux",
            "version": "3.2"
          },
          "description": "Linux 3.2",
          "family": "Linux",
          "id": 9,
          "product": "Linux",
          "systemName": "Linux",
          "type": "General",
          "vendor": "Linux",
          "version": "3.2"
        },
        "rawRiskScore": 951.142333984375,
        "riskScore": 951.142333984375,
        "services": [
          {
            "configurations": [
              {
                "name": "ssh.algorithms.compression",
                "value": "none,[zlib@openssh.com](mailto:zlib@openssh.com)"
              },
              {
                "name": "ssh.algorithms.encryption",
                "value": "[aes256-gcm@openssh.com](mailto:aes256-gcm@openssh.com),[chacha20-poly1305@openssh.com](mailto:chacha20-poly1305@openssh.com),aes256-ctr,aes256-cbc,[aes128-gcm@openssh.com](mailto:aes128-gcm@openssh.com),aes128-ctr,aes128-cbc"
              },
              {
                "name": "ssh.algorithms.hostkey",
                "value": "ssh-rsa,rsa-sha2-512,rsa-sha2-256,ecdsa-sha2-nistp256,ssh-ed25519"
              },
              {
                "name": "ssh.algorithms.kex",
                "value": "[curve25519-sha256@libssh.org](mailto:curve25519-sha256@libssh.org),ecdh-sha2-nistp256,ecdh-sha2-nistp384,ecdh-sha2-nistp521,diffie-hellman-group-exchange-sha256,diffie-hellman-group16-sha512,diffie-hellman-group18-sha512,diffie-hellman-group-exchange-sha1,diffie-hellman-group14-sha1"
              },
              {
                "name": "ssh.algorithms.mac",
                "value": "[hmac-sha2-256-etm@openssh.com](mailto:hmac-sha2-256-etm@openssh.com),[hmac-sha1-etm@openssh.com](mailto:hmac-sha1-etm@openssh.com),[umac-128-etm@openssh.com](mailto:umac-128-etm@openssh.com),[hmac-sha2-512-etm@openssh.com](mailto:hmac-sha2-512-etm@openssh.com),hmac-sha2-256,hmac-sha1,[umac-128@openssh.com](mailto:umac-128@openssh.com),hmac-sha2-512"
              },
              {
                "name": "ssh.banner",
                "value": "SSH-2.0-OpenSSH_7.7"
              },
              {
                "name": "ssh.protocol.version",
                "value": "2.0"
              },
              {
                "name": "ssh.rsa.pubkey.fingerprint",
                "value": "2D8D04AFEBA775C767F70848B2FFF48C"
              }
            ],
            "family": "OpenSSH",
            "links": [
              {
                "href": "https://example.com/api/3/assets/249/services/tcp/22",
                "rel": "self"
              },
              {
                "href": "https://example.com/api/3/assets/249/services/tcp/22/configurations",
                "rel": "Configurations"
              },
              {
                "href": "https://example.com/api/3/assets/249/services/tcp/22/databases",
                "rel": "Databases"
              },
              {
                "href": "https://example.com/api/3/assets/249/services/tcp/22/users",
                "rel": "Users"
              },
              {
                "href": "https://example.com/api/3/assets/249/services/tcp/22/user_groups",
                "rel": "User Groups"
              },
              {
                "href": "https://example.com/api/3/assets/249/services/tcp/22/web_applications",
                "rel": "Web Applications"
              }
            ],
            "name": "SSH",
            "port": 22,
            "product": "OpenSSH",
            "protocol": "tcp",
            "vendor": "OpenBSD",
            "version": "7.7"
          }
        ],
        "vulnerabilities": {
          "critical": 0,
          "exploits": 0,
          "malwareKits": 0,
          "moderate": 3,
          "severe": 1,
          "total": 4
        }
      }
    }
  },
  "version": "v1",
  "type": "action_event"
}
```

<summary>
docker run --rm -i rapid7/rapid7_insightvm:5.0.0 run < tests/get_asset.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Rapid7 InsightVM Console:5.0.0. Step name: get_asset_vulnerabilities\nFetching results from page 0\nFetching up to 500 resources from endpoint page 0 ...\nGot 23 resources from page 1 / 1\nAll pages consumed, returning results...\n",
    "status": "ok",
    "meta": {},
    "output": {
      "vulnerabilities": [
        {
          "id": "cifs-smb-signing-disabled",
          "instances": 2,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb-signing-disabled",
              "rel": "self"
            },
            {
              "id": "cifs-smb-signing-disabled",
              "href": "https://example.com/api/3/vulnerabilities/cifs-smb-signing-disabled",
              "rel": "Vulnerability"
            },
            {
              "id": "cifs-smb-signing-disabled",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb-signing-disabled/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "cifs-smb-signing-disabled",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb-signing-disabled/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 139,
              "proof": "<p><p>SMB signing is disabled</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            },
            {
              "port": 445,
              "proof": "<p><p>SMB signing is disabled</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "cifs-smb-signing-not-required",
          "instances": 2,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb-signing-not-required",
              "rel": "self"
            },
            {
              "id": "cifs-smb-signing-not-required",
              "href": "https://example.com/api/3/vulnerabilities/cifs-smb-signing-not-required",
              "rel": "Vulnerability"
            },
            {
              "id": "cifs-smb-signing-not-required",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb-signing-not-required/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "cifs-smb-signing-not-required",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb-signing-not-required/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 139,
              "proof": "<p><p>Smb signing is: disabled</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            },
            {
              "port": 445,
              "proof": "<p><p>Smb signing is: disabled</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "cifs-smb1-deprecated",
          "instances": 2,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb1-deprecated",
              "rel": "self"
            },
            {
              "id": "cifs-smb1-deprecated",
              "href": "https://example.com/api/3/vulnerabilities/cifs-smb1-deprecated",
              "rel": "Vulnerability"
            },
            {
              "id": "cifs-smb1-deprecated",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb1-deprecated/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "cifs-smb1-deprecated",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb1-deprecated/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 139,
              "proof": "<p><p>SMB1 is deprecated and should not be used</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            },
            {
              "port": 445,
              "proof": "<p><p>SMB1 is deprecated and should not be used</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "cifs-smb2-signing-not-required",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb2-signing-not-required",
              "rel": "self"
            },
            {
              "id": "cifs-smb2-signing-not-required",
              "href": "https://example.com/api/3/vulnerabilities/cifs-smb2-signing-not-required",
              "rel": "Vulnerability"
            },
            {
              "id": "cifs-smb2-signing-not-required",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb2-signing-not-required/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "cifs-smb2-signing-not-required",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/cifs-smb2-signing-not-required/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 445,
              "proof": "<p><ul><li>Running CIFS service</li><li>Configuration item smb2-enabled set to &#39;true&#39; matched</li><li>Configuration item smb2-signing set to &#39;enabled&#39; matched</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "generic-icmp-timestamp",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/generic-icmp-timestamp",
              "rel": "self"
            },
            {
              "id": "generic-icmp-timestamp",
              "href": "https://example.com/api/3/vulnerabilities/generic-icmp-timestamp",
              "rel": "Vulnerability"
            },
            {
              "id": "generic-icmp-timestamp",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/generic-icmp-timestamp/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "generic-icmp-timestamp",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/generic-icmp-timestamp/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "proof": "<p><p>Able to determine remote system time.</p></p>",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "msft-cve-2017-0146",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/msft-cve-2017-0146",
              "rel": "self"
            },
            {
              "id": "msft-cve-2017-0146",
              "href": "https://example.com/api/3/vulnerabilities/msft-cve-2017-0146",
              "rel": "Vulnerability"
            },
            {
              "id": "msft-cve-2017-0146",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/msft-cve-2017-0146/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "msft-cve-2017-0146",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/msft-cve-2017-0146/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "proof": "<p><p>Host returned expected exception that indicates vulnerability (INSUFF_SERVER_RESOURCES).</p></p>",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "msft-cve-2019-0708",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/msft-cve-2019-0708",
              "rel": "self"
            },
            {
              "id": "msft-cve-2019-0708",
              "href": "https://example.com/api/3/vulnerabilities/msft-cve-2019-0708",
              "rel": "Vulnerability"
            },
            {
              "id": "msft-cve-2019-0708",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/msft-cve-2019-0708/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "msft-cve-2019-0708",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/msft-cve-2019-0708/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p>Endpoint responded to payload with MCS Disconnect Provider Ultimatum PDU, indicating that it is not patched.</p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "netbios-nbstat-amplification",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/netbios-nbstat-amplification",
              "rel": "self"
            },
            {
              "id": "netbios-nbstat-amplification",
              "href": "https://example.com/api/3/vulnerabilities/netbios-nbstat-amplification",
              "rel": "Vulnerability"
            },
            {
              "id": "netbios-nbstat-amplification",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/netbios-nbstat-amplification/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "netbios-nbstat-amplification",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/netbios-nbstat-amplification/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 137,
              "proof": "<p><ul><li>Running CIFS Name Service service</li><li>Configuration item advertised-name-count set to &#39;4&#39; matched</li></ul></p>",
              "protocol": "udp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "rc4-cve-2013-2566",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/rc4-cve-2013-2566",
              "rel": "self"
            },
            {
              "id": "rc4-cve-2013-2566",
              "href": "https://example.com/api/3/vulnerabilities/rc4-cve-2013-2566",
              "rel": "Vulnerability"
            },
            {
              "id": "rc4-cve-2013-2566",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/rc4-cve-2013-2566/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "rc4-cve-2013-2566",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/rc4-cve-2013-2566/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p><ul><li><p>Negotiated with the following insecure cipher suites: <ul><li>TLS 1.0 ciphers: <ul><li>TLS_RSA_WITH_RC4_128_MD5</li><li>TLS_RSA_WITH_RC4_128_SHA</li></ul></li></ul></p></li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-3des-ciphers",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-3des-ciphers",
              "rel": "self"
            },
            {
              "id": "ssh-3des-ciphers",
              "href": "https://example.com/api/3/vulnerabilities/ssh-3des-ciphers",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-3des-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-3des-ciphers/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-3des-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-3des-ciphers/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure 3DES ciphers in use: 3des-cbc</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-cbc-ciphers",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cbc-ciphers",
              "rel": "self"
            },
            {
              "id": "ssh-cbc-ciphers",
              "href": "https://example.com/api/3/vulnerabilities/ssh-cbc-ciphers",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-cbc-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cbc-ciphers/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-cbc-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cbc-ciphers/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure CBC ciphers in use: aes128-cbc,3des-cbc,blowfish-cbc,cast128-cbc,aes192-cbc,aes256-cbc</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-cve-2015-4000",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cve-2015-4000",
              "rel": "self"
            },
            {
              "id": "ssh-cve-2015-4000",
              "href": "https://example.com/api/3/vulnerabilities/ssh-cve-2015-4000",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-cve-2015-4000",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cve-2015-4000/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-cve-2015-4000",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cve-2015-4000/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure key exchange in use: diffie-hellman-group1-sha1</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-cve-2016-2183-sweet32",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cve-2016-2183-sweet32",
              "rel": "self"
            },
            {
              "id": "ssh-cve-2016-2183-sweet32",
              "href": "https://example.com/api/3/vulnerabilities/ssh-cve-2016-2183-sweet32",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-cve-2016-2183-sweet32",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cve-2016-2183-sweet32/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-cve-2016-2183-sweet32",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-cve-2016-2183-sweet32/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure 3DES ciphers in use: 3des-cbc</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-rc4-ciphers",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-rc4-ciphers",
              "rel": "self"
            },
            {
              "id": "ssh-rc4-ciphers",
              "href": "https://example.com/api/3/vulnerabilities/ssh-rc4-ciphers",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-rc4-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-rc4-ciphers/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-rc4-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-rc4-ciphers/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure arcfour (RC4) ciphers in use: arcfour256,arcfour128,arcfour</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-weak-kex-algorithms",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-weak-kex-algorithms",
              "rel": "self"
            },
            {
              "id": "ssh-weak-kex-algorithms",
              "href": "https://example.com/api/3/vulnerabilities/ssh-weak-kex-algorithms",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-weak-kex-algorithms",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-weak-kex-algorithms/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-weak-kex-algorithms",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-weak-kex-algorithms/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure key exchange algorithms in use: diffie-hellman-group-exchange-sha1,diffie-hellman-group1-sha1</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssh-weak-message-authentication-code-algorithms",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-weak-message-authentication-code-algorithms",
              "rel": "self"
            },
            {
              "id": "ssh-weak-message-authentication-code-algorithms",
              "href": "https://example.com/api/3/vulnerabilities/ssh-weak-message-authentication-code-algorithms",
              "rel": "Vulnerability"
            },
            {
              "id": "ssh-weak-message-authentication-code-algorithms",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-weak-message-authentication-code-algorithms/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssh-weak-message-authentication-code-algorithms",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssh-weak-message-authentication-code-algorithms/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 22,
              "proof": "<p><ul><li>Running SSH service</li><li>Insecure MAC algorithms in use: [hmac-md5-etm@openssh.com](mailto:hmac-md5-etm@openssh.com),[hmac-sha1-96-etm@openssh.com](mailto:hmac-sha1-96-etm@openssh.com),[hmac-md5-96-etm@openssh.com](mailto:hmac-md5-96-etm@openssh.com),hmac-md5,hmac-sha1-96,hmac-md5-96</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssl-3des-ciphers",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-3des-ciphers",
              "rel": "self"
            },
            {
              "id": "ssl-3des-ciphers",
              "href": "https://example.com/api/3/vulnerabilities/ssl-3des-ciphers",
              "rel": "Vulnerability"
            },
            {
              "id": "ssl-3des-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-3des-ciphers/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssl-3des-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-3des-ciphers/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p><ul><li><p>Negotiated with the following insecure cipher suites: <ul><li>TLS 1.0 ciphers: <ul><li>TLS_RSA_WITH_3DES_EDE_CBC_SHA</li></ul></li></ul></p></li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssl-cve-2011-3389-beast",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-cve-2011-3389-beast",
              "rel": "self"
            },
            {
              "id": "ssl-cve-2011-3389-beast",
              "href": "https://example.com/api/3/vulnerabilities/ssl-cve-2011-3389-beast",
              "rel": "Vulnerability"
            },
            {
              "id": "ssl-cve-2011-3389-beast",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-cve-2011-3389-beast/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssl-cve-2011-3389-beast",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-cve-2011-3389-beast/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p><ul><li><p>Negotiated with the following insecure cipher suites: <ul><li>TLS 1.0 ciphers: <ul><li>TLS_ECDHE_RSA_WITH_AES_128_CBC_SHA</li><li>TLS_ECDHE_RSA_WITH_AES_256_CBC_SHA</li><li>TLS_RSA_WITH_3DES_EDE_CBC_SHA</li><li>TLS_RSA_WITH_AES_128_CBC_SHA</li><li>TLS_RSA_WITH_AES_256_CBC_SHA</li></ul></li></ul></p></li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssl-cve-2016-2183-sweet32",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-cve-2016-2183-sweet32",
              "rel": "self"
            },
            {
              "id": "ssl-cve-2016-2183-sweet32",
              "href": "https://example.com/api/3/vulnerabilities/ssl-cve-2016-2183-sweet32",
              "rel": "Vulnerability"
            },
            {
              "id": "ssl-cve-2016-2183-sweet32",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-cve-2016-2183-sweet32/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssl-cve-2016-2183-sweet32",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-cve-2016-2183-sweet32/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p><ul><li><p>Negotiated with the following insecure cipher suites: <ul><li>TLS 1.0 ciphers: <ul><li>TLS_RSA_WITH_3DES_EDE_CBC_SHA</li></ul></li></ul></p></li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "ssl-static-key-ciphers",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-static-key-ciphers",
              "rel": "self"
            },
            {
              "id": "ssl-static-key-ciphers",
              "href": "https://example.com/api/3/vulnerabilities/ssl-static-key-ciphers",
              "rel": "Vulnerability"
            },
            {
              "id": "ssl-static-key-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-static-key-ciphers/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "ssl-static-key-ciphers",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/ssl-static-key-ciphers/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p><ul><li><p>Negotiated with the following insecure cipher suites: <ul><li>TLS 1.0 ciphers: <ul><li>TLS_RSA_WITH_3DES_EDE_CBC_SHA</li><li>TLS_RSA_WITH_AES_128_CBC_SHA</li><li>TLS_RSA_WITH_AES_256_CBC_SHA</li><li>TLS_RSA_WITH_RC4_128_MD5</li><li>TLS_RSA_WITH_RC4_128_SHA</li></ul></li></ul></p></li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "telnet-open-port",
          "instances": 2,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/telnet-open-port",
              "rel": "self"
            },
            {
              "id": "telnet-open-port",
              "href": "https://example.com/api/3/vulnerabilities/telnet-open-port",
              "rel": "Vulnerability"
            },
            {
              "id": "telnet-open-port",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/telnet-open-port/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "telnet-open-port",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/telnet-open-port/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 9999,
              "proof": "<p><ul><li>Running Telnet service</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            },
            {
              "port": 999,
              "proof": "<p><ul><li>Running Telnet service</li></ul></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "tlsv1_0-enabled",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/tlsv1_0-enabled",
              "rel": "self"
            },
            {
              "id": "tlsv1_0-enabled",
              "href": "https://example.com/api/3/vulnerabilities/tlsv1_0-enabled",
              "rel": "Vulnerability"
            },
            {
              "id": "tlsv1_0-enabled",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/tlsv1_0-enabled/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "tlsv1_0-enabled",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/tlsv1_0-enabled/solution",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "port": 3389,
              "proof": "<p><p>Successfully connected over TLSv1.0</p></p>",
              "protocol": "tcp",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        },
        {
          "id": "windows-7-obsolete",
          "instances": 1,
          "links": [
            {
              "href": "https://example.com/api/3/assets/413/vulnerabilities/windows-7-obsolete",
              "rel": "self"
            },
            {
              "id": "windows-7-obsolete",
              "href": "https://example.com/api/3/vulnerabilities/windows-7-obsolete",
              "rel": "Vulnerability"
            },
            {
              "id": "windows-7-obsolete",
              "href": "https://example.com/api/3/assets/413/vulnerabilities/windows-7-obsolete/validations",
              "rel": "Vulnerability Validations"
            },
            {
              "id": "windows-7-obsolete",
              "href": "[example.com/api/3/assets/413/vulnerabilities/windows-7-obsolete/solution](http://example.com/api/3/assets/413/vulnerabilities/windows-7-obsolete/solution)",
              "rel": "Vulnerability Solutions"
            }
          ],
          "results": [
            {
              "key": "Microsoft Windows 7 Enterprise Edition SP1",
              "proof": "<p><p>Vulnerable OS: Microsoft Windows 7 Enterprise Edition SP1<p></p></p></p>",
              "since": "2020-08-18T23:29:15.348Z",
              "status": "vulnerable-version"
            }
          ],
          "since": "2020-08-18T23:29:15.348Z",
          "status": "vulnerable"
        }
      ]
    }
  },
  "version": "v1",
  "type": "action_event"
}
```

<summary>
docker run --rm -i rapid7/rapid7_insightvm:5.0.0 run < tests/get_asset_vulnerabilities.json
</summary>
</details>

<details>

```
{
  "body": {
    "log": "rapid7/Rapid7 InsightVM Console:5.0.0. Step name: get_asset_software\nUsing [https://example.com/api/3/assets/234/software\n](https://example.com/api/3/assets/234/software%5Cn)",
    "status": "ok",
    "meta": {},
    "output": {
      "software": [
        {
          "description": "Adobe Flash 18.0.0.209",
          "family": "Flash",
          "id": 31,
          "product": "Flash",
          "type": "Internet Client",
          "vendor": "Adobe",
          "version": "18.0.0.209"
        },
        {
          "description": "Microsoft .NET Framework 4.6",
          "family": ".NET Framework",
          "id": 35,
          "product": ".NET Framework 4.6",
          "vendor": "Microsoft"
        },
        {
          "description": "Microsoft .NET Framework 4.6 Client Profile",
          "family": ".NET Framework",
          "id": 36,
          "product": ".NET Framework 4.6 Client Profile",
          "vendor": "Microsoft"
        },
        {
          "description": "Microsoft Edge 20.10240.16384.0",
          "family": "Edge",
          "id": 33,
          "product": "Edge",
          "type": "Internet Client",
          "vendor": "Microsoft",
          "version": "20.10240.16384.0"
        },
        {
          "description": "Microsoft Internet Explorer 11.0.10240.16384",
          "family": "Internet Explorer",
          "id": 32,
          "product": "Internet Explorer",
          "type": "Internet Client",
          "vendor": "Microsoft",
          "version": "11.0.10240.16384"
        },
        {
          "description": "Microsoft MSXML 6.30.10240.16384",
          "family": "MSXML",
          "id": 29,
          "product": "MSXML",
          "vendor": "Microsoft",
          "version": "6.30.10240.16384"
        },
        {
          "description": "Microsoft MSXML 8.110.10240.16384",
          "family": "MSXML",
          "id": 34,
          "product": "MSXML",
          "vendor": "Microsoft",
          "version": "8.110.10240.16384"
        },
        {
          "description": "Microsoft Windows Media Player 12.0.10011.16397",
          "family": "Windows Media Player",
          "id": 30,
          "product": "Windows Media Player",
          "type": "Media Client",
          "vendor": "Microsoft",
          "version": "12.0.10011.16397"
        },
        {
          "description": "Rapid7 Insight Agent 3.1.1.9",
          "id": 1983,
          "product": "Rapid7 Insight Agent",
          "vendor": "Rapid7",
          "version": "3.1.1.9"
        },
        {
          "description": "VMware, Inc. VMware Tools 11.0.5.15389592",
          "id": 12,
          "product": "VMware Tools",
          "vendor": "VMware, Inc.",
          "version": "11.0.5.15389592"
        }
      ]
    }
  },
  "version": "v1",
  "type": "action_event"
}
```

<summary>
docker run --rm -i rapid7/rapid7_insightvm:5.0.0 run < tests/get_asset_software.json
</summary>
</details>

<details>

```
[*] Use ``make menu`` for available targets
[*] Including available Makefiles: ../../tools/Makefiles/Helpers.mk ../../tools/Makefiles/Colors.mk
--
[*] Running validators
[*] Validating plugin at .
[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Improperly formatted JSON example identified in Example input of action titled Get Asset Vulnerability Solutions. Please updated the JSON example in help.md with 2 space indentation.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 15617.778ms
```

<summary>
make validate
</summary>
</details>

<details>

```
[*] Validating plugin with all validators at .

[*] Running Integration Validators...
[*] Executing validator HelpValidator
[*] Executing validator ChangelogValidator
[*] Executing validator CloudReadyConnectionCredentialTokenValidator
[*] Executing validator RequiredKeysValidator
[*] Executing validator UseCaseValidator
[*] Executing validator SpecPropertiesValidator
[*] Executing validator SpecVersionValidator
[*] Executing validator FilesValidator
[*] Executing validator TagValidator
[*] Executing validator DescriptionValidator
[*] Executing validator TitleValidator
[*] Executing validator VendorValidator
[*] Executing validator DefaultValueValidator
[*] Executing validator IconValidator
[*] Executing validator RequiredValidator
[*] Executing validator VersionValidator
[*] Executing validator DockerfileParentValidator
[*] Executing validator ProfanityValidator
[*] Executing validator AcronymValidator
[*] Executing validator JSONValidator
[*] Executing validator OutputValidator
[*] Executing validator RegenerationValidator
[*] Executing validator HelpInputOutputValidator
[*] Executing validator SupportValidator
[*] Executing validator RuntimeValidator
[*] Executing validator VersionPinValidator
[*] Executing validator EncodingValidator
[*] Executing validator ExampleInputValidator
[*] Executing validator CloudReadyValidator
[*] Executing validator SupportedVersionValidator
[*] Executing validator UnapprovedKeywordsValidator
[*] Executing validator HelpExampleValidator
[*] Executing validator Version Increment Validator
[*] Executing validator ExceptionValidator
WARNING: Use of 'PluginException' or 'ConnectionTestException' is recommended when raising an exception.
violation: komand_rapid7_insightvm/util/resource_helpers.py: line,  117
[*] Executing validator CredentialsValidator
[*] Executing validator PasswordValidator
[*] Executing validator PrintValidator
[*] Executing validator ConfidentialValidator
[*] Executing validator DockerValidator
[*] Executing validator URLValidator
WARNING: URLs found that return a 4xx code. Verify they are publicly accessible and if not, update with a working URL.
violation: plugin.spec.yaml[1748]: https://insightvm.example.com/
violation: plugin.spec.yaml[1751]: https://insightvm.example.com/
violation: help.md[93]: https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest
violation: help.md[97]: https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest
violation: help.md[101]: https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest
violation: help.md[231]: https://example.com/api/3/vulnerabilities/ssh-default-account-admin-password-admin
violation: help.md[117]: https://example.com/api/3/solutions/adobe-flash-upgrade-28-0-0-126-windows
violation: help.md[127]: [http://get.adobe.com/flash/\](http://get.adobe.com/flash/%5C)
violation: help.md[210]: https://example.com/api/3/vulnerability_exceptions/1
violation: help.md[220]: https://example.com/api/3/users/1
violation: help.md[244]: https://example.com/api/3/users/1
violation: help.md[127]: http://get.adobe.com/flash/
violation: help.md[128]: http://get.adobe.com/flash/
violation: help.md[81]: https://example.com/api/3/assets/234/vulnerabilities/flash_player-cve-2017-11305/solution
violation: help.md[97]: https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest/prerequisites
violation: help.md[1284]: [https://example.com/.](https://example.com/)..
violation: help.md[1288]: [https://example.com/.](https://example.com/)..
violation: help.md[101]: https://example.com/api/3/solutions/adobe-flash-windows-upgrade-latest/supersedes
[*] Plugin failed validation! The following validation errors occurred:

Validator "HelpExampleValidator" failed!
        Cause: Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.
        Invalid JSON example identified in Example input of action titled Input. Please correct the JSON example in help.md.


----
[*] Total time elapsed: 192264.03ms
```

<summary>
icon-validate --all .
</summary>
</details>