### PR TITLE
Fix issue where undefined org ID is sent as zero value instead of non

### DIFF
--- a/plugins/automox/.CHECKSUM
+++ b/plugins/automox/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "75b8181176d097e4b3a69fadf4c35b75",
-	"manifest": "5b3ca7d7f6ab876b671761d90c40bb85",
-	"setup": "b3af5c60e0f9b556e1d4c5cf1534b877",
+	"spec": "ef6909ed3195645244f1fca04d1a2922",
+	"manifest": "54e43e9ae5f0e0f3d37d9fba197aad20",
+	"setup": "49990f4a121e259c35944d2862c986d0",
 	"schemas": [
 		{
 			"identifier": "action_on_vulnerability_sync_batch/schema.py",

--- a/plugins/automox/bin/icon_automox
+++ b/plugins/automox/bin/icon_automox
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Automox"
 Vendor = "automox"
-Version = "1.1.0"
+Version = "1.1.1"
 Description = "Automox is modernizing IT operations with continuous visibility, insight, and agility for your entire IT environment"
 
 

--- a/plugins/automox/help.md
+++ b/plugins/automox/help.md
@@ -1229,6 +1229,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.1.1 - Fix undefined org ID passed to actions when not required | Record outcome of connection tests
 * 1.1.0 - Add `report source` as optional input parameter to Upload Vulnerability Sync File action | Add report source to batch type
 * 1.0.0 - Initial plugin
 

--- a/plugins/automox/icon_automox/actions/list_devices/action.py
+++ b/plugins/automox/icon_automox/actions/list_devices/action.py
@@ -11,7 +11,12 @@ class ListDevices(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        devices = self.connection.automox_api.get_devices(params.get(Input.ORG_ID), params.get(Input.GROUP_ID))
+        # Don't define optional inputs to avoid zero value
+        group_id = None
+        if params.get(Input.GROUP_ID):
+            group_id = params.get(Input.GROUP_ID)
+
+        devices = self.connection.automox_api.get_devices(params.get(Input.ORG_ID), group_id)
         self.logger.info(f"Returned {len(devices)} devices")
 
         return {Output.DEVICES: devices}

--- a/plugins/automox/icon_automox/connection/connection.py
+++ b/plugins/automox/icon_automox/connection/connection.py
@@ -4,6 +4,7 @@ from .schema import ConnectionSchema, Input
 # Custom imports below
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
 from icon_automox.util.api_client import ApiClient
+import time
 
 
 class Connection(insightconnect_plugin_runtime.Connection):
@@ -18,9 +19,22 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.automox_api = ApiClient(self.logger, self.api_key)
 
     def test(self):
+        start_time = time.time()
+
         try:
             self.automox_api.get_orgs()
+
+            end_time = time.time()
+            elapsed_time = int(end_time - start_time)
+
+            self.automox_api.report_api_outcome(ApiClient.OUTCOME_SUCCESS, "connection_test", elapsed_time)
         except Exception as e:
+            end_time = time.time()
+            elapsed_time = int(end_time - start_time)
+            failure_message = "Unable to list orgs during api test."
+
+            self.automox_api.report_api_outcome(ApiClient.OUTCOME_FAIL, "connection_test", elapsed_time, failure_message)
+
             raise ConnectionTestException(cause=e.cause, assistance=e.assistance, data=e)
 
         return {}

--- a/plugins/automox/icon_automox/connection/connection.py
+++ b/plugins/automox/icon_automox/connection/connection.py
@@ -33,7 +33,9 @@ class Connection(insightconnect_plugin_runtime.Connection):
             elapsed_time = int(end_time - start_time)
             failure_message = "Unable to list orgs during api test."
 
-            self.automox_api.report_api_outcome(ApiClient.OUTCOME_FAIL, "connection_test", elapsed_time, failure_message)
+            self.automox_api.report_api_outcome(
+                ApiClient.OUTCOME_FAIL, "connection_test", elapsed_time, failure_message
+            )
 
             raise ConnectionTestException(cause=e.cause, assistance=e.assistance, data=e)
 

--- a/plugins/automox/icon_automox/util/api_client.py
+++ b/plugins/automox/icon_automox/util/api_client.py
@@ -341,11 +341,11 @@ class ApiClient:
             "version": ApiClient.VERSION,
             "function": function,
             "outcome": outcome,
-            "elapsed_time": elapsed_time
+            "elapsed_time": elapsed_time,
         }
 
         if outcome == ApiClient.OUTCOME_FAIL:
-            payload['reason_for_failure'] = fail_reason
+            payload["reason_for_failure"] = fail_reason
 
         try:
             self._call_api("POST", f"{self.endpoint}/integration-health", json_data=payload)

--- a/plugins/automox/plugin.spec.yaml
+++ b/plugins/automox/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: automox
 title: Automox
 description: Automox is modernizing IT operations with continuous visibility, insight, and agility for your entire IT environment
-version: 1.1.0
+version: 1.1.1
 supported_versions: ["All as of 1/21/2022"]
 vendor: automox
 support: partner

--- a/plugins/automox/setup.py
+++ b/plugins/automox/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="automox-automox-plugin",
-      version="1.1.0",
+      version="1.1.1",
       description="Automox is modernizing IT operations with continuous visibility, insight, and agility for your entire IT environment",
       author="automox",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - No longer send org ID with requests when it is not defined for actions; currently sends org ID 0
  - Update user-agent version
  - Add connection outcome recording for adoption visibility

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
