### PR TITLE
[SOAR-9503] REST Body Field

### DIFF
--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "acf25eac81a091fe06f3e10f1c0579b2",
-	"manifest": "42b0bc6d85a6921bf0968b39038f2a77",
-	"setup": "1743f95b2348e36ebd544a1f671d89b5",
+	"spec": "76a395e4784783e7468f7f64c1faf710",
+	"manifest": "21f38d847b819857d2841723ca634357",
+	"setup": "1485b78e3a1f2e8e92ab8e8b09e218ce",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",

--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "76a395e4784783e7468f7f64c1faf710",
+	"spec": "73c0759bc3d26f8863e01f83620e6d98",
 	"manifest": "21f38d847b819857d2841723ca634357",
 	"setup": "1485b78e3a1f2e8e92ab8e8b09e218ce",
 	"schemas": [

--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "9831d3a98f34e7e3d649108abc09af89",
+	"spec": "acf25eac81a091fe06f3e10f1c0579b2",
 	"manifest": "42b0bc6d85a6921bf0968b39038f2a77",
 	"setup": "1743f95b2348e36ebd544a1f671d89b5",
 	"schemas": [
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "post/schema.py",
-			"hash": "f8ede47dadd858a2b46b426007d74962"
+			"hash": "c07800514ac4f372ccc020c8b0f453b7"
 		},
 		{
 			"identifier": "put/schema.py",

--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "acf25eac81a091fe06f3e10f1c0579b2",
+	"spec": "9831d3a98f34e7e3d649108abc09af89",
 	"manifest": "42b0bc6d85a6921bf0968b39038f2a77",
 	"setup": "1743f95b2348e36ebd544a1f671d89b5",
 	"schemas": [
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "post/schema.py",
-			"hash": "c07800514ac4f372ccc020c8b0f453b7"
+			"hash": "f8ede47dadd858a2b46b426007d74962"
 		},
 		{
 			"identifier": "put/schema.py",

--- a/plugins/rest/bin/komand_rest
+++ b/plugins/rest/bin/komand_rest
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "HTTP Requests"
 Vendor = "rapid7"
-Version = "5.0.2"
+Version = "6.0.0"
 Description = "The HTTP Requests plugin to make it easy to integrate with RESTful services"
 
 

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -19,8 +19,6 @@ This plugin is often used to integrate with ad-hoc 3rd party API's in a workflow
 
 ## Setup
 
-Check out the [plugin guide](https://docs.rapid7.com/insightconnect/http-requests) for more details on how to configure this plugin.
-
 The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|
@@ -453,6 +451,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
+* 6.0.0 - PATCH accepts array of objects | POST supports x-www-form-urlencoded
 * 5.0.2 - Fix issue with JSON data parser for PATCH request
 * 5.0.1 - Update to make 'No Authentication' the default connection type
 * 5.0.0 - Add ability for user to choose if the plugin should fail on standard HTTP error codes (4xx-5xx) | Add 'No Authentication' as another authentication type

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -453,7 +453,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
-* 6.0.0 - PATCH accepts array of objects | POST supports x-www-form-urlencoded
+* 6.0.0 - POST supports x-www-form-urlencoded
 * 5.0.2 - Fix issue with JSON data parser for PATCH request
 * 5.0.1 - Update to make 'No Authentication' the default connection type
 * 5.0.0 - Add ability for user to choose if the plugin should fail on standard HTTP error codes (4xx-5xx) | Add 'No Authentication' as another authentication type

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -13,11 +13,13 @@ This plugin is often used to integrate with ad-hoc 3rd party API's in a workflow
 
 # Supported Product Versions
 
-* 2022-02-22
+* 2022-06-15
 
 # Documentation
 
 ## Setup
+
+Check out the [plugin guide](https://docs.rapid7.com/insightconnect/http-requests) for more details on how to configure this plugin.
 
 The connection configuration accepts the following parameters:
 

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -453,7 +453,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
-* 6.0.0 - POST supports x-www-form-urlencoded
+* 6.0.0 - POST supports x-www-form-urlencoded | PATCH to now take in an array of objects
 * 5.0.2 - Fix issue with JSON data parser for PATCH request
 * 5.0.1 - Update to make 'No Authentication' the default connection type
 * 5.0.0 - Add ability for user to choose if the plugin should fail on standard HTTP error codes (4xx-5xx) | Add 'No Authentication' as another authentication type

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -4,6 +4,22 @@ from .schema import PostInput, PostOutput, Component, Input, Output
 # Custom imports below
 from komand_rest.util.util import Common
 from komand_rest.util.util import convert_dict_body_to_string
+from typing import Dict, Any
+
+
+def convert_body_for_urlencoded(headers: Dict[str, str], body: Dict[str, Any]) -> str:
+    """
+    This method will encode the body if the headers == x-www-form-urlencoded
+    :param headers: Headers dict to read for conditional
+    :param body: Body dict to convert to string with encoding
+    :return: Body as an encoded string value
+    """
+    for key, value in headers.items():
+        if "content-type" in key.lower():
+            if "x-www-form-urlencoded" in value:
+                body = convert_dict_body_to_string(body)
+                break
+    return body
 
 
 class Post(insightconnect_plugin_runtime.Action):
@@ -16,11 +32,7 @@ class Post(insightconnect_plugin_runtime.Action):
         headers = params.get(Input.HEADERS, {})
         body = params.get(Input.BODY, {})
 
-        # Support encoding for x-www-form-urlencoded
-        for key, value in headers.items():
-            if "content-type" in key.lower():
-                if "x-www-form-urlencoded" in value:
-                    body = convert_dict_body_to_string(body)
+        convert_body_for_urlencoded(headers, body)
 
         response = self.connection.api.call_api(
             method="POST",

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -4,7 +4,6 @@ from .schema import PostInput, PostOutput, Component, Input, Output
 # Custom imports below
 from komand_rest.util.util import Common
 from komand_rest.util.util import convert_dict_body_to_string, convert_body_for_urlencoded
-from typing import Dict, Any, Union
 
 
 class Post(insightconnect_plugin_runtime.Action):

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -35,8 +35,6 @@ class Post(insightconnect_plugin_runtime.Action):
             headers=headers,
         )
 
-        print(response)
-
         return {
             Output.BODY_OBJECT: Common.body_object(response),
             Output.BODY_STRING: response.text,

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -4,6 +4,7 @@ import json
 
 # Custom imports below
 from komand_rest.util.util import Common
+from komand_rest.util.util import convert_dict_body_to_string
 
 
 class Post(insightconnect_plugin_runtime.Action):
@@ -16,16 +17,20 @@ class Post(insightconnect_plugin_runtime.Action):
         headers = params.get(Input.HEADERS, {})
         body = params.get(Input.BODY, {})
 
+        # Determine if headers / content-type == x-www-form-urlencoded
+        # If so, convert body to string and urlencode ('&', '=')
+        # Else, proceed with regular body
         for key, value in headers.items():
             if "content-type" in key.lower():
                 if "x-www-form-urlencoded" in value:
-                    # TODO Parse string for oAuth
-
+                    body = convert_dict_body_to_string(body)
+                    print("FORM ENCODED POINT")
                     return body
                 elif "json" in value:
-                    body = json.loads(body)
                     return body
-
+        # Error 415
+        # Basically, the data being sent is being refused because it is in the wrong format
+        # Determine the header type - application
         response = self.connection.api.call_api(
             method="POST",
             path=params.get(Input.ROUTE),

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -1,6 +1,6 @@
 import insightconnect_plugin_runtime
 from .schema import PostInput, PostOutput, Component, Input, Output
-import json
+import logging
 
 # Custom imports below
 from komand_rest.util.util import Common
@@ -17,16 +17,11 @@ class Post(insightconnect_plugin_runtime.Action):
         headers = params.get(Input.HEADERS, {})
         body = params.get(Input.BODY, {})
 
-        # Determine if headers / content-type == x-www-form-urlencoded
-        # If so, convert body to string and urlencode ('&', '=')
-        # Else, proceed with regular body
+        # Support encoding for x-www-form-urlencoded
         for key, value in headers.items():
             if "content-type" in key.lower():
                 if "x-www-form-urlencoded" in value:
                     body = convert_dict_body_to_string(body)
-                    return body
-                elif "json" in value:
-                    return body
 
         response = self.connection.api.call_api(
             method="POST",

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -1,6 +1,5 @@
 import insightconnect_plugin_runtime
 from .schema import PostInput, PostOutput, Component, Input, Output
-import logging
 
 # Custom imports below
 from komand_rest.util.util import Common

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -24,19 +24,18 @@ class Post(insightconnect_plugin_runtime.Action):
             if "content-type" in key.lower():
                 if "x-www-form-urlencoded" in value:
                     body = convert_dict_body_to_string(body)
-                    print("FORM ENCODED POINT")
                     return body
                 elif "json" in value:
                     return body
-        # Error 415
-        # Basically, the data being sent is being refused because it is in the wrong format
-        # Determine the header type - application
+
         response = self.connection.api.call_api(
             method="POST",
             path=params.get(Input.ROUTE),
             json_data=body,
-            headers=params.get(Input.HEADERS, {}),
+            headers=headers,
         )
+
+        print(response)
 
         return {
             Output.BODY_OBJECT: Common.body_object(response),

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -1,5 +1,6 @@
 import insightconnect_plugin_runtime
 from .schema import PostInput, PostOutput, Component, Input, Output
+import json
 
 # Custom imports below
 from komand_rest.util.util import Common
@@ -12,10 +13,23 @@ class Post(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
+        headers = params.get(Input.HEADERS, {})
+        body = params.get(Input.BODY, {})
+
+        for key, value in headers.items():
+            if "content-type" in key.lower():
+                if "x-www-form-urlencoded" in value:
+                    # TODO Parse string for oAuth
+
+                    return body
+                elif "json" in value:
+                    body = json.loads(body)
+                    return body
+
         response = self.connection.api.call_api(
             method="POST",
             path=params.get(Input.ROUTE),
-            json_data=params.get(Input.BODY, {}),
+            json_data=body,
             headers=params.get(Input.HEADERS, {}),
         )
 

--- a/plugins/rest/komand_rest/actions/post/action.py
+++ b/plugins/rest/komand_rest/actions/post/action.py
@@ -3,23 +3,8 @@ from .schema import PostInput, PostOutput, Component, Input, Output
 
 # Custom imports below
 from komand_rest.util.util import Common
-from komand_rest.util.util import convert_dict_body_to_string
-from typing import Dict, Any
-
-
-def convert_body_for_urlencoded(headers: Dict[str, str], body: Dict[str, Any]) -> str:
-    """
-    This method will encode the body if the headers == x-www-form-urlencoded
-    :param headers: Headers dict to read for conditional
-    :param body: Body dict to convert to string with encoding
-    :return: Body as an encoded string value
-    """
-    for key, value in headers.items():
-        if "content-type" in key.lower():
-            if "x-www-form-urlencoded" in value:
-                body = convert_dict_body_to_string(body)
-                break
-    return body
+from komand_rest.util.util import convert_dict_body_to_string, convert_body_for_urlencoded
+from typing import Dict, Any, Union
 
 
 class Post(insightconnect_plugin_runtime.Action):
@@ -32,7 +17,7 @@ class Post(insightconnect_plugin_runtime.Action):
         headers = params.get(Input.HEADERS, {})
         body = params.get(Input.BODY, {})
 
-        convert_body_for_urlencoded(headers, body)
+        body = convert_body_for_urlencoded(headers, body)
 
         response = self.connection.api.call_api(
             method="POST",

--- a/plugins/rest/komand_rest/actions/post/schema.py
+++ b/plugins/rest/komand_rest/actions/post/schema.py
@@ -27,7 +27,7 @@ class PostInput(insightconnect_plugin_runtime.Input):
   "title": "Variables",
   "properties": {
     "body": {
-      "type": "object",
+      "type": "string",
       "title": "Body",
       "description": "Payload to submit to the server when making the HTTP Request call",
       "order": 3

--- a/plugins/rest/komand_rest/actions/post/schema.py
+++ b/plugins/rest/komand_rest/actions/post/schema.py
@@ -27,7 +27,7 @@ class PostInput(insightconnect_plugin_runtime.Input):
   "title": "Variables",
   "properties": {
     "body": {
-      "type": "string",
+      "type": "object",
       "title": "Body",
       "description": "Payload to submit to the server when making the HTTP Request call",
       "order": 3

--- a/plugins/rest/komand_rest/util/util.py
+++ b/plugins/rest/komand_rest/util/util.py
@@ -62,7 +62,7 @@ def first(sequence, default=""):
     return next((x for x in sequence if x), default)
 
 
-def convert_dict_body_to_string(dict_object: Dict[str, Any]):
+def convert_dict_body_to_string(dict_object: Dict[str, Any]) -> str:
     """
     This method will convert a dict object to a string
     suitable for sending data in x-www-form-urlencoded format
@@ -72,8 +72,7 @@ def convert_dict_body_to_string(dict_object: Dict[str, Any]):
     output_string = ""
     for key, value in dict_object.items():
         output_string += f"{key}={value}&"
-    output_string = output_string[:-1]
-    return output_string
+    return output_string[:-1]
 
 
 class RestAPI(object):

--- a/plugins/rest/komand_rest/util/util.py
+++ b/plugins/rest/komand_rest/util/util.py
@@ -1,6 +1,7 @@
 import json
 from logging import Logger
 from urllib.parse import urlparse, urlsplit, urlunsplit
+from typing import Dict, Any
 
 import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -59,6 +60,20 @@ def url_path_join(*parts):
 
 def first(sequence, default=""):
     return next((x for x in sequence if x), default)
+
+
+def convert_dict_body_to_string(dict_object: Dict[str, Any]):
+    """
+    This method will convert a dict object to a string
+    suitable for sending data in x-www-form-urlencoded format
+    :param dict_object: The dict object to convert
+    :return: A new string properly formatted
+    """
+    output_string = ""
+    for key, value in dict_object.items():
+        output_string += f"{key}={value}&"
+    output_string = output_string[:-1]
+    return output_string
 
 
 class RestAPI(object):

--- a/plugins/rest/komand_rest/util/util.py
+++ b/plugins/rest/komand_rest/util/util.py
@@ -1,7 +1,7 @@
 import json
 from logging import Logger
 from urllib.parse import urlparse, urlsplit, urlunsplit
-from typing import Dict, Any
+from typing import Dict, Any, Union
 
 import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -73,6 +73,21 @@ def convert_dict_body_to_string(dict_object: Dict[str, Any]) -> str:
     for key, value in dict_object.items():
         output_string += f"{key}={value}&"
     return output_string[:-1]
+
+
+def convert_body_for_urlencoded(headers: Dict[str, str], body: Dict[str, Any]) -> Union[Dict[str, Any], str]:
+    """
+    This method will encode the body if the headers == x-www-form-urlencoded
+    :param headers: Headers dict to read for conditional
+    :param body: Body dict to convert to string with encoding
+    :return: Body as an encoded string value
+    """
+    for key, value in headers.items():
+        if "content-type" in key.lower():
+            if "x-www-form-urlencoded" in value:
+                body = convert_dict_body_to_string(body)
+                break
+    return body
 
 
 class RestAPI(object):

--- a/plugins/rest/komand_rest/util/util.py
+++ b/plugins/rest/komand_rest/util/util.py
@@ -76,22 +76,11 @@ def convert_dict_body_to_string(dict_object: Dict[str, Any]):
     return output_string
 
 
-def convert_string_to_dict(input_string: str) -> dict:
-    output_dict = {}
-    for parameter in input_string.split('&'):
-        try:
-            splitted_parameter = parameter.split('=')
-            output_dict[splitted_parameter[0]] = splitted_parameter[1]
-        except:
-            raise PluginException(cause="Wrong format of input_string")
-    return output_dict
-
-
 class RestAPI(object):
     CUSTOM_SECRET_INPUT = "CUSTOM_SECRET_INPUT"  # noqa: B105
 
     def __init__(
-            self, url: str, logger: Logger, ssl_verify: bool, default_headers: dict = None, fail_on_error: bool = True
+        self, url: str, logger: Logger, ssl_verify: bool, default_headers: dict = None, fail_on_error: bool = True
     ):
         self.url = url
         self.logger = logger
@@ -101,14 +90,14 @@ class RestAPI(object):
         self.fail_on_error = fail_on_error
 
     def with_credentials(
-            self, authentication_type: str, username: str = None, password: str = None, secret_key: str = None
+        self, authentication_type: str, username: str = None, password: str = None, secret_key: str = None
     ):
         if authentication_type in ("Basic Auth", "Digest Auth"):
             if not username or not password:
                 raise PluginException(
                     cause="Basic Auth authentication selected without providing username and password.",
                     assistance="The authentication type requires a username and password."
-                               " Please complete the connection with a username and password or change the authentication type.",
+                    " Please complete the connection with a username and password or change the authentication type.",
                 )
         else:
             if not secret_key and authentication_type != "Custom":
@@ -139,7 +128,7 @@ class RestAPI(object):
                         raise PluginException(
                             cause="'CUSTOM_SECRET_INPUT' used in authentication header, but no secret provided.",
                             assistance="When using 'CUSTOM_SECRET_INPUT' as a value in authentication headers the"
-                                       " 'secret_key' field is required.",
+                            " 'secret_key' field is required.",
                         )
                     new_headers[key] = secret_key
                 else:
@@ -147,7 +136,7 @@ class RestAPI(object):
             self.default_headers = new_headers
 
     def call_api(
-            self, method: str, path: str, data: str = None, json_data: dict = None, headers: dict = None
+        self, method: str, path: str, data: str = None, json_data: dict = None, headers: dict = None
     ) -> Response:
         try:
             data_string = json.dumps(data) if data else None

--- a/plugins/rest/komand_rest/util/util.py
+++ b/plugins/rest/komand_rest/util/util.py
@@ -76,11 +76,22 @@ def convert_dict_body_to_string(dict_object: Dict[str, Any]):
     return output_string
 
 
+def convert_string_to_dict(input_string: str) -> dict:
+    output_dict = {}
+    for parameter in input_string.split('&'):
+        try:
+            splitted_parameter = parameter.split('=')
+            output_dict[splitted_parameter[0]] = splitted_parameter[1]
+        except:
+            raise PluginException(cause="Wrong format of input_string")
+    return output_dict
+
+
 class RestAPI(object):
     CUSTOM_SECRET_INPUT = "CUSTOM_SECRET_INPUT"  # noqa: B105
 
     def __init__(
-        self, url: str, logger: Logger, ssl_verify: bool, default_headers: dict = None, fail_on_error: bool = True
+            self, url: str, logger: Logger, ssl_verify: bool, default_headers: dict = None, fail_on_error: bool = True
     ):
         self.url = url
         self.logger = logger
@@ -90,14 +101,14 @@ class RestAPI(object):
         self.fail_on_error = fail_on_error
 
     def with_credentials(
-        self, authentication_type: str, username: str = None, password: str = None, secret_key: str = None
+            self, authentication_type: str, username: str = None, password: str = None, secret_key: str = None
     ):
         if authentication_type in ("Basic Auth", "Digest Auth"):
             if not username or not password:
                 raise PluginException(
                     cause="Basic Auth authentication selected without providing username and password.",
                     assistance="The authentication type requires a username and password."
-                    " Please complete the connection with a username and password or change the authentication type.",
+                               " Please complete the connection with a username and password or change the authentication type.",
                 )
         else:
             if not secret_key and authentication_type != "Custom":
@@ -128,7 +139,7 @@ class RestAPI(object):
                         raise PluginException(
                             cause="'CUSTOM_SECRET_INPUT' used in authentication header, but no secret provided.",
                             assistance="When using 'CUSTOM_SECRET_INPUT' as a value in authentication headers the"
-                            " 'secret_key' field is required.",
+                                       " 'secret_key' field is required.",
                         )
                     new_headers[key] = secret_key
                 else:
@@ -136,7 +147,7 @@ class RestAPI(object):
             self.default_headers = new_headers
 
     def call_api(
-        self, method: str, path: str, data: str = None, json_data: dict = None, headers: dict = None
+            self, method: str, path: str, data: str = None, json_data: dict = None, headers: dict = None
     ) -> Response:
         try:
             data_string = json.dumps(data) if data else None
@@ -149,7 +160,6 @@ class RestAPI(object):
                 auth=self.auth,
                 verify=self.ssl_verify,
             )
-
             if not self.fail_on_error:
                 return response
 

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -137,7 +137,7 @@ actions:
       body:
         title: Body
         description: Payload to submit to the server when making the HTTP Request call
-        type: object
+        type: string
         required: false
         example: '{"user": "user@example.com"}'
     output:

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rest
 title: HTTP Requests
 description: The HTTP Requests plugin to make it easy to integrate with RESTful services
-version: 5.0.2
+version: 6.0.0
 vendor: rapid7
 support: community
 supported_versions: ["2022-02-22"]

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -137,7 +137,7 @@ actions:
       body:
         title: Body
         description: Payload to submit to the server when making the HTTP Request call
-        type: string
+        type: object
         required: false
         example: '{"user": "user@example.com"}'
     output:

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -7,7 +7,7 @@ description: The HTTP Requests plugin to make it easy to integrate with RESTful 
 version: 6.0.0
 vendor: rapid7
 support: community
-supported_versions: ["2022-02-22"]
+supported_versions: ["2022-06-15"]
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/rest

--- a/plugins/rest/setup.py
+++ b/plugins/rest/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rest-rapid7-plugin",
-      version="5.0.2",
+      version="6.0.0",
       description="The HTTP Requests plugin to make it easy to integrate with RESTful services",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Add functionality to accomodate credentials being sent in the body field with `x-www-form-urlencoded` in the headers

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [x] Screenshot of job output with the plugin changes
![Screenshot 2022-06-15 at 11 46 46](https://user-images.githubusercontent.com/93926445/173809516-b5f14a16-b190-4f37-a693-6bb0bb5a35ad.png)
![Screenshot 2022-06-15 at 11 47 14](https://user-images.githubusercontent.com/93926445/173809605-e9f71dbb-601e-4693-88d0-d7150ec1c564.png)

- [x] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder
![Screenshot 2022-06-15 at 11 47 43](https://user-images.githubusercontent.com/93926445/173809678-489ab7d8-c706-4d33-b089-43b5679db9fc.png)

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [x] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [x] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [x] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
