### PR TITLE
[SOAR-8733] Active Directory LDAP - Fix issue with escape brackets (#…

### DIFF
--- a/plugins/active_directory_ldap/.CHECKSUM
+++ b/plugins/active_directory_ldap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "038d3b86b7db897623b7e7e19a09bbdd",
-	"manifest": "d949ac7ddcfcd83463ef1caf6c4f9ded",
-	"setup": "cb517db4d68ebcae05d6d7e89674d1bd",
+	"spec": "95b1c65e983cad24e48aa8e8956ba8bd",
+	"manifest": "4ed07d1fefb30a1257046f5cb21713a1",
+	"setup": "766cd86d8bf92bc0aa0d85a387972315",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/active_directory_ldap/bin/komand_active_directory_ldap
+++ b/plugins/active_directory_ldap/bin/komand_active_directory_ldap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Active Directory LDAP"
 Vendor = "rapid7"
-Version = "5.3.2"
+Version = "5.3.3"
 Description = "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
 
 

--- a/plugins/active_directory_ldap/help.md
+++ b/plugins/active_directory_ldap/help.md
@@ -676,6 +676,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 5.3.3 - Fix issue with escaping brackets in Query action
 * 5.3.2 - Improve LDAP connection handling
 * 5.3.1 - Improved error messaging in case the specified group was not found in the Query Group Membership action
 * 5.3.0 - Add Unlock User action

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/modify_object/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/modify_object/action.py
@@ -22,11 +22,7 @@ class ModifyObject(insightconnect_plugin_runtime.Action):
         dn, search_base = formatter.format_dn(dn)
         self.logger.info(f"Escaped DN {dn}")
 
-        pairs = formatter.find_parentheses_pairs(dn)
-        # replace ( and ) when they are part of a name rather than a search parameter
-        if pairs:
-            dn = formatter.escape_brackets_for_query(dn, pairs)
-
+        dn = formatter.escape_brackets_for_query(dn)
         self.logger.info(dn)
 
         return {Output.SUCCESS: self.connection.client.modify_object(dn, search_base, attribute, attribute_value)}

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
@@ -1,6 +1,5 @@
-import ldap3
-
 import insightconnect_plugin_runtime
+import ldap3
 
 # Custom imports below
 from komand_active_directory_ldap.util.utils import ADUtils
@@ -20,14 +19,11 @@ class Query(insightconnect_plugin_runtime.Action):
         query = query.replace("\\>=", ">=")
         query = query.replace("\\<=", "<=")
 
-        # find pars of `(` `)`
-        pairs = formatter.find_parentheses_pairs(query)
-
         # replace ( and ) when they are part of a name rather than a search parameter
-        escaped_query = formatter.escape_brackets_for_query(query, pairs)
-        self.logger.info(f"Escaped query: {escaped_query}")
+        escaped_query = formatter.escape_brackets_for_query(query)
+        self.logger.info("Escaped query: %s", escaped_query)
 
-        attributes = params.get(Input.ATTRIBUTES)
+        attributes = params.get(Input.ATTRIBUTES, [])
         if not attributes:
             attributes = [ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES]
 

--- a/plugins/active_directory_ldap/plugin.spec.yaml
+++ b/plugins/active_directory_ldap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: active_directory_ldap
 title: Active Directory LDAP
 description: "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
-version: 5.3.2
+version: 5.3.3
 supported_versions: ["Azure Active Directory 2.0.89.0"]
 vendor: rapid7
 support: rapid7

--- a/plugins/active_directory_ldap/requirements.txt
+++ b/plugins/active_directory_ldap/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 ldap3==2.9.1
+parameterized==0.8.1

--- a/plugins/active_directory_ldap/setup.py
+++ b/plugins/active_directory_ldap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="active_directory_ldap-rapid7-plugin",
-      version="5.3.2",
+      version="5.3.3",
       description="This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network",
       author="rapid7",
       author_email="",

--- a/plugins/active_directory_ldap/unit_integration_test/test_query.py
+++ b/plugins/active_directory_ldap/unit_integration_test/test_query.py
@@ -17,7 +17,7 @@ class TestQuery(TestCase):
         test_connection.logger = log
         test_query.logger = log
 
-        with open("../tests/query.json") as file:
+        with open("../tests/query.json", encoding="utf-8") as file:
             data = json.load(file)
             connection_params = data.get("body").get("connection")
 
@@ -46,4 +46,3 @@ class TestQuery(TestCase):
             actual.get("distinguishedName"),
             'CN=Bob "Sponge,Pants" (somestuff),OU=Test Users,OU=User,DC=intad,DC=dslab,DC=internal',
         )
-        pass

--- a/plugins/active_directory_ldap/unit_test/__init__.py
+++ b/plugins/active_directory_ldap/unit_test/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))

--- a/plugins/active_directory_ldap/unit_test/test_action_unlock_user.py
+++ b/plugins/active_directory_ldap/unit_test/test_action_unlock_user.py
@@ -7,7 +7,6 @@ from unit_test.common import MockConnection
 from unit_test.common import default_connector
 from komand_active_directory_ldap.connection import Connection
 import logging
-import json
 
 
 class TestActionUnlockUser(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_escape_brackets_formatter.py
+++ b/plugins/active_directory_ldap/unit_test/test_escape_brackets_formatter.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+
+from komand_active_directory_ldap.util.utils import ADUtils
+from parameterized import parameterized
+
+
+class TestHostFormatter(TestCase):
+    @parameterized.expand(
+        [
+            ("(objectCategory=This is a (Test) here)", "(objectCategory=This is a \\28Test\\29 here)"),
+            (
+                "(&(objectCategory=This is a (Test) here)(TestField=*))",
+                "(&(objectCategory=This is a \\28Test\\29 here)(TestField=*))",
+            ),
+            ("(objectTest=NUL)(!(TestField=test\\))", "(objectTest=NUL)(!(TestField=test\\))"),
+            ("(objectCategory=My Testing ( Category ))", "(objectCategory=My Testing \\28 Category \\29)"),
+        ]
+    )
+    def test_host_formatter(self, query: str, expected_result: str):
+        result = ADUtils.escape_brackets_for_query(query)
+        self.assertEqual(expected_result, result)


### PR DESCRIPTION
…1312)

* Active Directory LDAP - 8733 - Fix issue with escape brackets

* Updated docstring, unittests

## Proposed Changes

### Description

Describe the proposed changes:

  -

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
