### PR TITLE
SOAR-8722 HTTPRest - New Branch (#1333)

### DIFF
--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "acf25eac81a091fe06f3e10f1c0579b2",
-	"manifest": "42b0bc6d85a6921bf0968b39038f2a77",
-	"setup": "1743f95b2348e36ebd544a1f671d89b5",
+	"spec": "e39e74c5ad06c281367ab4d5c0e902c0",
+	"manifest": "3a5a2a7d5d2a262c68919c90575ed2e6",
+	"setup": "67a559753717f7ed8c281c1383c8a7de",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",
@@ -13,7 +13,7 @@
 		},
 		{
 			"identifier": "patch/schema.py",
-			"hash": "72096cabe8e9e098cf717d56c77ab9bf"
+			"hash": "bbd7456c67d57f0ae295eae1f1f9f0c3"
 		},
 		{
 			"identifier": "post/schema.py",

--- a/plugins/rest/bin/komand_rest
+++ b/plugins/rest/bin/komand_rest
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "HTTP Requests"
 Vendor = "rapid7"
-Version = "5.0.2"
+Version = "5.0.3"
 Description = "The HTTP Requests plugin to make it easy to integrate with RESTful services"
 
 

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -13,7 +13,7 @@ This plugin is often used to integrate with ad-hoc 3rd party API's in a workflow
 
 # Supported Product Versions
 
-* 2022-02-22
+* 2022-06-15
 
 # Documentation
 
@@ -40,15 +40,16 @@ Example input:
   "authentication_type": "Basic Auth",
   "base_url": "https://httpbin.org",
   "basic_auth_credentials": {
-    "username": "user@example.com",
+    "username": "user@example.com", 
     "password": "mypassword"
   },
   "default_headers": {
-    "User-Agent": "Rapid7 InsightConnect"
+    "User-Agent": "Rapid7 InsightConnect" 
   },
   "fail_on_http_errors": true,
   "ssl_verify": true
 }
+
 ```
 
 Example input (with Custom header auth):
@@ -249,6 +250,7 @@ This action is used to make a PATCH request.
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |body|object|None|False|Payload to submit to the server when making the HTTP Request call|None|{"user": "user@example.com"}|
+|body_as_an_array|[]object|None|False|Payload (Array) to submit to the server when making the HTTP Request call|None|[{"user": "user@example.com"}]|
 |headers|object|None|False|Headers to use for the request. These will override any default headers|None|{"Host": "rapid7.com"}|
 |route|string|None|True|The route to append to the base URL e.g. /org/users|None|/org/users|
 
@@ -259,6 +261,9 @@ Example input:
   "body": {
     "user": "user@example.com"
   },
+  "body_as_an_array": [{
+    "user": "user@example.com"
+  }],
   "headers": {
     "Host": "rapid7.com"
   },
@@ -453,6 +458,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
+* 5.0.3 - POST supports x-www-form-urlencoded | PATCH to now take in an array of objects
 * 5.0.2 - Fix issue with JSON data parser for PATCH request
 * 5.0.1 - Update to make 'No Authentication' the default connection type
 * 5.0.0 - Add ability for user to choose if the plugin should fail on standard HTTP error codes (4xx-5xx) | Add 'No Authentication' as another authentication type

--- a/plugins/rest/komand_rest/actions/patch/action.py
+++ b/plugins/rest/komand_rest/actions/patch/action.py
@@ -2,7 +2,8 @@ import insightconnect_plugin_runtime
 from .schema import PatchInput, PatchOutput, Component, Input, Output
 
 # Custom imports below
-from komand_rest.util.util import Common
+from komand_rest.util.util import Common, MESSAGE_CAUSE_BOTH_INPUTS, MESSAGE_ASSISTANCE_BOTH_INPUTS
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 
 class Patch(insightconnect_plugin_runtime.Action):
@@ -15,10 +16,30 @@ class Patch(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
+        """
+        If both inputs exist throw pluginException
+        Otherwise determine which one is empty
+        Send non-empty data
+        """
+        body_non_array = params.get(Input.BODY, {})
+        body_array = params.get(Input.BODY_AS_AN_ARRAY, [])
+
+        if body_array and body_non_array:
+            raise PluginException(
+                cause=MESSAGE_CAUSE_BOTH_INPUTS,
+                assistance=MESSAGE_ASSISTANCE_BOTH_INPUTS,
+            )
+        elif body_array:
+            data = body_array
+        elif body_non_array:
+            data = body_non_array
+        else:
+            data = None
+
         response = self.connection.api.call_api(
             method="PATCH",
             path=params.get(Input.ROUTE),
-            json_data=params.get(Input.BODY, {}),
+            json_data=data,
             headers=params.get(Input.HEADERS, {}),
         )
 

--- a/plugins/rest/komand_rest/actions/patch/schema.py
+++ b/plugins/rest/komand_rest/actions/patch/schema.py
@@ -9,6 +9,7 @@ class Component:
 
 class Input:
     BODY = "body"
+    BODY_AS_AN_ARRAY = "body_as_an_array"
     HEADERS = "headers"
     ROUTE = "route"
     
@@ -31,6 +32,15 @@ class PatchInput(insightconnect_plugin_runtime.Input):
       "title": "Body",
       "description": "Payload to submit to the server when making the HTTP Request call",
       "order": 3
+    },
+    "body_as_an_array": {
+      "type": "array",
+      "title": "Body",
+      "description": "Payload (Array) to submit to the server when making the HTTP Request call",
+      "items": {
+        "type": "object"
+      },
+      "order": 4
     },
     "headers": {
       "type": "object",

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -4,10 +4,10 @@ products: [insightconnect]
 name: rest
 title: HTTP Requests
 description: The HTTP Requests plugin to make it easy to integrate with RESTful services
-version: 5.0.2
+version: 5.0.3
 vendor: rapid7
 support: community
-supported_versions: ["2022-02-22"]
+supported_versions: ["2022-06-15"]
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/rest
@@ -226,6 +226,12 @@ actions:
         type: object
         required: false
         example: '{"user": "user@example.com"}'
+      body_as_an_array:
+        title: Body
+        description: Payload (Array) to submit to the server when making the HTTP Request call
+        type: '[]object'
+        required: false
+        example: '[{"user": "user@example.com"}]'
     output:
       body_object:
         title: Body Object

--- a/plugins/rest/requirements.txt
+++ b/plugins/rest/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 requests==2.25.1
+parameterized==0.8.1

--- a/plugins/rest/setup.py
+++ b/plugins/rest/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rest-rapid7-plugin",
-      version="5.0.2",
+      version="5.0.3",
       description="The HTTP Requests plugin to make it easy to integrate with RESTful services",
       author="rapid7",
       author_email="",

--- a/plugins/rest/unit_test/test_patch.py
+++ b/plugins/rest/unit_test/test_patch.py
@@ -6,6 +6,9 @@ from mockconnection import MockConnection
 
 sys.path.append(os.path.abspath("../"))
 from komand_rest.actions.patch import Patch
+from insightconnect_plugin_runtime.exceptions import PluginException
+from komand_rest.util.util import MESSAGE_CAUSE_BOTH_INPUTS, MESSAGE_ASSISTANCE_BOTH_INPUTS
+from parameterized import parameterized
 
 
 class TestPatch(TestCase):
@@ -70,3 +73,44 @@ class TestPatch(TestCase):
         self.assertEqual(results["body_object"], {"SampleSuccessBody": "SampleVal"})
         self.assertEqual(results["body_string"], "SAMPLETEXT for method PATCH")
         self.assertEqual(results["headers"], {"SampleHeader": "SampleVal"})
+
+    @parameterized.expand(
+        [
+            ("https://www.google.com", {}, [{"action": "jumps"}, {"over": "dog"}, {"ip": "192.168.0.1"}], {}),
+            ("https://www.google.com", {}, [], {"client_id": "name", "client_secret": "passwd"}),
+        ]
+    )
+    def test_patch_with_either_value(self, route, headers, body_as_an_array, body):
+        test_conn = MockConnection()
+        test_action = Patch()
+
+        test_action.connection = test_conn
+        action_params = {
+            "route": route,
+            "headers": headers,
+            "body_as_an_array": body_as_an_array,
+            "body": body,
+        }
+
+        results = test_action.run(action_params)
+        self.assertEqual(results["body_object"], {"SampleSuccessBody": "SampleVal"})
+
+    def test_patch_with_both_bodies(self):
+        with self.assertRaises(PluginException) as error:
+            test_conn = MockConnection()
+            test_action = Patch()
+
+            test_action.connection = test_conn
+            action_params = {
+                "route": "https://www.google.com",
+                "headers": {},
+                "body_as_an_array": [{"action": "jumps"}, {"over": "dog"}, {"ip": "192.168.0.1"}],
+                "body": {"key": "value"},
+            }
+
+            test_action.run(action_params)
+        cause = MESSAGE_CAUSE_BOTH_INPUTS
+        assistance = MESSAGE_ASSISTANCE_BOTH_INPUTS
+
+        self.assertEqual(cause, error.exception.cause)
+        self.assertEqual(assistance, error.exception.assistance)

--- a/plugins/rest/unit_test/test_post.py
+++ b/plugins/rest/unit_test/test_post.py
@@ -58,3 +58,18 @@ class TestPost(TestCase):
         self.assertEqual(results["body_object"], {"SampleSuccessBody": "SampleVal"})
         self.assertEqual(results["body_string"], "SAMPLETEXT for method POST")
         self.assertEqual(results["headers"], {"SampleHeader": "SampleVal"})
+
+    def test_post_with_header(self):
+        test_conn = MockConnection()
+        test_action = Post()
+
+        test_action.connection = test_conn
+        action_params = {
+            "route": "https://www.google.com",
+            "headers": {"Content-Type": "application/x-www-form-urlencoded"},
+            "body": {"key": "value"},
+        }
+        results = test_action.run(action_params)
+
+        self.assertEqual(results["status"], 200)
+        self.assertEqual(results["body_object"], {"SampleSuccessBody": "SampleVal"})


### PR DESCRIPTION
* Update help.md
* Add new input body of array to support array objects in the patch request
* Add support for x-www-form-urlencoded in the POST action

## Proposed Changes

### Description

Describe the proposed changes:

  -

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
