### PR TITLE
[SOAR-8968] Microsoft Teams - Fix issue with Create Teams Enabled Group action input types

### DIFF
--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1ced7369d7bfef6425bdfb6bdf31c41c",
-	"manifest": "4e9319ac259185d214bfed03b8c1e145",
-	"setup": "9703029e776defad301b404eae979326",
+	"spec": "fcd364909c756df3ce5310e523099126",
+	"manifest": "163e3ac07b4cf134ca27a52fb33bd630",
+	"setup": "5dfdfec720bca50f4d7272ee3e376ce4",
 	"schemas": [
 		{
 			"identifier": "add_channel_to_team/schema.py",
@@ -21,7 +21,7 @@
 		},
 		{
 			"identifier": "create_teams_enabled_group/schema.py",
-			"hash": "1f0eb370a90fad1f443b7021c3b2b49f"
+			"hash": "d8544bf830118c309e9982399fe451c8"
 		},
 		{
 			"identifier": "delete_team/schema.py",

--- a/plugins/microsoft_teams/bin/icon_microsoft_teams
+++ b/plugins/microsoft_teams/bin/icon_microsoft_teams
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Teams"
 Vendor = "rapid7"
-Version = "3.2.0"
+Version = "4.0.0"
 Description = "The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users"
 
 

--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -584,8 +584,8 @@ This action is used to create a group in Azure and enable it for Microsoft Teams
 |group_name|string|None|True|Team name|None|test_group|
 |mail_enabled|boolean|None|True|Should e-mail should be enabled for this group|None|True|
 |mail_nickname|string|None|True|The nickname for the email address of this group in Outlook|None|TestGroup|
-|members|string[]|None|False|A list of usernames to set as members|None|["user@example.com"]|
-|owners|string[]|None|False|A list of usernames to set as owners|None|["user@example.com"]|
+|members|[]string|None|False|A list of usernames to set as members|None|["user@example.com"]|
+|owners|[]string|None|False|A list of usernames to set as owners|None|["user@example.com"]|
 
 Example input:
 
@@ -879,6 +879,7 @@ If there is more than one team with the same name in your organization, the olde
 
 # Version History
 
+* 4.0.0 - Fix issue with Create Teams Enabled Group action's members, and owners input field types
 * 3.2.0 - Send Message Action is updated to support chat messages via chat_id parameter, team_name is set to optional. | Update SDK to latest version.
 * 3.1.5 - Add `microsoft_teams` and `office365` keywords | Removed `microsoft, teams, office 365` keywords
 * 3.1.4 - Update help.md to include troubleshooting message about team names

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/create_teams_enabled_group/schema.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/create_teams_enabled_group/schema.py
@@ -51,15 +51,21 @@ class CreateTeamsEnabledGroupInput(insightconnect_plugin_runtime.Input):
       "order": 3
     },
     "members": {
-      "type": "string",
+      "type": "array",
       "title": "Members",
       "description": "A list of usernames to set as members",
+      "items": {
+        "type": "string"
+      },
       "order": 6
     },
     "owners": {
-      "type": "string",
+      "type": "array",
       "title": "Owners",
       "description": "A list of usernames to set as owners",
+      "items": {
+        "type": "string"
+      },
       "order": 5
     }
   },

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/azure_ad_utils.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/azure_ad_utils.py
@@ -161,10 +161,10 @@ def create_group(
     }
 
     if owners:
-        owners_payload = create_user_paylaod(logger, connection, owners)
+        owners_payload = create_user_payload(logger, connection, owners)
         payload["owners@odata.bind"] = owners_payload
     if members:
-        members_payload = create_user_paylaod(logger, connection, members)
+        members_payload = create_user_payload(logger, connection, members)
         payload["members@odata.bind"] = members_payload
 
     logger.info(f"Creating group with: {endpoint}")
@@ -189,7 +189,7 @@ def create_group(
     )
 
 
-def create_user_paylaod(logger: Logger, connection: insightconnect_plugin_runtime.connection, group_list: list) -> list:
+def create_user_payload(logger: Logger, connection: insightconnect_plugin_runtime.connection, group_list: list) -> list:
     """
     This takes a list of user names, gets their IDs, then returns a list of odata objects that can
     be fed into create group

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
 description: The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users
-version: 3.2.0
+version: 4.0.0
 supported_versions: ["Microsoft Graph API v1.0 2021-11-28"]
 vendor: rapid7
 support: community
@@ -619,14 +619,14 @@ actions:
       owners:
         title: Owners
         description: A list of usernames to set as owners
-        type: "string[]"
+        type: "[]string"
         required: false
         order: 5
         example: ['user@example.com']
       members:
         title: Members
         description: A list of usernames to set as members
-        type: "string[]"
+        type: "[]string"
         required: false
         order: 6
         example: ['user@example.com']

--- a/plugins/microsoft_teams/setup.py
+++ b/plugins/microsoft_teams/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="microsoft_teams-rapid7-plugin",
-      version="3.2.0",
+      version="4.0.0",
       description="The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users",
       author="rapid7",
       author_email="",

--- a/plugins/microsoft_teams/unit_test/payloads/get_group_id_from_name.json.resp
+++ b/plugins/microsoft_teams/unit_test/payloads/get_group_id_from_name.json.resp
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#groups",
+    "value": [
+        {
+            "id": "12345"
+        }
+    ]
+}

--- a/plugins/microsoft_teams/unit_test/payloads/get_members.json.resp
+++ b/plugins/microsoft_teams/unit_test/payloads/get_members.json.resp
@@ -1,0 +1,14 @@
+{
+"@odata.context": "https://graph.microsoft.com/v1.0/$metadata#teams/members",
+"@odata.count": 1,
+"value": [
+        {
+            "@odata.type": "#microsoft.graph.aadUserConversationMember",
+            "id": "MmFiOWM3OTYtMjkwMi00NWY4LWI3MTItN2M1YTYzY2Y0MWM0IyNlZWY5Y2IzNi0wNmRlLTQ2OWItODdjZC03MGY0Y2JlMzJkMTQ=",
+            "roles": [],
+            "displayName": "Jane Doe",
+            "userId": "eef9cb36-06de-469b-87cd-70f4cbe32d14",
+            "email": "jdoe@teamsip.onmicrosoft.com"
+        }
+    ]
+}

--- a/plugins/microsoft_teams/unit_test/payloads/get_user_info.json.resp
+++ b/plugins/microsoft_teams/unit_test/payloads/get_user_info.json.resp
@@ -1,0 +1,8 @@
+{
+    "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#users",
+    "value": [
+        {
+            "id": "12345"
+        }
+    ]
+}

--- a/plugins/microsoft_teams/unit_test/test_add_group_owner.py
+++ b/plugins/microsoft_teams/unit_test/test_add_group_owner.py
@@ -1,0 +1,30 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from icon_microsoft_teams.actions.add_group_owner.action import AddGroupOwner
+from icon_microsoft_teams.actions.add_group_owner.schema import Input
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+from util import Util
+from unittest import TestCase, mock
+
+STUB_GROUP_NAME = "test"
+STUB_MEMBER_LOGIN = "test"
+
+STUB_EXAMPLE_ACTION_RESPONSE = {"success": True}
+
+
+class TestAddGroupOwner(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(AddGroupOwner())
+
+        self.payload = {Input.GROUP_NAME: STUB_GROUP_NAME, Input.MEMBER_LOGIN: STUB_MEMBER_LOGIN}
+
+    @mock.patch("requests.get", side_effect=Util.mocked_requests)
+    @mock.patch("requests.post", side_effect=Util.mocked_requests)
+    def test_add_group_owner(self, mock_requests_get, mock_requests_post) -> None:
+        response = self.action.run(self.payload)
+        expected_response = STUB_EXAMPLE_ACTION_RESPONSE
+        self.assertEqual(response, expected_response)

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
@@ -1,0 +1,35 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from icon_microsoft_teams.actions.add_member_to_channel.action import AddMemberToChannel
+from icon_microsoft_teams.actions.add_member_to_channel.schema import Input
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+from util import Util
+from unittest import TestCase, mock
+
+STUB_GROUP_NAME = "test"
+STUB_MEMBER_LOGIN = "test"
+STUB_CHANNEL_NAME = "Example Channel"
+
+STUB_EXAMPLE_ACTION_RESPONSE = {"success": True}
+
+
+class TestAddGroupOwner(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(AddMemberToChannel())
+
+        self.payload = {
+            Input.GROUP_NAME: STUB_GROUP_NAME,
+            Input.MEMBER_LOGIN: STUB_MEMBER_LOGIN,
+            Input.CHANNEL_NAME: STUB_CHANNEL_NAME,
+        }
+
+    @mock.patch("requests.get", side_effect=Util.mocked_requests)
+    @mock.patch("requests.post", side_effect=Util.mocked_requests)
+    def test_add_group_owner(self, mock_requests_get, mock_requests_post) -> None:
+        response = self.action.run(self.payload)
+        expected_response = STUB_EXAMPLE_ACTION_RESPONSE
+        self.assertEqual(response, expected_response)

--- a/plugins/microsoft_teams/unit_test/util.py
+++ b/plugins/microsoft_teams/unit_test/util.py
@@ -64,8 +64,16 @@ class Util:
             return MockResponse("get_channels", 200)
         if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels/56789/messages":
             return MockResponse("send_message_channel", 200)
+        if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels/56789/members/":
+            return MockResponse("get_members", 201)
         if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels/56789/messages/1636037542013/replies":
             return MockResponse("send_message_thread", 200)
         if args[0] == "https://graph.microsoft.com/beta/chats/19:10000_20000@unq.gbl.spaces/messages":
             return MockResponse("send_message_chat", 200)
+        if args[0] == "https://graph.microsoft.com/v1.0/1/users?$filter=userPrincipalName eq 'test'":
+            return MockResponse("get_user_info", 200)
+        if args[0] == "https://graph.microsoft.com/v1.0/1/groups?$filter=displayName eq 'test'":
+            return MockResponse("get_group_id_from_name", 200)
+        if args[0] == "https://graph.microsoft.com/beta/groups/12345/owners/$ref":
+            return MockResponse("no_content", 204)
         raise Exception("Not implemented")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix issue with Create Teams Enabled Group action input types

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [x] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [x] Screenshot of job output with the plugin changes
- [x] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
