### PR TITLE
[SOAR-10021] Active Directory LDAP - Fix issue with modify object action, enhanced LDAP logging, fix issue with variable error when connection fails

### DIFF
--- a/plugins/active_directory_ldap/.CHECKSUM
+++ b/plugins/active_directory_ldap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "95b1c65e983cad24e48aa8e8956ba8bd",
-	"manifest": "4ed07d1fefb30a1257046f5cb21713a1",
-	"setup": "766cd86d8bf92bc0aa0d85a387972315",
+	"spec": "d0866f82751dbd271f612985f7310899",
+	"manifest": "8db9fcae3702e3b536839df6b932c6c8",
+	"setup": "36a752ba6a1df853ccb70a9713c15ec6",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/active_directory_ldap/bin/komand_active_directory_ldap
+++ b/plugins/active_directory_ldap/bin/komand_active_directory_ldap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Active Directory LDAP"
 Vendor = "rapid7"
-Version = "5.3.3"
+Version = "5.3.4"
 Description = "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
 
 

--- a/plugins/active_directory_ldap/help.md
+++ b/plugins/active_directory_ldap/help.md
@@ -676,6 +676,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 5.3.4 - Fix issue with space character in DN in modify object action | Enhanced LDAP logging | Fix issue with variable error when connection fails 
 * 5.3.3 - Fix issue with escaping brackets in Query action
 * 5.3.2 - Improve LDAP connection handling
 * 5.3.1 - Improved error messaging in case the specified group was not found in the Query Group Membership action

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/modify_object/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/modify_object/action.py
@@ -19,10 +19,10 @@ class ModifyObject(insightconnect_plugin_runtime.Action):
         dn = params.get(Input.DISTINGUISHED_NAME)
         attribute = params.get(Input.ATTRIBUTE_TO_MODIFY)
         attribute_value = params.get(Input.ATTRIBUTE_VALUE)
-        dn, search_base = formatter.format_dn(dn)
+        dn, _ = formatter.format_dn(dn)
         self.logger.info(f"Escaped DN {dn}")
 
         dn = formatter.escape_brackets_for_query(dn)
         self.logger.info(dn)
 
-        return {Output.SUCCESS: self.connection.client.modify_object(dn, search_base, attribute, attribute_value)}
+        return {Output.SUCCESS: self.connection.client.modify_object(dn, attribute, attribute_value)}

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/util/api.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/util/api.py
@@ -6,6 +6,7 @@ import ldap3
 from ldap3 import MODIFY_REPLACE, ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES
 from ldap3 import extend
 from ldap3.core.exceptions import LDAPBindError, LDAPAuthorizationDeniedResult, LDAPSocketOpenError, LDAPException
+from ldap3.utils.log import set_library_log_detail_level, set_library_log_hide_sensitive_data, ERROR
 
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.util.utils import ADUtils
@@ -14,11 +15,13 @@ from komand_active_directory_ldap.util.utils import ADUtils
 def with_connection(action):
     @wraps(action)
     def wrapper(self, *args, **kwargs):
+        connection = None
         try:
             connection = self.establish_connection()
             result = action(self, connection, *args, **kwargs)
         finally:
-            connection.unbind()
+            if connection:
+                connection.unbind()
         return result
 
     return wrapper
@@ -33,6 +36,9 @@ class ActiveDirectoryLdapAPI:
         self.referrals = referrals
         self.user_name = user_name
         self.password = password
+
+        set_library_log_detail_level(ERROR)
+        set_library_log_hide_sensitive_data(True)
 
     def establish_connection(self) -> ldap3.Connection:
         """
@@ -76,12 +82,12 @@ class ActiveDirectoryLdapAPI:
                 auto_referrals=self.referrals,
                 authentication=authentication,
             )
-        except LDAPBindError as e:
-            raise PluginException(preset=PluginException.Preset.USERNAME_PASSWORD, data=e)
-        except LDAPAuthorizationDeniedResult as e:
-            raise PluginException(preset=PluginException.Preset.UNAUTHORIZED, data=e)
-        except LDAPSocketOpenError as e:
-            raise PluginException(preset=PluginException.Preset.SERVICE_UNAVAILABLE, data=e)
+        except LDAPBindError as error:
+            raise PluginException(preset=PluginException.Preset.USERNAME_PASSWORD, data=error)
+        except LDAPAuthorizationDeniedResult as error:
+            raise PluginException(preset=PluginException.Preset.UNAUTHORIZED, data=error)
+        except LDAPSocketOpenError as error:
+            raise PluginException(preset=PluginException.Preset.SERVICE_UNAVAILABLE, data=error)
         return conn
 
     def host_formatter(self, host: str) -> str:
@@ -118,11 +124,11 @@ class ActiveDirectoryLdapAPI:
         try:
             conn.raise_exceptions = True
             conn.add(dn, ["person", "user"], parameters)
-        except LDAPException as e:
+        except LDAPException as error:
             raise PluginException(
                 cause="LDAP returned an error message.",
                 assistance="Creating new user failed, error returned by LDAP.",
-                data=e,
+                data=error,
             )
         success = True
 
@@ -164,11 +170,11 @@ class ActiveDirectoryLdapAPI:
         try:
             conn.raise_exceptions = True
             conn.modify(dn=dn, changes=password_expire)
-        except LDAPException as e:
+        except LDAPException as error:
             raise PluginException(
                 cause="LDAP returned an error.",
                 assistance="Error was returned when trying to force password reset for this user.",
-                data=e,
+                data=error,
             )
 
         return True
@@ -188,11 +194,11 @@ class ActiveDirectoryLdapAPI:
                 group = extend.ad_add_members_to_groups(conn, dn, group_dn, fix=True, raise_error=True)
             else:
                 group = extend.ad_remove_members_from_groups(conn, dn, group_dn, fix=True, raise_error=True)
-        except LDAPException as e:
+        except LDAPException as error:
             raise PluginException(
                 cause="Either the user or group distinguished name was not found.",
                 assistance="Please check that the distinguished names are correct",
-                data=e,
+                data=error,
             )
 
         if group is False:
@@ -202,10 +208,10 @@ class ActiveDirectoryLdapAPI:
         return group
 
     @with_connection
-    def modify_object(self, conn, dn: str, search_base: str, attribute: str, attribute_value: str):
+    def modify_object(self, conn, dn: str, attribute: str, attribute_value: str):
         conn.search(
-            search_base=search_base,
-            search_filter=f"(distinguishedName={dn})",
+            search_base=dn,
+            search_filter="(objectClass=*)",
             attributes=[ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES],
         )
         result = conn.response_to_json()
@@ -244,17 +250,23 @@ class ActiveDirectoryLdapAPI:
 
     @with_connection
     def query(self, conn, search_base: str, escaped_query: str, attributes):
-        conn.extend.standard.paged_search(
-            search_base=search_base,
-            search_filter=escaped_query,
-            attributes=attributes,
-            paged_size=100,
-            generator=False,
-        )
-
-        result_list_json = conn.response_to_json()
-        result_list_object = json.loads(result_list_json)
-        return result_list_object.get("entries")
+        try:
+            conn.extend.standard.paged_search(
+                search_base=search_base,
+                search_filter=escaped_query,
+                attributes=attributes,
+                paged_size=100,
+                generator=False,
+            )
+            result_list_json = conn.response_to_json()
+            result_list_object = json.loads(result_list_json)
+            return result_list_object.get("entries")
+        except Exception as error:
+            raise PluginException(
+                cause="Error occurred while running LDAP query",
+                assistance="Check the error message for more information. If it's needed contact support for help.",
+                data=str(error),
+            )
 
     @with_connection
     def query_group_membership(self, conn, base: str, group_name: str, include_groups: str, expand_nested_groups: str):
@@ -277,12 +289,12 @@ class ActiveDirectoryLdapAPI:
                 query = f"(&(objectClass=user)(memberOf:={group_dn}))"
             entries = self.__search_data(conn, base=base, filter_query=query).get("entries")
             return entries
-        except (AttributeError, IndexError) as e:
+        except (AttributeError, IndexError) as error:
             raise PluginException(
                 cause="LDAP returned unexpected response.",
                 assistance="Check that the provided inputs are correct and try again. If the issue persists please "
                 "contact support.",
-                data=e,
+                data=error,
             )
 
     def __search_data(self, conn, base: str, filter_query: str) -> dict:
@@ -300,11 +312,11 @@ class ActiveDirectoryLdapAPI:
         try:
             conn.raise_exceptions = True
             success = extend.ad_modify_password(conn, dn, new_password, old_password=None)
-        except LDAPException as e:
+        except LDAPException as error:
             raise PluginException(
                 cause="LDAP returned an error in the response.",
                 assistance="LDAP failed to reset the password for this user",
-                data=e,
+                data=error,
             )
 
         return success

--- a/plugins/active_directory_ldap/plugin.spec.yaml
+++ b/plugins/active_directory_ldap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: active_directory_ldap
 title: Active Directory LDAP
 description: "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
-version: 5.3.3
+version: 5.3.4
 supported_versions: ["Azure Active Directory 2.0.89.0"]
 vendor: rapid7
 support: rapid7

--- a/plugins/active_directory_ldap/setup.py
+++ b/plugins/active_directory_ldap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="active_directory_ldap-rapid7-plugin",
-      version="5.3.3",
+      version="5.3.4",
       description="This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix issue with modify object action
  - Enhanced LDAP logging (Extended for Query action, and for docker container logs)
  - Fix issue with variable error when connection fails

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section

### Run

<details>

```
{
  "body": {
    "log": "rapid7/Active Directory LDAP:5.3.4. Step name: modify_object\nEscaped DN CN=Test User,OU=users,DC=example,DC=org\nCN=Test User,OU=users,DC=example,DC=org\nConnecting to 172.17.0.2:1389\nFailed to connect to the server with NTLM, attempting to connect with basic auth\nConnected!\n",
    "status": "ok",
    "meta": {},
    "output": {
      "success": true
    }
  },
  "version": "v1",
  "type": "action_event"
}
```

<summary>
docker run --rm -i rapid7/active_directory_ldap:5.3.4 run < tests/modify_object.json (For cn=Test User,ou=users,dc=example,dc=org)
</summary>
</details>
