### PR TITLE
Insight IDR - 10421 - Enabled could_ready flag, fix issue with NoneType object in advanced query on log action

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "314c8271bea462fcee5643f57b0e4565",
+	"spec": "d62281011455bd445d8f930af6079780",
 	"manifest": "66a6aeb2dabc6740a4935d3b0f6b038a",
 	"setup": "11e30d38ce98dc35ca19afff71bd68c6",
 	"schemas": [

--- a/plugins/rapid7_insightidr/Dockerfile
+++ b/plugins/rapid7_insightidr/Dockerfile
@@ -7,8 +7,6 @@ LABEL sdk=python
 # Add any custom package dependencies here
 # NOTE: Add pip packages to requirements.txt
 
-RUN apk add gcc musl-dev
-
 # End package dependencies
 
 # Add source code

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -21,7 +21,7 @@ Do more with Investigations in [InsightIDR](https://www.rapid7.com/products/insi
 
 # Supported Product Versions
 
-* Latest release successfully tested on 2022-06-15.
+* Latest release successfully tested on 2022-07-20.
 
 # Documentation
 

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/endpoints.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/endpoints.py
@@ -19,7 +19,7 @@ class Investigations:
             "Japan": "ap",
         }
 
-        return f"https://{region_map.get(region_code)}.api.insight.rapid7.com/"
+        return f"https://{region_map.get(region_code, 'us')}.api.insight.rapid7.com/"
 
     @staticmethod
     def list_investigations(console_url: str) -> str:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -5,8 +5,9 @@ name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
 version: 4.0.0
-supported_versions: ["Latest release successfully tested on 2022-06-15."]
+supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7
+cloud_ready: true
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/rapid7_insightidr
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
@@ -17,7 +18,7 @@ support: rapid7
 status: []
 hub_tags:
   use_cases: [threat_detection_and_response]
-  keywords: [siem, rapid7]
+  keywords: [siem, rapid7, cloud_enabled]
   features: []
 types:
   investigation_metadata:


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Cloud_ready flag set to true
  - Fix issue with NoneType object in Advanced query on log action

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [X] Screenshot of job output with the plugin changes
- [X] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
