### PR TITLE
[SOAR-10246] - Any.Run OS params fix

### DIFF
--- a/plugins/any_run/.CHECKSUM
+++ b/plugins/any_run/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "020347b44fdaf53b2645016fff967a98",
-	"manifest": "4b60f2e9fb006628d3e41cec32206638",
-	"setup": "bdbb679b8c580c8e3505d0a2fb52681c",
+	"spec": "7493a09b1b19f2bb892fa20d0803ab30",
+	"manifest": "7240c2b11e70e922fb013dfe77750e3e",
+	"setup": "b41bb39ab95c4daca258ccc121319e3f",
 	"schemas": [
 		{
 			"identifier": "get_history/schema.py",

--- a/plugins/any_run/bin/icon_any_run
+++ b/plugins/any_run/bin/icon_any_run
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Any.Run"
 Vendor = "rapid7"
-Version = "1.1.1"
+Version = "1.1.2"
 Description = "Analyze suspicious and malicious activities using the cloud-based malware analysis service"
 
 

--- a/plugins/any_run/help.md
+++ b/plugins/any_run/help.md
@@ -966,6 +966,7 @@ When configuring the connection, only one authentication method can be supplied.
 
 # Version History
 
+* 1.1.2 - Fix issue with file defaulting to Windows 7 32-Bit
 * 1.1.1 - Fix issue with invalid inputs in Run Analysis action | Fix issue where Run Analysis action fails if optional inputs are provided as empty strings | Fix issue where Get Report action fails when fields in output contain `None` value | Improve error handling
 * 1.1.0 - Allow user agent input when using URL type in Run Analysis action
 * 1.0.0 - Initial plugin

--- a/plugins/any_run/icon_any_run/util/api.py
+++ b/plugins/any_run/icon_any_run/util/api.py
@@ -16,15 +16,16 @@ class AnyRunAPI:
         return self._call_api("GET", self.url + task_id)
 
     def run_analysis(self, json_data, files):
-        return self._call_api("POST", self.url, files=files, json_data=json_data)
+        return self._call_api("POST", self.url, files=files, data=json_data)
 
-    def _call_api(self, method, url, params=None, json_data=None, files=None):
+    def _call_api(self, method, url, params=None, json_data=None, data=None, files=None):
         response = {"text": ""}
         try:
             response = requests.request(
                 method,
                 url,
                 files=files,
+                data=data,
                 json=json_data,
                 params=params,
                 headers=self.authentication_header,

--- a/plugins/any_run/plugin.spec.yaml
+++ b/plugins/any_run/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: any_run
 title: "Any.Run"
 description: Analyze suspicious and malicious activities using the cloud-based malware analysis service
-version: 1.1.1
+version: 1.1.2
 supported_versions: ["Any.Run API 2022-05-17"]
 vendor: rapid7
 support: community

--- a/plugins/any_run/setup.py
+++ b/plugins/any_run/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="any_run-rapid7-plugin",
-      version="1.1.1",
+      version="1.1.2",
       description="Analyze suspicious and malicious activities using the cloud-based malware analysis service",
       author="rapid7",
       author_email="",

--- a/plugins/any_run/unit_test/util.py
+++ b/plugins/any_run/unit_test/util.py
@@ -68,8 +68,8 @@ class Util:
             return MockResponse("not_found", 404)
         if kwargs.get("files") == {"file": ("file.txt", b"Rapid7 InsightConnect\n")}:
             return MockResponse("run_analysis", 201)
-        if kwargs.get("json", {}).get("obj_url") == "http://example.com":
+        if kwargs.get("data", {}).get("obj_url") == "http://example.com":
             return MockResponse("run_analysis", 201)
-        if kwargs.get("json", {}).get("obj_url") == "https://upload.example.com/test.png":
+        if kwargs.get("data", {}).get("obj_url") == "https://upload.example.com/test.png":
             return MockResponse("run_analysis", 201)
         raise Exception("Not implemented")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix for run analysis on file defaulting to windows 7 32-bit on any.run platform

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [x] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [x] Screenshot of job output with the plugin changes
- [x] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder
![Screenshot 2022-07-26 at 13 00 05](https://user-images.githubusercontent.com/93926445/181000910-1b5c75e9-7e45-44ec-b2a8-22e0e1b74930.png)
![Screenshot 2022-07-26 at 13 08 13](https://user-images.githubusercontent.com/93926445/181002262-89ba4997-4eb4-4a41-9b93-2b317208a00a.png)


### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [x] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [x] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [x] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
