### PR TITLE
[SOAR-10641] Insight IDR - Fix issue with Get Query Results and Get All Saved Queries actions

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d62281011455bd445d8f930af6079780",
-	"manifest": "66a6aeb2dabc6740a4935d3b0f6b038a",
-	"setup": "11e30d38ce98dc35ca19afff71bd68c6",
+	"spec": "0fccd6e571e7920d1e047bb71236c1ce",
+	"manifest": "57732748bc02de982621105668ee651d",
+	"setup": "4112d40d20eb9c14b1a88060b250d921",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "4.0.0"
+Version = "4.0.1"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -1316,6 +1316,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 4.0.1 - Fix issue with `Get Query Results` and `Get All Saved Queries` actions
 * 4.0.0 - Add new actions Create Investigation, Search Investigations, Update Investigation, Set Investigation Priority, Set Investigation Disposition, and List Alerts for Investigation | Update actions List Investigations, Set Status of Investigation, Assign User to Investigation | Enabled cloud 
 * 3.2.0 - Add new actions Get A Saved Query and Get All Saved Queries
 * 3.1.5 - Patch issue parsing labels in Advanced Query on Log and Advanced Query on Log Set actions

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
@@ -17,7 +17,7 @@ class GetAllSavedQueries(insightconnect_plugin_runtime.Action):
 
     def run(self):
         request = ResourceHelper(self.connection.session, self.logger)
-        response = request.resource_request(Queries.get_all_queries(self.connection.url), "get")
+        response = request.resource_request(Queries.get_all_queries(self.connection.region), "get")
         try:
             result = json.loads(response["resource"])
             saved_queries = insightconnect_plugin_runtime.helper.clean(result.get("saved_queries"))

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/action.py
@@ -26,7 +26,7 @@ class Query(insightconnect_plugin_runtime.Action):
         three_months_seconds = 7776000
         request_params = {"from": (time_now - three_months_seconds) * 1000, "to": time_now * 1000}
         response = request.resource_request(
-            QueryLogs.get_query_logs(self.connection.url, params.get(Input.ID)),
+            QueryLogs.get_query_logs(self.connection.region, params.get(Input.ID)),
             "get",
             params=request_params,
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -16,7 +16,8 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
     def connect(self, params={}):
         api_key = params.get(Input.API_KEY).get("secretKey")
-        self.url = Investigations.connection_api_url(params.get(Input.REGION))
+        self.region = params.get(Input.REGION)
+        self.url = Investigations.connection_api_url(self.region)
         if not self.url.endswith("/"):
             self.url = f"{self.url}/"
 

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/endpoints.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/endpoints.py
@@ -1,13 +1,10 @@
-class Investigations:
-
-    # Methods to populate Investigation endpoints
-
+class Util:
     @staticmethod
-    def connection_api_url(region_code: str) -> str:
+    def map_region(region: str) -> str:
         """
         URI for listing investigations
-        :param region_code: URL to the InsightIDR console
-        :return: pre-populated /idr/v2/investigations/
+        :param region: The region code for the InsightIDR API to be mapped
+        :return: Region-code
         """
         region_map = {
             "United States 1": "us",
@@ -18,8 +15,21 @@ class Investigations:
             "Australia": "au",
             "Japan": "ap",
         }
+        return region_map.get(region, "us")
 
-        return f"https://{region_map.get(region_code, 'us')}.api.insight.rapid7.com/"
+
+class Investigations:
+
+    # Methods to populate Investigation endpoints
+
+    @staticmethod
+    def connection_api_url(region_code: str) -> str:
+        """
+        URI for listing investigations
+        :param region_code: The region code for the InsightIDR API to be mapped
+        :return: pre-populated /idr/v2/investigations/
+        """
+        return f"https://{Util.map_region(region_code)}.api.insight.rapid7.com/"
 
     @staticmethod
     def list_investigations(console_url: str) -> str:
@@ -149,26 +159,26 @@ class Threats:
 
 class QueryLogs:
     @staticmethod
-    def get_query_logs(console_url: str, log_id: str):
+    def get_query_logs(region_code: str, log_id: str):
         """
         URI for adding get_query_logs
-        :param console_url: URL to the InsightIDR console
+        :param region_code: The region code for the InsightIDR API to be mapped
         :param log_id: The ID of a log for which the indicators are going to be added
         :return: pre-populated /query/logs/{log_id}
         """
 
-        return f"{console_url}query/logs/{log_id}"
+        return f"https://{Util.map_region(region_code)}.rest.logs.insight.rapid7.com/query/logs/{log_id}"
 
 
 class Queries:
     @staticmethod
-    def get_all_queries(console_url: str):
+    def get_all_queries(region_code: str):
         """
         URI for retrieving all saved queries
-        :param console_url: URL to the InsightIDR console
+        :param region_code: The region code for the InsightIDR API to be mapped
         :return: pre-populated /query/saved_queries
         """
-        return f"{console_url}query/saved_queries"
+        return f"https://{Util.map_region(region_code)}.rest.logs.insight.rapid7.com/query/saved_queries"
 
     @staticmethod
     def get_query_by_id(console_url: str, query_id: str):

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 4.0.0
+version: 4.0.1
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7
 cloud_ready: true

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="4.0.0",
+      version="4.0.1",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/mock.py
+++ b/plugins/rapid7_insightidr/unit_test/mock.py
@@ -1,7 +1,7 @@
 import json
 import os
-from util import Util
 
+from util import Util
 
 REQUEST_GET = "get"
 REQUEST_POST = "post"
@@ -52,42 +52,45 @@ class MockResponse:
 
 
 def mock_request_post(url: str) -> MockResponse:
-    if url == f"{Util.STUB_URL}/query/saved_queries/{STUB_QUERY_ID}":
+    if url == f"{Util.STUB_URL_API}/query/saved_queries/{STUB_QUERY_ID}":
         return MockResponse("get_a_saved_query", 200)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations":
         return MockResponse("create_investigation", 201)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/_search":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/_search":
         return MockResponse("search_investigations", 200)
 
 
 def mock_request_get(url: str) -> MockResponse:
-    if url == f"{Util.STUB_URL}/query/saved_queries":
+    if url == f"{Util.STUB_URL_REST}/query/saved_queries":
         return MockResponse("get_all_saved_queries", 200)
-    if url == f"{Util.STUB_URL}/query/saved_queries/{STUB_QUERY_ID}":
+    if url == f"{Util.STUB_URL_API}/query/saved_queries/{STUB_QUERY_ID}":
         return MockResponse("get_a_saved_query", 200)
-    if url == f"{Util.STUB_URL}/query/saved_queries/{STUB_QUERY_ID_NOT_FOUND}":
+    if url == f"{Util.STUB_URL_API}/query/saved_queries/{STUB_QUERY_ID_NOT_FOUND}":
         return MockResponse("get_a_saved_query_404", 404)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}":
         return MockResponse("get_investigation", 200)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/alerts":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/alerts":
         return MockResponse("list_alerts_for_investigation", 200)
     if "investigations" in url:
         return MockResponse("list_investigations", 200)
 
 
 def mock_request_patch(url: str) -> MockResponse:
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}":
         return MockResponse("update_investigation", 200)
 
 
 def mock_request_put(url: str) -> MockResponse:
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/priority/{STUB_PRIORITY}":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/priority/{STUB_PRIORITY}":
         return MockResponse("update_investigation", 200)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/status/{STUB_STATUS}":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/status/{STUB_STATUS}":
         return MockResponse("update_investigation", 200)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/disposition/{STUB_DISPOSITION}":
+    if (
+        url
+        == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/disposition/{STUB_DISPOSITION}"
+    ):
         return MockResponse("update_investigation", 200)
-    if url == f"{Util.STUB_URL}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/assignee":
+    if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}/assignee":
         return MockResponse("update_investigation", 200)
 
 

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -16,7 +16,8 @@ class Meta:
 
 
 class Util:
-    STUB_URL = "https://us.api.insight.rapid7.com"
+    STUB_URL_API = "https://us.api.insight.rapid7.com"
+    STUB_URL_REST = "https://us.rest.logs.insight.rapid7.com"
 
     @staticmethod
     def default_connector(action, connect_params: object = None):
@@ -70,11 +71,11 @@ class Util:
                     )
                 )
 
-        if args[0] == f"{Util.STUB_URL}/log_search/management/labels/00000000-0000-0000-0000-000000000006":
+        if args[0] == f"{Util.STUB_URL_API}/log_search/management/labels/00000000-0000-0000-0000-000000000006":
             return MockResponse("label_006", 200)
-        elif args[0] == f"{Util.STUB_URL}/log_search/management/labels/00000000-0000-0000-0000-000000000007":
+        elif args[0] == f"{Util.STUB_URL_API}/log_search/management/labels/00000000-0000-0000-0000-000000000007":
             return MockResponse("label_007", 200)
-        elif args[0] == f"{Util.STUB_URL}/log_search/management/labels/not exist label - 404":
+        elif args[0] == f"{Util.STUB_URL_API}/log_search/management/labels/not exist label - 404":
             return MockResponse("label_404", 404)
 
         raise Exception("Not implemented")
@@ -103,29 +104,29 @@ class Util:
                     )
                 )
 
-        if args[0] == f"{Util.STUB_URL}/log_search/management/logs":
+        if args[0] == f"{Util.STUB_URL_API}/log_search/management/logs":
             return MockResponse("logs", 200)
         elif (
-            args[0] == f"{Util.STUB_URL}/log_search/query/logs/log_id"
-            or args[0] == f"{Util.STUB_URL}/log_search/query/logsets/log_id"
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id"
         ):
             return MockResponse("log_id", 200)
         elif (
-            args[0] == f"{Util.STUB_URL}/log_search/query/logs/log_id2"
-            or args[0] == f"{Util.STUB_URL}/log_search/query/logsets/log_id2"
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id2"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id2"
         ):
             return MockResponse("log_id2", 200)
         elif (
-            args[0] == f"{Util.STUB_URL}/log_search/query/logs/log_id3"
-            or args[0] == f"{Util.STUB_URL}/log_search/query/logsets/log_id3"
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id3"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id3"
         ):
             return MockResponse("log_id3", 200)
         elif (
-            args[0] == f"{Util.STUB_URL}/log_search/query/logs/log_id4"
-            or args[0] == f"{Util.STUB_URL}/log_search/query/logsets/log_id4"
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id4"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id4"
         ):
             return MockResponse("log_id4", 200)
-        elif args[0] == f"{Util.STUB_URL}/log_search/management/logsets":
+        elif args[0] == f"{Util.STUB_URL_API}/log_search/management/logsets":
             return MockResponse("logsets", 200)
 
         raise Exception("Not implemented")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix issue with Get Query Logs and Get All Saved Queries actions

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
