### PR TITLE
Servicenow - 8054 - Cloud enabled | Changed connection input url to i…

### DIFF
--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "10d53bdf82c37c0b290281136cbc0f88",
-	"manifest": "2f2a522675cee522c2242211dd17dfb4",
-	"setup": "8e0ff7a93fff897cc42a5c0b1eed36c7",
+	"spec": "2ccdc1d3e4c16dea641d60a9f2bc5c0d",
+	"manifest": "cf4eb0bd5fad2581228598de5a028f02",
+	"setup": "c87f2f8ef34f6425c6f17c79a517a08f",
 	"schemas": [
 		{
 			"identifier": "create_ci/schema.py",
@@ -65,7 +65,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "1a6b0194e7a5b19b7b22282c6ed87aa2"
+			"hash": "2289c026eff99b21a313d2223949e5ab"
 		},
 		{
 			"identifier": "incident_changed/schema.py",

--- a/plugins/servicenow/bin/icon_servicenow
+++ b/plugins/servicenow/bin/icon_servicenow
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ServiceNow"
 Vendor = "rapid7"
-Version = "6.0.1"
+Version = "7.0.0"
 Description = "ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes"
 
 

--- a/plugins/servicenow/help.md
+++ b/plugins/servicenow/help.md
@@ -13,7 +13,7 @@ Note: This plugin affects only the underlying tables in a ServiceNow instance, n
 # Requirements
 
 * ServiceNow username and password
-* ServiceNow instance URL
+* ServiceNow instance name
 
 # Supported Product Versions
 
@@ -28,8 +28,8 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |client_login|credential_username_password|None|True|The ServiceNow username and password for basic authentication API interaction|None|{"username":"user1", "password":"mypassword"}|
+|instance|string|None|True|The instance of ServiceNow from the URL, e.g. https://{instance}.service-now.com|None|instance|
 |timeout|integer|30|False|The interval in seconds before abandoning an attempt to access ServiceNow|None|30|
-|url|string|None|True|The full URL for your instance of ServiceNow, e.g. https://instance.servicenow.com|None|https://instance.servicenow.com|
 
 Example input:
 
@@ -39,8 +39,8 @@ Example input:
     "username": "user1",
     "password": "mypassword"
   },
-  "timeout": 30,
-  "url": "https://instance.servicenow.com"
+  "instance": "instance",
+  "timeout": 30
 }
 ```
 
@@ -154,7 +154,9 @@ Example input:
 
 ```
 {
-  "additional_fields": "{"description": "incident description"}",
+  "additional_fields": {
+    "description": "incident description"
+  },
   "assigned_to": "user",
   "assignment_group": "Team Development Code Reviewers",
   "business_service": "All",
@@ -235,7 +237,7 @@ Example input:
 
 ```
 {
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+  "attachment_id": "9de5069c5afe602b2ea0a04b66beb2c0"
 }
 ```
 
@@ -670,7 +672,9 @@ Example input:
 
 ```
 {
-  "additional_fields": "{"description": "incident description"}",
+  "additional_fields": {
+    "description": "incident description"
+  },
   "assigned_to": "user",
   "assignment_group": "Recommendation Admin",
   "business_service": "All",
@@ -865,6 +869,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 7.0.0 - Cloud enabled | Changed connection input `URL` to `instance`
 * 6.0.1 - Fix base64 decoding in Put Incident Attachment action
 * 6.0.0 - Add additional file information in output for Get Attachments for an Incident
 * 5.2.0 - Add new action Get Attachments for an Incident | Add unit test for action Get Attachments for an Incident and Get Incident Attachment

--- a/plugins/servicenow/icon_servicenow/connection/connection.py
+++ b/plugins/servicenow/icon_servicenow/connection/connection.py
@@ -18,10 +18,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         api_route = "api/now/"
         incident_table = "incident"
 
-        self.base_url = params.get(Input.URL, "")
-
-        if not self.base_url.endswith("/"):
-            self.base_url = f"{self.base_url}/"
+        self.base_url = f"https://{params.get(Input.INSTANCE, '')}.service-now.com/"
 
         username = params[Input.CLIENT_LOGIN].get("username", "")
         password = params[Input.CLIENT_LOGIN].get("password", "")

--- a/plugins/servicenow/icon_servicenow/connection/schema.py
+++ b/plugins/servicenow/icon_servicenow/connection/schema.py
@@ -5,8 +5,8 @@ import json
 
 class Input:
     CLIENT_LOGIN = "client_login"
+    INSTANCE = "instance"
     TIMEOUT = "timeout"
-    URL = "url"
     
 
 class ConnectionSchema(insightconnect_plugin_runtime.Input):
@@ -21,23 +21,23 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "description": "The ServiceNow username and password for basic authentication API interaction",
       "order": 2
     },
+    "instance": {
+      "type": "string",
+      "title": "ServiceNow Instance",
+      "description": "The instance of ServiceNow from the URL, e.g. https://{instance}.service-now.com",
+      "order": 1
+    },
     "timeout": {
       "type": "integer",
       "title": "Timeout",
       "description": "The interval in seconds before abandoning an attempt to access ServiceNow",
       "default": 30,
       "order": 3
-    },
-    "url": {
-      "type": "string",
-      "title": "ServiceNow URL",
-      "description": "The full URL for your instance of ServiceNow, e.g. https://instance.servicenow.com",
-      "order": 1
     }
   },
   "required": [
     "client_login",
-    "url"
+    "instance"
   ],
   "definitions": {
     "credential_username_password": {

--- a/plugins/servicenow/plugin.spec.yaml
+++ b/plugins/servicenow/plugin.spec.yaml
@@ -4,11 +4,12 @@ products: ["insightconnect"]
 name: servicenow
 title: ServiceNow
 description: ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes
-version: 6.0.1
+version: 7.0.0
 supported_versions: ["2020-03-11 Orlando"]
 vendor: rapid7
 support: rapid7
 status: []
+cloud_ready: true
 resources:
   vendor_url: https://www.servicenow.com/
   docs_url: https://docs.rapid7.com/insightconnect/servicenow
@@ -19,9 +20,8 @@ tags:
 - tables
 hub_tags:
   use_cases: [remediation_management, asset_inventory]
-  keywords: [servicenow, incidents, cmdb]
+  keywords: [servicenow, incidents, cmdb, cloud_enabled]
   features: []
-
 types:
   comments_worknotes:
     sys_id:
@@ -81,12 +81,12 @@ types:
       type: string
       required: false
 connection:
-  url:
-    title: ServiceNow URL
-    description: The full URL for your instance of ServiceNow, e.g. https://instance.servicenow.com
+  instance:
+    title: ServiceNow Instance
+    description: The instance of ServiceNow from the URL, e.g. https://{instance}.service-now.com
     type: string
     required: true
-    example: https://instance.servicenow.com
+    example: instance
   client_login:
     title: Client Login Information
     description: The ServiceNow username and password for basic authentication API interaction

--- a/plugins/servicenow/setup.py
+++ b/plugins/servicenow/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="servicenow-rapid7-plugin",
-      version="6.0.1",
+      version="7.0.0",
       description="ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes",
       author="rapid7",
       author_email="",

--- a/plugins/servicenow/unit_test/util.py
+++ b/plugins/servicenow/unit_test/util.py
@@ -14,7 +14,7 @@ class Util:
             params = connect_params
         else:
             params = {
-                Input.URL: "https://rapid7.com",
+                Input.INSTANCE: "rapid7",
                 Input.CLIENT_LOGIN: {"username": "user1", "password": "mypassword"},
             }
         default_connection.connect(params)
@@ -49,24 +49,24 @@ class Util:
                 return json.loads(self.text)
 
         if kwargs["url"] in [
-            "https://rapid7.com/api/now/attachment/b259f4062d9f78f9ffdd6efd05c492c7/file",
-            "https://rapid7.com/api/now/attachment/52e4a8abb1b66fc04ba11001955e7dcb/file",
-            "https://rapid7.com/api/now/attachment/53e4a8abb1b66fc04ba11001955e7dcb/file",
+            "https://rapid7.service-now.com/api/now/attachment/b259f4062d9f78f9ffdd6efd05c492c7/file",
+            "https://rapid7.service-now.com/api/now/attachment/52e4a8abb1b66fc04ba11001955e7dcb/file",
+            "https://rapid7.service-now.com/api/now/attachment/53e4a8abb1b66fc04ba11001955e7dcb/file",
         ]:
             return MockResponse("get_attachment_file", 200, {})
         elif (
             kwargs["url"]
-            == "https://rapid7.com/api/now/attachment?sysparm_query=table_sys_id=3072d01d07a552f6d0ea83ef29c936be"
+            == "https://rapid7.service-now.com/api/now/attachment?sysparm_query=table_sys_id=3072d01d07a552f6d0ea83ef29c936be"
         ):
             return MockResponse("get_attachment_by_table_sys_id.json", 200)
         elif (
             kwargs["url"]
-            == "https://rapid7.com/api/now/attachment?sysparm_query=table_sys_id=51e4a8abb1b66fc04ba11001955e7dcb"
+            == "https://rapid7.service-now.com/api/now/attachment?sysparm_query=table_sys_id=51e4a8abb1b66fc04ba11001955e7dcb"
         ):
             return MockResponse("get_attachment_by_table_sys_id_many.json", 200)
         elif (
             kwargs["url"]
-            == "https://rapid7.com/api/now/attachment?sysparm_query=table_sys_id=c1565da4456c2df374793d471d6ae8dd"
+            == "https://rapid7.service-now.com/api/now/attachment?sysparm_query=table_sys_id=c1565da4456c2df374793d471d6ae8dd"
         ):
             return MockResponse("get_attachment_by_table_sys_id_empty.json", 200)
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Cloud enabled
  - Changed connection input `url` to `instance`

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
