### PR TITLE
[SOAR-10434] Darktrace - Added verify SSL certificate boolean field to the plugin connection release

### DIFF
--- a/plugins/darktrace/.CHECKSUM
+++ b/plugins/darktrace/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "5a03b0e3129550d228c7a45c142c4a28",
-	"manifest": "bc09ae86c6d088e0809af3d30f1f3512",
-	"setup": "48fc7b8153e8b8e057f13ef9828bcb77",
+	"spec": "c8261456904e42cd309ad10ba638b31f",
+	"manifest": "27c4c88e17eda5d2ba66fc215620e1a0",
+	"setup": "d4b190d55f4a11daeb6d57879617e574",
 	"schemas": [
 		{
 			"identifier": "update_watched_domains/schema.py",
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "8e20cf512e6c3063145da312114063e5"
+			"hash": "bf2017ce32bda5ea3cb0695cce2d789b"
 		},
 		{
 			"identifier": "pull_alerts/schema.py",
-			"hash": "fefa74081ac2d38ad6f5a9e6ade6e133"
+			"hash": "f4ce66f4730a2f1cd29e03369d9e6c5e"
 		}
 	]
 }

--- a/plugins/darktrace/bin/icon_darktrace
+++ b/plugins/darktrace/bin/icon_darktrace
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Darktrace"
 Vendor = "rapid7"
-Version = "2.0.1"
+Version = "2.1.0"
 Description = "Automate the management of watched domains and alerting using the Darktrace plugin"
 
 

--- a/plugins/darktrace/help.md
+++ b/plugins/darktrace/help.md
@@ -10,6 +10,10 @@ Powered by Cyber AI, [Darktrace’s Enterprise Immune System](https://www.darktr
 
 * Requires a public and private API token
 
+# Supported Product Versions
+
+* 2022-08-08
+
 # Documentation
 
 ## Setup
@@ -20,14 +24,17 @@ The connection configuration accepts the following parameters:
 |----|----|-------|--------|-----------|----|-------|
 |api_private_token|credential_secret_key|None|True|Enter API private token|None|1452d258-7c12-7c12-7c12-1452d25874c2|
 |api_public_token|credential_secret_key|None|True|Enter API public token|None|1452d258-7c12-7c12-7c12-1452d25874c2|
-|url|string|None|True|API URL|None|None|
+|ssl_verification|boolean|True|True|Indicates whether to verify SSL certificate or not|None|True|
+|url|string|None|True|API URL|None|https://example.com|
 
 Example input:
 
 ```
 {
   "api_private_token": "1452d258-7c12-7c12-7c12-1452d25874c2",
-  "api_public_token": "1452d258-7c12-7c12-7c12-1452d25874c2"
+  "api_public_token": "1452d258-7c12-7c12-7c12-1452d25874c2",
+  "ssl_verification": true,
+  "url": "https://example.com"
 }
 ```
 
@@ -93,7 +100,7 @@ This trigger is used to trigger workflows on model breach alerts and logs.
 |----|----|-------|--------|-----------|----|-------|
 |did|integer|None|False|ID of device modelled in the Darktrace system|None|1|
 |frequency|integer|300|False|Poll frequency in seconds|None|300|
-|minscore|integer|None|False|Return only breaches with a minimum score. Valid values are 0-100.|None|10|
+|minscore|integer|None|False|Return only breaches with a minimum score. Valid values are 0-100|None|10|
 |pbid|integer|None|False|Only return the model breach with the specified policy breach ID|None|300|
 |pid|integer|None|False|Only return model breaches for the specified model|None|300|
 |uuid|string|None|False|Only return model breaches for the specified model|None|fc707223-d2d2-475c-b09b-dec4e800eb2e|
@@ -279,6 +286,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 2.1.0 - Added verify SSL certificate boolean field to the plugin connection
 * 2.0.1 - Updated help.md file
 * 2.0.0 - Fix input `0` for parameters DID, PBID, Min Score and PID in trigger Get Alerts | Create new custom type for trigger Get Alerts | Change type of input parameter Min Score to integer in trigger Get Alerts
 * 1.1.0 - Add new trigger Pull Alerts

--- a/plugins/darktrace/icon_darktrace/connection/connection.py
+++ b/plugins/darktrace/icon_darktrace/connection/connection.py
@@ -17,11 +17,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
             params.get(Input.URL),
             params.get(Input.API_PUBLIC_TOKEN).get("secretKey"),
             params.get(Input.API_PRIVATE_TOKEN).get("secretKey"),
+            params.get(Input.SSL_VERIFICATION),
             self.logger,
         )
 
     def test(self):
         try:
             return {"success": self.client.get_status() != {}}
-        except PluginException as e:
-            raise ConnectionTestException(cause=e.cause, assistance=e.assistance, data=e.data)
+        except PluginException as error:
+            raise ConnectionTestException(cause=error.cause, assistance=error.assistance, data=error.data)

--- a/plugins/darktrace/icon_darktrace/connection/schema.py
+++ b/plugins/darktrace/icon_darktrace/connection/schema.py
@@ -6,6 +6,7 @@ import json
 class Input:
     API_PRIVATE_TOKEN = "api_private_token"
     API_PUBLIC_TOKEN = "api_public_token"
+    SSL_VERIFICATION = "ssl_verification"
     URL = "url"
     
 
@@ -19,12 +20,19 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "$ref": "#/definitions/credential_secret_key",
       "title": "API Private Token",
       "description": "Enter API private token",
-      "order": 3
+      "order": 4
     },
     "api_public_token": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "API Public Token",
       "description": "Enter API public token",
+      "order": 3
+    },
+    "ssl_verification": {
+      "type": "boolean",
+      "title": "Verify SSL Certificate",
+      "description": "Indicates whether to verify SSL certificate or not",
+      "default": true,
       "order": 2
     },
     "url": {
@@ -37,6 +45,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
   "required": [
     "api_private_token",
     "api_public_token",
+    "ssl_verification",
     "url"
   ],
   "definitions": {

--- a/plugins/darktrace/icon_darktrace/triggers/pull_alerts/schema.py
+++ b/plugins/darktrace/icon_darktrace/triggers/pull_alerts/schema.py
@@ -44,7 +44,7 @@ class PullAlertsInput(insightconnect_plugin_runtime.Input):
     "minscore": {
       "type": "integer",
       "title": "Min Score",
-      "description": "Return only breaches with a minimum score. Valid values are 0-100.",
+      "description": "Return only breaches with a minimum score. Valid values are 0-100",
       "order": 3
     },
     "pbid": {

--- a/plugins/darktrace/icon_darktrace/triggers/pull_alerts/trigger.py
+++ b/plugins/darktrace/icon_darktrace/triggers/pull_alerts/trigger.py
@@ -44,10 +44,10 @@ class PullAlerts(insightconnect_plugin_runtime.Trigger):
                         "uuid": params.get(Input.UUID),
                     }
                 )
-            except PluginException as e:
-                self.logger.info(f"{e.cause} {e.assistance} {e.data}")
-            except Exception as e:
-                self.logger.info(f"{e}")
+            except PluginException as error:
+                self.logger.info(f"{error.cause} {error.assistance} {error.data}")
+            except Exception as error:
+                self.logger.info(f"{error}")
 
             if data:
                 if isinstance(data, dict):

--- a/plugins/darktrace/icon_darktrace/util/api.py
+++ b/plugins/darktrace/icon_darktrace/util/api.py
@@ -1,18 +1,24 @@
-import hmac
 import hashlib
-from datetime import datetime
+import hmac
 import json
-import requests
+from datetime import datetime
+from logging import Logger
+from typing import Any, Dict
 from urllib import parse
+
+import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 
 
 class DarkTraceAPI:
-    def __init__(self, url: str, public_token: str, private_token: str, logger: object):
+    def __init__(
+        self, url: str, public_token: str, private_token: str, ssl_verification: bool = True, logger: Logger = None
+    ):
         self.url = url.rstrip("/")
         self.public_token = public_token
         self.private_token = private_token
+        self.ssl_verification = ssl_verification
         self.logger = logger
 
     def get_status(self):
@@ -50,8 +56,49 @@ class DarkTraceAPI:
             hashlib.sha1,
         ).hexdigest()
 
-    def _call_api(self, method: str, path: str, data: dict = None, params: dict = None) -> dict:
+    def _get_headers(self, endpoint: str) -> Dict[str, Any]:
+        """Returns the headers needed for all the Darktrace API requests
+
+        :param endpoint: Endpoint for headers to be generated
+        :type endpoint: str
+
+        :return: Dictionary contains headers needed for Darktrace API requests
+        :rtype: Dict[str, Any]
+        """
+
         date = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+        headers = {
+            "DTAPI-Token": self.public_token,
+            "DTAPI-Date": date,
+            "DTAPI-Signature": self._get_signature(endpoint, date),
+        }
+        return headers
+
+    def _process_request_response(self, response: requests.Response) -> Dict[str, Any]:
+        """Processes the request response depending on it's status code
+
+        :param response: Response from requests.request
+        :type response: requests.Response
+
+        :return: Dict containing JSON API response
+        :rtype: Dict[str, Any]
+        """
+
+        if response.status_code == 400:
+            raise PluginException(preset=PluginException.Preset.BAD_REQUEST, data=response.text)
+        if response.status_code == 401:
+            raise PluginException(preset=PluginException.Preset.USERNAME_PASSWORD, data=response.text)
+        if response.status_code == 403:
+            raise PluginException(preset=PluginException.Preset.API_KEY, data=response.text)
+        if response.status_code == 404:
+            raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response.text)
+        if 300 <= response.status_code < 500:
+            raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
+        if 200 <= response.status_code < 300:
+            return response.json() if response.text else {}
+        raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
+
+    def _call_api(self, method: str, path: str, data: dict = None, params: dict = None) -> dict:
         query = None
         if params:
             query = parse.urlencode(params)
@@ -63,31 +110,17 @@ class DarkTraceAPI:
         if query:
             endpoint = f"{endpoint}?{query}"
 
-        headers = {
-            "DTAPI-Token": self.public_token,
-            "DTAPI-Date": date,
-            "DTAPI-Signature": self._get_signature(endpoint, date),
-        }
-
         try:
-            response = requests.request(method, f"{self.url}/{path}", data=data, params=params, headers=headers)
-
-            if response.status_code == 401:
-                raise PluginException(preset=PluginException.Preset.USERNAME_PASSWORD, data=response.text)
-            if response.status_code == 403:
-                raise PluginException(preset=PluginException.Preset.API_KEY, data=response.text)
-            if response.status_code == 404:
-                raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response.text)
-            if response.status_code >= 400:
-                raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
-
-            if 200 <= response.status_code < 300:
-                if response.text:
-                    return response.json()
-                return {}
-
-            raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
-        except json.decoder.JSONDecodeError as e:
-            raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=e)
-        except requests.exceptions.HTTPError as e:
-            raise PluginException(preset=PluginException.Preset.UNKNOWN, data=e)
+            response = requests.request(
+                method,
+                f"{self.url}/{path}",
+                data=data,
+                params=params,
+                headers=self._get_headers(endpoint),
+                verify=self.ssl_verification,
+            )
+            return self._process_request_response(response)
+        except json.decoder.JSONDecodeError as error:
+            raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=error)
+        except requests.exceptions.HTTPError as error:
+            raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=error)

--- a/plugins/darktrace/plugin.spec.yaml
+++ b/plugins/darktrace/plugin.spec.yaml
@@ -3,10 +3,11 @@ extension: plugin
 products: [insightconnect]
 name: darktrace
 title: Darktrace
-version: 2.0.1
+version: 2.1.0
 description: Automate the management of watched domains and alerting using the Darktrace plugin
 vendor: rapid7
 support: rapid7
+supported_versions: ["2022-08-08"]
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/darktrace
@@ -602,23 +603,30 @@ types:
       type: "[]triggeredComponents"
       description: Triggeredcomponents
       required: false
-
 connection:
   url:
     title: URL
-    type: string
     description: API URL
+    type: string
     required: true
+    example: https://example.com
+  ssl_verification:
+    title: Verify SSL Certificate
+    description: Indicates whether to verify SSL certificate or not
+    type: boolean
+    required: true
+    default: true
+    example: true
   api_public_token:
     title: API Public Token
-    type: credential_secret_key
     description: Enter API public token
+    type: credential_secret_key
     required: true
     example: 1452d258-7c12-7c12-7c12-1452d25874c2
   api_private_token:
     title: API Private Token
-    type: credential_secret_key
     description: Enter API private token
+    type: credential_secret_key
     required: true
     example: 1452d258-7c12-7c12-7c12-1452d25874c2
 actions:
@@ -701,7 +709,7 @@ triggers:
       minscore:
         title: Min Score
         type: integer
-        description: Return only breaches with a minimum score. Valid values are 0-100.
+        description: Return only breaches with a minimum score. Valid values are 0-100
         example: 10
         required: false
       pbid:

--- a/plugins/darktrace/requirements.txt
+++ b/plugins/darktrace/requirements.txt
@@ -1,3 +1,5 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
+parameterized==0.8.1
+timeout-decorator==0.5.0

--- a/plugins/darktrace/setup.py
+++ b/plugins/darktrace/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="darktrace-rapid7-plugin",
-      version="2.0.1",
+      version="2.1.0",
       description="Automate the management of watched domains and alerting using the Darktrace plugin",
       author="rapid7",
       author_email="",

--- a/plugins/darktrace/unit_test/__init__.py
+++ b/plugins/darktrace/unit_test/__init__.py
@@ -1,0 +1,4 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath('../'))

--- a/plugins/darktrace/unit_test/mock.py
+++ b/plugins/darktrace/unit_test/mock.py
@@ -1,0 +1,119 @@
+import json
+import os
+from typing import Any, Callable, Dict
+from unittest import TestCase, mock
+
+import requests
+import timeout_decorator
+
+STUB_URL = "https://example.com"
+STUB_PRIVATE_API_KEY = "1111111111111111111111111111111111111111"
+STUB_PUBLIC_API_KEY = "2222222222222222222222222222222222222222"
+STUB_SSL_VERIFICATION = True
+
+STUB_CONNECTION = {
+    "url": STUB_URL,
+    "api_private_token": {"secretKey": STUB_PRIVATE_API_KEY},
+    "api_public_token": {"secretKey": STUB_PUBLIC_API_KEY},
+    "ssl_verification": STUB_SSL_VERIFICATION,
+}
+
+STUB_RESPONSE_TEXT = "Example Text"
+
+
+def timeout_pass(error_callback=None):
+    def function_timeout(function: Callable):
+        def function_wrapper(*args, **kwargs):
+            try:
+                return function(*args, **kwargs)
+            except timeout_decorator.timeout_decorator.TimeoutError:
+                return error_callback() if error_callback else None
+
+        return function_wrapper
+
+    return function_timeout
+
+
+class MockTriggerResponse:
+    actual = None
+
+    @staticmethod
+    def send(parameters: Dict[str, Any]):
+        MockTriggerResponse.actual = parameters
+
+
+class ErrorChecker:
+    expected = {}
+
+    @staticmethod
+    def set_expected(expected: Dict[str, Any]):
+        ErrorChecker.expected = expected
+
+    @staticmethod
+    def check_error():
+        if MockTriggerResponse.actual == ErrorChecker.expected:
+            return True
+        TestCase.assertEqual(MockTriggerResponse.actual, ErrorChecker.expected)
+
+
+class MockResponse:
+    def __init__(self, filename: str, status_code: int, text: str = "") -> None:
+        self.filename = filename
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        with open(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), f"responses/{self.filename}.json.resp")
+        ) as file:
+            return json.load(file)
+
+
+def mocked_request(side_effect: Callable) -> None:
+    mock_function = requests
+    mock_function.request = mock.Mock(side_effect=side_effect)
+
+
+def mock_conditions(url: str, status_code: int) -> MockResponse:
+    if status_code == 201:
+        return MockResponse("invalid_json", status_code, STUB_RESPONSE_TEXT)
+    if url == f"{STUB_URL}/status":
+        return MockResponse("get_status", status_code, STUB_RESPONSE_TEXT)
+    elif url == f"{STUB_URL}/intelfeed":
+        return MockResponse("update_watched_domains", status_code, STUB_RESPONSE_TEXT)
+    elif url == f"{STUB_URL}/modelbreaches":
+        return MockResponse("pull_alerts", status_code, STUB_RESPONSE_TEXT)
+
+    raise Exception("Response has been not implemented")
+
+
+def mock_request_200(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 200)
+
+
+def mock_request_201_invalid_json(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 201)
+
+
+def mock_request_400(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 400)
+
+
+def mock_request_401(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 401)
+
+
+def mock_request_403(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 403)
+
+
+def mock_request_404(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 404)
+
+
+def mock_request_405(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 405)
+
+
+def mock_request_500(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 500)

--- a/plugins/darktrace/unit_test/responses/get_status.json.resp
+++ b/plugins/darktrace/unit_test/responses/get_status.json.resp
@@ -1,0 +1,3 @@
+{
+  "example": "test"
+}

--- a/plugins/darktrace/unit_test/responses/invalid_json.json.resp
+++ b/plugins/darktrace/unit_test/responses/invalid_json.json.resp
@@ -1,0 +1,1 @@
+Invalid JSON

--- a/plugins/darktrace/unit_test/responses/pull_alerts.json.resp
+++ b/plugins/darktrace/unit_test/responses/pull_alerts.json.resp
@@ -1,0 +1,147 @@
+{
+  "creationTime": 1599807740000,
+  "commentCount": 0,
+  "pbid": 11,
+  "time": 1599807736000,
+  "model": {
+    "then": {
+      "name": "System::Packet Loss",
+      "pid": 371,
+      "phid": 371,
+      "uuid": "b81117bc-2d11-4ed6-11d0-9dd2958cfbff",
+      "logic": {
+        "data": [
+          780
+        ],
+        "type": "componentList",
+        "version": 1
+      },
+      "throttle": 86400,
+      "sharedEndpoints": false,
+      "actions": {
+        "alert": true,
+        "antigena": {},
+        "breach": true,
+        "model": true,
+        "setPriority": false,
+        "setTag": false,
+        "setType": false
+      },
+      "tags": [],
+      "interval": 3600,
+      "sequenced": false,
+      "active": true,
+      "modified": "2020-09-01 00:11:34",
+      "activeTimes": {
+        "devices": {},
+        "tags": {},
+        "type": "exclusions",
+        "version": 2
+      },
+      "priority": 0,
+      "autoUpdatable": true,
+      "autoUpdate": true,
+      "autoSuppress": true,
+      "description": "Packet loss is higher than 30%. Sustained packet loss at or above this level will significantly impact Darktrace detections.\\n\\nAction: Investigate why Darktrace is missing so much traffic. Use the status page to see if the loss is occurring on specific subnets. This model indicates the packet loss is occurring before Darktrace ingestion rather than a problem with the appliance.",
+      "behaviour": "decreasing",
+      "defeats": [],
+      "created": {
+        "by": "System"
+      },
+      "edited": {
+        "by": "Nobody"
+      },
+      "version": 10
+    },
+    "now": {
+      "name": "System::Packet Loss",
+      "pid": 371,
+      "phid": 371,
+      "uuid": "b81117bc-2d11-4ed6-11d0-9dd2958cfbff",
+      "logic": {
+        "data": [
+          780
+        ],
+        "type": "componentList",
+        "version": 1
+      },
+      "throttle": 86400,
+      "sharedEndpoints": false,
+      "actions": {
+        "alert": true,
+        "antigena": {},
+        "breach": true,
+        "model": true,
+        "setPriority": false,
+        "setTag": false,
+        "setType": false
+      },
+      "tags": [],
+      "interval": 3600,
+      "sequenced": false,
+      "active": true,
+      "modified": "2020-09-01 00:11:34",
+      "activeTimes": {
+        "devices": {},
+        "tags": {},
+        "type": "exclusions",
+        "version": 2
+      },
+      "priority": 0,
+      "autoUpdatable": true,
+      "autoUpdate": true,
+      "autoSuppress": true,
+      "description": "Packet loss is higher than 30%. Sustained packet loss at or above this level will significantly impact Darktrace detections.\\n\\nAction: Investigate why Darktrace is missing so much traffic. Use the status page to see if the loss is occurring on specific subnets. This model indicates the packet loss is occurring before Darktrace ingestion rather than a problem with the appliance.",
+      "behaviour": "decreasing",
+      "defeats": [],
+      "created": {
+        "by": "System"
+      },
+      "edited": {
+        "by": "Nobody"
+      },
+      "message": "Increasing cooldown to 24 hours, as the 3.1 software update improved the recognition and reporting of packet loss feeding into Darktrace, which has resulted in this model firing more frequently than required.",
+      "version": 10
+    }
+  },
+  "triggeredComponents": [
+    {
+      "time": 1599807735000,
+      "cbid": 11,
+      "cid": 780,
+      "chid": 780,
+      "size": 1,
+      "threshold": 0,
+      "interval": 3600,
+      "logic": {
+        "data": {
+          "left": "A"
+        },
+        "version": "v0.1"
+      },
+      "metric": {
+        "mlid": 256,
+        "name": "capturelosstoomuchloss",
+        "label": "Capture loss Detected upstream"
+      },
+      "triggeredFilters": [
+        {
+          "cfid": 7657,
+          "id": "A",
+          "filterType": "Message",
+          "arguments": {
+            "value": ".*rate above [3-9][0-9]\\..*\\%$"
+          },
+          "comparatorType": "matches regular expression",
+          "trigger": {
+            "value": "Host ip-192-168-10-1: The capture loss script detected an estimated loss rate above 45.679%, worker drop rate: 0.000%"
+          }
+        }
+      ]
+    }
+  ],
+  "score": 0.278,
+  "device": {
+    "did": -1
+  }
+}

--- a/plugins/darktrace/unit_test/responses/update_watched_domains.json.resp
+++ b/plugins/darktrace/unit_test/responses/update_watched_domains.json.resp
@@ -1,0 +1,5 @@
+{
+  "response": "SUCCESS",
+  "added": 0,
+  "updated": 0
+}

--- a/plugins/darktrace/unit_test/test_connection.py
+++ b/plugins/darktrace/unit_test/test_connection.py
@@ -1,0 +1,33 @@
+import logging
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
+
+from icon_darktrace.connection.connection import Connection
+from insightconnect_plugin_runtime.exceptions import ConnectionTestException, PluginException
+
+from mock import STUB_CONNECTION, mock_request_200, mock_request_403
+
+
+class TestConnection(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+    @mock.patch("requests.request", side_effect=mock_request_200)
+    def test_connection_ok(self, mocked_request: mock.Mock) -> None:
+        expected = {"success": True}
+        self.assertEqual(self.connection.test(), expected)
+
+    @mock.patch("requests.request", side_effect=mock_request_403)
+    def test_connection_error(self, mocked_request: mock.Mock) -> None:
+        with self.assertRaises(ConnectionTestException) as context:
+            self.connection.test()
+        self.assertEqual(
+            context.exception.cause,
+            PluginException.causes[PluginException.Preset.API_KEY],
+        )

--- a/plugins/darktrace/unit_test/test_pull_alerts.py
+++ b/plugins/darktrace/unit_test/test_pull_alerts.py
@@ -1,0 +1,141 @@
+import logging
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
+
+import timeout_decorator
+from icon_darktrace.connection.connection import Connection
+from icon_darktrace.triggers.pull_alerts import PullAlerts
+from icon_darktrace.triggers.pull_alerts.schema import Output
+
+from mock import STUB_CONNECTION, ErrorChecker, MockTriggerResponse, mock_request_200, timeout_pass
+
+TIMEOUT = 2
+
+STUB_TRIGGER_SEND_RESPONSE = {
+    "creationTime": 1599807740000,
+    "commentCount": 0,
+    "pbid": 11,
+    "time": 1599807736000,
+    "model": {
+        "then": {
+            "name": "System::Packet Loss",
+            "pid": 371,
+            "phid": 371,
+            "uuid": "b81117bc-2d11-4ed6-11d0-9dd2958cfbff",
+            "logic": {"data": [780], "type": "componentList", "version": 1},
+            "throttle": 86400,
+            "sharedEndpoints": False,
+            "actions": {
+                "alert": True,
+                "antigena": {},
+                "breach": True,
+                "model": True,
+                "setPriority": False,
+                "setTag": False,
+                "setType": False,
+            },
+            "tags": [],
+            "interval": 3600,
+            "sequenced": False,
+            "active": True,
+            "modified": "2020-09-01 00:11:34",
+            "activeTimes": {"devices": {}, "tags": {}, "type": "exclusions", "version": 2},
+            "priority": 0,
+            "autoUpdatable": True,
+            "autoUpdate": True,
+            "autoSuppress": True,
+            "description": "Packet loss is higher than 30%. Sustained packet loss at or above this level will significantly impact Darktrace detections.\\n\\nAction: Investigate why Darktrace is missing so much traffic. Use the status page to see if the loss is occurring on specific subnets. This model indicates the packet loss is occurring before Darktrace ingestion rather than a problem with the appliance.",
+            "behaviour": "decreasing",
+            "defeats": [],
+            "created": {"by": "System"},
+            "edited": {"by": "Nobody"},
+            "version": 10,
+        },
+        "now": {
+            "name": "System::Packet Loss",
+            "pid": 371,
+            "phid": 371,
+            "uuid": "b81117bc-2d11-4ed6-11d0-9dd2958cfbff",
+            "logic": {"data": [780], "type": "componentList", "version": 1},
+            "throttle": 86400,
+            "sharedEndpoints": False,
+            "actions": {
+                "alert": True,
+                "antigena": {},
+                "breach": True,
+                "model": True,
+                "setPriority": False,
+                "setTag": False,
+                "setType": False,
+            },
+            "tags": [],
+            "interval": 3600,
+            "sequenced": False,
+            "active": True,
+            "modified": "2020-09-01 00:11:34",
+            "activeTimes": {"devices": {}, "tags": {}, "type": "exclusions", "version": 2},
+            "priority": 0,
+            "autoUpdatable": True,
+            "autoUpdate": True,
+            "autoSuppress": True,
+            "description": "Packet loss is higher than 30%. Sustained packet loss at or above this level will significantly impact Darktrace detections.\\n\\nAction: Investigate why Darktrace is missing so much traffic. Use the status page to see if the loss is occurring on specific subnets. This model indicates the packet loss is occurring before Darktrace ingestion rather than a problem with the appliance.",
+            "behaviour": "decreasing",
+            "defeats": [],
+            "created": {"by": "System"},
+            "edited": {"by": "Nobody"},
+            "message": "Increasing cooldown to 24 hours, as the 3.1 software update improved the recognition and reporting of packet loss feeding into Darktrace, which has resulted in this model firing more frequently than required.",
+            "version": 10,
+        },
+    },
+    "triggeredComponents": [
+        {
+            "time": 1599807735000,
+            "cbid": 11,
+            "cid": 780,
+            "chid": 780,
+            "size": 1,
+            "threshold": 0,
+            "interval": 3600,
+            "logic": {"data": {"left": "A"}, "version": "v0.1"},
+            "metric": {"mlid": 256, "name": "capturelosstoomuchloss", "label": "Capture loss Detected upstream"},
+            "triggeredFilters": [
+                {
+                    "cfid": 7657,
+                    "id": "A",
+                    "filterType": "Message",
+                    "arguments": {"value": ".*rate above [3-9][0-9]\\..*\\%$"},
+                    "comparatorType": "matches regular expression",
+                    "trigger": {
+                        "value": "Host ip-192-168-10-1: The capture loss script detected an estimated loss rate above 45.679%, worker drop rate: 0.000%"
+                    },
+                }
+            ],
+        }
+    ],
+    "score": 0.278,
+    "device": {"did": -1},
+}
+
+
+class TestPullAlerts(TestCase):
+    @mock.patch("requests.request", side_effect=mock_request_200)
+    def setUp(self, mock_request: mock.Mock) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.trigger = PullAlerts()
+        self.trigger.connection = self.connection
+        self.trigger.logger = logging.getLogger("action logger")
+
+    @timeout_pass(error_callback=ErrorChecker.check_error)
+    @timeout_decorator.timeout(TIMEOUT)
+    @mock.patch("requests.request", side_effect=mock_request_200)
+    @mock.patch("insightconnect_plugin_runtime.Trigger.send", side_effect=MockTriggerResponse.send)
+    def test_pull_alerts_ok(self, mocked_request: mock.Mock, mocked_trigger_send: mock.Mock) -> None:
+        ErrorChecker.set_expected({Output.RESULTS: [STUB_TRIGGER_SEND_RESPONSE]})
+        self.trigger.run()

--- a/plugins/darktrace/unit_test/test_update_watched_domains.py
+++ b/plugins/darktrace/unit_test/test_update_watched_domains.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from typing import Callable
+from unittest import mock
+
+from parameterized import parameterized
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from unittest import TestCase
+
+from icon_darktrace.actions.update_watched_domains import UpdateWatchedDomains
+from icon_darktrace.connection.connection import Connection
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+from mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_400,
+    mock_request_401,
+    mock_request_403,
+    mock_request_404,
+    mock_request_405,
+    mock_request_500,
+    mocked_request,
+)
+
+STUB_ACTION_INPUT = {
+    "description": "Watched Domains managed by InsightConnect",
+    "entry": "",
+    "expiration_time": "",
+    "hostname": False,
+    "source": "InsightConnect",
+    "watched_domain_status": False,
+}
+
+
+class TestUpdateWatchedDomains(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = UpdateWatchedDomains()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+    @mock.patch("requests.request", side_effect=mock_request_200)
+    def test_update_watched_domains_ok(self, mocked_request: mock.Mock) -> None:
+        response = self.action.run(STUB_ACTION_INPUT)
+        self.assertEqual(response, {"success": True, "added": 0, "updated": 0})
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, PluginException.causes[PluginException.Preset.INVALID_JSON]),
+            (mock_request_401, PluginException.causes[PluginException.Preset.USERNAME_PASSWORD]),
+            (mock_request_400, PluginException.causes[PluginException.Preset.BAD_REQUEST]),
+            (mock_request_403, PluginException.causes[PluginException.Preset.API_KEY]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_405, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+        ]
+    )
+    def test_update_watched_domains_error(self, mock_request: Callable, exception: str) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run()
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Added verify SSL certificate boolean field to the plugin connection

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
