### PR TITLE
SentinelOne 8.0.0 Release 

### DIFF
--- a/plugins/sentinelone/.CHECKSUM
+++ b/plugins/sentinelone/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "261444b1e56692fec559b4b22fee2940",
-	"manifest": "c3fd9ba8e03ba2d3b5053b445d5cea06",
-	"setup": "08cc10bde04b4cc896e96e0450d9001e",
+	"spec": "5c36793285b9f044ff41177874fef3d7",
+	"manifest": "58bf11ebfb7f850d98049269400de8c1",
+	"setup": "f8cde65d20d275f743809a7f8bffcdae",
 	"schemas": [
 		{
 			"identifier": "activities_list/schema.py",
@@ -29,7 +29,7 @@
 		},
 		{
 			"identifier": "blacklist/schema.py",
-			"hash": "c6ffebf6aa51317ef0df89844b6e2d74"
+			"hash": "eee49108f67a93973575f26805ad4860"
 		},
 		{
 			"identifier": "blacklist_by_content_hash/schema.py",
@@ -105,11 +105,11 @@
 		},
 		{
 			"identifier": "update_analyst_verdict/schema.py",
-			"hash": "7314acbe634d3d365a140ee254367547"
+			"hash": "a81e2f8c2713a525fdd1421a0dc81148"
 		},
 		{
 			"identifier": "update_incident_status/schema.py",
-			"hash": "bf7e8fa3a099c80f3772b72515d7a84e"
+			"hash": "860558dfedae61412612d81b82232e7f"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/plugins/sentinelone/bin/komand_sentinelone
+++ b/plugins/sentinelone/bin/komand_sentinelone
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "SentinelOne"
 Vendor = "rapid7"
-Version = "7.0.0"
+Version = "8.0.0"
 Description = "The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne"
 
 

--- a/plugins/sentinelone/help.md
+++ b/plugins/sentinelone/help.md
@@ -61,20 +61,17 @@ This action is used to update incident status.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|incident_ids|[]string|None|True|A list of alert or threat IDs to update the incident status on|None|["1118189762920424575", "1118189762920424576"]|
 |incident_status|string|None|True|Incident status|['unresolved', 'in progress', 'resolved']|resolved|
-|type|string|None|True|Type of incidents|['threats', 'alerts']|threats|
+|threat_id|string|None|True|ID of a threat|None|1118189762920424575|
+|type|string|None|True|Type of incident|['threat', 'alert']|threat|
 
 Example input:
 
 ```
 {
-  "incident_ids": [
-    "1118189762920424575",
-    "1118189762920424576"
-  ],
   "incident_status": "resolved",
-  "type": "threats"
+  "threat_id": "1118189762920424575",
+  "type": "threat"
 }
 ```
 
@@ -101,19 +98,16 @@ This action is used to update analyst verdict.
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |analyst_verdict|string|None|True|Analyst verdict|['true positive', 'suspicious', 'false positive', 'undefined']|true positive|
-|incident_ids|[]string|None|True|A list of alert or threat IDs on which we may update the analyst verdict|None|["1118189762920424575", "1118189762920424576"]|
-|type|string|None|True|Type of incidents|['threats', 'alerts']|threats|
+|threat_id|string|None|True|ID of a threat|None|1118189762920424575|
+|type|string|None|True|Type of incident|['threat', 'alert']|threat|
 
 Example input:
 
 ```
 {
   "analyst_verdict": "true positive",
-  "incident_ids": [
-    "1118189762920424575",
-    "1118189762920424576"
-  ],
-  "type": "threats"
+  "threat_id": "1118189762920424575",
+  "type": "threat"
 }
 ```
 
@@ -1030,13 +1024,15 @@ Example input:
 
 |Name|Type|Required|Description|
 |----|----|--------|-----------|
+|message|string|True|Return details about action results|
 |success|boolean|True|Return true if blacklist item was created or deleted|
 
 Example output:
 
 ```
 {
-  "success": true
+  "success": true,
+  "message": "The given hash has been blocked"
 }
 ```
 
@@ -1994,6 +1990,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 8.0.0 - Update for Blacklist action: Fix for unblocked action | Update for Update Analyst Verdict and Update Incident Status actions: Accepting only single thread ID in order to standardize inputs | Update for Quarantine action: unification of the output data when action fails   
 * 7.0.0 - Add new actions Update Analyst Verdict and Update Incident Status | Fix Get Agent Details and Search Agents actions to handle more response scenarios | Add option to authentication with API key
 * 6.2.0 - New actions Create Query, Get Query Status, Cancel Running Query, Get Events, Get Events By Type
 * 6.1.0 - Add new actions Disable Agent and Enable Agent

--- a/plugins/sentinelone/komand_sentinelone/actions/blacklist/schema.py
+++ b/plugins/sentinelone/komand_sentinelone/actions/blacklist/schema.py
@@ -14,6 +14,7 @@ class Input:
     
 
 class Output:
+    MESSAGE = "message"
     SUCCESS = "success"
     
 
@@ -61,6 +62,12 @@ class BlacklistOutput(insightconnect_plugin_runtime.Output):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "message": {
+      "type": "string",
+      "title": "Message",
+      "description": "Return details about action results",
+      "order": 2
+    },
     "success": {
       "type": "boolean",
       "title": "Success",
@@ -69,6 +76,7 @@ class BlacklistOutput(insightconnect_plugin_runtime.Output):
     }
   },
   "required": [
+    "message",
     "success"
   ]
 }

--- a/plugins/sentinelone/komand_sentinelone/actions/update_analyst_verdict/action.py
+++ b/plugins/sentinelone/komand_sentinelone/actions/update_analyst_verdict/action.py
@@ -16,18 +16,10 @@ class UpdateAnalystVerdict(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         incident_type = params.get(Input.TYPE)
         analyst_verdict = params.get(Input.ANALYST_VERDICT).replace(" ", "_")
-        incidents = self.connection.remove_non_existing_incidents(
-            list(set(params.get(Input.INCIDENT_IDS))), incident_type
-        )
-        incidents = self.connection.validate_incident_state(incidents, incident_type, analyst_verdict, "analystVerdict")
-        if not incidents:
-            raise PluginException(
-                cause=f"No {incident_type} to update in SentinelOne.",
-                assistance=f"Please verify the log, the {incident_type} are already set to the new analyst verdict"
-                " or do not exist in SentinelOne.",
-            )
-
-        response = self.connection.update_analyst_verdict(incidents, analyst_verdict, incident_type)
+        incident = params.get(Input.THREAT_ID)
+        self.connection.check_if_incident_exist(incident, incident_type)
+        self.connection.validate_incident_state(incident, incident_type, analyst_verdict, "analystVerdict")
+        response = self.connection.update_analyst_verdict(incident, analyst_verdict, incident_type)
         affected = response.get("data", {}).get("affected", 0)
 
         return {Output.AFFECTED: affected}

--- a/plugins/sentinelone/komand_sentinelone/actions/update_analyst_verdict/schema.py
+++ b/plugins/sentinelone/komand_sentinelone/actions/update_analyst_verdict/schema.py
@@ -4,12 +4,12 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Updates an analyst verdict for each incident ID provided"
+    DESCRIPTION = "Updates an analyst verdict for incident ID provided"
 
 
 class Input:
     ANALYST_VERDICT = "analyst_verdict"
-    INCIDENT_IDS = "incident_ids"
+    THREAT_ID = "threat_id"
     TYPE = "type"
     
 
@@ -35,29 +35,26 @@ class UpdateAnalystVerdictInput(insightconnect_plugin_runtime.Input):
       ],
       "order": 2
     },
-    "incident_ids": {
-      "type": "array",
-      "title": "Incident IDs",
-      "description": "A list of alert or threat IDs on which we may update the analyst verdict",
-      "items": {
-        "type": "string"
-      },
+    "threat_id": {
+      "type": "string",
+      "title": "Threat ID",
+      "description": "ID of a threat",
       "order": 1
     },
     "type": {
       "type": "string",
       "title": "Type",
-      "description": "Type of incidents",
+      "description": "Type of incident",
       "enum": [
-        "threats",
-        "alerts"
+        "threat",
+        "alert"
       ],
       "order": 3
     }
   },
   "required": [
     "analyst_verdict",
-    "incident_ids",
+    "threat_id",
     "type"
   ]
 }

--- a/plugins/sentinelone/komand_sentinelone/actions/update_incident_status/action.py
+++ b/plugins/sentinelone/komand_sentinelone/actions/update_incident_status/action.py
@@ -16,18 +16,10 @@ class UpdateIncidentStatus(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         incident_type = params.get(Input.TYPE)
         incident_status = params.get(Input.INCIDENT_STATUS).replace(" ", "_")
-        incidents = self.connection.remove_non_existing_incidents(
-            list(set(params.get(Input.INCIDENT_IDS))), incident_type
-        )
-        incidents = self.connection.validate_incident_state(incidents, incident_type, incident_status, "incidentStatus")
-        if not incidents:
-            raise PluginException(
-                cause=f"No {incident_type} to update in SentinelOne.",
-                assistance=f"Please verify the log, the {incident_type} are already set to the new incident status"
-                " or do not exist in SentinelOne.",
-            )
-
-        response = self.connection.update_incident_status(incidents, incident_status, incident_type)
+        incident = params.get(Input.THREAT_ID)
+        self.connection.check_if_incident_exist(incident, incident_type)
+        self.connection.validate_incident_state(incident, incident_type, incident_status, "incidentStatus")
+        response = self.connection.update_incident_status(incident, incident_status, incident_type)
         affected = response.get("data", {}).get("affected", 0)
 
         return {Output.AFFECTED: affected}

--- a/plugins/sentinelone/komand_sentinelone/actions/update_incident_status/schema.py
+++ b/plugins/sentinelone/komand_sentinelone/actions/update_incident_status/schema.py
@@ -4,12 +4,12 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Updates an incident status for each incident ID provided"
+    DESCRIPTION = "Updates an incident status for incident ID provided"
 
 
 class Input:
-    INCIDENT_IDS = "incident_ids"
     INCIDENT_STATUS = "incident_status"
+    THREAT_ID = "threat_id"
     TYPE = "type"
     
 
@@ -23,15 +23,6 @@ class UpdateIncidentStatusInput(insightconnect_plugin_runtime.Input):
   "type": "object",
   "title": "Variables",
   "properties": {
-    "incident_ids": {
-      "type": "array",
-      "title": "Incident IDs",
-      "description": "A list of alert or threat IDs to update the incident status on",
-      "items": {
-        "type": "string"
-      },
-      "order": 1
-    },
     "incident_status": {
       "type": "string",
       "title": "Incident Status",
@@ -43,20 +34,26 @@ class UpdateIncidentStatusInput(insightconnect_plugin_runtime.Input):
       ],
       "order": 2
     },
+    "threat_id": {
+      "type": "string",
+      "title": "Threat ID",
+      "description": "ID of a threat",
+      "order": 1
+    },
     "type": {
       "type": "string",
       "title": "Type",
-      "description": "Type of incidents",
+      "description": "Type of incident",
       "enum": [
-        "threats",
-        "alerts"
+        "threat",
+        "alert"
       ],
       "order": 3
     }
   },
   "required": [
-    "incident_ids",
     "incident_status",
+    "threat_id",
     "type"
   ]
 }

--- a/plugins/sentinelone/komand_sentinelone/util/helper.py
+++ b/plugins/sentinelone/komand_sentinelone/util/helper.py
@@ -5,3 +5,9 @@ class Helper:
             return ",".join(joined_array)
         else:
             return None
+
+
+class BlacklistMessage:
+    blocked = "The given hash has been blocked"
+    unblocked = "The given hash has been unlocked"
+    not_exists = "The given hash does not exist"

--- a/plugins/sentinelone/plugin.spec.yaml
+++ b/plugins/sentinelone/plugin.spec.yaml
@@ -3,7 +3,7 @@ extension: plugin
 products: [insightconnect]
 name: sentinelone
 title: SentinelOne
-version: 7.0.0
+version: 8.0.0
 supported_versions: ["2.0.0", "2.1.0"]
 description: The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne
 vendor: rapid7
@@ -2113,6 +2113,11 @@ actions:
         description: Return true if blacklist item was created or deleted
         type: boolean
         required: true
+      message:
+        title: Message
+        description: Return details about action results
+        type: string
+        required: true
   threats_fetch_file:
     title: Fetch Threats File
     description: Fetch a file associated with the threat that matches the filter. Your user role must have permissions to Fetch Threat File - Admin, IR Team, SOC
@@ -2617,13 +2622,13 @@ actions:
         required: false
   update_analyst_verdict:
     title: Update Analyst Verdict
-    description: Updates an analyst verdict for each incident ID provided
+    description: Updates an analyst verdict for incident ID provided
     input:
-      incident_ids:
-        title: Incident IDs
-        description: A list of alert or threat IDs on which we may update the analyst verdict
-        type: "[]string"
-        example: ["1118189762920424575", "1118189762920424576"]
+      threat_id:
+        title: Threat ID
+        description: ID of a threat
+        type: "string"
+        example: "1118189762920424575"
         required: true
       analyst_verdict:
         title: Analyst Verdict
@@ -2638,12 +2643,12 @@ actions:
         required: true
       type:
         title: Type
-        description: Type of incidents
+        description: Type of incident
         type: string
         enum:
-          - threats
-          - alerts
-        example: threats
+          - threat
+          - alert
+        example: threat
         required: true
     output:
       affected:
@@ -2653,13 +2658,13 @@ actions:
         required: false
   update_incident_status:
     title: Update Incident Status
-    description: Updates an incident status for each incident ID provided
+    description: Updates an incident status for incident ID provided
     input:
-      incident_ids:
-        title: Incident IDs
-        description: A list of alert or threat IDs to update the incident status on
-        type: "[]string"
-        example: ["1118189762920424575", "1118189762920424576"]
+      threat_id:
+        title: Threat ID
+        description:  ID of a threat
+        type: "string"
+        example: "1118189762920424575"
         required: true
       incident_status:
         title: Incident Status
@@ -2673,12 +2678,12 @@ actions:
         required: true
       type:
         title: Type
-        description: Type of incidents
+        description: Type of incident
         type: string
         enum:
-          - threats
-          - alerts
-        example: threats
+          - threat
+          - alert
+        example: threat
         required: true
     output:
       affected:

--- a/plugins/sentinelone/requirements.txt
+++ b/plugins/sentinelone/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 timeout-decorator==0.5.0
+parameterized==0.8.1

--- a/plugins/sentinelone/setup.py
+++ b/plugins/sentinelone/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="sentinelone-rapid7-plugin",
-      version="7.0.0",
+      version="8.0.0",
       description="The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne",
       author="rapid7",
       author_email="",

--- a/plugins/sentinelone/unit_test/payloads/alerts_non_existing.json.resp
+++ b/plugins/sentinelone/unit_test/payloads/alerts_non_existing.json.resp
@@ -1,8 +1,7 @@
 {
-  "data": [
-  ],
+  "data": [],
   "pagination": {
     "nextCursor": null,
-    "totalItems": 1
+    "totalItems": 0
   }
 }

--- a/plugins/sentinelone/unit_test/test_blacklist.py
+++ b/plugins/sentinelone/unit_test/test_blacklist.py
@@ -26,19 +26,19 @@ class TestBlacklist(TestCase):
 
     @patch("requests.request", side_effect=Util.mocked_requests_get)
     def test_should_success_when_blacklist(self, mock_request):
-        expected = {"success": True}
+        expected = {"message": "The given hash has been blocked", "success": True}
         actual = self.action.run({Input.HASH: "3395856ce81f2b7382dee72602f798b642f14140", Input.BLACKLIST_STATE: True})
         self.assertEqual(expected, actual)
 
     @patch("requests.request", side_effect=Util.mocked_requests_get)
     def test_should_success_when_unblacklist(self, mock_request):
-        expected = {"success": True}
+        expected = {"message": "The given hash has been unlocked", "success": True}
         actual = self.action.run({Input.HASH: "3395856ce81f2b7382dee72602f798b642f14140", Input.BLACKLIST_STATE: False})
         self.assertEqual(expected, actual)
 
     @patch("requests.request", side_effect=Util.mocked_requests_get)
     def test_should_success_when_blacklist_and_description(self, mock_request):
-        expected = {"success": True}
+        expected = {"message": "The given hash has been blocked", "success": True}
         actual = self.action.run(
             {
                 Input.HASH: "3395856ce81f2b7382dee72602f798b642f14140",
@@ -50,7 +50,7 @@ class TestBlacklist(TestCase):
 
     @patch("requests.request", side_effect=Util.mocked_requests_get)
     def test_should_success_when_unblacklist_and_description(self, mock_request):
-        expected = {"success": True}
+        expected = {"message": "The given hash has been unlocked", "success": True}
         actual = self.action.run(
             {
                 Input.HASH: "3395856ce81f2b7382dee72602f798b642f14140",

--- a/plugins/sentinelone/unit_test/test_update_analyst_verdict.py
+++ b/plugins/sentinelone/unit_test/test_update_analyst_verdict.py
@@ -25,73 +25,34 @@ class TestUpdateAnalystVerdict(TestCase):
             test_cases.append(
                 {
                     "verdict": "true positive",
-                    "ids": [f"valid_{_type}_id_1", f"valid_{_type}_id_2"],
-                    "expected": {"affected": 2},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on 2 valid {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "verdict": "suspicious",
-                    "ids": [f"valid_{_type}_id_1", f"valid_{_type}_id_1", f"valid_{_type}_id_1", f"valid_{_type}_id_1"],
+                    "threat_id": f"valid_{_type}_id_1",
                     "expected": {"affected": 1},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on a valid duplicated {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "verdict": "false positive",
-                    "ids": [f"valid_{_type}_id_1", f"same_status_{_type}_id_1"],
-                    "expected": {"affected": 1},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on a valid and a same status {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "verdict": "suspicious",
-                    "ids": [f"valid_{_type}_id_1", f"non_existing_{_type}_id_1"],
-                    "expected": {"affected": 1},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on a valid and a non existing {_type}s.",
+                    "_type": f"{_type}",
+                    "description": f"Test updating analyst verdict on 2 valid {_type}.",
                 }
             )
 
         for case in test_cases:
             with self.subTest(case["description"]):
                 actual = self.action.run(
-                    {Input.INCIDENT_IDS: case["ids"], Input.ANALYST_VERDICT: case["verdict"], Input.TYPE: case["_type"]}
+                    {
+                        Input.THREAT_ID: case["threat_id"],
+                        Input.ANALYST_VERDICT: case["verdict"],
+                        Input.TYPE: case["_type"],
+                    }
                 )
                 self.assertEqual(case["expected"], actual)
 
     @patch("requests.request", side_effect=Util.mocked_requests_get)
-    def test_update_analyst_verdict_exceptions(self, mock_request):
+    def test_update_analyst_verdict_exceptions_when_same_status_already_set(self, mock_request):
         test_cases = []
         for _type in ["threat", "alert"]:
             test_cases.append(
                 {
                     "verdict": "false_positive",
-                    "ids": [f"same_status_{_type}_id_1"],
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on a {_type}s with the same status already set.",
-                }
-            )
-            test_cases.append(
-                {
-                    "verdict": "suspicious",
-                    "ids": [f"non_existing_{_type}_id_1"],
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on a non existing {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "verdict": "false_positive",
-                    "ids": [f"non_existing_{_type}_id_1", f"same_status_{_type}_id_1"],
-                    "_type": f"{_type}s",
-                    "description": f"Test updating analyst verdict on a non existing {_type}s.",
+                    "threat_id": f"same_status_{_type}_id_1",
+                    "_type": f"{_type}",
+                    "description": f"Test updating analyst verdict on a {_type} with the same status already set.",
                 }
             )
 
@@ -101,14 +62,43 @@ class TestUpdateAnalystVerdict(TestCase):
                 with self.assertRaises(PluginException) as error:
                     self.action.run(
                         {
-                            Input.INCIDENT_IDS: case["ids"],
+                            Input.THREAT_ID: case["threat_id"],
                             Input.ANALYST_VERDICT: case["verdict"],
                             Input.TYPE: incident_type,
                         }
                     )
                 self.assertEqual(f"No {incident_type} to update in SentinelOne.", error.exception.cause)
                 self.assertEqual(
-                    f"Please verify the log, the {incident_type} are already set to the new analyst"
-                    " verdict or do not exist in SentinelOne.",
+                    f"Please verify the log, the {incident_type} are already set to the new analyst verdict",
+                    error.exception.assistance,
+                )
+
+    @patch("requests.request", side_effect=Util.mocked_requests_get)
+    def test_update_analyst_verdict_exceptions_when_incident_does_not_exists(self, mock_request):
+        test_cases = []
+        for _type in ["threat", "alert"]:
+            test_cases.append(
+                {
+                    "verdict": "unresolved",
+                    "threat_id": f"non_existing_{_type}_id_1",
+                    "_type": f"{_type}",
+                    "description": f"Test updating incident status on a non existing {_type}.",
+                }
+            )
+
+        for case in test_cases:
+            incident_type = case["_type"]
+            with self.subTest(case["description"]):
+                with self.assertRaises(PluginException) as error:
+                    self.action.run(
+                        {
+                            Input.THREAT_ID: case["threat_id"],
+                            Input.ANALYST_VERDICT: case["verdict"],
+                            Input.TYPE: incident_type,
+                        }
+                    )
+                self.assertEqual(f"No {incident_type} to update in SentinelOne.", error.exception.cause)
+                self.assertEqual(
+                    f"Please verify the log, the {incident_type} are do not exist in SentinelOne.",
                     error.exception.assistance,
                 )

--- a/plugins/sentinelone/unit_test/test_update_incident_status.py
+++ b/plugins/sentinelone/unit_test/test_update_incident_status.py
@@ -25,73 +25,63 @@ class TestUpdateIncidentStatus(TestCase):
             test_cases.append(
                 {
                     "status": "resolved",
-                    "ids": [f"valid_{_type}_id_1", f"valid_{_type}_id_2"],
-                    "expected": {"affected": 2},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on 2 valid {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "status": "in progress",
-                    "ids": [f"valid_{_type}_id_1", f"valid_{_type}_id_1", f"valid_{_type}_id_1"],
+                    "threat_id": f"valid_{_type}_id_1",
                     "expected": {"affected": 1},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on a valid duplicated {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "status": "in progress",
-                    "ids": [f"valid_{_type}_id_1", f"same_status_{_type}_id_1"],
-                    "expected": {"affected": 1},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on a valid and a same status {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "status": "resolved",
-                    "ids": [f"valid_{_type}_id_1", f"non_existing_{_type}_id_1"],
-                    "expected": {"affected": 1},
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on a valid and a non existing {_type}s.",
+                    "_type": f"{_type}",
+                    "description": f"Test updating incident status on 1 valid {_type}.",
                 }
             )
 
         for case in test_cases:
             with self.subTest(case["description"]):
                 actual = self.action.run(
-                    {Input.INCIDENT_IDS: case["ids"], Input.INCIDENT_STATUS: case["status"], Input.TYPE: case["_type"]}
+                    {
+                        Input.THREAT_ID: case["threat_id"],
+                        Input.INCIDENT_STATUS: case["status"],
+                        Input.TYPE: case["_type"],
+                    }
                 )
                 self.assertEqual(case["expected"], actual)
 
     @patch("requests.request", side_effect=Util.mocked_requests_get)
-    def test_update_incident_status_exceptions(self, mock_request):
+    def test_update_incident_status_exception_when_same_status_already_set(self, mock_request):
         test_cases = []
         for _type in ["threat", "alert"]:
             test_cases.append(
                 {
-                    "status": "in progress",
-                    "ids": [f"same_status_{_type}_id_1", f"non_existing_{_type}_id_1"],
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on a {_type}s with the same status already set.",
+                    "status": "in_progress",
+                    "threat_id": f"same_status_{_type}_id_1",
+                    "_type": f"{_type}",
+                    "description": f"Test updating incident status on a {_type} with the same status already set.",
                 }
             )
+        for case in test_cases:
+            incident_type = case["_type"]
+            with self.subTest(case["description"]):
+                with self.assertRaises(PluginException) as error:
+                    self.action.run(
+                        {
+                            Input.THREAT_ID: case["threat_id"],
+                            Input.INCIDENT_STATUS: case["status"],
+                            Input.TYPE: incident_type,
+                        }
+                    )
+                self.assertEqual(f"No {incident_type} to update in SentinelOne.", error.exception.cause)
+                self.assertEqual(
+                    f"Please verify the log, the {incident_type} are already set to the new analyst verdict",
+                    error.exception.assistance,
+                )
+
+    @patch("requests.request", side_effect=Util.mocked_requests_get)
+    def test_update_incident_status_exception_when_incident_does_not_exists(self, mock_request):
+        test_cases = []
+        for _type in ["threat", "alert"]:
             test_cases.append(
                 {
                     "status": "unresolved",
-                    "ids": [f"non_existing_{_type}_id_1"],
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on a non existing {_type}s.",
-                }
-            )
-            test_cases.append(
-                {
-                    "status": "in progress",
-                    "ids": [f"same_status_{_type}_id_1"],
-                    "_type": f"{_type}s",
-                    "description": f"Test updating incident status on a {_type}s with the same status already set.",
+                    "threat_id": f"non_existing_{_type}_id_1",
+                    "_type": f"{_type}",
+                    "description": f"Test updating incident status on a non existing {_type}.",
                 }
             )
 
@@ -101,14 +91,13 @@ class TestUpdateIncidentStatus(TestCase):
                 with self.assertRaises(PluginException) as error:
                     self.action.run(
                         {
-                            Input.INCIDENT_IDS: case["ids"],
+                            Input.THREAT_ID: case["threat_id"],
                             Input.INCIDENT_STATUS: case["status"],
                             Input.TYPE: incident_type,
                         }
                     )
                 self.assertEqual(f"No {incident_type} to update in SentinelOne.", error.exception.cause)
                 self.assertEqual(
-                    f"Please verify the log, the {incident_type} are already set to the new incident"
-                    " status or do not exist in SentinelOne.",
+                    f"Please verify the log, the {incident_type} are do not exist in SentinelOne.",
                     error.exception.assistance,
                 )

--- a/plugins/sentinelone/unit_test/util.py
+++ b/plugins/sentinelone/unit_test/util.py
@@ -9,7 +9,6 @@ from requests.exceptions import HTTPError
 import json
 import logging
 
-from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_sentinelone.connection.schema import Input
 
 
@@ -145,9 +144,8 @@ class Util:
             "ids"
         ) == ["non_existing_alert_id_1"]:
             return MockResponse("alerts_non_existing", 200)
-        elif args[1] == "https://rapid7.com/web/api/v2.1/threats" and kwargs.get("params", {}).get("ids") in [
-            ["valid_threat_id_1"],
-            ["valid_threat_id_2"],
+        elif args[1] == "https://rapid7.com/web/api/v2.1/threats" and kwargs.get("params", {}).get("ids") == [
+            "valid_threat_id_1"
         ]:
             return MockResponse("threats", 200)
         elif args[1] == "https://rapid7.com/web/api/v2.1/cloud-detection/alerts" and kwargs.get("params", {}).get(


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

- Blacklist action: Fix for unblocked action
- Update Analyst Verdict action: Accepting only single thread ID in order to standardize inputs
- Update Incident Status action: Accepting only single thread ID in order to standardize inputs
- Quarantine action: unification of the output data when action fails

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
