### PR TITLE
Python 3 Script - Updated indentation fix

### DIFF
--- a/plugins/python_3_script/.CHECKSUM
+++ b/plugins/python_3_script/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "bfe1e776f08ad90e27ad857dd0a5f345",
-	"manifest": "21e6f9d693dabab090be37f314f31e5f",
-	"setup": "037b8280fd59ebda74b918a5a5fbbeed",
+	"spec": "5d0523c6b55dff5e9c4894568f90239f",
+	"manifest": "958342b84cf7931f56bdd247286b8677",
+	"setup": "ba94c92fb2a347d56eef8b71971130f5",
 	"schemas": [
 		{
 			"identifier": "run/schema.py",

--- a/plugins/python_3_script/bin/icon_python_3_script
+++ b/plugins/python_3_script/bin/icon_python_3_script
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Python 3 Script"
 Vendor = "rapid7"
-Version = "4.0.1"
+Version = "4.0.2"
 Description = "Run a Python 3 script"
 
 

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -132,6 +132,7 @@ If installation fails, try increasing the `Timeout` connection input to `900` (1
 
 # Version History
 
+* 4.0.2 - Run: Fix issue with indentation where users have non-empty credentials for input function
 * 4.0.1 - Resolve issue where users experience issues with installing Python packages, and indentation for input function 
 * 4.0.0 - Add custom script credentials in Connection
 * 3.0.0 - Add custom credentials in Run action

--- a/plugins/python_3_script/icon_python_3_script/actions/run/action.py
+++ b/plugins/python_3_script/icon_python_3_script/actions/run/action.py
@@ -9,7 +9,7 @@ from .schema import Component, Input, RunInput, RunOutput
 
 sys.path.append("/var/cache/python_dependencies/lib/python3.8/site-packages")
 
-INDENTATION_CHARACTER = " "
+INDENTATION_CHARACTER = " " * 4
 
 
 class Run(insightconnect_plugin_runtime.Action):
@@ -19,8 +19,8 @@ class Run(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        function_ = params.get(Input.FUNCTION, "").replace("\t", INDENTATION_CHARACTER)
-        function_ = self._add_credentials_to_function(function_)
+        function_ = params.get(Input.FUNCTION, "")
+        function_ = self._add_credentials_to_function(function_, self._check_indentation_character(function_))
 
         self.logger.info(f"Input: (below)\n\n{params.get(Input.INPUT)}\n")
         self.logger.info(f"Function: (below)\n\n{function_}\n")
@@ -78,3 +78,21 @@ class Run(insightconnect_plugin_runtime.Action):
         function_lines = function_.split("\n")
         function_lines = [function_lines[0]] + credentials_definition + function_lines[1:]
         return "\n".join(function_lines)
+
+    @staticmethod
+    def _check_indentation_character(function_: str) -> str:
+        """
+        This function returns the indentation character that is used in the input python's function
+        :param function_: Python script function
+        :type: str
+        :return: Indentation character that is used
+        :rtype: str
+        """
+
+        indentation_character = ""
+        first_new_line_index = function_.index("\n")
+        for character in function_[first_new_line_index + 1 :]:
+            if character in ("\t", " "):
+                indentation_character += character
+            else:
+                return indentation_character

--- a/plugins/python_3_script/plugin.spec.yaml
+++ b/plugins/python_3_script/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: rapid7
 status: []
 description: Run a Python 3 script
-version: 4.0.1
+version: 4.0.2
 supported_versions: ["Python 3.8.1"]
 enable_cache: true
 resources:

--- a/plugins/python_3_script/setup.py
+++ b/plugins/python_3_script/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="python_3_script-rapid7-plugin",
-      version="4.0.1",
+      version="4.0.2",
       description="Run a Python 3 script",
       author="rapid7",
       author_email="",

--- a/plugins/python_3_script/unit_test/test_run.py
+++ b/plugins/python_3_script/unit_test/test_run.py
@@ -47,3 +47,19 @@ class TestRun(TestCase):
             action.run(params=params)
         self.assertEqual(error.exception.cause, "Output type was None")
         self.assertEqual(error.exception.assistance, "Ensure that output has a non-None data type")
+
+    @parameterized.expand(
+        [
+            ["def run(params={}):\n\treturn {'username': username}", "\t"],
+            ["def run(params={}):\n\t\treturn {'username': username}", "\t\t"],
+            ["def run(params={}):\n\t return {'username': username}", "\t "],
+            ["def run(params={}):\n return {'username': username}", " "],
+            ["def run(params={}):\n  return {'username': username}", "  "],
+            ["def run(params={}):\n   return {'username': username}", "   "],
+            ["def run(params={}):\n    return {'username': username}", "    "],
+        ]
+    )
+    def test_check_indentation_character(self, mock_exec_python_function: Mock, function_: str, expected: str) -> None:
+        action = Util.default_connector(Run())
+        response = action._check_indentation_character(function_)
+        self.assertEqual(response, expected)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Run: Updated indentation fix for input function when user has non-empty credentials

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
