### PR TITLE
Release Threatcrowd - Added SSL verification field to the connection part

### DIFF
--- a/plugins/threatcrowd/.CHECKSUM
+++ b/plugins/threatcrowd/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "66335f82585998e8c019d6ea635c111e",
-	"manifest": "baf0292d7a4758277caca26988c3c46e",
-	"setup": "11084a954368da2f00d3036e1579f3a9",
+	"spec": "eac86ca9af1546307e7a9c191198d1ba",
+	"manifest": "eebd465959193ac54b86a541a5a164f2",
+	"setup": "b063d8873af5f32d9c8ad7e6b08d9090",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/plugins/threatcrowd/.CHECKSUM
+++ b/plugins/threatcrowd/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "9676bed028c1aa028873de10418aa8fc",
-	"manifest": "b0865ebeae346363cbf0788e585529d3",
-	"setup": "92c6f78cdd9543c1a61374ff1b6f82d0",
+	"spec": "66335f82585998e8c019d6ea635c111e",
+	"manifest": "baf0292d7a4758277caca26988c3c46e",
+	"setup": "11084a954368da2f00d3036e1579f3a9",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",
@@ -29,7 +29,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "da5382221ca2a33a2f854e17b068d502"
+			"hash": "653ae167218c479b1fbf01bb60b44727"
 		}
 	]
 }

--- a/plugins/threatcrowd/bin/icon_threatcrowd
+++ b/plugins/threatcrowd/bin/icon_threatcrowd
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Threat Crowd"
 Vendor = "rapid7"
-Version = "3.0.3"
+Version = "4.0.0"
 Description = "Threat Crowd is an open source search engine for threats. Using the Threat Crowd plugin for Rapid7 InsightConnect, users can search by domain, IP address, email address, and other information to discover threats"
 
 

--- a/plugins/threatcrowd/bin/icon_threatcrowd
+++ b/plugins/threatcrowd/bin/icon_threatcrowd
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Threat Crowd"
 Vendor = "rapid7"
-Version = "4.0.0"
+Version = "3.1.0"
 Description = "Threat Crowd is an open source search engine for threats. Using the Threat Crowd plugin for Rapid7 InsightConnect, users can search by domain, IP address, email address, and other information to discover threats"
 
 

--- a/plugins/threatcrowd/help.md
+++ b/plugins/threatcrowd/help.md
@@ -13,11 +13,27 @@ and other information to discover and enrich information about threats in real-t
 
 _This plugin does not contain any requirements._
 
+# Supported Product Versions
+
+* Threatcrowd API 2022-11-02
+
 # Documentation
 
 ## Setup
 
-_This plugin does not contain a connection._
+The connection configuration accepts the following parameters:
+
+|Name|Type|Default|Required|Description|Enum|Example|
+|----|----|-------|--------|-----------|----|-------|
+|ssl_verification|boolean|True|True|Indicates whether to verify SSL certificate or not|None|True|
+
+Example input:
+
+```
+{
+  "ssl_verification": true
+}
+```
 
 ## Technical Details
 
@@ -356,6 +372,7 @@ This variable can be used in automated decisions to check if ThreatCrowd has inf
 
 # Version History
 
+* 4.0.0 - Connection: Add SSL Verification boolean field that indicates whether to verify SSL certificate or not | Add unittests
 * 3.0.3 - Add PluginException for case 'Too many connections' response from server | Change IP address in api.py file
 * 3.0.2 - Add source and license URLs in plugin spec | Set `USER` to `nobody` in Dockerfile
 * 3.0.1 - Add Hash input conversion to lowercase in the Hash action to match API requirements

--- a/plugins/threatcrowd/help.md
+++ b/plugins/threatcrowd/help.md
@@ -372,7 +372,7 @@ This variable can be used in automated decisions to check if ThreatCrowd has inf
 
 # Version History
 
-* 4.0.0 - Connection: Add SSL Verification boolean field that indicates whether to verify SSL certificate or not | Add unittests
+* 3.1.0 - Connection: Add SSL Verification boolean field that indicates whether to verify SSL certificate or not | Add unittests
 * 3.0.3 - Add PluginException for case 'Too many connections' response from server | Change IP address in api.py file
 * 3.0.2 - Add source and license URLs in plugin spec | Set `USER` to `nobody` in Dockerfile
 * 3.0.1 - Add Hash input conversion to lowercase in the Hash action to match API requirements

--- a/plugins/threatcrowd/icon_threatcrowd/connection/connection.py
+++ b/plugins/threatcrowd/icon_threatcrowd/connection/connection.py
@@ -1,5 +1,5 @@
 import insightconnect_plugin_runtime
-from .schema import ConnectionSchema
+from .schema import ConnectionSchema, Input
 
 # Custom imports below
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
@@ -12,8 +12,8 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.client = None
 
     def connect(self, params={}):
-        self.client = ThreadCrowdAPI(self.logger)
-        pass
+        self.ssl_verification = params.get(Input.SSL_VERIFICATION, True)
+        self.client = ThreadCrowdAPI(self.ssl_verification, self.logger)
 
     def test(self):
         try:

--- a/plugins/threatcrowd/icon_threatcrowd/connection/schema.py
+++ b/plugins/threatcrowd/icon_threatcrowd/connection/schema.py
@@ -4,11 +4,27 @@ import json
 
 
 class Input:
-    pass
+    SSL_VERIFICATION = "ssl_verification"
+    
 
 class ConnectionSchema(insightconnect_plugin_runtime.Input):
     schema = json.loads("""
-   {}
+   {
+  "type": "object",
+  "title": "Variables",
+  "properties": {
+    "ssl_verification": {
+      "type": "boolean",
+      "title": "Verify SSL Certificate",
+      "description": "Indicates whether to verify SSL certificate or not",
+      "default": true,
+      "order": 1
+    }
+  },
+  "required": [
+    "ssl_verification"
+  ]
+}
     """)
 
     def __init__(self):

--- a/plugins/threatcrowd/plugin.spec.yaml
+++ b/plugins/threatcrowd/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: threatcrowd
 title: Threat Crowd
 description: Threat Crowd is an open source search engine for threats. Using the Threat Crowd plugin for Rapid7 InsightConnect, users can search by domain, IP address, email address, and other information to discover threats
-version: 4.0.0
+version: 3.1.0
 vendor: rapid7
 support: rapid7
 supported_versions: ["Threatcrowd API 2022-11-02"]

--- a/plugins/threatcrowd/plugin.spec.yaml
+++ b/plugins/threatcrowd/plugin.spec.yaml
@@ -4,9 +4,10 @@ products: [insightconnect]
 name: threatcrowd
 title: Threat Crowd
 description: Threat Crowd is an open source search engine for threats. Using the Threat Crowd plugin for Rapid7 InsightConnect, users can search by domain, IP address, email address, and other information to discover threats
-version: 3.0.3
+version: 4.0.0
 vendor: rapid7
 support: rapid7
+supported_versions: ["Threatcrowd API 2022-11-02"]
 status: []
 cloud_ready: true
 resources:
@@ -55,6 +56,14 @@ types:
       description: SHA1 hash value
       type: string
       required: true
+connection:
+  ssl_verification:
+    title: Verify SSL Certificate
+    description: Indicates whether to verify SSL certificate or not
+    type: boolean
+    required: true
+    default: true
+    example: true
 actions:
   domain:
     title: Domain Lookup

--- a/plugins/threatcrowd/requirements.txt
+++ b/plugins/threatcrowd/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 validators==0.15.0
+parameterized==0.8.1

--- a/plugins/threatcrowd/setup.py
+++ b/plugins/threatcrowd/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="threatcrowd-rapid7-plugin",
-      version="3.0.3",
+      version="4.0.0",
       description="Threat Crowd is an open source search engine for threats. Using the Threat Crowd plugin for Rapid7 InsightConnect, users can search by domain, IP address, email address, and other information to discover threats",
       author="rapid7",
       author_email="",

--- a/plugins/threatcrowd/setup.py
+++ b/plugins/threatcrowd/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="threatcrowd-rapid7-plugin",
-      version="4.0.0",
+      version="3.1.0",
       description="Threat Crowd is an open source search engine for threats. Using the Threat Crowd plugin for Rapid7 InsightConnect, users can search by domain, IP address, email address, and other information to discover threats",
       author="rapid7",
       author_email="",

--- a/plugins/threatcrowd/unit_test/mock.py
+++ b/plugins/threatcrowd/unit_test/mock.py
@@ -1,0 +1,75 @@
+import json
+import os
+from typing import Callable
+from unittest import mock
+
+import requests
+from icon_threatcrowd.connection.schema import Input
+
+STUB_CONNECTION = {Input.SSL_VERIFICATION: True}
+
+STUB_RESPONSE_TEXT = "RESPONSE"
+
+
+class MockResponse:
+    def __init__(self, filename: str, status_code: int, text: str = STUB_RESPONSE_TEXT) -> None:
+        self.filename = filename
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        with open(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), f"responses/{self.filename}.json.resp")
+        ) as file:
+            return json.load(file)
+
+
+def mocked_request(side_effect: Callable) -> None:
+    mock_function = requests
+    mock_function.request = mock.Mock(side_effect=side_effect)
+
+
+def mock_conditions(url: str, status_code: int) -> MockResponse:
+    if status_code == 201:
+        return MockResponse("invalid_json", status_code)
+    elif status_code == 401:
+        return MockResponse("empty_response", status_code)
+    if url == "https://www.threatcrowd.org/searchApi/v2/ip/report/?ip=54.192.230.36":
+        return MockResponse("empty_response", status_code)
+    elif url == "https://www.threatcrowd.org/searchApi/v2/ip/report/":
+        return MockResponse("address", status_code)
+    elif url == "https://www.threatcrowd.org/searchApi/v2/antivirus/report/":
+        return MockResponse("av", status_code)
+    elif url == "https://www.threatcrowd.org/searchApi/v2/domain/report/":
+        return MockResponse("domain", status_code)
+    elif url == "https://www.threatcrowd.org/searchApi/v2/email/report/":
+        return MockResponse("email", status_code)
+    elif url == "https://www.threatcrowd.org/searchApi/v2/file/report/":
+        return MockResponse("hash", status_code)
+    elif url == "https://www.threatcrowd.org/vote.php":
+        return MockResponse("empty_response", status_code)
+    raise Exception("Response has been not implemented")
+
+
+def mock_request_200(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 200)
+
+
+def mock_request_201_invalid_json(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 201)
+
+
+def mock_request_401(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 401)
+
+
+def mock_request_404(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 404)
+
+
+def mock_request_500(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 500)
+
+
+def mock_request_503(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[1], 503)

--- a/plugins/threatcrowd/unit_test/responses/address.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/address.json.resp
@@ -1,0 +1,21 @@
+{
+  "response_code": 200,
+  "resolutions": [
+    {
+      "domain": "example.com",
+      "last_resolved": "2018-09-03"
+    },
+    {
+      "domain": "example2.com",
+      "last_resolved": "2018-07-14"
+    },
+    {
+      "domain": "example3.com",
+      "last_resolved": "2020-06-17"
+    }
+  ],
+  "hashes": [],
+  "votes": 0,
+  "permalink": "https://www.threatcrowd.org/ip.php?ip=13.33.17.182",
+  "references": []
+}

--- a/plugins/threatcrowd/unit_test/responses/av.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/av.json.resp
@@ -1,0 +1,14 @@
+{
+  "response_code": 200,
+  "found": true,
+  "hashes": [
+      "31d0e421894004393c48de1769744687",
+      "5cd3f073caac28f915cf501d00030b31",
+      "bbd9acdd758ec2316855306e83dba469",
+      "ef9d8cd06de03bd5f07b01c1cce9761f",
+      "06bd026c77ce6ab8d85b6ae92bb34034",
+      "2af64ba808c79dccd2c1d84f010b22d7"
+  ],
+  "permalink": "https://www.threatcrowd.org/listMalware.php?antivirus=plugx",
+  "references": []
+}

--- a/plugins/threatcrowd/unit_test/responses/domain.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/domain.json.resp
@@ -1,0 +1,38 @@
+{
+  "response_code": 200,
+  "resolutions": [
+    {
+      "ip_address": "-",
+      "last_resolved": "2016-02-17"
+    },
+    {
+      "ip_address": "198.51.100.1",
+      "last_resolved": "2017-03-03"
+    },
+    {
+      "ip_address": "198.51.100.1",
+      "last_resolved": "2018-04-30"
+    },
+    {
+      "ip_address": "198.51.100.1",
+      "last_resolved": "2020-07-24"
+    },
+    {
+      "ip_address": "198.51.100.1",
+      "last_resolved": "2019-12-28"
+    },
+    {
+      "ip_address": "198.51.100.1",
+      "last_resolved": "2017-07-13"
+    }
+  ],
+  "emails": [
+    "user@example.com"
+  ],
+  "found": true,
+  "hashes": [],
+  "votes": -1,
+  "permalink": "https://www.threatcrowd.org/domain.php?domain=1119.leke.cn",
+  "references": [],
+  "subdomains": []
+}

--- a/plugins/threatcrowd/unit_test/responses/email.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/email.json.resp
@@ -1,0 +1,7 @@
+{
+  "response_code": 200,
+  "domains": ["porta-kiln.com"],
+  "found": true,
+  "permalink": "https://www.threatcrowd.org/email.php?email=user@example.com",
+  "references": []
+}

--- a/plugins/threatcrowd/unit_test/responses/empty_response.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/empty_response.json.resp
@@ -1,0 +1,1 @@
+{"message": "Empty"}

--- a/plugins/threatcrowd/unit_test/responses/hash.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/hash.json.resp
@@ -1,0 +1,32 @@
+{
+  "response_code": 200,
+  "domains": [
+    "hpservice.homepc.it",
+    "facebook.controlliamo.com"
+  ],
+  "found": true,
+  "md5": "31d0e421894004393c48de1769744687",
+  "sha1": "4f0eb746d81a616fb9bdff058997ef47a4209a76",
+  "ips": [
+    "8.8.8.8"
+  ],
+  "permalink": "https://www.threatcrowd.org/malware.php?md5=31d0e421894004393c48de1769744687",
+  "references": [],
+  "scans": [
+    "Error Scanning File",
+    "Malware-gen*Win32*Malware-gen",
+    "Gen*Variant.Symmi.50061",
+    "W32/Trojan.VSQD-1927",
+    "BDS/Plugx.266990",
+    "Gen*Variant.Symmi.50061",
+    "Gen*Variant.Symmi.50061",
+    "Win32/Korplug.CF",
+    "W32/FakeAV.CX",
+    "Generic11_c.CDQL",
+    "Trojan.SuspectCRC*Backdoor.Win32.Gulpix",
+    "Riskware ( 0040eff71 )",
+    "Trojan.Win32.Generic*Backdoor.Win32.Gulpix.yk",
+    "Backdoor*Win32/Plugx",
+    "Gen*Variant.Symmi.50061[ZP]"
+  ]
+}

--- a/plugins/threatcrowd/unit_test/responses/invalid_json.json.resp
+++ b/plugins/threatcrowd/unit_test/responses/invalid_json.json.resp
@@ -1,0 +1,1 @@
+INVALID_JSON

--- a/plugins/threatcrowd/unit_test/test_address.py
+++ b/plugins/threatcrowd/unit_test/test_address.py
@@ -1,0 +1,77 @@
+import os
+import sys
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from typing import Callable
+from unittest import TestCase, mock
+from unittest.mock import Mock
+
+from icon_threatcrowd.actions.address import Address
+from icon_threatcrowd.actions.address.schema import Input
+from icon_threatcrowd.connection.connection import Connection
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestAddress(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = Address()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+        self.payload = {Input.DOMAIN: "198.51.100.1"}
+
+    @mock.patch("icon_threatcrowd.actions.address.Address.ip_check")
+    def test_address_ok(self, mocked_ip_check: Mock) -> None:
+        mocked_request(mock_request_200)
+        response = self.action.run(self.payload)
+        expected_response = {
+            "domains": [
+                {"domain": "example.com", "last_resolved": "2018-09-03"},
+                {"domain": "example2.com", "last_resolved": "2018-07-14"},
+                {"domain": "example3.com", "last_resolved": "2020-06-17"},
+            ],
+            "found": True,
+            "hashes": [],
+            "malicious": "50/50 chance malicious",
+            "permalink": "https://www.threatcrowd.org/ip.php?ip=13.33.17.182",
+            "references": [],
+        }
+        self.assertEqual(expected_response, response)
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, PluginException.causes[PluginException.Preset.INVALID_JSON]),
+            (mock_request_401, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+            (mock_request_503, PluginException.causes[PluginException.Preset.SERVICE_UNAVAILABLE]),
+        ],
+    )
+    @mock.patch("icon_threatcrowd.actions.address.Address.ip_check")
+    def test_address_exception(self, mock_request: Callable, exception: str, mocked_ip_check: Mock) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(self.payload)
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )

--- a/plugins/threatcrowd/unit_test/test_av.py
+++ b/plugins/threatcrowd/unit_test/test_av.py
@@ -1,0 +1,75 @@
+import os
+import sys
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from typing import Callable
+from unittest import TestCase
+
+from icon_threatcrowd.actions.av import Av
+from icon_threatcrowd.actions.av.schema import Input
+from icon_threatcrowd.connection.connection import Connection
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestAv(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = Av()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+        self.payload = {Input.ANTIVIRUS: "plugx"}
+
+    def test_av_ok(self) -> None:
+        mocked_request(mock_request_200)
+        response = self.action.run(self.payload)
+        expected_response = {
+            "found": True,
+            "hashes": [
+                "31d0e421894004393c48de1769744687",
+                "5cd3f073caac28f915cf501d00030b31",
+                "bbd9acdd758ec2316855306e83dba469",
+                "ef9d8cd06de03bd5f07b01c1cce9761f",
+                "06bd026c77ce6ab8d85b6ae92bb34034",
+                "2af64ba808c79dccd2c1d84f010b22d7",
+            ],
+            "permalink": "https://www.threatcrowd.org/listMalware.php?antivirus=plugx",
+            "references": [],
+        }
+        self.assertEqual(expected_response, response)
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, PluginException.causes[PluginException.Preset.INVALID_JSON]),
+            (mock_request_401, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+            (mock_request_503, PluginException.causes[PluginException.Preset.SERVICE_UNAVAILABLE]),
+        ],
+    )
+    def test_address_exception(self, mock_request: Callable, exception: str) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(self.payload)
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )

--- a/plugins/threatcrowd/unit_test/test_connection.py
+++ b/plugins/threatcrowd/unit_test/test_connection.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+import logging
+from typing import Callable
+from unittest import TestCase
+
+from icon_threatcrowd.connection.connection import Connection
+from insightconnect_plugin_runtime.exceptions import ConnectionTestException
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestConnection(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+    def test_connection_ok(self):
+        mocked_request(mock_request_200)
+        response = self.connection.test()
+        expected_response = {"success": True}
+        self.assertEqual(response, expected_response)
+
+    @parameterized.expand(
+        [(mock_request_401,), (mock_request_404,), (mock_request_500,), (mock_request_503,)],
+    )
+    def test_connection_exception(self, mock_request: Callable) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(ConnectionTestException) as context:
+            self.connection.test()
+        self.assertEqual(
+            context.exception.cause,
+            "An unexpected error occurred during the API request.",
+        )

--- a/plugins/threatcrowd/unit_test/test_domain.py
+++ b/plugins/threatcrowd/unit_test/test_domain.py
@@ -1,0 +1,79 @@
+import os
+import sys
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from typing import Callable
+from unittest import TestCase
+
+from icon_threatcrowd.actions.domain import Domain
+from icon_threatcrowd.actions.domain.schema import Input
+from icon_threatcrowd.connection.connection import Connection
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestDomain(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = Domain()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+        self.payload = {Input.DOMAIN: "https://example.com"}
+
+    def test_domain_ok(self) -> None:
+        mocked_request(mock_request_200)
+        response = self.action.run(self.payload)
+        expected_response = {
+            "domains": [
+                {"ip_address": "-", "last_resolved": "2016-02-17"},
+                {"ip_address": "198.51.100.1", "last_resolved": "2017-03-03"},
+                {"ip_address": "198.51.100.1", "last_resolved": "2018-04-30"},
+                {"ip_address": "198.51.100.1", "last_resolved": "2020-07-24"},
+                {"ip_address": "198.51.100.1", "last_resolved": "2019-12-28"},
+                {"ip_address": "198.51.100.1", "last_resolved": "2017-07-13"},
+            ],
+            "emails": ["user@example.com"],
+            "found": True,
+            "hashes": [],
+            "malicious": "Malicious",
+            "permalink": "https://www.threatcrowd.org/domain.php?domain=1119.leke.cn",
+            "references": [],
+            "subdomains": [],
+        }
+        self.assertEqual(expected_response, response)
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, PluginException.causes[PluginException.Preset.INVALID_JSON]),
+            (mock_request_401, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+            (mock_request_503, PluginException.causes[PluginException.Preset.SERVICE_UNAVAILABLE]),
+        ],
+    )
+    def test_domain_exception(self, mock_request: Callable, exception: str) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(self.payload)
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )

--- a/plugins/threatcrowd/unit_test/test_email.py
+++ b/plugins/threatcrowd/unit_test/test_email.py
@@ -1,0 +1,68 @@
+import os
+import sys
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from typing import Callable
+from unittest import TestCase
+
+from icon_threatcrowd.actions.email import Email
+from icon_threatcrowd.actions.email.schema import Input
+from icon_threatcrowd.connection.connection import Connection
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestEmail(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = Email()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+        self.payload = {Input.EMAIL: "user@example.com"}
+
+    def test_email_ok(self) -> None:
+        mocked_request(mock_request_200)
+        response = self.action.run(self.payload)
+        expected_response = {
+            "domains": ["porta-kiln.com"],
+            "found": True,
+            "permalink": "https://www.threatcrowd.org/email.php?email=user@example.com",
+            "references": [],
+        }
+        self.assertEqual(expected_response, response)
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, PluginException.causes[PluginException.Preset.INVALID_JSON]),
+            (mock_request_401, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+            (mock_request_503, PluginException.causes[PluginException.Preset.SERVICE_UNAVAILABLE]),
+        ],
+    )
+    def test_email_exception(self, mock_request: Callable, exception: str) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(self.payload)
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )

--- a/plugins/threatcrowd/unit_test/test_hash.py
+++ b/plugins/threatcrowd/unit_test/test_hash.py
@@ -1,0 +1,87 @@
+import os
+import sys
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from typing import Callable
+from unittest import TestCase
+
+from icon_threatcrowd.actions.hash import Hash
+from icon_threatcrowd.actions.hash.schema import Input
+from icon_threatcrowd.connection.connection import Connection
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestHash(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = Hash()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+        self.payload = {Input.HASH: "9de5069c5afe602b2ea0a04b66beb2c0"}
+
+    def test_hash_ok(self) -> None:
+        mocked_request(mock_request_200)
+        response = self.action.run(self.payload)
+        expected_response = {
+            "domains": ["hpservice.homepc.it", "facebook.controlliamo.com"],
+            "found": True,
+            "hashes": {"md5": "31d0e421894004393c48de1769744687", "sha1": "4f0eb746d81a616fb9bdff058997ef47a4209a76"},
+            "ips": ["8.8.8.8"],
+            "permalink": "https://www.threatcrowd.org/malware.php?md5=31d0e421894004393c48de1769744687",
+            "references": [],
+            "scans": [
+                "Error Scanning File",
+                "Malware-gen*Win32*Malware-gen",
+                "Gen*Variant.Symmi.50061",
+                "W32/Trojan.VSQD-1927",
+                "BDS/Plugx.266990",
+                "Gen*Variant.Symmi.50061",
+                "Gen*Variant.Symmi.50061",
+                "Win32/Korplug.CF",
+                "W32/FakeAV.CX",
+                "Generic11_c.CDQL",
+                "Trojan.SuspectCRC*Backdoor.Win32.Gulpix",
+                "Riskware ( 0040eff71 )",
+                "Trojan.Win32.Generic*Backdoor.Win32.Gulpix.yk",
+                "Backdoor*Win32/Plugx",
+                "Gen*Variant.Symmi.50061[ZP]",
+            ],
+        }
+        self.assertEqual(expected_response, response)
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, PluginException.causes[PluginException.Preset.INVALID_JSON]),
+            (mock_request_401, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+            (mock_request_503, PluginException.causes[PluginException.Preset.SERVICE_UNAVAILABLE]),
+        ],
+    )
+    def test_hash_exception(self, mock_request: Callable, exception: str) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(self.payload)
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )

--- a/plugins/threatcrowd/unit_test/test_votes.py
+++ b/plugins/threatcrowd/unit_test/test_votes.py
@@ -1,0 +1,63 @@
+import os
+import sys
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from typing import Callable
+from unittest import TestCase
+
+from icon_threatcrowd.actions.votes import Votes
+from icon_threatcrowd.actions.votes.schema import Input
+from icon_threatcrowd.connection.connection import Connection
+from parameterized import parameterized
+
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_201_invalid_json,
+    mock_request_401,
+    mock_request_404,
+    mock_request_500,
+    mock_request_503,
+    mocked_request,
+)
+
+
+class TestVotes(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = Votes()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("action logger")
+
+        self.payload = {Input.ENTITY: "user@example.com", Input.VOTE: False}
+
+    def test_votes_ok(self) -> None:
+        mocked_request(mock_request_200)
+        response = self.action.run(self.payload)
+        expected_response = {"status": "200"}
+        self.assertEqual(expected_response, response)
+
+    @parameterized.expand(
+        [
+            (mock_request_201_invalid_json, "Vote submission failed for unknown reason."),
+            (mock_request_401, PluginException.causes[PluginException.Preset.UNKNOWN]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+            (mock_request_503, PluginException.causes[PluginException.Preset.SERVICE_UNAVAILABLE]),
+        ],
+    )
+    def test_votes_exception(self, mock_request: Callable, exception: str) -> None:
+        mocked_request(mock_request)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(self.payload)
+        self.assertEqual(
+            context.exception.cause,
+            exception,
+        )


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Added SSL verification field to the connection part

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
