### PR TITLE
[PLGN-31] whois - Add .monster and .nl tld (#1496)

### DIFF
--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "f658825644f1e5169354b9760baf5b53",
-	"manifest": "b9be3f122f9cf4efb75ddb2c748a9cbd",
-	"setup": "32553895a500fa53c7be3721e25712a5",
+	"spec": "07e61afc61329eddafd572b937e10746",
+	"manifest": "12b6a25b98a92d19ce77924eb5b02cde",
+	"setup": "4889069ba412bd9db5897f177e616f22",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -14,10 +14,13 @@ ADD . /python/src
 WORKDIR /python/src
 # Add any package dependencies here
 RUN apt-get update && apt-get install -y whois git
-RUN pip install git+https://github.com/komand/python-whois.git@0.6.13
+RUN pip install git+https://github.com/komand/python-whois.git@0.7.0
 
 # End package dependencies
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 RUN python setup.py build && python setup.py install
+
+# User to run plugin code. The two supported users are: root, nobody
+USER nobody
 
 ENTRYPOINT ["/usr/local/bin/komand_whois"]

--- a/plugins/whois/bin/komand_whois
+++ b/plugins/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "3.0.3"
+Version = "3.1.0"
 Description = "The WHOIS plugin enables address and domain lookups in the WHOIS databases"
 
 

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -165,6 +165,7 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
+* 3.1.0 - Add support for `.monster` and `.nl` domains
 * 3.0.3 - Add PluginException in Domain and Address action when response is empty
 * 3.0.2 - Support non-UTF-8 responses in the Address action
 * 3.0.1 - Clean up help.md formatting

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: The WHOIS plugin enables address and domain lookups in the WHOIS databases
-version: 3.0.3
+version: 3.1.0
 vendor: rapid7
 support: community
 status: []

--- a/plugins/whois/setup.py
+++ b/plugins/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="3.0.3",
+      version="3.1.0",
       description="The WHOIS plugin enables address and domain lookups in the WHOIS databases",
       author="rapid7",
       author_email="",

--- a/plugins/whois/whois.conf
+++ b/plugins/whois/whois.conf
@@ -654,7 +654,7 @@
 \.mom$ whois.uniregistry.net
 \.monash$ whois.nic.monash
 \.money$ whois.donuts.co
-\.monster$ whois.afilias-srs.net
+\.monster$ whois.nic.monster
 \.mopar$ whois.afilias-srs.net
 \.mormon$ whois.afilias-srs.net
 \.mortgage$ whois.rightside.co


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  -  monster and nl tlds
  
*Regarding failed validator:*

https://rapid7.slack.com/archives/G0121JRRYF9/p1669209556869009

Apparently the os dependency was added before and now we have to live with it.

*Regarding failed unit-test:*

Github action does not have python-whois package installed so it cant perform unit-tests.