### PR TITLE
[PLGN-57] Microsoft Teams - Fixed issue where `font-size` value appeared in the urls, and domains output fields

### DIFF
--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e515d0a11cb23367222f3a63bc1ed59d",
-	"manifest": "c2d96f27acc701fdc4b47f8800800b6d",
-	"setup": "eab5b3ebc2a2432ba3223114d267c560",
+	"spec": "9dc081841d9ebaafe5eafeac7fc0cd13",
+	"manifest": "4cfe57648636c28e808f1934268c1aa6",
+	"setup": "4d82ee201b9930bad0dcce5e5a3ba619",
 	"schemas": [
 		{
 			"identifier": "add_channel_to_team/schema.py",

--- a/plugins/microsoft_teams/bin/icon_microsoft_teams
+++ b/plugins/microsoft_teams/bin/icon_microsoft_teams
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Teams"
 Vendor = "rapid7"
-Version = "4.1.0"
+Version = "4.1.1"
 Description = "The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users"
 
 

--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -881,6 +881,7 @@ If there is more than one team with the same name in your organization, the olde
 
 # Version History
 
+* 4.1.1 - New Message Received: Fixed issue where `font-size` value appeared in the `urls`, and `domains` output fields
 * 4.1.0 - Cloud enabled | Add Channel to Team: The user has the option to select the type of channel to be created. The available types are `Standard`, and `Private` 
 * 4.0.0 - Fix issue with Create Teams Enabled Group action's members, and owners input field types
 * 3.2.0 - Send Message Action is updated to support chat messages via chat_id parameter, team_name is set to optional. | Update SDK to latest version.

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
 description: The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users
-version: 4.1.0
+version: 4.1.1
 supported_versions: ["Microsoft Graph API v1.0 2021-11-28"]
 vendor: rapid7
 support: community

--- a/plugins/microsoft_teams/setup.py
+++ b/plugins/microsoft_teams/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="microsoft_teams-rapid7-plugin",
-      version="4.1.0",
+      version="4.1.1",
       description="The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users",
       author="rapid7",
       author_email="",

--- a/plugins/microsoft_teams/unit_test/payloads/get_messages.json
+++ b/plugins/microsoft_teams/unit_test/payloads/get_messages.json
@@ -11,6 +11,12 @@
         "content": "This should be first"
       },
       "createdDateTime": 11
+    },
+    {
+      "body": {
+        "content": "<div>\n<div itemprop=\"copy-paste-block\">!enrich-indicator <span style=\"font-size:11.0pt\"><span style=\"font-family:&quot;Calibri&quot;,sans-serif\"><u><a href=\"http://example.com/s/?domain=test\" rel=\"noreferrer noopener\" target=\"_blank\" title=\"https://example.com?domain=test\" style=\"color:#6888c9\">https://example.com</a></u></span></span></div>\n</div>",
+        "contentType": "html"
+      }
     }
   ]
 }

--- a/plugins/microsoft_teams/unit_test/test_add_channel_to_team.py
+++ b/plugins/microsoft_teams/unit_test/test_add_channel_to_team.py
@@ -1,16 +1,17 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
+from unittest.mock import Mock
 
 from icon_microsoft_teams.actions.add_channel_to_team.action import AddChannelToTeam
 from icon_microsoft_teams.actions.add_channel_to_team.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
+from parameterized import parameterized
 
 from util import Util
-from unittest import TestCase, mock
-from unittest.mock import Mock
-from parameterized import parameterized
 
 STUB_TEAM_NAME = "Example Team"
 STUB_CHANNEL_NAME = "ExampleName"

--- a/plugins/microsoft_teams/unit_test/test_add_group_owner.py
+++ b/plugins/microsoft_teams/unit_test/test_add_group_owner.py
@@ -1,14 +1,15 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
 
 from icon_microsoft_teams.actions.add_group_owner.action import AddGroupOwner
 from icon_microsoft_teams.actions.add_group_owner.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 from util import Util
-from unittest import TestCase, mock
 
 STUB_GROUP_NAME = "test"
 STUB_MEMBER_LOGIN = "test"

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
@@ -1,14 +1,15 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
 
 from icon_microsoft_teams.actions.add_member_to_channel.action import AddMemberToChannel
 from icon_microsoft_teams.actions.add_member_to_channel.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 from util import Util
-from unittest import TestCase, mock
 
 STUB_GROUP_NAME = "test"
 STUB_MEMBER_LOGIN = "test"

--- a/plugins/microsoft_teams/unit_test/test_send_message.py
+++ b/plugins/microsoft_teams/unit_test/test_send_message.py
@@ -1,15 +1,17 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
+from unittest.mock import patch
+
 from icon_microsoft_teams.actions.send_message import SendMessage
 from icon_microsoft_teams.actions.send_message.schema import Input, Output
-from unit_test.util import Util
-from unittest.mock import patch
-from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from parameterized import parameterized
+
+from unit_test.util import Util
 
 
 @patch("requests.get", side_effect=Util.mocked_requests)

--- a/plugins/microsoft_teams/unit_test/test_strip_html.py
+++ b/plugins/microsoft_teams/unit_test/test_strip_html.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from icon_microsoft_teams.util.strip_html import strip_html
 
 

--- a/plugins/microsoft_teams/unit_test/util.py
+++ b/plugins/microsoft_teams/unit_test/util.py
@@ -1,7 +1,7 @@
 import json
 import logging
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fixed issue where `font-size` value appeared in the urls, and domains output fields 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [X] Screenshot of job output with the plugin changes
- [X] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
