### PR TITLE
Release Microsoft Teams - New Message Received: Fixed issue where font-size value appeared in the urls, and domains output fields | Update Microsoft Teams Action Add Member to Channel

### DIFF
--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "9dc081841d9ebaafe5eafeac7fc0cd13",
+	"spec": "c276307ff7a8a9b4b5c655bd6268b6a2",
 	"manifest": "4cfe57648636c28e808f1934268c1aa6",
 	"setup": "4d82ee201b9930bad0dcce5e5a3ba619",
 	"schemas": [
@@ -13,7 +13,7 @@
 		},
 		{
 			"identifier": "add_member_to_channel/schema.py",
-			"hash": "10f752bff368711bb6aaf351a4a62c30"
+			"hash": "8f89402618bda5e8653c8b0ac9a81662"
 		},
 		{
 			"identifier": "add_member_to_team/schema.py",

--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e515d0a11cb23367222f3a63bc1ed59d",
-	"manifest": "c2d96f27acc701fdc4b47f8800800b6d",
-	"setup": "eab5b3ebc2a2432ba3223114d267c560",
+	"spec": "9dc081841d9ebaafe5eafeac7fc0cd13",
+	"manifest": "4cfe57648636c28e808f1934268c1aa6",
+	"setup": "4d82ee201b9930bad0dcce5e5a3ba619",
 	"schemas": [
 		{
 			"identifier": "add_channel_to_team/schema.py",

--- a/plugins/microsoft_teams/bin/icon_microsoft_teams
+++ b/plugins/microsoft_teams/bin/icon_microsoft_teams
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Teams"
 Vendor = "rapid7"
-Version = "4.1.0"
+Version = "4.1.1"
 Description = "The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users"
 
 

--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -59,6 +59,7 @@ This action is used to add a conversation member to a channel. This operation is
 |channel_name|string|None|True|Name of the channel to which the member is to be added|None|InsightConnect Channel|
 |group_name|string|None|True|Name of the group in which the channel is located|None|InsightConnect Team|
 |member_login|string|None|True|The login of the group member to be added to a channel|None|user@example.com|
+|role|string|Member|True|Role of the member to add|['Owner', 'Member']|Owner|
 
 Example input:
 
@@ -66,7 +67,8 @@ Example input:
 {
   "channel_name": "InsightConnect Channel",
   "group_name": "InsightConnect Team",
-  "member_login": "user@example.com"
+  "member_login": "user@example.com",
+  "role": "Owner"
 }
 ```
 
@@ -261,10 +263,10 @@ Example input:
 
 ```
 {
-  "channel_name": "InsightConnect Channel",
+  "channel_guid": "xxxxx-xxxxx-xxxx-xxxx",
+  "is_html": false,
   "message": "Hello!",
-  "team_name": "InsightConnect Team",
-  "thread_id": 1595889908700
+  "team_guid": "xxxxx-xxxxx-xxxx-xxxx"
 }
 ```
 
@@ -881,7 +883,7 @@ If there is more than one team with the same name in your organization, the olde
 
 # Version History
 
-* 4.1.1 - New Message Received: Fixed issue where `font-size` value appeared in the `urls`, and `domains` output fields
+* 4.1.1 - New Message Received: Fixed issue where `font-size` value appeared in the `urls`, and `domains` output fields | Can choose the role of a member when adding them to a channel
 * 4.1.0 - Cloud enabled | Add Channel to Team: The user has the option to select the type of channel to be created. The available types are `Standard`, and `Private` 
 * 4.0.0 - Fix issue with Create Teams Enabled Group action's members, and owners input field types
 * 3.2.0 - Send Message Action is updated to support chat messages via chat_id parameter, team_name is set to optional. | Update SDK to latest version.

--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -881,6 +881,7 @@ If there is more than one team with the same name in your organization, the olde
 
 # Version History
 
+* 4.1.1 - New Message Received: Fixed issue where `font-size` value appeared in the `urls`, and `domains` output fields
 * 4.1.0 - Cloud enabled | Add Channel to Team: The user has the option to select the type of channel to be created. The available types are `Standard`, and `Private` 
 * 4.0.0 - Fix issue with Create Teams Enabled Group action's members, and owners input field types
 * 3.2.0 - Send Message Action is updated to support chat messages via chat_id parameter, team_name is set to optional. | Update SDK to latest version.

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_channel/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_channel/action.py
@@ -24,6 +24,7 @@ class AddMemberToChannel(insightconnect_plugin_runtime.Action):
         group_id = get_group_id_from_name(self.logger, self.connection, params.get(Input.GROUP_NAME))
         channels = get_channels_from_microsoft(self.logger, self.connection, group_id, params.get(Input.CHANNEL_NAME))
         user_id = get_user_info(self.logger, self.connection, params.get(Input.MEMBER_LOGIN))
+        role = params.get(Input.ROLE, "Member").lower()
         try:
             channel_id = channels[0].get("id")
             user_id = user_id.get("id")
@@ -43,4 +44,4 @@ class AddMemberToChannel(insightconnect_plugin_runtime.Action):
                 assistance="If the issue persists please contact support.",
                 data=e,
             )
-        return {Output.SUCCESS: add_user_to_channel(self.logger, self.connection, group_id, channel_id, user_id)}
+        return {Output.SUCCESS: add_user_to_channel(self.logger, self.connection, group_id, channel_id, user_id, role)}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_channel/schema.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_channel/schema.py
@@ -11,6 +11,7 @@ class Input:
     CHANNEL_NAME = "channel_name"
     GROUP_NAME = "group_name"
     MEMBER_LOGIN = "member_login"
+    ROLE = "role"
     
 
 class Output:
@@ -40,12 +41,24 @@ class AddMemberToChannelInput(insightconnect_plugin_runtime.Input):
       "title": "Member Login",
       "description": "The login of the group member to be added to a channel",
       "order": 1
+    },
+    "role": {
+      "type": "string",
+      "title": "Member Role",
+      "description": "Role of the member to add",
+      "default": "Member",
+      "enum": [
+        "Owner",
+        "Member"
+      ],
+      "order": 4
     }
   },
   "required": [
     "channel_name",
     "group_name",
-    "member_login"
+    "member_login",
+    "role"
   ]
 }
     """)

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/azure_ad_utils.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/azure_ad_utils.py
@@ -397,6 +397,7 @@ def add_user_to_channel(
     group_id: str,
     channel_id: str,
     user_id: str,
+    role: str,
 ) -> bool:
     endpoint = f"https://graph.microsoft.com/beta/teams/{group_id}/channels/{channel_id}/members/"
     logger.info(f"Adding user to channel with: {endpoint}")
@@ -405,7 +406,7 @@ def add_user_to_channel(
         endpoint,
         json={
             "@odata.type": "#microsoft.graph.aadUserConversationMember",
-            "roles": [],
+            "roles": [role],
             "user@odata.bind": f"https://graph.microsoft.com/beta/users/{user_id}",
         },
         headers=connection.get_headers(),

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -707,6 +707,16 @@ actions:
         type: string
         required: true
         example: InsightConnect Channel
+      role:
+        title: Member Role
+        description: Role of the member to add
+        type: string
+        enum:
+          - Owner
+          - Member
+        required: true
+        example: Owner
+        default: Member
     output:
       success:
         title: Success

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
 description: The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users
-version: 4.1.0
+version: 4.1.1
 supported_versions: ["Microsoft Graph API v1.0 2021-11-28"]
 vendor: rapid7
 support: community

--- a/plugins/microsoft_teams/setup.py
+++ b/plugins/microsoft_teams/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="microsoft_teams-rapid7-plugin",
-      version="4.1.0",
+      version="4.1.1",
       description="The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users",
       author="rapid7",
       author_email="",

--- a/plugins/microsoft_teams/unit_test/payloads/get_messages.json
+++ b/plugins/microsoft_teams/unit_test/payloads/get_messages.json
@@ -11,6 +11,12 @@
         "content": "This should be first"
       },
       "createdDateTime": 11
+    },
+    {
+      "body": {
+        "content": "<div>\n<div itemprop=\"copy-paste-block\">!enrich-indicator <span style=\"font-size:11.0pt\"><span style=\"font-family:&quot;Calibri&quot;,sans-serif\"><u><a href=\"http://example.com/s/?domain=test\" rel=\"noreferrer noopener\" target=\"_blank\" title=\"https://example.com?domain=test\" style=\"color:#6888c9\">https://example.com</a></u></span></span></div>\n</div>",
+        "contentType": "html"
+      }
     }
   ]
 }

--- a/plugins/microsoft_teams/unit_test/test_add_channel_to_team.py
+++ b/plugins/microsoft_teams/unit_test/test_add_channel_to_team.py
@@ -1,16 +1,17 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
+from unittest.mock import Mock
 
 from icon_microsoft_teams.actions.add_channel_to_team.action import AddChannelToTeam
 from icon_microsoft_teams.actions.add_channel_to_team.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
+from parameterized import parameterized
 
 from util import Util
-from unittest import TestCase, mock
-from unittest.mock import Mock
-from parameterized import parameterized
 
 STUB_TEAM_NAME = "Example Team"
 STUB_CHANNEL_NAME = "ExampleName"

--- a/plugins/microsoft_teams/unit_test/test_add_group_owner.py
+++ b/plugins/microsoft_teams/unit_test/test_add_group_owner.py
@@ -1,14 +1,15 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
 
 from icon_microsoft_teams.actions.add_group_owner.action import AddGroupOwner
 from icon_microsoft_teams.actions.add_group_owner.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 from util import Util
-from unittest import TestCase, mock
 
 STUB_GROUP_NAME = "test"
 STUB_MEMBER_LOGIN = "test"

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
@@ -1,14 +1,15 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase, mock
 
 from icon_microsoft_teams.actions.add_member_to_channel.action import AddMemberToChannel
 from icon_microsoft_teams.actions.add_member_to_channel.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 from util import Util
-from unittest import TestCase, mock
 
 STUB_GROUP_NAME = "test"
 STUB_MEMBER_LOGIN = "test"

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
@@ -7,18 +7,18 @@ from unittest import TestCase, mock
 
 from icon_microsoft_teams.actions.add_member_to_channel.action import AddMemberToChannel
 from icon_microsoft_teams.actions.add_member_to_channel.schema import Input
-from insightconnect_plugin_runtime.exceptions import PluginException
 
 from util import Util
 
 STUB_GROUP_NAME = "test"
 STUB_MEMBER_LOGIN = "test"
 STUB_CHANNEL_NAME = "Example Channel"
+STUB_MEMBER_ROLE = "Owner"
 
 STUB_EXAMPLE_ACTION_RESPONSE = {"success": True}
 
 
-class TestAddGroupOwner(TestCase):
+class TestAddMemberToChannel(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(AddMemberToChannel())
 
@@ -26,11 +26,12 @@ class TestAddGroupOwner(TestCase):
             Input.GROUP_NAME: STUB_GROUP_NAME,
             Input.MEMBER_LOGIN: STUB_MEMBER_LOGIN,
             Input.CHANNEL_NAME: STUB_CHANNEL_NAME,
+            Input.ROLE: STUB_MEMBER_ROLE,
         }
 
     @mock.patch("requests.get", side_effect=Util.mocked_requests)
     @mock.patch("requests.post", side_effect=Util.mocked_requests)
-    def test_add_group_owner(self, mock_requests_get, mock_requests_post) -> None:
+    def test_add_member_to_channel(self, mock_requests_get, mock_requests_post) -> None:
         response = self.action.run(self.payload)
         expected_response = STUB_EXAMPLE_ACTION_RESPONSE
         self.assertEqual(response, expected_response)

--- a/plugins/microsoft_teams/unit_test/test_send_message.py
+++ b/plugins/microsoft_teams/unit_test/test_send_message.py
@@ -1,15 +1,17 @@
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
+from unittest.mock import patch
+
 from icon_microsoft_teams.actions.send_message import SendMessage
 from icon_microsoft_teams.actions.send_message.schema import Input, Output
-from unit_test.util import Util
-from unittest.mock import patch
-from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from parameterized import parameterized
+
+from unit_test.util import Util
 
 
 @patch("requests.get", side_effect=Util.mocked_requests)

--- a/plugins/microsoft_teams/unit_test/test_strip_html.py
+++ b/plugins/microsoft_teams/unit_test/test_strip_html.py
@@ -1,4 +1,5 @@
 from unittest import TestCase
+
 from icon_microsoft_teams.util.strip_html import strip_html
 
 

--- a/plugins/microsoft_teams/unit_test/util.py
+++ b/plugins/microsoft_teams/unit_test/util.py
@@ -1,7 +1,7 @@
 import json
 import logging
-import sys
 import os
+import sys
 
 sys.path.append(os.path.abspath("../"))
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - New Message Received: Fixed issue where font-size value appeared in the urls, and domains output fields
  - Update Microsoft Teams Action Add Member to Channel

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [X] Screenshot of job output with the plugin changes
- [X] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
