### PR TITLE
[PLGN-109] Cisco Firepower Management Center - Release

### DIFF
--- a/plugins/cisco_firepower_management_center/.CHECKSUM
+++ b/plugins/cisco_firepower_management_center/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "49e62427d0d74297c138ba90ad6c207c",
-	"manifest": "ac3fddc14ab80d69ab6270b07b1d6af9",
-	"setup": "f4ece57764fd50768f42d776dd99ae19",
+	"spec": "82cae4262be8822308c42a02462a2558",
+	"manifest": "a59b68649de3c18ba05e5c18bc5f75c5",
+	"setup": "b3983dca67fd60580f64107798fe102e",
 	"schemas": [
 		{
 			"identifier": "add_address_to_group/schema.py",

--- a/plugins/cisco_firepower_management_center/bin/icon_cisco_firepower_management_center
+++ b/plugins/cisco_firepower_management_center/bin/icon_cisco_firepower_management_center
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Cisco Firepower Management Center"
 Vendor = "rapid7"
-Version = "2.0.0"
+Version = "2.0.1"
 Description = "This plugin utilizes Cisco Firepower Management Center to create URL block policies and manage address objects to block hosts"
 
 

--- a/plugins/cisco_firepower_management_center/help.md
+++ b/plugins/cisco_firepower_management_center/help.md
@@ -544,6 +544,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 2.0.1 - Fix issue in Add Address to Group action where Network Groups that had no objects would result in action failure
 * 2.0.0 - Combine Cisco Firepower and Cisco Firepower Management Center plugins
 * 1.2.0 - New actions - Check If Address in Group, Add Address to Group, Remove Address from Group
 * 1.1.0 - New actions - Create Address Object, Delete Address Object

--- a/plugins/cisco_firepower_management_center/icon_cisco_firepower_management_center/actions/add_address_to_group/action.py
+++ b/plugins/cisco_firepower_management_center/icon_cisco_firepower_management_center/actions/add_address_to_group/action.py
@@ -38,8 +38,7 @@ class AddAddressToGroup(insightconnect_plugin_runtime.Action):
         required_field = ["type", "id", "name"]
         for field in required_field:
             new_address_object[field] = address_object.get(field)
-
-        address_group["objects"].append(new_address_object)
+        address_group.setdefault("objects", []).append(new_address_object)
         address_group.pop("links", None)
 
         return address_group

--- a/plugins/cisco_firepower_management_center/plugin.spec.yaml
+++ b/plugins/cisco_firepower_management_center/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: community
 status: []
 description: This plugin utilizes Cisco Firepower Management Center to create URL block policies and manage address objects to block hosts
-version: 2.0.0
+version: 2.0.1
 supported_versions: ["6.6.0"]
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/cisco_firepower_management_center

--- a/plugins/cisco_firepower_management_center/requirements.txt
+++ b/plugins/cisco_firepower_management_center/requirements.txt
@@ -3,5 +3,5 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 fmcapi==20211214.0
 validators==0.18.2
-pyOpenSSL==21.0.0
+pyOpenSSL==23.0.0
 parameterized==0.8.1

--- a/plugins/cisco_firepower_management_center/setup.py
+++ b/plugins/cisco_firepower_management_center/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="cisco_firepower_management_center-rapid7-plugin",
-      version="2.0.0",
+      version="2.0.1",
       description="This plugin utilizes Cisco Firepower Management Center to create URL block policies and manage address objects to block hosts",
       author="rapid7",
       author_email="",

--- a/plugins/cisco_firepower_management_center/unit_test/parameters/add_address_to_group.json.resp
+++ b/plugins/cisco_firepower_management_center/unit_test/parameters/add_address_to_group.json.resp
@@ -294,6 +294,40 @@
           }
         }
       }
+    ],
+    [
+      "no_objects",
+      "example.com",
+      "Test_Group_Empty",
+      {
+        "network_group": {
+          "links": {
+            "self": "https://example.com/api/fmc_config/v1/domain/44d88612-fea8-a8f3-6de8-2e1278abb02f/object/networkgroups/00000000-0000-0000-0000-000000000001"
+          },
+          "type": "NetworkGroup",
+          "objects": [
+            {
+              "type": "FQDN",
+              "name": "example1.com",
+              "id": "00000000-0000-0ed3-0000-017179870402"
+            }
+          ],
+          "overridable": "False",
+          "name": "Test_Group_Empty",
+          "id": "00000000-0000-0000-0000-000000000001",
+          "metadata": {
+            "timestamp": 0,
+            "lastUser": {
+              "name": "admin"
+            },
+            "domain": {
+              "name": "Global",
+              "id": "44d88612-fea8-a8f3-6de8-2e1278abb02f",
+              "type": "Domain"
+            }
+          }
+        }
+      }
     ]
   ]
 }

--- a/plugins/cisco_firepower_management_center/unit_test/responses/add_address_to_group_empty_objects.json.resp
+++ b/plugins/cisco_firepower_management_center/unit_test/responses/add_address_to_group_empty_objects.json.resp
@@ -1,0 +1,27 @@
+{
+  "links": {
+    "self": "https://example.com/api/fmc_config/v1/domain/44d88612-fea8-a8f3-6de8-2e1278abb02f/object/networkgroups/00000000-0000-0000-0000-000000000001"
+  },
+  "type": "NetworkGroup",
+  "objects": [
+    {
+      "type": "FQDN",
+      "name": "example1.com",
+      "id": "00000000-0000-0ed3-0000-017179870402"
+    }
+  ],
+  "overridable": "False",
+  "name": "Test_Group_Empty",
+  "id": "00000000-0000-0000-0000-000000000001",
+  "metadata": {
+    "timestamp": 0,
+    "lastUser": {
+      "name": "admin"
+    },
+    "domain": {
+      "name": "Global",
+      "id": "44d88612-fea8-a8f3-6de8-2e1278abb02f",
+      "type": "Domain"
+    }
+  }
+}

--- a/plugins/cisco_firepower_management_center/unit_test/responses/get_address_groups.json.resp
+++ b/plugins/cisco_firepower_management_center/unit_test/responses/get_address_groups.json.resp
@@ -83,6 +83,27 @@
           "type": "Domain"
         }
       }
+    },
+    {
+      "links": {
+        "self": "https://example.com/api/fmc_config/v1/domain/44d88612-fea8-a8f3-6de8-2e1278abb02f/object/networkgroups/00000000-0000-0000-0000-000000000003"
+      },
+      "type": "NetworkGroup",
+      "overridable": "False",
+      "description": " ",
+      "name": "Test_Group_Empty",
+      "id": "00000000-0000-0000-0000-000000000003",
+      "metadata": {
+        "timestamp": 1645465669233,
+        "lastUser": {
+          "name": "admin"
+        },
+        "domain": {
+          "name": "Global",
+          "id": "44d88612-fea8-a8f3-6de8-2e1278abb02f",
+          "type": "Domain"
+        }
+      }
     }
   ],
   "paging": {

--- a/plugins/cisco_firepower_management_center/unit_test/util.py
+++ b/plugins/cisco_firepower_management_center/unit_test/util.py
@@ -140,6 +140,11 @@ class Util:
             return MockResponse("add_address_to_group", 200)
         if (
             args[1]
+            == "https://example.com/api/fmc_config/v1/domain/44d88612-fea8-a8f3-6de8-2e1278abb02f/object/networkgroups/00000000-0000-0000-0000-000000000003"
+        ):
+            return MockResponse("add_address_to_group_empty_objects", 200)
+        if (
+            args[1]
             == "https://example.com/api/fmc_config/v1/domain/44d88612-fea8-a8f3-6de8-2e1278abb02f/object/networkgroups/00000000-0000-0000-0000-000000000002"
         ):
             return MockResponse("remove_address_from_group", 200)


### PR DESCRIPTION
…Key Error) (#1564)

* Set default "objects" in address_group in action AddAddressToGroup

* Update help.md version

* Update pyOpenSSL version

* Update Unit Test

## Proposed Changes

### Description

Describe the proposed changes:

  - Prevent Key Error in Group with no Address Objects when adding Address Object to Group

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
