### PR TITLE
Release Insight Agent - Fix incorrect behavior for unquarantine when the agent ID is wrong

### DIFF
--- a/plugins/rapid7_insight_agent/.CHECKSUM
+++ b/plugins/rapid7_insight_agent/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a63c10548a751a711a58fe7c23b78c2a",
-	"manifest": "e85356effd1e15e9fe426dd3511d0a0d",
-	"setup": "7a781c53259d9250f52a3cb740803398",
+	"spec": "08d8bc61f3baccd06bcdcd766e953a22",
+	"manifest": "9b20bf1aa9d0cf8e982b79b7d8972443",
+	"setup": "46125175ec1dd04d01f6a5b973a3616a",
 	"schemas": [
 		{
 			"identifier": "check_agent_status/schema.py",

--- a/plugins/rapid7_insight_agent/bin/icon_rapid7_insight_agent
+++ b/plugins/rapid7_insight_agent/bin/icon_rapid7_insight_agent
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 Insight Agent"
 Vendor = "rapid7"
-Version = "1.1.0"
+Version = "1.1.1"
 Description = "Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization"
 
 

--- a/plugins/rapid7_insight_agent/help.md
+++ b/plugins/rapid7_insight_agent/help.md
@@ -204,6 +204,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.1.1 - Quarantine: Fix incorrect behavior for unquarantine when the agent ID is wrong
 * 1.1.0 - Cloud enabled
 * 1.0.4 - Add new supported regions for API | Create unit tests for actions Check Agent Status, Quarantine, Get Agent Details  
 * 1.0.3 - Documentation update

--- a/plugins/rapid7_insight_agent/icon_rapid7_insight_agent/util/graphql_api/api_connection.py
+++ b/plugins/rapid7_insight_agent/icon_rapid7_insight_agent/util/graphql_api/api_connection.py
@@ -63,6 +63,18 @@ class ApiConnection:
 
         :return: boolean
         """
+
+        # Check if agent with ID exists
+        payload = {
+            "query": "query( $orgID: String! $agentID: String! ) { assets( orgId: $orgID ids: [$agentID] ){ agent { id quarantineState{ currentState } agentStatus } } }",
+            "variables": {"orgID": self.org_key, "agentID": agent_id},
+        }
+        results_object = self._post_payload(payload)
+        agent = results_object.get("data").get("assets")[0].get("agent")
+        if not agent:
+            return False
+
+        # if exists then unquarantine it
         unquarantine_payload = {
             "query": "mutation( $orgID:String! $agentID:String!) { unquarantineAssets( orgId:$orgID assetIds: [$agentID] ) { results { assetId failed } } }",
             "variables": {"orgID": self.org_key, "agentID": agent_id},
@@ -272,7 +284,7 @@ class ApiConnection:
 
         return has_next_page, results_object, next_agents
 
-    def _find_agent_in_agents(self, agents: [dict], agent_input: str, agent_type: str) -> Optional[dict]:
+    def _find_agent_in_agents(self, agents: [dict], agent_input: str, agent_type: str) -> Optional[dict]:  # noqa: C901
         """
         Given a list of agent objects, find the agent that matches our input.
 

--- a/plugins/rapid7_insight_agent/plugin.spec.yaml
+++ b/plugins/rapid7_insight_agent/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insight_agent
 title: Rapid7 Insight Agent
 description: Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization
-version: 1.1.0
+version: 1.1.1
 supported_versions: ["Rapid7 Insight Agent 2022-04-06"]
 vendor: rapid7
 support: rapid7

--- a/plugins/rapid7_insight_agent/setup.py
+++ b/plugins/rapid7_insight_agent/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insight_agent-rapid7-plugin",
-      version="1.1.0",
+      version="1.1.1",
       description="Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix incorrect behavior for unquarantine when the agent ID is wrong

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [X] Screenshot of job output with the plugin changes
- [X] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
