### PR TITLE
[PLGN-123] Jira - Create Issue Failure on Multiple Existing Issue Type

### DIFF
--- a/plugins/jira/.CHECKSUM
+++ b/plugins/jira/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d24d30b277dd4cd355e22d6c89158de3",
-	"manifest": "2eb3ebed255b957cfa9e02ef0b550226",
-	"setup": "685580b3002d0fa82b24ae89dabf0f6f",
+	"spec": "2ec7f27be9297ed44674311c47661f0f",
+	"manifest": "b1c0f6d7eeef9e571dd22c0f53772948",
+	"setup": "dd9374f70a49ecbb4109f132c068e4f3",
 	"schemas": [
 		{
 			"identifier": "assign_issue/schema.py",

--- a/plugins/jira/bin/komand_jira
+++ b/plugins/jira/bin/komand_jira
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Jira"
 Vendor = "rapid7"
-Version = "6.3.0"
+Version = "6.3.1"
 Description = "Automate the creation, search and management of issues, users, and alerting for Jira Software, Jira Server, and Jira ServiceDesk"
 
 

--- a/plugins/jira/help.md
+++ b/plugins/jira/help.md
@@ -1104,6 +1104,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 6.3.1 - Fix Issue Where Create Issue failed when multiple versions of the input Issue Type exists in Jira
 * 6.3.0 - Add PAT authentication scheme for Jira on-prem
 * 6.2.1 - Fix issue in Find Issues action where normalize_user has an attribute error for labels | Changed Dockerfile to don't use slim version
 * 6.2.0 - Fix issue in Get Comments actions where normalize_user is missing the is_cloud argument from client connection

--- a/plugins/jira/komand_jira/util/util.py
+++ b/plugins/jira/komand_jira/util/util.py
@@ -1,6 +1,5 @@
 import logging
 import base64
-from insightconnect_plugin_runtime.exceptions import PluginException
 
 
 def normalize_comment(source, is_cloud=False, logger=logging.getLogger()):

--- a/plugins/jira/plugin.spec.yaml
+++ b/plugins/jira/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: rapid7
 status: []
 description: Automate the creation, search and management of issues, users, and alerting for Jira Software, Jira Server, and Jira ServiceDesk
-version: 6.3.0
+version: 6.3.1
 supported_versions: ["Jira Server 6.0", "Jira (Cloud)", "Jira ServiceDesk (Cloud)"]
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/jira

--- a/plugins/jira/setup.py
+++ b/plugins/jira/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="jira-rapid7-plugin",
-      version="6.3.0",
+      version="6.3.1",
       description="Automate the creation, search and management of issues, users, and alerting for Jira Software, Jira Server, and Jira ServiceDesk",
       author="rapid7",
       author_email="",

--- a/plugins/jira/unit_test/test_create_issue.py
+++ b/plugins/jira/unit_test/test_create_issue.py
@@ -80,12 +80,6 @@ class MockClient:
     def create_issue(self, fields):
         return MockIssue()
 
-    def issue_type_by_name(self, issue_type):
-        if issue_type:
-            pass
-        else:
-            raise KeyError("Issue type was not provided")
-
     def issue_types(self):
         issue_type = {
             "raw": {"name": "Task", "scope": {"type": "PROJECT", "project": {"id": "10000"}}, "id": "10001"},

--- a/plugins/jira/unit_test/test_create_issue.py
+++ b/plugins/jira/unit_test/test_create_issue.py
@@ -86,6 +86,20 @@ class MockClient:
         else:
             raise KeyError("Issue type was not provided")
 
+    def issue_types(self):
+        issue_type = {
+            "raw": {
+                "name": "Task",
+                "scope": {"type": "PROJECT", "project": {"id": "10000"}},
+                "id": "10001"
+            },
+            "name": "Task",
+            "scope": {"type": "PROJECT", "project": {"id": "10000"}},
+            "id": "10001"
+        }
+        issue_type_object = namedtuple("IssueType", issue_type.keys())(*issue_type.values())
+        return [issue_type_object]
+
     def fields(self):
         return client_fields
 
@@ -161,6 +175,24 @@ class TestCreateIssue(TestCase):
         self.test_action.connection = MockConnection()
         with self.assertRaises(PluginException):
             self.test_action.run(action_params)
+
+    def test_create_issue_fake_type_raise_exception(self):
+        action_params = {
+            "attachment_bytes": "",
+            "attachment_filename": "",
+            "description": "A test description",
+            "fields": {},
+            "project": "projectName",
+            "summary": "test Summary",
+            "type": "Fake Task",
+        }
+        cause = "Issue type not known or user doesn't have permissions."
+        assistance = "Talk to your Jira administrator to add the type or delegate necessary permissions, or choose an available type."
+        self.test_action.connection = MockConnection()
+        with self.assertRaises(PluginException) as error:
+            self.test_action.run(action_params)
+        self.assertEqual(cause, error.exception.cause)
+        self.assertEqual(assistance, error.exception.assistance)
 
     def test_create_issue_no_description(self):
         action_params = {
@@ -258,6 +290,8 @@ class TestCreateIssue(TestCase):
         self.test_action.connection = MockConnection()
         with self.assertRaises(PluginException):
             self.test_action.run(action_params)
+
+
 
     # Leave this here, it comes in handy for debugging.
 

--- a/plugins/jira/unit_test/test_create_issue.py
+++ b/plugins/jira/unit_test/test_create_issue.py
@@ -88,14 +88,10 @@ class MockClient:
 
     def issue_types(self):
         issue_type = {
-            "raw": {
-                "name": "Task",
-                "scope": {"type": "PROJECT", "project": {"id": "10000"}},
-                "id": "10001"
-            },
+            "raw": {"name": "Task", "scope": {"type": "PROJECT", "project": {"id": "10000"}}, "id": "10001"},
             "name": "Task",
             "scope": {"type": "PROJECT", "project": {"id": "10000"}},
-            "id": "10001"
+            "id": "10001",
         }
         issue_type_object = namedtuple("IssueType", issue_type.keys())(*issue_type.values())
         return [issue_type_object]
@@ -290,8 +286,6 @@ class TestCreateIssue(TestCase):
         self.test_action.connection = MockConnection()
         with self.assertRaises(PluginException):
             self.test_action.run(action_params)
-
-
 
     # Leave this here, it comes in handy for debugging.
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Create Issue fails when Issue Types that hold the same name in Jira exist. Update to change Issue Type Validation.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
