### PR TITLE
[PLGN-58] - PowerShell password bug fix

### DIFF
--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -14,42 +14,6 @@
 		{
 			"identifier": "connection/schema.py",
 			"hash": "e07a2185f24153dd7ee3e3a1d09f5f4b"
-		},
-		{
-			"identifier": "insightconnect_plugin_runtime/schema.py",
-			"hash": "98e2cf8bf394d0b6f97cdfeb657ea71b"
-		},
-		{
-			"identifier": "marshmallow/schema.py",
-			"hash": "7c9fc22caa77ab8be9957e79867f426a"
-		},
-		{
-			"identifier": "hello/schema.py",
-			"hash": "92ec4b966e523fe43b8d3e1589ecd235"
-		},
-		{
-			"identifier": "return_bad_json/schema.py",
-			"hash": "bb41c13e9e71e212c1545150a16f8b73"
-		},
-		{
-			"identifier": "throw_exception/schema.py",
-			"hash": "7cdacec63e0eaeefc7f0adc5ebbae8ce"
-		},
-		{
-			"identifier": "connection/schema.py",
-			"hash": "f1bf7d508c81c245888665a322d984e8"
-		},
-		{
-			"identifier": "hello_trigger/schema.py",
-			"hash": "6fda62f9b28a899e2ecb7aab1311bbb2"
-		},
-		{
-			"identifier": "return_bad_json_trigger/schema.py",
-			"hash": "9a207816ba5b0ab0f9e4f40d86c4cc3e"
-		},
-		{
-			"identifier": "throw_exception_trigger/schema.py",
-			"hash": "23e4aee31e1c532d9ed50830efad1b8d"
 		}
 	]
 }

--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -14,6 +14,42 @@
 		{
 			"identifier": "connection/schema.py",
 			"hash": "e07a2185f24153dd7ee3e3a1d09f5f4b"
+		},
+		{
+			"identifier": "insightconnect_plugin_runtime/schema.py",
+			"hash": "98e2cf8bf394d0b6f97cdfeb657ea71b"
+		},
+		{
+			"identifier": "marshmallow/schema.py",
+			"hash": "7c9fc22caa77ab8be9957e79867f426a"
+		},
+		{
+			"identifier": "hello/schema.py",
+			"hash": "92ec4b966e523fe43b8d3e1589ecd235"
+		},
+		{
+			"identifier": "return_bad_json/schema.py",
+			"hash": "bb41c13e9e71e212c1545150a16f8b73"
+		},
+		{
+			"identifier": "throw_exception/schema.py",
+			"hash": "7cdacec63e0eaeefc7f0adc5ebbae8ce"
+		},
+		{
+			"identifier": "connection/schema.py",
+			"hash": "f1bf7d508c81c245888665a322d984e8"
+		},
+		{
+			"identifier": "hello_trigger/schema.py",
+			"hash": "6fda62f9b28a899e2ecb7aab1311bbb2"
+		},
+		{
+			"identifier": "return_bad_json_trigger/schema.py",
+			"hash": "9a207816ba5b0ab0f9e4f40d86c4cc3e"
+		},
+		{
+			"identifier": "throw_exception_trigger/schema.py",
+			"hash": "23e4aee31e1c532d9ed50830efad1b8d"
 		}
 	]
 }

--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "0425e2b2daf8c3e06cf1cf2fd8f8e91c",
-	"manifest": "1fa8493bf98110d971bf3e131ca57714",
-	"setup": "908fee8844a5bc2037bac1646b667bc2",
+	"spec": "1975cbdb035046e333e5d6c6cccab38e",
+	"manifest": "41031537795c37b079cc8085e6c104e9",
+	"setup": "ef6ac17dc0c1e5774af2d1ded916ee91",
 	"schemas": [
 		{
 			"identifier": "execute_script/schema.py",

--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1975cbdb035046e333e5d6c6cccab38e",
-	"manifest": "41031537795c37b079cc8085e6c104e9",
-	"setup": "ef6ac17dc0c1e5774af2d1ded916ee91",
+	"spec": "0425e2b2daf8c3e06cf1cf2fd8f8e91c",
+	"manifest": "1fa8493bf98110d971bf3e131ca57714",
+	"setup": "908fee8844a5bc2037bac1646b667bc2",
 	"schemas": [
 		{
 			"identifier": "execute_script/schema.py",

--- a/plugins/powershell/bin/icon_powershell
+++ b/plugins/powershell/bin/icon_powershell
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "PowerShell"
 Vendor = "rapid7"
-Version = "3.0.0"
+Version = "3.0.1"
 Description = "Run a PowerShell script"
 
 

--- a/plugins/powershell/bin/komand_powershell
+++ b/plugins/powershell/bin/komand_powershell
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "PowerShell"
 Vendor = "rapid7"
-Version = "3.0.0"
+Version = "3.0.1"
 Description = "Run a PowerShell script"
 
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -27,8 +27,8 @@ The connection configuration accepts the following parameters. SSL is enforced f
 |credentials|credential_username_password|None|False|Username and password|None|{"username": "user", "password": "mypassword"}|
 |kerberos|kerberos|None|False|Connection information required for Kerberos|None| {"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}|
 |port|integer|5986|False|Port number, defaults are 5986 for SSL and 5985 for unencrypted|None|5986|
-|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as powershell variable (`$secret_key`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|script_username_and_password|credential_username_password|None|False|Username and password available in script as powershell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}|
+|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as PowerShell variable (`$secretKey`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}||script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables |None|{"username": "user", "password": "mypassword"}|
 
 Example input:
 
@@ -65,9 +65,9 @@ This action is used to execute PowerShell script in the form of a string.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
-|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 
 Example input:
 
@@ -103,9 +103,9 @@ This action is used to execute PowerShell script encoded as a base64 file on a r
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
-|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 
 Example input:
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -65,9 +65,9 @@ This action is used to execute PowerShell script in the form of a string.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
-|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 
 Example input:
 
@@ -103,9 +103,9 @@ This action is used to execute PowerShell script encoded as a base64 file on a r
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
-|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 
 Example input:
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -187,6 +187,7 @@ Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw
 
 # Version History
 
+* 3.0.1 - Bug fix - Fix issue where single quotes in password causes parsing error
 * 3.0.0 - Move custom script credentials to Connection | Update runtime to insightconnect_plugin_runtime
 * 2.2.0 - Add custom credentials in Execute Script and PowerShell String actions | Update plugin to allow unencrypted connections when connection is targeting port 5985
 * 2.1.4 - Update `docs_url` in plugin spec with a new link to [plugin setup guide](https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/)

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -10,6 +10,7 @@
 
 * For local Orchestrator execution, ensure connectivity to any network resources the script will use
 * For remote server execution, a PowerShell-enabled server and administrative credentials
+* When adding a password for the script, try to avoid special or escape characters such as single or double quotes
 
 # Supported Product Versions
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -27,8 +27,8 @@ The connection configuration accepts the following parameters. SSL is enforced f
 |credentials|credential_username_password|None|False|Username and password|None|{"username": "user", "password": "mypassword"}|
 |kerberos|kerberos|None|False|Connection information required for Kerberos|None| {"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}|
 |port|integer|5986|False|Port number, defaults are 5986 for SSL and 5985 for unencrypted|None|5986|
-|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as PowerShell variable (`$secretKey`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}||script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables |None|{"username": "user", "password": "mypassword"}|
+|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as powershell variable (`$secret_key`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|script_username_and_password|credential_username_password|None|False|Username and password available in script as powershell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}|
 
 Example input:
 
@@ -65,9 +65,9 @@ This action is used to execute PowerShell script in the form of a string.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 
 Example input:
 
@@ -103,9 +103,9 @@ This action is used to execute PowerShell script encoded as a base64 file on a r
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 
 Example input:
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -65,9 +65,9 @@ This action is used to execute PowerShell script in the form of a string.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 
 Example input:
 
@@ -103,9 +103,9 @@ This action is used to execute PowerShell script encoded as a base64 file on a r
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 
 Example input:
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -27,8 +27,8 @@ The connection configuration accepts the following parameters. SSL is enforced f
 |credentials|credential_username_password|None|False|Username and password|None|{"username": "user", "password": "mypassword"}|
 |kerberos|kerberos|None|False|Connection information required for Kerberos|None| {"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}|
 |port|integer|5986|False|Port number, defaults are 5986 for SSL and 5985 for unencrypted|None|5986|
-|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as PowerShell variable (`$secretKey`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}||script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables |None|{"username": "user", "password": "mypassword"}|
+|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as powershell variable (`$secret_key`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|script_username_and_password|credential_username_password|None|False|Username and password available in script as powershell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}|
 
 Example input:
 
@@ -65,9 +65,9 @@ This action is used to execute PowerShell script in the form of a string.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 
 Example input:
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -27,8 +27,8 @@ The connection configuration accepts the following parameters. SSL is enforced f
 |credentials|credential_username_password|None|False|Username and password|None|{"username": "user", "password": "mypassword"}|
 |kerberos|kerberos|None|False|Connection information required for Kerberos|None| {"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}|
 |port|integer|5986|False|Port number, defaults are 5986 for SSL and 5985 for unencrypted|None|5986|
-|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as powershell variable (`$secret_key`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|script_username_and_password|credential_username_password|None|False|Username and password available in script as powershell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}|
+|script_secret_key|credential_secret_key|None|False|Credential secret key available in script as PowerShell variable (`$secretKey`)|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables (`$username`, `$password`)|None|{"username": "user", "password": "mypassword"}||script_username_and_password|credential_username_password|None|False|Username and password available in script as PowerShell variables |None|{"username": "user", "password": "mypassword"}|
 
 Example input:
 
@@ -65,9 +65,9 @@ This action is used to execute PowerShell script in the form of a string.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.17|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
-|script|string|None|True|PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|Get-Date|
 
 Example input:
 
@@ -103,9 +103,9 @@ This action is used to execute PowerShell script encoded as a base64 file on a r
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
+|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
-|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 
 Example input:
 
@@ -119,10 +119,10 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|stderr|string|False|PowerShell standard error|
-|stdout|string|False|PowerShell standard output|
+|Name|Type|Required|Description|Example|
+|----|----|--------|-----------|--------|
+|stderr|string|False|PowerShell standard error|Fatal error.|
+|stdout|string|False|PowerShell standard output|Tuesday, January 11, 2022 5:05:42 AM|
 
 Example output:
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -103,9 +103,9 @@ This action is used to execute PowerShell script encoded as a base64 file on a r
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 |address|string|None|False|IP address of the remote host e.g. 192.168.1.1. If address is left blank PowerShell will run locally|None|10.0.1.15|
 |host_name|string|None|False|Case-sensitive name of the remote host, eg. MyComputer for Kerberos connection only|None|windows|
+|script|bytes|None|True|PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection|None|R2V0LURhdGU=|
 
 Example input:
 
@@ -119,10 +119,10 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|--------|
-|stderr|string|False|PowerShell standard error|Fatal error.|
-|stdout|string|False|PowerShell standard output|Tuesday, January 11, 2022 5:05:42 AM|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|stderr|string|False|PowerShell standard error|
+|stdout|string|False|PowerShell standard output|
 
 Example output:
 

--- a/plugins/powershell/icon_powershell/util/util.py
+++ b/plugins/powershell/icon_powershell/util/util.py
@@ -302,7 +302,7 @@ def add_credentials_to_script(powershell_script: str, credentials: dict) -> str:
     if username:
         credentials_definition += f"$username = '{username}'\n"
     if password:
-        credentials_definition += f'$password = "{password}" | ConvertTo-SecureString -asPlainText -Force\n'
+        credentials_definition += f"$password = '{password}' | ConvertTo-SecureString -asPlainText -Force\n"
     if secret_key:
         credentials_definition += f"$secret_key = '{secret_key}'\n"
 

--- a/plugins/powershell/icon_powershell/util/util.py
+++ b/plugins/powershell/icon_powershell/util/util.py
@@ -298,7 +298,7 @@ def add_credentials_to_script(powershell_script: str, credentials: dict) -> str:
     if username:
         credentials_definition += f"$username = '{username}'\n"
     if password:
-        credentials_definition += f"$password = '{password}' | ConvertTo-SecureString -asPlainText -Force\n"
+        credentials_definition += f'$password = "{password}" | ConvertTo-SecureString -asPlainText -Force\n'
     if secret_key:
         credentials_definition += f"$secret_key = '{secret_key}'\n"
 

--- a/plugins/powershell/icon_powershell/util/util.py
+++ b/plugins/powershell/icon_powershell/util/util.py
@@ -79,7 +79,11 @@ def run_powershell_script(
         stdout = action.safe_encode(stdout)
     if stderr:
         stderr = action.safe_encode(stderr)
-
+    if "ParserError" in stderr:
+        raise PluginException(
+            cause="Error parsing script.",
+            assistance="Refer to help.md. Ensure you are not using special characters such as quotes in your password.",
+        )
     return {"stdout": stdout, "stderr": stderr}
 
 

--- a/plugins/powershell/plugin.spec.yaml
+++ b/plugins/powershell/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: powershell
 title: PowerShell
 description: Run a PowerShell script
-version: 3.0.0
+version: 3.0.1
 supported_versions: ["PowerShell 6.1.2"]
 vendor: rapid7
 support: community

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -4,3 +4,4 @@
 git+https://github.com/komand/pywinrm.git@v0.3.1dev0#pywinrm
 requests-kerberos==0.12.0
 requests-credssp==1.1.0
+parameterized      0.8.1

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -4,4 +4,4 @@
 git+https://github.com/komand/pywinrm.git@v0.3.1dev0#pywinrm
 requests-kerberos==0.12.0
 requests-credssp==1.1.0
-parameterized      0.8.1
+parameterized==0.8.1

--- a/plugins/powershell/setup.py
+++ b/plugins/powershell/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="powershell-rapid7-plugin",
-      version="3.0.0",
+      version="3.0.1",
       description="Run a PowerShell script",
       author="rapid7",
       author_email="",

--- a/plugins/powershell/unit_test/test_util.py
+++ b/plugins/powershell/unit_test/test_util.py
@@ -18,9 +18,7 @@ class TestUtil(TestCase):
                 "new_username",
                 "new_password",
                 "new_secret_key",
-                "$username = 'new_username'"
-                + '\n$password = "new_password"'
-                + " | ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
+                "$username = 'new_username'\n$password = 'new_password' | ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
             ),
         ]
     )

--- a/plugins/powershell/unit_test/test_util.py
+++ b/plugins/powershell/unit_test/test_util.py
@@ -6,9 +6,7 @@ sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from parameterized import parameterized
 
-# from unit_test.util import Util
 from icon_powershell.util.util import add_credentials_to_script
-# from icon_powershell.actions.powershell_string.schema import Input
 
 
 class TestUtil(TestCase):

--- a/plugins/powershell/unit_test/test_util.py
+++ b/plugins/powershell/unit_test/test_util.py
@@ -20,7 +20,7 @@ class TestUtil(TestCase):
                 "new_username",
                 "new_password",
                 "new_secret_key",
-                "$username = 'new_username'\n$password = 'new_password' | ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
+                "$username = 'new_username'" + '\n$password = "new_password"' + "| ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
             ),
         ]
     )

--- a/plugins/powershell/unit_test/test_util.py
+++ b/plugins/powershell/unit_test/test_util.py
@@ -6,9 +6,9 @@ sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from parameterized import parameterized
 
-from unit_test.util import Util
+# from unit_test.util import Util
 from icon_powershell.util.util import add_credentials_to_script
-from icon_powershell.actions.powershell_string.schema import Input
+# from icon_powershell.actions.powershell_string.schema import Input
 
 
 class TestUtil(TestCase):
@@ -22,7 +22,7 @@ class TestUtil(TestCase):
                 "new_secret_key",
                 "$username = 'new_username'"
                 + '\n$password = "new_password"'
-                + "| ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
+                + " | ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
             ),
         ]
     )

--- a/plugins/powershell/unit_test/test_util.py
+++ b/plugins/powershell/unit_test/test_util.py
@@ -20,7 +20,9 @@ class TestUtil(TestCase):
                 "new_username",
                 "new_password",
                 "new_secret_key",
-                "$username = 'new_username'" + '\n$password = "new_password"' + "| ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
+                "$username = 'new_username'"
+                + '\n$password = "new_password"'
+                + "| ConvertTo-SecureString -asPlainText -Force\n$secret_key = 'new_secret_key'\nfirst line\nsecond line",
             ),
         ]
     )


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix issue where single quotes in script password causes parsing error

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
