### PR TITLE
[PLGN-133] Solarwinds - updated id outputs as integers to line up with expected inputs

### DIFF
--- a/plugins/samanage/.CHECKSUM
+++ b/plugins/samanage/.CHECKSUM
@@ -1,19 +1,19 @@
 {
-	"spec": "9a19470246bb70539077dfbf4cab8f7e",
+	"spec": "6f730a8050404e5d598b6a11f7322755",
 	"manifest": "6a68cb31feae4a8775c16672e9f10328",
 	"setup": "d6979aff362bd571a3905d51c4f60d5f",
 	"schemas": [
 		{
 			"identifier": "assign_incident/schema.py",
-			"hash": "8084a86d8cadfc40384cc0ca9f15295c"
+			"hash": "a6c9d7097d8c8bbfdf20b3502adfcb01"
 		},
 		{
 			"identifier": "attach_incident/schema.py",
-			"hash": "ea6a5c87ab60e9786b7b1fed1199b22e"
+			"hash": "4c345a785af289a4610de771803a7196"
 		},
 		{
 			"identifier": "change_incident_state/schema.py",
-			"hash": "5eb33c08cd00a7fc410eef279deba18a"
+			"hash": "5f37409a77bbff5536c8968ba3a83679"
 		},
 		{
 			"identifier": "comment_incident/schema.py",
@@ -21,11 +21,11 @@
 		},
 		{
 			"identifier": "create_incident/schema.py",
-			"hash": "4cb9f0355803053285448117292c3022"
+			"hash": "ac83556a0310efa7e961df55175925a2"
 		},
 		{
 			"identifier": "create_user/schema.py",
-			"hash": "f7c3f5e77cc65ba8fa84843fad9cc89c"
+			"hash": "07a168fd9b9834f98a4313631456f811"
 		},
 		{
 			"identifier": "delete_incident/schema.py",
@@ -41,19 +41,19 @@
 		},
 		{
 			"identifier": "get_incident/schema.py",
-			"hash": "97728b14d06dec0a3c86e7255287ef5c"
+			"hash": "29b8a41decd4f03a1f79bfc881702e52"
 		},
 		{
 			"identifier": "list_incidents/schema.py",
-			"hash": "f25d854752671ad20625534ecddf4bd9"
+			"hash": "37a34902e405ed310204388d0a8d7876"
 		},
 		{
 			"identifier": "list_users/schema.py",
-			"hash": "867f241055b817b096f7e77a7d5515a7"
+			"hash": "a940d2999157c1ece3fb4b90460eafb8"
 		},
 		{
 			"identifier": "tag_incident/schema.py",
-			"hash": "327bc9c3d622527b9f6483a0dd03caa0"
+			"hash": "94dd47b2bc04ea1efc7383e91bec3b49"
 		},
 		{
 			"identifier": "connection/schema.py",
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "new_incidents/schema.py",
-			"hash": "a768e6585b807614ebdff9c162de1c27"
+			"hash": "5f999a6a55e02ce66d35f67b0092ddaf"
 		}
 	]
 }

--- a/plugins/samanage/help.md
+++ b/plugins/samanage/help.md
@@ -18,7 +18,7 @@ This plugin utilizes the [Solarwinds Service desk API](https://www.samanage.com/
 
 # Supported Product Versions
 
-* Solarwinds Service Desk with API version 2.1
+* API version 2.1
 
 # Documentation
 
@@ -66,51 +66,51 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident|incident|True|Updated incident|{'id': '10000', 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incident|incident|True|Updated incident|{'id': 10000, 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
 
 Example output:
 ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
-      "id": "1000",
+      "id": 1000,
       "name": "Equipment",
       "default_tags": "",
       "parent_id": "10000",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -120,9 +120,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -134,16 +134,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -161,37 +161,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
@@ -211,7 +211,7 @@ This action is used to create a new incident.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|assignee|string|None|False|Email of the assignee|None|user@example.com|
+|assignee|string|None|False|Email of the assignee|None|https://example.com|
 |category_name|string|None|False|Name of the category for the new incident|None|test|
 |description|string|None|False|Description|None|Description example|
 |due_at|date|None|False|Due at|None|02-02-2022|
@@ -219,7 +219,7 @@ This action is used to create a new incident.
 |name|string|None|True|Name|None|Example name|
 |priority|string|None|True|Priority|['None', 'Low', 'Medium', 'High', 'Critical']|Low|
 |problem|integer|None|False|Number of a problem associated with the new incident|None|1234|
-|requester|string|None|True|Email of the requester|None|user@example.com|
+|requester|string|None|True|Email of the requester|None|user@example.com|', '|assignee|string|None|False|Email of the assignee|None|user@example.com|
 |solutions|[]integer|None|False|List of numbers of solutions associated with the new incident|None|[123, 456]|
 
 Example input:
@@ -247,52 +247,52 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident|incident|True|Newly created incident|{'id': '10000', 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incident|incident|True|Newly created incident|{'id': 10000, 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
 
 Example output:
 
 ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
-      "id": "1000",
+      "id": 1000,
       "name": "Equipment",
       "default_tags": "",
-      "parent_id": "10000",
-      "default_assignee_id": "1"
+      "parent_id": 10000,
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -302,9 +302,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -316,16 +316,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -343,37 +343,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
@@ -405,8 +405,8 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
 |success|boolean|True|Was the operation successful?|True|
 
 Example output:
@@ -441,52 +441,52 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident|incident|True|Incident with new tags|{'id': '10000', 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New', 'tag_list': 'tag1'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incident|incident|True|Incident with new tags|{'id': 10000, 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New', 'tag_list': 'tag1'}|
 
 Example output:
 
 ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
-      "id": "1000",
+      "id": 1000,
       "name": "Equipment",
       "default_tags": "",
-      "parent_id": "10000",
-      "default_assignee_id": "1"
+      "parent_id": 10000,
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -496,9 +496,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -510,16 +510,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -537,37 +537,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
@@ -589,9 +589,9 @@ _This action does not contain any inputs._
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incidents|[]incident|True|List of all incidents|[{"id": "10000", "number": "1000", "name": "Incident Name", "description": "description", "state": "New"}]|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incidents|[]incident|True|List of all incidents|[{"id": 10000, "number": "1000", "name": "Incident Name", "description": "description", "state": "New"}]|
 
 Example output:
 
@@ -601,43 +601,43 @@ Example output:
     ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
       "id": "1000",
       "name": "Equipment",
       "default_tags": "",
-      "parent_id": "10000",
-      "default_assignee_id": "1"
+      "parent_id": 10000,
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -647,9 +647,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -661,16 +661,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -688,37 +688,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
@@ -740,22 +740,21 @@ _This action does not contain any inputs._
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|users|[]solarwinds_user|True|A list of all users|[{"id": "10000", "name": "Example User", "title": "Support Agent", "disabled": False, "email": "user@example.com", "created_at": "2030-01-01T00:00:00.000+00:00", "phone": "(800) 555-0100", "mobile_phone": "(800) 555-0100"}]|
-Example output:
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|users|[]solarwinds_user|True|A list of all users|[{"id": 10000, "name": "Example User", "title": "Support Agent", "disabled": False, "email": "user@example.com", "created_at": "2030-01-01T00:00:00.000+00:00", "phone": "(800) 555-0100", "mobile_phone": "(800) 555-0100"}]|
 
 ```
 {
   "users": [
     {
-      "id": "4245115",
+      "id": 4245115,
       "name": "Example User",
       "disabled": false,
       "email": "user@example.com",
       "created_at": "2018-11-22T08:13:00.000-05:00",
       "role": {
-        "id": "461180",
+        "id": 461180,
         "name": "Requester",
         "description": "Requester role to view and submit service request.",
         "portal": true,
@@ -763,7 +762,7 @@ Example output:
       },
       "salt": "04f20390ecf0c97571167c6c3350782663b6a7e0",
       "group_ids": [
-        "4492327"
+        4492327
       ],
       "custom_fields_values": [],
       "avatar": {
@@ -783,12 +782,12 @@ Example output:
       "phone": "12345678",
       "mobile_phone": "87654321",
       "department": {
-        "id": "133361",
+        "id": 133361,
         "name": "Information Technology",
         "default_assignee_id": "4485265"
       },
       "role": {
-        "id": "461179",
+        "id": 461179,
         "name": "Service Agent User",
         "description": "Almost like an administrator but no access to setup.",
         "portal": false,
@@ -796,7 +795,7 @@ Example output:
       },
       "salt": "b3e360e65de5b592ce1ff92e1d90acedbaddbcf7",
       "group_ids": [
-        "4491226"
+        4491226
       ],
       "custom_fields_values": [],
       "avatar": {
@@ -806,7 +805,7 @@ Example output:
       },
       "mfa_enabled": false,
       "reports_to": {
-        "id": "4485266",
+        "id": 4485266,
         "name": "Helpdesk",
         "disabled": false,
         "is_user": false,
@@ -816,13 +815,13 @@ Example output:
         }
       },
       "site": {
-        "id": "96691",
+        "id": 96691,
         "name": "Headquarters",
         "location": "Main Office"
       }
     },
     {
-      "id": "4238379",
+      "id": 4238379,
       "name": "Example User",
       "disabled": false,
       "email": "user@example.com",
@@ -830,7 +829,7 @@ Example output:
       "last_login": "2018-11-21T17:20:46.000-05:00",
       "phone": "(800) 555-0100",
       "role": {
-        "id": "461178",
+        "id": 461178,
         "name": "Administrator",
         "description": "This is the all powerful administrator user!",
         "portal": false,
@@ -838,8 +837,8 @@ Example output:
       },
       "salt": "7e2c35f51cc6ccdf727f7e48bc42403adbf6534d",
       "group_ids": [
-        "4485265",
-        "4485266"
+        4485265,
+        4485266
       ],
       "custom_fields_values": [],
       "avatar": {
@@ -873,52 +872,52 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident|incident|True|Details of an incident with the given ID|{'id': '10000', 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incident|incident|True|Details of an incident with the given ID|{'id': 10000, 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
 
 Example output:
 
 ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
-      "id": "1000",
+      "id": 1000,
       "name": "Equipment",
       "default_tags": "",
-      "parent_id": "10000",
-      "default_assignee_id": "1"
+      "parent_id": 10000,
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -928,9 +927,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -942,16 +941,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -969,37 +968,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
@@ -1031,8 +1030,8 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
 |success|boolean|True|Was the operation successful?|True|
 
 Example output:
@@ -1050,7 +1049,7 @@ This action is used to create a new user.
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|------|
+|----|----|-------|--------|-----------|----|-------|
 |department|string|None|False|Department|None|Marketing|
 |email|string|None|True|Email address|None|user@example.com|
 |mobile_phone|string|None|False|Mobile phone number|None|(800) 555-0100|
@@ -1065,19 +1064,19 @@ Example input:
 {
   "department": "Marketing",
   "email": "user@example.com",
-  "mobile_phone": "+10000000",
+  "mobile_phone": "(800) 555-0100",
   "name": "Example User",
-  "phone": 10000000,
-  "role": "Administrator"
+  "phone": "(800) 555-0100",
+  "role": "Requester",
+  "site": "Boston"
 }
 ```
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|user|solarwinds_user|True|Newly created user|{'id': '10000', 'name': 'Example User', 'title': 'Support Agent', 'disabled': False, 'email': 'user@example.com', 'created_at': '2030-01-01T00:00:00.000+00:00', 'phone': '(800) 555-0100', 'mobile_phone': '(800) 555-0100'}|
-Example output:
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|user|solarwinds_user|True|Newly created user|{'id': 10000, 'name': 'Example User', 'title': 'Support Agent', 'disabled': False, 'email': 'user@example.com', 'created_at': '2030-01-01T00:00:00.000+00:00', 'phone': '(800) 555-0100', 'mobile_phone': '(800) 555-0100'}|
 
 ```
 {
@@ -1090,18 +1089,18 @@ Example output:
     "phone": "123456",
     "mobile_phone": "0012345",
     "department": {
-      "id": "133365",
+      "id": 133365,
       "name": "Marketing"
     },
     "role": {
-      "id": "461182",
+      "id": 461182,
       "name": "Read Only",
       "portal": false,
       "show_my_tasks": false
     },
     "salt": "fc136bca03c6361bf1e564e18d70cc421b1fc582",
     "group_ids": [
-      "4492546"
+      4492546
     ],
     "custom_fields_values": [],
     "avatar": {
@@ -1134,9 +1133,9 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|comments|[]solarwinds_comment|True|All comments of an incident|[{"id": "1", "body": "Comment body", "is_private": "true", "created_at": "2025-01-01T00:00:00.000+01:00", "updated_at": "2025-01-01T00:00:00.000+01:00", "user": {}, "commenter_id": "1", "commenter_type": "Incident"}]|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|comments|[]solarwinds_comment|True|All comments of an incident|[{"id": 1, "body": "Comment body", "is_private": "true", "created_at": "2025-01-01T00:00:00.000+01:00", "updated_at": "2025-01-01T00:00:00.000+01:00", "user": {}, "commenter_id": 1, "commenter_type": "Incident"}]|
 
 Example output:
 
@@ -1147,7 +1146,7 @@ Example output:
       "id": 39639360,
       "body": "<p>Comment comment comment</p>",
       "user": {
-        "id": "423837",
+        "id": 423837,
         "name": "Example User",
         "disabled": false,
         "email": "user@example.com",
@@ -1155,7 +1154,7 @@ Example output:
         "last_login": "2018-11-21T17:20:46.000-05:00",
         "phone": "(800) 555-0100",
         "role": {
-          "id": "461178",
+          "id": 461178,
           "name": "Administrator",
           "description": "Test description",
           "portal": false,
@@ -1163,8 +1162,8 @@ Example output:
         },
         "salt": "9de5069c5afe602b2ea0a04b66beb2c0",
         "group_ids": [
-          "4485265",
-          "4485266"
+          4485265,
+          4485266
         ],
         "custom_fields_values": [],
         "avatar": {
@@ -1185,14 +1184,14 @@ Example output:
       ],
       "isTask": false,
       "task_info": {},
-      "commenter_id": "31851783",
+      "commenter_id": 3185178,
       "commenter_type": "Incident"
     },
     {
-      "id": "39646936",
+      "id": 39646936,
       "body": "A comment",
       "user": {
-        "id": "4238379",
+        "id": 4238379,
         "name": "Example User",
         "disabled": false,
         "email": "user@example.com",
@@ -1200,7 +1199,7 @@ Example output:
         "last_login": "2018-11-21T17:20:46.000-05:00",
         "phone": "(800) 555-0100",
         "role": {
-          "id": "461178",
+          "id": 461178,
           "name": "Administrator",
           "description": "Test Description",
           "portal": false,
@@ -1208,8 +1207,8 @@ Example output:
         },
         "salt": "7e2c35f51cc6ccdf727f7e48bc42403adbf6534d",
         "group_ids": [
-          "4485265",
-          "4485266"
+          4485265,
+          4485266
         ],
         "custom_fields_values": [],
         "avatar": {
@@ -1230,7 +1229,7 @@ Example output:
       ],
       "isTask": false,
       "task_info": {},
-      "commenter_id": "31851783",
+      "commenter_id": 31851783,
       "commenter_type": "Incident"
     }
   ]
@@ -1261,10 +1260,9 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|attachment|solarwinds_attachment|True|Newly created attachment|{'id': '27211951', 'content_type': 'text/plain', 'size': 12, 'filename': 'Hello.txt', 'url': 'https://example.com', 'shared_attachment': False, 'attachable_id': 31851783, 'attachable_type': 'Incident', 'attachment_type': 'attachment'}|
-Example output:
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|attachment|solarwinds_attachment|True|Newly created attachment|{'id': 27211951, 'content_type': 'text/plain', 'size': 12, 'filename': 'Hello.txt', 'url': 'https://example.com', 'shared_attachment': False, 'attachable_id': 31851783, 'attachable_type': 'Incident', 'attachment_type': 'attachment'}|
 
 ```
 {
@@ -1309,24 +1307,24 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|comment|solarwinds_comment|True|Newly created comment|{'id': '1', 'body': 'Comment body', 'is_private': 'true', 'created_at': '2025-01-01T00:00:00.000+01:00', 'updated_at': '2025-01-01T00:00:00.000+01:00', 'user': {}, 'commenter_id': '1', 'commenter_type': 'Incident'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|comment|solarwinds_comment|True|Newly created comment|{'id': 1, 'body': 'Comment body', 'is_private': 'true', 'created_at': '2025-01-01T00:00:00.000+01:00', 'updated_at': '2025-01-01T00:00:00.000+01:00', 'user': {}, 'commenter_id': 1, 'commenter_type': 'Incident'}|
 
 Example output:
 
 ```
 {
   "comment": {
-    "id": "1",
+    "id": 1,
     "body": "Comment body",
     "is_private": "true",
     "created_at": "2025-01-01T00:00:00.000+01:00",
     "updated_at": "2025-01-01T00:00:00.000+01:00",
     "user": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -1336,7 +1334,7 @@ Example output:
         "initials": "EU"
       }
     },
-    "commenter_id": "1",
+    "commenter_id": 1,
     "commenter_type": "Incident"
   }
 }
@@ -1364,52 +1362,52 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident|incident|True|Updated incident|{'id': '10000', 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'Assigned'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incident|incident|True|Updated incident|{'id': 10000, 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'Assigned'}|
 
 Example output:
 
 ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
-      "id": "1000",
+      "id": 1000,
       "name": "Equipment",
       "default_tags": "",
-      "parent_id": "10000",
-      "default_assignee_id": "1"
+      "parent_id": 10000,
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -1419,9 +1417,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -1433,16 +1431,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -1460,37 +1458,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
@@ -1524,52 +1522,52 @@ Example input:
 
 ##### Output
 
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident|incident|False|Incident|{'id': '10000', 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
+|Name|Type|Required|Description|
+|----|----|--------|-----------|
+|incident|incident|False|Incident|{'id': 10000, 'number': '1000', 'name': 'Incident Name', 'description': 'description', 'state': 'New'}|
 
 Example output:
 
 ```
 {
   "incident": {
-    "id": "10000",
+    "id": 10000,
     "number": "1000",
     "name": "Incident Example Name",
     "description": "Example incident description",
     "state": "New",
     "site": {
-      "id": "1",
+      "id": 1,
       "name": "Austin TX, USA",
       "location": "AUS",
       "description": "",
       "time_zone": ""
     },
     "department": {
-      "id": "1",
+      "id": 1,
       "name": "Support",
       "description": "",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "category": {
-      "id": "10000",
+      "id": 10000,
       "name": "Facilities",
       "default_tags": "tagA, tagB",
       "parent_id": "null",
-      "default_assignee_id": "1"
+      "default_assignee_id": 1
     },
     "subcategory": {
-      "id": "1000",
+      "id": 1000,
       "name": "Equipment",
       "default_tags": "",
-      "parent_id": "10000",
-      "default_assignee_id": "1"
+      "parent_id": 10000,
+      "default_assignee_id": 1
     },
     "priority": "High",
     "assignee": {
-      "group_id": "1",
+      "group_id": 1,
       "is_user": "true",
-      "id": "1",
+      "id": 1,
       "name": "Example User",
       "email": "user@example.com",
       "avatar": {
@@ -1579,9 +1577,9 @@ Example output:
       }
     },
     "requester": {
-      "id": "1",
-      "account_id": "1",
-      "user_id": "1",
+      "id": 1,
+      "account_id": 1,
+      "user_id": 1,
       "email": "user@example.com",
       "name": "Example User",
       "disabled": false,
@@ -1593,16 +1591,16 @@ Example output:
     },
     "custom_fields_values": [
       {
-        "id": "10",
-        "custom_field_id": "1",
+        "id": 10,
+        "custom_field_id": 1,
         "name": "Text custom field",
         "value": "content",
         "options": "",
         "type_name": "Text"
       },
       {
-        "id": "100",
-        "custom_field_id": "2",
+        "id": 100,
+        "custom_field_id": 2,
         "name": "User custom field",
         "value": "1",
         "options": "",
@@ -1620,37 +1618,37 @@ Example output:
     "origin": "api",
     "incidents": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "problems": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "changes": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "solutions": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "releases": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],
     "configuration_items": [
       {
-        "id": "100",
+        "id": 100,
         "href": "https://example.com"
       }
     ],

--- a/plugins/samanage/komand_samanage/actions/assign_incident/schema.py
+++ b/plugins/samanage/komand_samanage/actions/assign_incident/schema.py
@@ -128,7 +128,7 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -227,13 +227,13 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -337,7 +337,7 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -373,7 +373,7 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -435,13 +435,13 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -545,7 +545,7 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -581,7 +581,7 @@ class AssignIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/actions/attach_incident/schema.py
+++ b/plugins/samanage/komand_samanage/actions/attach_incident/schema.py
@@ -78,7 +78,7 @@ class AttachIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_attachment",
       "properties": {
         "attachable_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Attachable ID",
           "description": "ID of the item this attachment belongs to",
           "order": 3
@@ -96,7 +96,7 @@ class AttachIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 2
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID of the attachment",
           "order": 1

--- a/plugins/samanage/komand_samanage/actions/change_incident_state/schema.py
+++ b/plugins/samanage/komand_samanage/actions/change_incident_state/schema.py
@@ -135,7 +135,7 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -234,13 +234,13 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -344,7 +344,7 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -380,7 +380,7 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -442,13 +442,13 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -552,7 +552,7 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -588,7 +588,7 @@ class ChangeIncidentStateOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/actions/create_incident/schema.py
+++ b/plugins/samanage/komand_samanage/actions/create_incident/schema.py
@@ -200,7 +200,7 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -299,13 +299,13 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -409,7 +409,7 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -445,7 +445,7 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -507,13 +507,13 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -617,7 +617,7 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -653,7 +653,7 @@ class CreateIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/actions/create_user/schema.py
+++ b/plugins/samanage/komand_samanage/actions/create_user/schema.py
@@ -168,7 +168,7 @@ class CreateUserOutput(insightconnect_plugin_runtime.Output):
           "order": 3
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1

--- a/plugins/samanage/komand_samanage/actions/get_incident/schema.py
+++ b/plugins/samanage/komand_samanage/actions/get_incident/schema.py
@@ -120,7 +120,7 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -219,13 +219,13 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -329,7 +329,7 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -365,7 +365,7 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -427,13 +427,13 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -537,7 +537,7 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -573,7 +573,7 @@ class GetIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/actions/list_incidents/schema.py
+++ b/plugins/samanage/komand_samanage/actions/list_incidents/schema.py
@@ -108,7 +108,7 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -207,13 +207,13 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -317,7 +317,7 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -353,7 +353,7 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -415,13 +415,13 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -525,7 +525,7 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -561,7 +561,7 @@ class ListIncidentsOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/actions/list_users/schema.py
+++ b/plugins/samanage/komand_samanage/actions/list_users/schema.py
@@ -113,7 +113,7 @@ class ListUsersOutput(insightconnect_plugin_runtime.Output):
           "order": 3
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1

--- a/plugins/samanage/komand_samanage/actions/tag_incident/schema.py
+++ b/plugins/samanage/komand_samanage/actions/tag_incident/schema.py
@@ -131,7 +131,7 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -230,13 +230,13 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -340,7 +340,7 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -376,7 +376,7 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -438,13 +438,13 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -548,7 +548,7 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -584,7 +584,7 @@ class TagIncidentOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/triggers/new_incidents/schema.py
+++ b/plugins/samanage/komand_samanage/triggers/new_incidents/schema.py
@@ -120,7 +120,7 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
           "order": 9
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -219,13 +219,13 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
               "order": 5
             },
             "group_id": {
-              "type": "string",
+              "type": "integer",
               "title": "Group Id",
               "description": "Group ID",
               "order": 1
             },
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 4
@@ -329,7 +329,7 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_id",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 1
@@ -365,7 +365,7 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
           "title": "solarwinds_problem",
           "properties": {
             "id": {
-              "type": "string",
+              "type": "integer",
               "title": "ID",
               "description": "ID",
               "order": 3
@@ -427,13 +427,13 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
           "order": 5
         },
         "group_id": {
-          "type": "string",
+          "type": "integer",
           "title": "Group Id",
           "description": "Group ID",
           "order": 1
         },
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 4
@@ -537,7 +537,7 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_id",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 1
@@ -573,7 +573,7 @@ class NewIncidentsOutput(insightconnect_plugin_runtime.Output):
       "title": "solarwinds_problem",
       "properties": {
         "id": {
-          "type": "string",
+          "type": "integer",
           "title": "ID",
           "description": "ID",
           "order": 3

--- a/plugins/samanage/komand_samanage/util/api.py
+++ b/plugins/samanage/komand_samanage/util/api.py
@@ -18,7 +18,7 @@ def is_key_field(key_to_check):
         return False
 
 
-def update_id_values_to_strings(data):
+def update_id_values_to_integers(data):
     """
     According to the Solarwinds (Samanage) API, Ids can be returned as either integers or strings
     In order to ensure consistency and allow output checking, convert all ids to be strings
@@ -26,19 +26,19 @@ def update_id_values_to_strings(data):
     for key, value in data.items():
         if isinstance(value, dict):
             # Item is a dict - recursive use of function
-            update_id_values_to_strings(value)
+            update_id_values_to_integers(value)
         elif isinstance(value, list):
             # Item is a list - recursive use of function if dict else update any id fields
             for i in range(0, len(value)):
                 if isinstance(value[i], dict):
-                    update_id_values_to_strings(value[i])
+                    update_id_values_to_integers(value[i])
                 elif is_key_field(key):
-                    value[i] = str(value[i])
+                    value[i] = int(value[i])
 
         else:
             if is_key_field(key):
                 # Item is a key field - update
-                data[key] = str(value)
+                data[key] = int(value)
 
 
 class SamanageAPI:
@@ -58,7 +58,7 @@ class SamanageAPI:
         response = self._call_api("GET", "incidents")
         # Update response data to change ids to strings if necessary
         for item in response:
-            update_id_values_to_strings(item)
+            update_id_values_to_integers(item)
         return response
 
     def get_incident(self, incident_id):
@@ -66,7 +66,7 @@ class SamanageAPI:
 
         response = self._call_api("GET", url, params={"layout": "long", "audit_archive": True})
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def add_tags_to_incident(self, incident_id, tags):
@@ -74,7 +74,7 @@ class SamanageAPI:
         json = {"incident": {"add_to_tag_list": ", ".join(tags)}}
         response = self._call_api("PUT", url, json=json, params={"layout": "long", "audit_archive": True})
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def create_incident(
@@ -109,7 +109,7 @@ class SamanageAPI:
         json = insightconnect_plugin_runtime.helper.clean(json)
         response = self._call_api("POST", url, json=json, params={"layout": "long", "audit_archive": True})
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def delete_incident(self, incident_id):
@@ -122,7 +122,7 @@ class SamanageAPI:
 
         response = self._call_api("POST", url, json=json)
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def get_comments(self, incident_id):
@@ -132,7 +132,7 @@ class SamanageAPI:
 
         # Update response data to change ids to strings if necessary
         for value in response:
-            update_id_values_to_strings(value)
+            update_id_values_to_integers(value)
         return response
 
     def assign_incident(self, incident_id, assignee):
@@ -141,7 +141,7 @@ class SamanageAPI:
         json = {"incident": {"assignee": {"email": assignee}}}
         response = self._call_api("PUT", url, json=json, params={"layout": "long", "audit_archive": True})
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def change_incident_state(self, incident_id, state):
@@ -150,7 +150,7 @@ class SamanageAPI:
         json = {"incident": {"state": state}}
         response = self._call_api("PUT", url, json=json, params={"layout": "long", "audit_archive": True})
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def attach_file_to_incident(self, incident_id, attachment_bytes, attachment_name):
@@ -188,7 +188,7 @@ class SamanageAPI:
 
         try:
             attachment = json.loads(result["stdout"])
-            update_id_values_to_strings(attachment)
+            update_id_values_to_integers(attachment)
             return attachment
         except json.JSONDecodeError:
             raise PluginException(
@@ -200,7 +200,7 @@ class SamanageAPI:
         response = self._call_api("GET", "users")
         # Update response data to change ids to strings if necessary
         for item in response:
-            update_id_values_to_strings(item)
+            update_id_values_to_integers(item)
         return response
 
     def create_user(self, email, name=None, phone=None, mobile_phone=None, role=None, department=None):
@@ -217,7 +217,7 @@ class SamanageAPI:
         json = insightconnect_plugin_runtime.helper.clean(json)
         response = self._call_api("POST", "users", json=json)
         # Update response data to change ids to strings if necessary
-        update_id_values_to_strings(response)
+        update_id_values_to_integers(response)
         return response
 
     def delete_user(self, user_id):

--- a/plugins/samanage/plugin.spec.yaml
+++ b/plugins/samanage/plugin.spec.yaml
@@ -56,7 +56,7 @@ types:
     id:
       title: ID
       description: ID
-      type: string
+      type: integer
   solarwinds_avatar:
     type:
       title: Avatar type
@@ -74,7 +74,7 @@ types:
     group_id:
       title: Group Id
       description: Group ID
-      type: string
+      type: integer
       required: false
     is_user:
       title: Is user
@@ -87,7 +87,7 @@ types:
     id:
       title: ID
       description: ID
-      type: string
+      type: integer
     email:
       title: Email
       description: Email of assignee
@@ -115,7 +115,7 @@ types:
     id:
       title: ID
       description: ID
-      type: string
+      type: integer
   solarwinds_field:
     name:
       title: Name
@@ -144,7 +144,7 @@ types:
     id:
       title: ID
       description: ID
-      type: string
+      type: integer
     name:
       title: Name
       description: Name
@@ -221,7 +221,7 @@ types:
     id:
       title: ID
       description: ID
-      type: string
+      type: integer
     name:
       title: Name
       description: Name of the user
@@ -270,7 +270,7 @@ types:
     id:
       title: ID
       description: ID of the attachment
-      type: string
+      type: integer
     filename:
       title: Filename
       description: Name of the attachment
@@ -278,7 +278,7 @@ types:
     attachable_id:
       title: Attachable ID
       description: ID of the item this attachment belongs to
-      type: string
+      type: integer
     attachable_type:
       title: Attachable Type
       description: Type of the item this attachment belongs to
@@ -315,7 +315,7 @@ triggers:
         title: Incident
         type: incident
         required: false
-        example: {"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "New"}
+        example: {"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "New"}
 actions:
   list_incidents:
     title: List Incidents
@@ -326,7 +326,7 @@ actions:
         description: List of all incidents
         type: '[]incident'
         required: true
-        example: [{"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "New"}]
+        example: [{"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "New"}]
   get_incident:
     title: Get Incident
     description: Get incident details
@@ -343,7 +343,7 @@ actions:
         description: Details of an incident with the given ID
         type: incident
         required: true
-        example: {"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "New"}
+        example: {"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "New"}
   tag_incident:
     title: Tag Incident
     description: Add tags to an incident
@@ -366,7 +366,7 @@ actions:
         description: Incident with new tags
         type: incident
         required: true
-        example: {"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "New", "tag_list": "tag1"}
+        example: {"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "New", "tag_list": "tag1"}
   create_incident:
     title: Create Incident
     description: Create a new incident
@@ -443,7 +443,7 @@ actions:
         description: Newly created incident
         type: incident
         required: true
-        example: {"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "New"}
+        example: {"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "New"}
   delete_incident:
     title: Delete Incident
     description: Delete an incident
@@ -490,7 +490,7 @@ actions:
         description: Newly created comment
         type: solarwinds_comment
         required: true
-        example: { "id": "1","body": "Comment body","is_private": "true","created_at": "2025-01-01T00:00:00.000+01:00","updated_at": "2025-01-01T00:00:00.000+01:00","user": { },"commenter_id": "1","commenter_type": "Incident" }
+        example: { "id": 1,"body": "Comment body","is_private": "true","created_at": "2025-01-01T00:00:00.000+01:00","updated_at": "2025-01-01T00:00:00.000+01:00","user": { },"commenter_id": 1,"commenter_type": "Incident" }
   get_comments:
     title: Get Comments
     description: Get all comments of an incident
@@ -507,7 +507,7 @@ actions:
         description: All comments of an incident
         type: '[]solarwinds_comment'
         required: true
-        example: [{"id": "1","body": "Comment body","is_private": "true","created_at": "2025-01-01T00:00:00.000+01:00","updated_at": "2025-01-01T00:00:00.000+01:00","user": {},"commenter_id": "1","commenter_type": "Incident"}]
+        example: [{"id": 1,"body": "Comment body","is_private": "true","created_at": "2025-01-01T00:00:00.000+01:00","updated_at": "2025-01-01T00:00:00.000+01:00","user": {},"commenter_id": 1,"commenter_type": "Incident"}]
   assign_incident:
     title: Assign Incident
     description: Assign a person to an incident
@@ -530,7 +530,7 @@ actions:
         description: Updated incident
         type: incident
         required: true
-        example: {"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "New"}
+        example: {"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "New"}
   change_incident_state:
     title: Change Incident State
     description: Update the state of an incident
@@ -559,7 +559,7 @@ actions:
         description: Updated incident
         type: incident
         required: true
-        example: {"id": "10000","number": "1000","name": "Incident Name","description": "description","state": "Assigned"}
+        example: {"id": 10000,"number": "1000","name": "Incident Name","description": "description","state": "Assigned"}
   attach_incident:
     title: Attach Incident
     description: Attach a file to an incident
@@ -588,7 +588,7 @@ actions:
         description: Newly created attachment
         type: solarwinds_attachment
         required: true
-        example: { "id": "27211951","content_type": "text/plain", "size": 12, "filename": "Hello.txt", "url": "https://example.com","shared_attachment": False,"attachable_id": 31851783,"attachable_type": "Incident","attachment_type": "attachment"}
+        example: { "id": 27211951,"content_type": "text/plain", "size": 12, "filename": "Hello.txt", "url": "https://example.com","shared_attachment": False,"attachable_id": 31851783,"attachable_type": "Incident","attachment_type": "attachment"}
   list_users:
     title: List Users
     description: List all users
@@ -598,7 +598,7 @@ actions:
         description: A list of all users
         type: '[]solarwinds_user'
         required: true
-        example: [{"id": "10000","name": "Example User","title": "Support Agent","disabled": false,"email": "user@example.com","created_at": "2030-01-01T00:00:00.000+00:00","phone": "(800) 555-0100","mobile_phone": "(800) 555-0100"}]
+        example: [{"id": 10000,"name": "Example User","title": "Support Agent","disabled": false,"email": "user@example.com","created_at": "2030-01-01T00:00:00.000+00:00","phone": "(800) 555-0100","mobile_phone": "(800) 555-0100"}]
   create_user:
     title: Create User
     description: Create a new user
@@ -651,7 +651,7 @@ actions:
         description: Newly created user
         type: solarwinds_user
         required: true
-        example: { "id": "10000","name": "Example User","title": "Support Agent","disabled": false,"email": "user@example.com","created_at": "2030-01-01T00:00:00.000+00:00","phone": "(800) 555-0100","mobile_phone": "(800) 555-0100" }
+        example: { "id": 10000,"name": "Example User","title": "Support Agent","disabled": false,"email": "user@example.com","created_at": "2030-01-01T00:00:00.000+00:00","phone": "(800) 555-0100","mobile_phone": "(800) 555-0100" }
   delete_user:
     title: Delete User
     description: Delete a user


### PR DESCRIPTION
### Description
Noticed when testing the previous Samanage PR that although I had forced all ids output to be strings (either integer or string can be output), that this made it trickier for the workflow use case due to input ids needing to be integers.
Updated to force output ids to be integers instead. 
Successfully tested in dev environment. 


