### PR TITLE
[PLGN-164] Cisco Umbrella Reporting - Updated docs with links

### DIFF
--- a/plugins/cisco_umbrella_reporting/.CHECKSUM
+++ b/plugins/cisco_umbrella_reporting/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "714a605c9930bb3a147cdb1effc07d47",
-	"manifest": "639e6a2f2860bfd111b39c16c77f7b21",
-	"setup": "b967d2799d6599d155337ddffdac4952",
+	"spec": "d5397d1b94af079c9d5615828f0c67a3",
+	"manifest": "09d6849d63e1498f55adb4c07281eb79",
+	"setup": "ab07d9773a525dbf74c6fc70e910645f",
 	"schemas": [
 		{
 			"identifier": "get_domain_visits/schema.py",

--- a/plugins/cisco_umbrella_reporting/bin/icon_cisco_umbrella_reporting
+++ b/plugins/cisco_umbrella_reporting/bin/icon_cisco_umbrella_reporting
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Cisco Umbrella Reporting"
 Vendor = "rapid7"
-Version = "1.0.0"
+Version = "1.0.1"
 Description = "This plugin utilizes Cisco Umbrella to get the most complete view of the relationships and evolution of Internet domains, IP addresses, and autonomous systems to pinpoint attackers infrastructures and predict future threats"
 
 

--- a/plugins/cisco_umbrella_reporting/help.md
+++ b/plugins/cisco_umbrella_reporting/help.md
@@ -9,7 +9,7 @@ This plugin utilizes Cisco Umbrella to get the most complete view of the relatio
 
 # Requirements
 
-* Requires an API Key and Secret from Cisco Umbrella
+* Requires an API Key and Secret from Cisco Umbrella (Legacy API Key) - In the links section it's described how to create/refresh/delete it)
 * Requires Cisco Umbrella organization ID
 
 # Documentation
@@ -23,6 +23,10 @@ The connection configuration accepts the following parameters:
 |api_key|credential_secret_key|None|True|Cisco Umbrella API key|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |api_secret|credential_secret_key|None|True|Cisco Umbrella API secret key|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |organization_id|string|None|True|ID of your Cisco Umbrella organization|None|2961483|
+
+The API key is a UUID-v4.
+
+*Note this plugin uses v1 of the Cisco API and therefore a legacy API key should be used ([Documentation #5](https://support.umbrella.com/hc/en-us/articles/8989122216340-Introducing-the-new-Cisco-Umbrella-Open-API)). To create/refresh/delete legacy keys please refer to this documentation ([Creating/Refreshing/Deleting legacy Umbrella API Keys](https://developer.cisco.com/docs/cloud-security/#!umbrella-legacy-authentication/prerequisites)). A future plugin update will move to using v2 of the Cisco API.*
 
 Example input:
 
@@ -115,6 +119,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 1.0.1 - Docs - Update help.md to include information about legacy keys
 * 1.0.0 - Initial plugin
 
 # Links
@@ -124,3 +129,4 @@ _This plugin does not contain any troubleshooting information._
 * [Cisco Umbrella](https://umbrella.cisco.com/)
 * [Cisco Umbrella Docs](https://docs.umbrella.com/)
 * [Cisco Umbrella Reporting](https://docs.umbrella.com/deployment-umbrella/docs/getting-started-learning-to-use-reports-and-exporting-reports)
+* [Creating/Refreshing/Deleting legacy Umbrella API Keys](https://developer.cisco.com/docs/cloud-security/#!umbrella-legacy-authentication/prerequisites)

--- a/plugins/cisco_umbrella_reporting/plugin.spec.yaml
+++ b/plugins/cisco_umbrella_reporting/plugin.spec.yaml
@@ -3,7 +3,7 @@ extension: plugin
 products: [insightconnect]
 name: cisco_umbrella_reporting
 title: Cisco Umbrella Reporting
-version: 1.0.0
+version: 1.0.1
 description: This plugin utilizes Cisco Umbrella to get the most complete view of the relationships
   and evolution of Internet domains, IP addresses, and autonomous systems to pinpoint
   attackers infrastructures and predict future threats

--- a/plugins/cisco_umbrella_reporting/requirements.txt
+++ b/plugins/cisco_umbrella_reporting/requirements.txt
@@ -1,3 +1,4 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
+parameterized==0.8.1

--- a/plugins/cisco_umbrella_reporting/setup.py
+++ b/plugins/cisco_umbrella_reporting/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="cisco_umbrella_reporting-rapid7-plugin",
-      version="1.0.0",
+      version="1.0.1",
       description="This plugin utilizes Cisco Umbrella to get the most complete view of the relationships and evolution of Internet domains, IP addresses, and autonomous systems to pinpoint attackers infrastructures and predict future threats",
       author="rapid7",
       author_email="",

--- a/plugins/cisco_umbrella_reporting/unit_test/mock.py
+++ b/plugins/cisco_umbrella_reporting/unit_test/mock.py
@@ -1,0 +1,78 @@
+import os
+import json
+from unittest import mock
+from typing import Callable, Optional
+from icon_cisco_umbrella_reporting.connection.schema import Input
+import requests
+
+STUB_API_KEY = "12345688765432"
+STUB_API_SECRET = "12345678987654"
+STUB_ORG_ID = "1234567"
+STUB_CONNECTION = {
+    Input.API_KEY: {"secretKey": STUB_API_KEY},
+    Input.API_SECRET: {"secretKey": STUB_API_SECRET},
+    Input.ORGANIZATION_ID: STUB_ORG_ID,
+}
+
+
+class MockResponse:
+    def __init__(self, filename: str, status_code: int, text: str = "") -> None:
+        self.filename = filename
+        self.status_code = status_code
+        self.text = text
+
+    def json(self):
+        with open(
+            os.path.join(os.path.dirname(os.path.realpath(__file__)), f"responses/{self.filename}.json.resp")
+        ) as file:
+            return json.load(file)
+
+
+def mocked_request(side_effect: Callable) -> None:
+    mock_function = requests
+    mock_function.request = mock.Mock(side_effect=side_effect)
+
+
+def mock_conditions(status_code: int) -> MockResponse:
+    return MockResponse("domains", status_code)
+
+
+def mock_conditions_connection(status_code: int) -> MockResponse:
+    if status_code == 200:
+        return MockResponse("test_connection_ok", status_code)
+    elif status_code >= 400:
+        return MockResponse("test_connection_bad", status_code)
+
+    raise Exception("Response has not been implemented")
+
+
+def mock_request_200(*args) -> MockResponse:
+    return mock_conditions(200)
+
+
+def mock_request_202() -> MockResponse:
+    return mock_conditions(202)
+
+
+def mock_request_204() -> MockResponse:
+    return mock_conditions(204)
+
+
+def mock_request_400() -> MockResponse:
+    return mock_conditions(400)
+
+
+def mock_request_401() -> MockResponse:
+    return mock_conditions(401)
+
+
+def mock_request_403() -> MockResponse:
+    return mock_conditions(403)
+
+
+def mock_request_404() -> MockResponse:
+    return mock_conditions(404)
+
+
+def mock_request_500(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], 500)

--- a/plugins/cisco_umbrella_reporting/unit_test/mock.py
+++ b/plugins/cisco_umbrella_reporting/unit_test/mock.py
@@ -33,8 +33,8 @@ def mocked_request(side_effect: Callable) -> None:
     mock_function.request = mock.Mock(side_effect=side_effect)
 
 
-def mock_conditions(status_code: int) -> MockResponse:
-    return MockResponse("domains", status_code)
+def mock_conditions(method: str, url: str, status_code: int) -> MockResponse:
+    return MockResponse("get_domain_visits", status_code)
 
 
 def mock_conditions_connection(status_code: int) -> MockResponse:
@@ -46,33 +46,29 @@ def mock_conditions_connection(status_code: int) -> MockResponse:
     raise Exception("Response has not been implemented")
 
 
-def mock_request_200(*args) -> MockResponse:
-    return mock_conditions(200)
+def mock_request_200(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 200)
 
 
-def mock_request_202() -> MockResponse:
-    return mock_conditions(202)
+def mock_request_202(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 202)
 
 
-def mock_request_204() -> MockResponse:
-    return mock_conditions(204)
+def mock_request_204(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 204)
 
 
-def mock_request_400() -> MockResponse:
-    return mock_conditions(400)
+def mock_request_400(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 400)
 
 
-def mock_request_401() -> MockResponse:
-    return mock_conditions(401)
+def mock_request_401(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 401)
 
 
-def mock_request_403() -> MockResponse:
-    return mock_conditions(403)
+def mock_request_403(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 403)
 
 
-def mock_request_404() -> MockResponse:
-    return mock_conditions(404)
-
-
-def mock_request_500(*args, **kwargs) -> MockResponse:
-    return mock_conditions(args[0], 500)
+def mock_request_404(*args, **kwargs) -> MockResponse:
+    return mock_conditions(args[0], args[1], 404)

--- a/plugins/cisco_umbrella_reporting/unit_test/responses/get_domain_visits.json.resp
+++ b/plugins/cisco_umbrella_reporting/unit_test/responses/get_domain_visits.json.resp
@@ -1,0 +1,3 @@
+{
+    "domain_visits": []
+}

--- a/plugins/cisco_umbrella_reporting/unit_test/test_get_domain_visits.py
+++ b/plugins/cisco_umbrella_reporting/unit_test/test_get_domain_visits.py
@@ -1,0 +1,55 @@
+import sys
+import os
+
+sys.path.append(os.path.abspath("../"))
+
+from parameterized import parameterized
+from unittest import TestCase, mock
+from icon_cisco_umbrella_reporting.connection.connection import Connection
+from icon_cisco_umbrella_reporting.actions.get_domain_visits import GetDomainVisits
+from insightconnect_plugin_runtime.exceptions import PluginException
+import logging
+from unit_test.mock import (
+    STUB_CONNECTION,
+    mock_request_200,
+    mock_request_400,
+    mock_request_401,
+    mock_request_403,
+    mock_request_404,
+    mock_request_500,
+    mocked_request,
+)
+
+
+class TestGetDomainVisits(TestCase):
+    def setUp(self) -> None:
+        self.connection = Connection()
+        self.connection.logger = logging.getLogger("Connection logger")
+        self.connection.connect(STUB_CONNECTION)
+
+        self.action = GetDomainVisits()
+        self.action.connection = self.connection
+        self.action.logger = logging.getLogger("Action logger")
+
+    @mock.patch("requests.request", side_effect=mock_request_200)
+    def test_get_domain_visits(self):
+        response = self.action.run()
+        expected_response = {"ok": "ok"}
+
+        self.assertEqual(response, expected_response)
+
+    @parameterized.expand(
+        [
+            (mock_request_400, "Invalid request."),
+            (mock_request_401, PluginException.causes[PluginException.Preset.USERNAME_PASSWORD]),
+            (mock_request_403, PluginException.causes[PluginException.Preset.UNAUTHORIZED]),
+            (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
+            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
+        ],
+    )
+    def test_not_ok(self, mock_request, exception):
+        mocked_request(mock_request)
+
+        with self.assertRaises(PluginException) as context:
+            self.action.run()
+        self.assertEqual(context.exception.cause, exception)

--- a/plugins/cisco_umbrella_reporting/unit_test/test_get_domain_visits.py
+++ b/plugins/cisco_umbrella_reporting/unit_test/test_get_domain_visits.py
@@ -33,7 +33,7 @@ class TestGetDomainVisits(TestCase):
     @mock.patch("requests.request", side_effect=mock_request_200)
     def test_get_domain_visits(self, other_arg):
         response = self.action.run()
-        expected_response = {'domain_visits': []}
+        expected_response = {"domain_visits": []}
 
         self.assertEqual(response, expected_response)
 

--- a/plugins/cisco_umbrella_reporting/unit_test/test_get_domain_visits.py
+++ b/plugins/cisco_umbrella_reporting/unit_test/test_get_domain_visits.py
@@ -16,7 +16,6 @@ from unit_test.mock import (
     mock_request_401,
     mock_request_403,
     mock_request_404,
-    mock_request_500,
     mocked_request,
 )
 
@@ -32,19 +31,18 @@ class TestGetDomainVisits(TestCase):
         self.action.logger = logging.getLogger("Action logger")
 
     @mock.patch("requests.request", side_effect=mock_request_200)
-    def test_get_domain_visits(self):
+    def test_get_domain_visits(self, other_arg):
         response = self.action.run()
-        expected_response = {"ok": "ok"}
+        expected_response = {'domain_visits': []}
 
         self.assertEqual(response, expected_response)
 
     @parameterized.expand(
         [
-            (mock_request_400, "Invalid request."),
+            (mock_request_400, PluginException.causes[PluginException.Preset.UNKNOWN]),
             (mock_request_401, PluginException.causes[PluginException.Preset.USERNAME_PASSWORD]),
             (mock_request_403, PluginException.causes[PluginException.Preset.UNAUTHORIZED]),
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
-            (mock_request_500, PluginException.causes[PluginException.Preset.SERVER_ERROR]),
         ],
     )
     def test_not_ok(self, mock_request, exception):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Update docs to let user know to use legacy API key since reporting is currently using v1 api.
  - Added unit tests

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
