### PR TITLE
[PLGN-175] Update Sentinelone trigger info

### DIFF
--- a/plugins/sentinelone/.CHECKSUM
+++ b/plugins/sentinelone/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "e11f48695757cbe5baea690dab4bd410",
+	"spec": "5f858669b0d3da01f0a237c63c0f4fba",
 	"manifest": "95e7567d224e0330006c817ebd9ad6df",
 	"setup": "ab1a8d52a10a5304ede6877740364166",
 	"schemas": [
@@ -125,7 +125,7 @@
 		},
 		{
 			"identifier": "get_threats/schema.py",
-			"hash": "49e661c98f96cc6530676b0421ecfb33"
+			"hash": "dd29361ebe31f3a6e85282fd9003d803"
 		}
 	]
 }

--- a/plugins/sentinelone/help.md
+++ b/plugins/sentinelone/help.md
@@ -2036,7 +2036,7 @@ For the Trigger settings, only set the Resolved field to False if solely resolve
 
 # Version History
 
-* 8.1.0 - Added New actions: Fetch file for agent ID and Run remote script
+* 8.1.0 - Added New actions: Fetch file for agent ID and Run remote script. Updated description for Trigger resolved field
 * 8.0.1 - Search Agents: Remove duplicate results when Case Sensitive is false
 * 8.0.0 - Connection: Added Service user (API only user type) authentication | Removed Basic Authentication
 * 7.1.0 - Update for Blacklist action: Fix for unblocked action | Update for Quarantine action: unification of the output data when action fails | Add troubleshooting information about use Type Converter | Mark as Benign action: update description 

--- a/plugins/sentinelone/help.md
+++ b/plugins/sentinelone/help.md
@@ -1720,7 +1720,7 @@ This trigger is used to get threats.
 |classifications|[]string|None|False|List of classifications to search|None|[""]|
 |engines|[]string|None|False|Included engines|None|[""]|
 |frequency|integer|5|False|Poll frequency in seconds|None|5|
-|resolved|boolean|None|False|Include resolved threats|None|True|
+|resolved|boolean|None|False|Set True to only trigger on resolved threats|None|True|
 
 Example input:
 ```
@@ -2032,6 +2032,7 @@ Example output:
 ## Troubleshooting
 
 To convert `threat` into an array use Type Converter Plugin
+For the Trigger settings, only set the Resolved field to False if solely resolved threats should be retrieved (i.e. setting to False will not include unresolved threats)
 
 # Version History
 

--- a/plugins/sentinelone/komand_sentinelone/triggers/get_threats/schema.py
+++ b/plugins/sentinelone/komand_sentinelone/triggers/get_threats/schema.py
@@ -62,7 +62,7 @@ class GetThreatsInput(insightconnect_plugin_runtime.Input):
     "resolved": {
       "type": "boolean",
       "title": "Resolved",
-      "description": "Include resolved threats",
+      "description": "Set True to only trigger on resolved threats",
       "order": 1
     }
   }

--- a/plugins/sentinelone/plugin.spec.yaml
+++ b/plugins/sentinelone/plugin.spec.yaml
@@ -2812,7 +2812,7 @@ triggers:
     input:
       resolved:
         title: Resolved
-        description: Include resolved threats
+        description: Set True to only trigger on resolved threats
         type: boolean
         required: false
         example: true


### PR DESCRIPTION
### Description

Describe the proposed changes:
**Background:**
The description for the 'Resolved' field in the Trigger was causing confusion - 'Include resolved threats' gave the impression that both resolved and unresolved would be included if True was set however setting this to True causes the underlying API to only return resolved threats. 

**Solution:**
Updated the description and added a note to the troubleshooting guide. 

**Note:**
No update to the version history as this will be wrapped up with an existing SentinelOne update (version 8.1.0).
