### PR TITLE
[PLGN-195] InsightIDR Plugin 4.4.1 - Release

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1269f7da66d29101d04cf97a4edf473d",
-	"manifest": "4dce763e62744df2b76786865b5d4ffa",
-	"setup": "612ce041c3959dbde19bff7ff9794190",
+	"spec": "75444a2e82472472693710a7b1832857",
+	"manifest": "6a96577325d5879b22985690a66c8016",
+	"setup": "61374c8e64bcff7c2fb1b6bd81f9c2c3",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "4.4.0"
+Version = "4.4.1"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -1723,6 +1723,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 4.4.1 - `List Alerts for Investigation`: fix issue with retrieving `detection_rule_rrn`   
 * 4.4.0 - `List Alerts for Investigation`: changed schema output for `detection_rule_rrn` 
 * 4.3.0 - `Query`: Add new parameter `most_recent_first`
 * 4.2.1 - `Create Investigation`, `Update Investigation`: Fix issue where action fails when email address field is not empty

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
@@ -1,14 +1,13 @@
+import json
+from typing import Dict, Any
+
 import insightconnect_plugin_runtime
-from .schema import ListAlertsForInvestigationInput, ListAlertsForInvestigationOutput, Input, Output, Component
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 
-# Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-
-# Custom imports below
-import json
+from .schema import ListAlertsForInvestigationInput, ListAlertsForInvestigationOutput, Input, Output, Component
 
 
 class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
@@ -31,7 +30,6 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
 
         endpoint = Investigations.list_alerts_for_investigation(self.connection.url, identifier)
         response = request.resource_request(endpoint, "get", params=parameters)
-
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
@@ -40,6 +38,7 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
             )
+        self._get_rule_rrn(result)
         try:
             alerts = clean(result.get("data", {}))
             metadata = result.get("metadata", {})
@@ -50,3 +49,12 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
             )
+
+    def _get_rule_rrn(self, result: Dict[str, Any]) -> None:
+        """
+        Retrieve rule rrn from all records,
+        due to inconsistent API from insightIDR
+        """
+        for data in result.get("data"):
+            if isinstance(data.get("detection_rule_rrn"), dict):
+                data["detection_rule_rrn"] = data.get("detection_rule_rrn", {}).get("rule_rrn", "")

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 4.4.0
+version: 4.4.1
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7
 cloud_ready: true

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="4.4.0",
+      version="4.4.1",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/mock.py
+++ b/plugins/rapid7_insightidr/unit_test/mock.py
@@ -96,6 +96,10 @@ def mock_request_get(url: str) -> MockResponse:
         return MockResponse("list_investigations", 200)
 
 
+def mock_request_for_different_rrn_object(*args, **kwargs) -> MockResponse:
+    return MockResponse("list_alerts_for_investigation_rrn_as_object", 200)
+
+
 def mock_request_patch(url: str) -> MockResponse:
     if url == f"{Util.STUB_URL_API}/idr/v2/investigations/{STUB_INVESTIGATION_IDENTIFIER}":
         return MockResponse("update_investigation", 200)

--- a/plugins/rapid7_insightidr/unit_test/payloads/list_alerts_for_investigation_rrn_as_object.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/list_alerts_for_investigation_rrn_as_object.json.resp
@@ -1,0 +1,20 @@
+{
+  "data": [
+    {
+      "alert_type": "Example Type",
+      "alert_type_description": "Example Description",
+      "created_time": "01-01-2020T00:00:00",
+      "detection_rule_rrn": {"rule_name": "ExampleName", "rule_rrn": "rrn:example"},
+      "first_event_time": "01-01-2020T00:00:00",
+      "id": "11111111-1111-1111-1111-111111111111",
+      "latest_event_time": "01-01-2020T00:00:00",
+      "title": "Example Title"
+    }
+  ],
+  "metadata": {
+    "index": 0,
+    "size": 1,
+    "total_data": 1,
+    "total_pages": 1
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/test_list_alerts_for_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_alerts_for_investigation.py
@@ -11,7 +11,7 @@ from komand_rapid7_insightidr.actions.list_alerts_for_investigation import ListA
 from komand_rapid7_insightidr.actions.list_alerts_for_investigation.schema import Input
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
-from unit_test.mock import mock_get_request, STUB_INVESTIGATION_IDENTIFIER
+from unit_test.mock import mock_get_request, STUB_INVESTIGATION_IDENTIFIER, mock_request_for_different_rrn_object
 from unit_test.util import Util
 
 
@@ -31,11 +31,7 @@ class TestCreateInvestigation(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(ListAlertsForInvestigation())
         self.connection = self.action.connection
-
-    @patch("requests.Session.get", side_effect=mock_get_request)
-    def test_list_alerts_for_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER})
-        expected = {
+        self.expected_result = {
             "alerts": [
                 {
                     "alert_type": "Example Type",
@@ -50,4 +46,15 @@ class TestCreateInvestigation(TestCase):
             ],
             "metadata": {"index": 0, "size": 1, "total_data": 1, "total_pages": 1},
         }
-        self.assertEqual(actual, expected)
+
+    @patch("requests.Session.get", side_effect=mock_get_request)
+    def test_list_alerts_for_investigation(self, _mock_req):
+        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER})
+
+        self.assertEqual(actual, self.expected_result)
+
+    @patch("requests.Session.get", side_effect=mock_request_for_different_rrn_object)
+    def test_list_alerts_for_investigation_when_different_rrn_type(self, _mock_req):
+        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER})
+
+        self.assertEqual(actual, self.expected_result)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - The API of InsightIDR is very inconsistent, for detection rule sometimes we retrieve `detection_rule_rrn` as string, but sometimes as object. The change is about, in scenario when API retrieve object we fetch only `rule_rrn` filed as string.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
