### PR TITLE
SOAR-13594: Zoom auth update

### DIFF
--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -304,7 +304,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
-* 2.1.0 - Create user: Removed redundant enum option from `type` input | Added unit tests
+* 2.1.0 - Create user: Removed redundant enum option from `type` input | Added unit tests | Improve authentication logic
 * 2.0.0 - Update connection for latest Zoom API authentication | Add Monitor Sign In and Out Activity task
 * 1.0.0 - Initial plugin
 

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -7,7 +7,7 @@ from .schema import (
 )
 
 # Custom imports below
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 from icon_zoom.util.event import Event
 
 
@@ -152,13 +152,13 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
 
     @staticmethod
     def _get_datetime_now() -> datetime:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
 
         return now
 
     @staticmethod
     def _get_datetime_last_24_hours() -> datetime:
-        now = datetime.now()
+        now = datetime.now(timezone.utc)
         last_24 = now - timedelta(hours=24)
 
         return last_24

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -124,11 +124,11 @@ class ZoomAPI:
                 )
 
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
-        except json.decoder.JSONDecodeError as e:
-            self.logger.info(f"Invalid json: {e}")
+        except json.decoder.JSONDecodeError as error:
+            self.logger.info(f"Invalid json: {error}")
             raise PluginException(preset=PluginException.Preset.INVALID_JSON)
-        except requests.exceptions.HTTPError as e:
-            self.logger.info(f"Request to f{url} failed: {e}")
+        except requests.exceptions.HTTPError as error:
+            self.logger.info(f"Request to f{url} failed: {error}")
             raise PluginException(preset=PluginException.Preset.UNKNOWN)
 
     def _handle_response(self, response: Response, allow_404: bool, original_call_args: dict):

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -110,14 +110,18 @@ class ZoomAPI:
             self.logger.info(f"Got response status code: {response.status_code}")
 
             if response.status_code in [400, 401, 404, 409, 429, 204] or (200 <= response.status_code < 300):
-                return self._handle_response(response=response, allow_404=allow_404, original_call_args={
-                    "method": method,
-                    "url": url,
-                    "params": params,
-                    "json_data": json_data,
-                    "allow_404": allow_404,
-                    "auth": auth,
-                })
+                return self._handle_response(
+                    response=response,
+                    allow_404=allow_404,
+                    original_call_args={
+                        "method": method,
+                        "url": url,
+                        "params": params,
+                        "json_data": json_data,
+                        "allow_404": allow_404,
+                        "auth": auth,
+                    },
+                )
 
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
         except json.decoder.JSONDecodeError as e:

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -1,6 +1,4 @@
 import json
-import datetime
-import time
 from logging import Logger
 from typing import Optional
 
@@ -35,37 +33,12 @@ class ZoomAPI:
         self.logger = logger
 
         self.oauth_token: Optional[str] = None
-        self.oauth_last_refresh_timestamp: Optional[float] = None
+        self.refresh_oauth_token()
 
-    def refresh_oauth_token_if_needed(self) -> None:
+    def refresh_oauth_token(self) -> None:
         """
-        Refreshes OAuth token if needed.
+        Retrieves a new server-to-server OAuth token from Zoom
         :return: None
-        """
-        if self.oauth_last_refresh_timestamp and not self._should_refresh_oauth_token(
-            last_refresh_timestamp=self.oauth_last_refresh_timestamp
-        ):
-            return
-
-        # Refresh should happen, so do the refresh.
-        try:
-            self.logger.info("Making call to get new OAuth token")
-            oauth_token = self.get_oauth_token()
-            now_timestamp = self._get_current_time_epoch()
-        except Exception as error:
-            raise PluginException(
-                cause=f"Unable to refresh OAuth token: {error}.",
-                assistance="Ensure connection credentials are correct.",
-                data=error,
-            )
-
-        self.oauth_token = oauth_token
-        self.oauth_last_refresh_timestamp = now_timestamp
-
-    def get_oauth_token(self) -> str:
-        """
-        Retrieves a server-to-server OAuth token from Zoom
-        :return: OAuth token
         """
 
         params = {"grant_type": "account_credentials", "account_id": self.account_id}
@@ -83,7 +56,7 @@ class ZoomAPI:
             )
 
         self.logger.info("Request for new OAuth token was successful!")
-        return access_token
+        self.oauth_token = access_token
 
     def get_user(self, user_id: str) -> Optional[dict]:
         return self._call_api("GET", f"{self.api_url}/users/{user_id}")
@@ -126,10 +99,6 @@ class ZoomAPI:
         allow_404: bool = False,
         auth: AuthBase = None,
     ) -> Optional[dict]:  # noqa: MC0001
-
-        if not isinstance(auth, HTTPBasicAuth):
-            self.refresh_oauth_token_if_needed()
-
         # If HTTPBasicAuth isn't provided (for calls to get OAuth token), then
         # use BearerAuth since we have a token already
         if not auth:
@@ -141,7 +110,14 @@ class ZoomAPI:
             self.logger.info(f"Got response status code: {response.status_code}")
 
             if response.status_code in [400, 401, 404, 409, 429, 204] or (200 <= response.status_code < 300):
-                return self._handle_response(response=response, allow_404=allow_404)
+                return self._handle_response(response=response, allow_404=allow_404, original_call_args={
+                    "method": method,
+                    "url": url,
+                    "params": params,
+                    "json_data": json_data,
+                    "allow_404": allow_404,
+                    "auth": auth,
+                })
 
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=response.text)
         except json.decoder.JSONDecodeError as e:
@@ -151,7 +127,7 @@ class ZoomAPI:
             self.logger.info(f"Request to f{url} failed: {e}")
             raise PluginException(preset=PluginException.Preset.UNKNOWN)
 
-    def _handle_response(self, response: Response, allow_404: bool):
+    def _handle_response(self, response: Response, allow_404: bool, original_call_args: dict):
         """
         Helper function to process the response based on the status code returned.
         :param response: Response object
@@ -162,11 +138,9 @@ class ZoomAPI:
             raise PluginException(preset=PluginException.Preset.BAD_REQUEST, data=response.json())
 
         if response.status_code == 401:
-            resp = json.loads(response.text)
-            raise PluginException(
-                cause=resp.get("message"),
-                assistance="Verify that the credentials configured within the Zoom plugin connection are correct.",
-            )
+            self.logger.info(f"Received HTTP {response.status_code}, re-authenticating to Zoom...")
+            self.refresh_oauth_token()
+            return self._call_api(**original_call_args)
 
         if response.status_code == 404:
             if allow_404:
@@ -208,33 +182,3 @@ class ZoomAPI:
             )
         else:
             raise PluginException(cause="Account is rate-limited by an unknown quota.", assistance="Try again later.")
-
-    @staticmethod
-    def _get_current_time_epoch() -> float:
-        """
-        Gets the current epoch time
-        :return: Current time in unix epoch
-        """
-        now = datetime.datetime.now()
-        now_millis = time.mktime(now.timetuple())
-
-        return now_millis
-
-    def _should_refresh_oauth_token(self, last_refresh_timestamp: float) -> bool:
-        """
-        Determines whether or not the OAuth token should be refreshed.
-        Calculated differences >=55 minutes will return True.
-        :param last_refresh_timestamp: Unix epoch timestamp representing last time the OAuth token was refreshed
-        :return: Boolean, True if a token refresh should happen, False otherwise
-        """
-        # 55 minutes in seconds. Zoom API refresh is 60 minutes, but we'll use 55 minutes for headroom.
-        fifty_five_minutes = 3300
-
-        now = ZoomAPI._get_current_time_epoch()
-        previous_time = last_refresh_timestamp
-        self.logger.info(f"Calculating OAuth token refresh, last refreshed at {previous_time}, current time {now}")
-
-        time_difference = now - previous_time
-        should_refresh = time_difference >= fifty_five_minutes
-
-        return should_refresh

--- a/plugins/zoom/unit_test/mock.py
+++ b/plugins/zoom/unit_test/mock.py
@@ -28,13 +28,18 @@ STUB_CREATE_USER = {
     Input.LAST_NAME: "LastName",
 }
 
+REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI.refresh_oauth_token"
+
 
 class Util:
     @staticmethod
-    def default_connector(action: Action) -> Action:
+    @mock.patch(REFRESH_OAUTH_TOKEN_PATH)
+    def default_connector(action: Action, mock_refresh_call) -> Action:
+        mock_refresh_call.return_value = None
         default_connection = Connection()
         default_connection.logger = logging.getLogger("connection logger")
         default_connection.connect(STUB_CONNECTION)
+        default_connection.zoom_api.oauth_token = STUB_OAUTH_TOKEN
         action.connection = default_connection
         action.logger = logging.getLogger("action logger")
         return action

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -11,7 +11,6 @@ REQUESTS_PATH = "requests.request"
 
 
 class MockResponse:
-
     def __init__(self, status_code: int):
         self.status_code = status_code
 
@@ -20,7 +19,6 @@ class MockResponse:
 
 
 class MyTestCase(TestCase):
-
     @patch(REFRESH_OAUTH_TOKEN_PATH)
     @patch(REQUESTS_PATH)
     def test_unauthenticated_first_run(self, mock_request, mock_refresh):
@@ -42,5 +40,5 @@ class MyTestCase(TestCase):
         self.assertDictEqual(result, {})
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -1,0 +1,46 @@
+import logging
+import unittest
+from unittest import TestCase
+from unittest.mock import patch
+
+from icon_zoom.util.api import ZoomAPI, BearerAuth
+
+
+REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI.refresh_oauth_token"
+REQUESTS_PATH = "requests.request"
+
+
+class MockResponse:
+
+    def __init__(self, status_code: int):
+        self.status_code = status_code
+
+    def json(self) -> dict:
+        return {}
+
+
+class MyTestCase(TestCase):
+
+    @patch(REFRESH_OAUTH_TOKEN_PATH)
+    @patch(REQUESTS_PATH)
+    def test_unauthenticated_first_run(self, mock_request, mock_refresh):
+        mock_refresh.return_value = "blah"
+        api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", logger=logging.getLogger())
+
+        mock_request.side_effect = [MockResponse(status_code=401), MockResponse(status_code=200)]
+        result = api._call_api(method="POST", url="http://example.com", auth=BearerAuth(api.oauth_token))
+        self.assertDictEqual(result, {})
+
+    @patch(REFRESH_OAUTH_TOKEN_PATH)
+    @patch(REQUESTS_PATH)
+    def test_authenticated_first_run(self, mock_request, mock_refresh):
+        mock_refresh.return_value = "blah"
+        api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", logger=logging.getLogger())
+
+        mock_request.side_effect = [MockResponse(status_code=200)]
+        result = api._call_api(method="POST", url="http://example.com", auth=BearerAuth(api.oauth_token))
+        self.assertDictEqual(result, {})
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/plugins/zoom/unit_test/test_create_user.py
+++ b/plugins/zoom/unit_test/test_create_user.py
@@ -47,7 +47,7 @@ class TestCreateUser(TestCase):
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
         ],
     )
-    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token_if_needed", return_value=None)
+    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request, exception, mock_refresh):
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:

--- a/plugins/zoom/unit_test/test_delete_user.py
+++ b/plugins/zoom/unit_test/test_delete_user.py
@@ -47,7 +47,7 @@ class TestDeleteUser(TestCase):
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
         ]
     )
-    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token_if_needed", return_value=None)
+    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request, exception, mock_refresh):
         mocked_request(mock_request)
 

--- a/plugins/zoom/unit_test/test_get_user.py
+++ b/plugins/zoom/unit_test/test_get_user.py
@@ -84,7 +84,7 @@ class TestGetUser(TestCase):
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
         ],
     )
-    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token_if_needed", return_value=None)
+    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request, exception, mock_refresh):
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -6,17 +6,22 @@ from unittest.mock import patch
 from icon_zoom.util.event import Event
 from icon_zoom.tasks.monitor_sign_in_out_activity.task import MonitorSignInOutActivity
 from icon_zoom.connection.connection import Connection
-from unit_test.mock import STUB_CONNECTION
+from unit_test.mock import STUB_CONNECTION, STUB_OAUTH_TOKEN
 
+REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI.refresh_oauth_token"
 GET_USER_ACTIVITY_EVENTS_PATH = "icon_zoom.util.api.ZoomAPI.get_user_activity_events"
 GET_DATETIME_NOW_PATH = "icon_zoom.tasks.monitor_sign_in_out_activity.task.MonitorSignInOutActivity._get_datetime_now"
 
 
 class TestGetUserActivityEvents(unittest.TestCase):
-    def setUp(self) -> None:
+
+    @patch(REFRESH_OAUTH_TOKEN_PATH)
+    def setUp(self, mock_refresh_call) -> None:
+        mock_refresh_call.return_value = None
         self.connection = Connection()
         self.connection.logger = logging.getLogger("connection logger")
         self.connection.connect(STUB_CONNECTION)
+        self.connection.zoom_api.oauth_token = STUB_OAUTH_TOKEN
 
         self.action = MonitorSignInOutActivity()
         self.action.connection = self.connection

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -14,7 +14,6 @@ GET_DATETIME_NOW_PATH = "icon_zoom.tasks.monitor_sign_in_out_activity.task.Monit
 
 
 class TestGetUserActivityEvents(unittest.TestCase):
-
     @patch(REFRESH_OAUTH_TOKEN_PATH)
     def setUp(self, mock_refresh_call) -> None:
         mock_refresh_call.return_value = None


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Updates Zoom authentication logic to re-authenticate only when needed
  - Updates datetime calls to use a timezone to improve time accuracy

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
