### PR TITLE
SOAR-13594,13667: Update Zoom Auth and Add JWT

### DIFF
--- a/plugins/zoom/.CHECKSUM
+++ b/plugins/zoom/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "5dcfc0bacfdc6036a662cbb0e5126659",
-	"manifest": "971209359ae35e16b468529870d59720",
-	"setup": "7c48b11404f92cc2aa2a52f3bdf952b4",
+	"spec": "d8e257125d799a257b9a737cf2f91836",
+	"manifest": "c6d21865840af36d4c533cd3a063613f",
+	"setup": "c63b0baf19567cdf79670f42e4dd8777",
 	"schemas": [
 		{
 			"identifier": "create_user/schema.py",
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "ae571620dec323e9ed834ee27055efac"
+			"hash": "bd5152d91d04053f8ef4234ea03bbb7b"
 		},
 		{
 			"identifier": "monitor_sign_in_out_activity/schema.py",

--- a/plugins/zoom/.CHECKSUM
+++ b/plugins/zoom/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "d8e257125d799a257b9a737cf2f91836",
+	"spec": "d761994a31bceaad443d92a3360c684c",
 	"manifest": "c6d21865840af36d4c533cd3a063613f",
 	"setup": "c63b0baf19567cdf79670f42e4dd8777",
 	"schemas": [
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "bd5152d91d04053f8ef4234ea03bbb7b"
+			"hash": "eba2f34fe6858ab2769d8086e6441d01"
 		},
 		{
 			"identifier": "monitor_sign_in_out_activity/schema.py",

--- a/plugins/zoom/bin/icon_zoom
+++ b/plugins/zoom/bin/icon_zoom
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Zoom"
 Vendor = "rapid7"
-Version = "2.1.0"
+Version = "3.0.0"
 Description = "Trigger workflows on user activity while also managing your users with the Zoom plugin"
 
 

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -35,6 +35,7 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |account_id|credential_secret_key|None|False|Zoom app account ID, required for OAuth authentication|None|dBs0x4Kf7HuIK0LLbzMduW|
+|authentication_retry_limit|integer|5|False|How many times to retry authentication to Zoom before failing, required for OAuth authentication|None|5|
 |client_id|credential_secret_key|None|False|Zoom app client ID, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |client_secret|credential_secret_key|None|False|Zoom app client secret, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |jwt_token|credential_secret_key|None|False|Zoom JWT token, without the Bearer prefix|None|9de5069c5afe602b2ea0a04b66beb2c0|
@@ -44,6 +45,7 @@ Example input:
 ```
 {
   "account_id": "dBs0x4Kf7HuIK0LLbzMduW",
+  "authentication_retry_limit": 5,
   "client_id": "9de5069c5afe602b2ea0a04b66beb2c0",
   "client_secret": "9de5069c5afe602b2ea0a04b66beb2c0",
   "jwt_token": "9de5069c5afe602b2ea0a04b66beb2c0"

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -20,6 +20,7 @@ Business, or Enterprise plan.
       * Requires account ID as well as client ID and secret from a Server-to-Server OAuth app in the Zoom Marketplace.
       * Server-to-Server OAuth app has the `report:read:admin` scope enabled
     * For JWT, requires a JWT token from a JWT app in the Zoom Marketplace - it is recommended that the generated JWT token has a long expiration date to prevent having to update the token frequently.
+      * Please note that JWT authentication is deprecated and will be removed from the Zoom API in June, 2023. 
     
 # Supported Product Versions
 
@@ -309,6 +310,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Version History
 
+* 3.0.0 - Add back JWT authentication in addition to OAuth (please note JWT will be removed from the Zoom API in June 2023) | Improve OAuth logic to help prevent infinite looping
 * 2.1.0 - Create user: Removed redundant enum option from `type` input | Added unit tests | Improve authentication logic
 * 2.0.0 - Update connection for latest Zoom API authentication | Add Monitor Sign In and Out Activity task
 * 1.0.0 - Initial plugin

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -15,9 +15,12 @@ Business, or Enterprise plan.
 # Requirements
 
 * Must have Zoom Pro, Business, or Enterprise plan to support REST API
-* Requires account ID as well as client ID and secret from a Server-to-Server OAuth app in the Zoom Marketplace
-* Server-to-Server OAuth app has the `report:read:admin` scope enabled
-
+* API credentials for either of the following Zoom API authentication types: 
+    * For OAuth 2.0:
+      * Requires account ID as well as client ID and secret from a Server-to-Server OAuth app in the Zoom Marketplace.
+      * Server-to-Server OAuth app has the `report:read:admin` scope enabled
+    * For JWT, requires a JWT token from a JWT app in the Zoom Marketplace - it is recommended that the generated JWT token has a long expiration date to prevent having to update the token frequently.
+    
 # Supported Product Versions
 
 * Zoom API v2.10

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -37,7 +37,7 @@ The connection configuration accepts the following parameters:
 |account_id|credential_secret_key|None|False|Zoom app account ID, required for OAuth authentication|None|dBs0x4Kf7HuIK0LLbzMduW|
 |client_id|credential_secret_key|None|False|Zoom app client ID, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |client_secret|credential_secret_key|None|False|Zoom app client secret, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|jwt_token|credential_secret_key|None|False|Zoom JWT token|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|jwt_token|credential_secret_key|None|False|Zoom JWT token, without the Bearer prefix|None|9de5069c5afe602b2ea0a04b66beb2c0|
 
 Example input:
 

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -33,9 +33,10 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|account_id|credential_secret_key|None|True|Zoom app account ID|None|dBs0x4Kf7HuIK0LLbzMduW|
-|client_id|credential_secret_key|None|True|Zoom app client ID|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|client_secret|credential_secret_key|None|True|Zoom app client secret|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|account_id|credential_secret_key|None|False|Zoom app account ID, required for OAuth authentication|None|dBs0x4Kf7HuIK0LLbzMduW|
+|client_id|credential_secret_key|None|False|Zoom app client ID, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|client_secret|credential_secret_key|None|False|Zoom app client secret, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|jwt_token|credential_secret_key|None|False|Zoom JWT token|None|9de5069c5afe602b2ea0a04b66beb2c0|
 
 Example input:
 
@@ -43,7 +44,8 @@ Example input:
 {
   "account_id": "dBs0x4Kf7HuIK0LLbzMduW",
   "client_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "client_secret": "9de5069c5afe602b2ea0a04b66beb2c0"
+  "client_secret": "9de5069c5afe602b2ea0a04b66beb2c0",
+  "jwt_token": "9de5069c5afe602b2ea0a04b66beb2c0"
 }
 ```
 

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -19,9 +19,11 @@ class Connection(insightconnect_plugin_runtime.Connection):
         client_secret = params.get(Input.CLIENT_SECRET, {}).get(secret_key)
         jwt_token = params.get(Input.JWT_TOKEN, {}).get(secret_key)
 
-        if jwt_token is not None:
+        if jwt_token:
+            self.logger.info("JWT token provided, connecting to Zoom via JWT")
             self.zoom_api = ZoomAPI(logger=self.logger, jwt_token=jwt_token)
-        elif (account_id is not None) and (client_id is not None) and (client_secret is not None):
+        elif account_id and client_id and client_secret:
+            self.logger.info("OAuth credentials provided, connecting to Zoom via OAuth")
             self.zoom_api = ZoomAPI(
                 logger=self.logger, account_id=account_id, client_id=client_id, client_secret=client_secret,
             )

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -20,6 +20,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         client_secret = params.get(Input.CLIENT_SECRET, {}).get(secret_key)
         oauth_authentication_retry_limit = params.get(Input.AUTHENTICATION_RETRY_LIMIT, 5)
 
+        # JWT input
         jwt_token = params.get(Input.JWT_TOKEN, {}).get(secret_key)
 
         if jwt_token:

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -25,14 +25,18 @@ class Connection(insightconnect_plugin_runtime.Connection):
         elif account_id and client_id and client_secret:
             self.logger.info("OAuth credentials provided, connecting to Zoom via OAuth")
             self.zoom_api = ZoomAPI(
-                logger=self.logger, account_id=account_id, client_id=client_id, client_secret=client_secret,
+                logger=self.logger,
+                account_id=account_id,
+                client_id=client_id,
+                client_secret=client_secret,
             )
         else:
-            raise PluginException(cause="Credentials for either JWT Token or OAuth are required, "
-                                        "although none were provided.",
-                                  assistance="If using JWT, please input only the JWT Token in your connection "
-                                             "configuration. If using OAuth, please input only the "
-                                             "Account ID, Client ID, and Client Secret.")
+            raise PluginException(
+                cause="Credentials for either JWT Token or OAuth are required, " "although none were provided.",
+                assistance="If using JWT, please input only the JWT Token in your connection "
+                "configuration. If using OAuth, please input only the "
+                "Account ID, Client ID, and Client Secret.",
+            )
 
     def test(self):
         try:

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -14,9 +14,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
     def connect(self, params):
         secret_key = "secretKey"  # nosec: B105
 
+        # OAuth inputs
         account_id = params.get(Input.ACCOUNT_ID, {}).get(secret_key)
         client_id = params.get(Input.CLIENT_ID, {}).get(secret_key)
         client_secret = params.get(Input.CLIENT_SECRET, {}).get(secret_key)
+        oauth_authentication_retry_limit = params.get(Input.AUTHENTICATION_RETRY_LIMIT, 5)
+
         jwt_token = params.get(Input.JWT_TOKEN, {}).get(secret_key)
 
         if jwt_token:
@@ -29,6 +32,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 account_id=account_id,
                 client_id=client_id,
                 client_secret=client_secret,
+                oauth_retry_limit=oauth_authentication_retry_limit
             )
         else:
             raise PluginException(

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -12,15 +12,25 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.zoom_api = None
 
     def connect(self, params):
-        SECRETKEY = "secretKey"
+        secret_key = "secretKey"
 
-        account_id = params[Input.ACCOUNT_ID][SECRETKEY]
-        client_id = params[Input.CLIENT_ID][SECRETKEY]
-        client_secret = params[Input.CLIENT_SECRET][SECRETKEY]
+        account_id = params.get(Input.ACCOUNT_ID, {}).get(secret_key)
+        client_id = params.get(Input.CLIENT_ID, {}).get(secret_key)
+        client_secret = params.get(Input.CLIENT_SECRET, {}).get(secret_key)
+        jwt_token = params.get(Input.JWT_TOKEN, {}).get(secret_key)
 
-        self.zoom_api = ZoomAPI(
-            account_id=account_id, client_id=client_id, client_secret=client_secret, logger=self.logger
-        )
+        if jwt_token is not None:
+            self.zoom_api = ZoomAPI(logger=self.logger, jwt_token=jwt_token)
+        elif (account_id is not None) and (client_id is not None) and (client_secret is not None):
+            self.zoom_api = ZoomAPI(
+                logger=self.logger, account_id=account_id, client_id=client_id, client_secret=client_secret,
+            )
+        else:
+            raise PluginException(cause="Credentials for either JWT Token or OAuth are required, "
+                                        "although none were provided.",
+                                  assistance="If using JWT, please input only the JWT Token in your connection "
+                                             "configuration. If using OAuth, please input only the "
+                                             "Account ID, Client ID, and Client Secret.")
 
     def test(self):
         try:

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -33,11 +33,11 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 account_id=account_id,
                 client_id=client_id,
                 client_secret=client_secret,
-                oauth_retry_limit=oauth_authentication_retry_limit
+                oauth_retry_limit=oauth_authentication_retry_limit,
             )
         else:
             raise PluginException(
-                cause="Credentials for either JWT Token or OAuth are required, " "although none were provided.",
+                cause="Credentials for either JWT Token or OAuth are required, although none were provided.",
                 assistance="If using JWT, please input only the JWT Token in your connection "
                 "configuration. If using OAuth, please input only the "
                 "Account ID, Client ID, and Client Secret.",

--- a/plugins/zoom/icon_zoom/connection/connection.py
+++ b/plugins/zoom/icon_zoom/connection/connection.py
@@ -12,7 +12,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.zoom_api = None
 
     def connect(self, params):
-        secret_key = "secretKey"
+        secret_key = "secretKey"  # nosec: B105
 
         account_id = params.get(Input.ACCOUNT_ID, {}).get(secret_key)
         client_id = params.get(Input.CLIENT_ID, {}).get(secret_key)

--- a/plugins/zoom/icon_zoom/connection/schema.py
+++ b/plugins/zoom/icon_zoom/connection/schema.py
@@ -37,7 +37,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
     "jwt_token": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "JWT Token",
-      "description": "Zoom JWT token",
+      "description": "Zoom JWT token, without the Bearer prefix",
       "order": 4
     }
   },

--- a/plugins/zoom/icon_zoom/connection/schema.py
+++ b/plugins/zoom/icon_zoom/connection/schema.py
@@ -5,6 +5,7 @@ import json
 
 class Input:
     ACCOUNT_ID = "account_id"
+    AUTHENTICATION_RETRY_LIMIT = "authentication_retry_limit"
     CLIENT_ID = "client_id"
     CLIENT_SECRET = "client_secret"
     JWT_TOKEN = "jwt_token"
@@ -22,6 +23,13 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "description": "Zoom app account ID, required for OAuth authentication",
       "order": 3
     },
+    "authentication_retry_limit": {
+      "type": "integer",
+      "title": "OAuth Authentication Retry Limit",
+      "description": "How many times to retry authentication to Zoom before failing, required for OAuth authentication",
+      "default": 5,
+      "order": 4
+    },
     "client_id": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Client ID",
@@ -38,7 +46,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "$ref": "#/definitions/credential_secret_key",
       "title": "JWT Token",
       "description": "Zoom JWT token, without the Bearer prefix",
-      "order": 4
+      "order": 5
     }
   },
   "definitions": {

--- a/plugins/zoom/icon_zoom/connection/schema.py
+++ b/plugins/zoom/icon_zoom/connection/schema.py
@@ -7,6 +7,7 @@ class Input:
     ACCOUNT_ID = "account_id"
     CLIENT_ID = "client_id"
     CLIENT_SECRET = "client_secret"
+    JWT_TOKEN = "jwt_token"
     
 
 class ConnectionSchema(insightconnect_plugin_runtime.Input):
@@ -18,27 +19,28 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
     "account_id": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Account ID",
-      "description": "Zoom app account ID",
+      "description": "Zoom app account ID, required for OAuth authentication",
       "order": 3
     },
     "client_id": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Client ID",
-      "description": "Zoom app client ID",
+      "description": "Zoom app client ID, required for OAuth authentication",
       "order": 1
     },
     "client_secret": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Client Secret",
-      "description": "Zoom app client secret",
+      "description": "Zoom app client secret, required for OAuth authentication",
       "order": 2
+    },
+    "jwt_token": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "JWT Token",
+      "description": "Zoom JWT token",
+      "order": 4
     }
   },
-  "required": [
-    "account_id",
-    "client_id",
-    "client_secret"
-  ],
   "definitions": {
     "credential_secret_key": {
       "id": "credential_secret_key",

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -107,11 +107,12 @@ class ZoomAPI:
             }
 
             self.logger.info(f"Got status code {response.status_code} from OAuth token refresh")
-            if response.status_code in codes.keys():
-                raise codes[response.status_code]
+            for key, value in codes:
+                if response.status_code == key:
+                    raise value
 
             # Handle unknown status codes
-            elif response.status_code in range(0, 199) or response.status_code >= 300:
+            if response.status_code in range(0, 199) or response.status_code >= 300:
                 raise PluginException(preset=PluginException.Preset.UNKNOWN)
 
         except requests.exceptions.HTTPError as error:

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -38,9 +38,10 @@ class ZoomAPI:
         self.jwt_token = jwt_token
         self.logger = logger
 
+        self.oauth_token: Optional[str] = None
+
         # JWT is -not- being used, so get an OAuth token
         if not jwt_token:
-            self.oauth_token: Optional[str] = None
             self._refresh_oauth_token()
 
     def get_user(self, user_id: str) -> Optional[dict]:

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -198,10 +198,8 @@ class ZoomAPI:
                 return self._call_api(**original_call_args)
 
             raise PluginException(
-                cause="The JWT token provided in the plugin connection configuration is either "
-                "invalid or expired.",
-                assistance="Please update the plugin connection configuration with a valid or "
-                "updated JWT token.",
+                cause="The JWT token provided in the plugin connection configuration is either " "invalid or expired.",
+                assistance="Please update the plugin connection configuration with a valid or " "updated JWT token.",
             )
 
         if response.status_code == 404:

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -230,6 +230,11 @@ class ZoomAPI:
                 assistance="Please update the plugin connection configuration with a valid or " "updated JWT token.",
             )
 
+        # If we reach this point, all known/documented status codes have been exhausted, so the Zoom API has likely
+        # changed and the plugin will require an update.
+        raise PluginException(cause=f"Received an undocumented status code from the Zoom API ({response.status_code})",
+                              assistance="Please contact support for assistance.")
+
     @staticmethod
     def get_exception_for_rate_limit(response: Response) -> PluginException:
         rate_limit_type = response.headers.get("X-RateLimit-Type", "")

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -33,30 +33,7 @@ class ZoomAPI:
         self.logger = logger
 
         self.oauth_token: Optional[str] = None
-        self.refresh_oauth_token()
-
-    # def refresh_oauth_token(self) -> None:
-    #     """
-    #     Retrieves a new server-to-server OAuth token from Zoom
-    #     :return: None
-    #     """
-    #
-    #     params = {"grant_type": "account_credentials", "account_id": self.account_id}
-    #
-    #     auth = HTTPBasicAuth(self.client_id, self.client_secret)
-    #
-    #     self.logger.info("Requesting new OAuth token from Zoom...")
-    #     response = self._call_api(method="POST", url=self.oauth_url, params=params, auth=auth)
-    #     try:
-    #         access_token = response["access_token"]
-    #     except KeyError:
-    #         raise PluginException(
-    #             cause=f"Unable to get access token: {response.get('reason', '')}.",
-    #             assistance="Ensure your connection configuration is using correct credentials.",
-    #         )
-    #
-    #     self.logger.info("Request for new OAuth token was successful!")
-    #     self.oauth_token = access_token
+        self._refresh_oauth_token()
 
     def get_user(self, user_id: str) -> Optional[dict]:
         return self._call_api("GET", f"{self.api_url}/users/{user_id}")

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -83,11 +83,15 @@ class ZoomAPI:
             codes = {
                 400: PluginException(preset=PluginException.Preset.BAD_REQUEST),
                 401: PluginException(preset=PluginException.Preset.UNAUTHORIZED),
-                403: PluginException(cause="Configured credentials do not have permission for this API endpoint.",
-                                     assistance="Please ensure credentials have required permissions."),
+                403: PluginException(
+                    cause="Configured credentials do not have permission for this API endpoint.",
+                    assistance="Please ensure credentials have required permissions.",
+                ),
                 429: self._handle_rate_limit_error(response),
-                4700: PluginException(cause="Configured credentials do not have permission for this API endpoint.",
-                                      assistance="Please ensure credentials have required permissions."),
+                4700: PluginException(
+                    cause="Configured credentials do not have permission for this API endpoint.",
+                    assistance="Please ensure credentials have required permissions.",
+                ),
             }
 
             self.logger.info(f"Got status code {response.status_code} from OAuth token refresh")

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -77,7 +77,8 @@ class ZoomAPI:
 
         try:
             self.logger.info("Calling Zoom API to refresh OAuth token...")
-            response = requests.post("https://zoom.us/oauth/token", params=params, auth=auth)
+            # Attempt to refresh OAuth token with 2-minute timeout
+            response = requests.post("https://zoom.us/oauth/token", params=params, auth=auth, timeout=120)
 
             # Handle known status codes
             codes = {
@@ -105,6 +106,10 @@ class ZoomAPI:
         except requests.exceptions.HTTPError as error:
             self.logger.info(f"Request to get OAuth token failed: {error}")
             raise PluginException(preset=PluginException.Preset.UNKNOWN)
+
+        except requests.exceptions.Timeout as error:
+            self.logger.info(f"Request to get OAuth token timed out: {error}")
+            raise PluginException(preset=PluginException.Preset.TIMEOUT)
 
         try:
             response_data = response.json()

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -204,15 +204,15 @@ class ZoomAPI:
         rate_limit_retry_after = response.headers.get("Retry-After")
 
         if rate_limit_type == "Light":
-            raise PluginException(
+            return PluginException(
                 cause="Account is rate-limited by the maximum per-second limit for this API.",
                 assistance="Try again later.",
             )
         elif rate_limit_type == "Heavy":
-            raise PluginException(
+            return PluginException(
                 cause=f"Account is rate-limited by the maximum daily limit for this API "
                 f"(limit: {rate_limit_limit} calls per day, {rate_limit_remaining} remaining.)",
                 assistance=f"Try again after {rate_limit_retry_after}.",
             )
         else:
-            raise PluginException(cause="Account is rate-limited by an unknown quota.", assistance="Try again later.")
+            return PluginException(cause="Account is rate-limited by an unknown quota.", assistance="Try again later.")

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -264,7 +264,4 @@ class ZoomAPI:
         return PluginException(cause="Account is rate-limited by an unknown quota.", assistance="Try again later.")
 
     def _is_using_oauth(self) -> bool:
-        if (self.account_id and self.client_id and self.client_secret) or self.oauth_token:
-            return True
-        else:
-            return False
+        return bool((self.account_id and self.client_id and self.client_secret) or self.oauth_token)

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -78,6 +78,7 @@ class ZoomAPI:
             else:
                 return events
 
+    # noqa: MC0001
     def _refresh_oauth_token(self):
         """
         Retrieves a new server-to-server OAuth token from Zoom

--- a/plugins/zoom/icon_zoom/util/api.py
+++ b/plugins/zoom/icon_zoom/util/api.py
@@ -24,12 +24,14 @@ class BearerAuth(AuthBase):
 
 
 class ZoomAPI:
-    def __init__(self,
-                 logger: Logger,
-                 account_id: Optional[str] = None,  # For OAuth only
-                 client_id: Optional[str] = None,  # For OAuth only
-                 client_secret: Optional[str] = None,  # For OAuth only
-                 jwt_token: Optional[str] = None):  # For JWT auth only
+    def __init__(
+        self,
+        logger: Logger,
+        account_id: Optional[str] = None,  # For OAuth only
+        client_id: Optional[str] = None,  # For OAuth only
+        client_secret: Optional[str] = None,  # For OAuth only
+        jwt_token: Optional[str] = None,
+    ):  # For JWT auth only
         self.api_url = "https://api.zoom.us/v2"
         self.oauth_url = "https://zoom.us/oauth/token"
         self.account_id = account_id
@@ -193,10 +195,12 @@ class ZoomAPI:
                 self._refresh_oauth_token()
                 return self._call_api(**original_call_args)
             else:
-                raise PluginException(cause="The JWT token provided in the plugin connection configuration is either "
-                                            "invalid or expired.",
-                                      assistance="Please update the plugin connection configuration with a valid or "
-                                                 "updated JWT token.")
+                raise PluginException(
+                    cause="The JWT token provided in the plugin connection configuration is either "
+                    "invalid or expired.",
+                    assistance="Please update the plugin connection configuration with a valid or "
+                    "updated JWT token.",
+                )
 
         if response.status_code == 404:
             if allow_404:

--- a/plugins/zoom/icon_zoom/util/util.py
+++ b/plugins/zoom/icon_zoom/util/util.py
@@ -1,7 +1,3 @@
-import datetime
-import jwt
-
-
 DEFAULT_TASK_TYPE = "CMEF"
 
 
@@ -9,10 +5,3 @@ class UserType:
     @staticmethod
     def value_of(user_type: str) -> int:
         return {"Basic": 1, "Licensed": 2}.get(user_type)
-
-
-def generate_jwt_token(api_key: str, secret: str) -> str:
-    """Generate a JWT token for a Zoom API Auth; short lived"""
-    payload = {"iss": api_key, "exp": datetime.datetime.now() + datetime.timedelta(seconds=60)}
-    jwt_encoded = str(jwt.encode(payload, secret), "utf-8")
-    return jwt_encoded

--- a/plugins/zoom/icon_zoom/util/util.py
+++ b/plugins/zoom/icon_zoom/util/util.py
@@ -1,3 +1,7 @@
+import datetime
+import jwt
+
+
 DEFAULT_TASK_TYPE = "CMEF"
 
 
@@ -5,3 +9,10 @@ class UserType:
     @staticmethod
     def value_of(user_type: str) -> int:
         return {"Basic": 1, "Licensed": 2}.get(user_type)
+
+
+def generate_jwt_token(api_key: str, secret: str) -> str:
+    """Generate a JWT token for a Zoom API Auth; short lived"""
+    payload = {"iss": api_key, "exp": datetime.datetime.now() + datetime.timedelta(seconds=60)}
+    jwt_encoded = str(jwt.encode(payload, secret), "utf-8")
+    return jwt_encoded

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: zoom
 title: Zoom
 description: Trigger workflows on user activity while also managing your users with the Zoom plugin
-version: 2.1.0
+version: 3.0.0
 vendor: rapid7
 support: rapid7
 status: []
@@ -24,22 +24,28 @@ enable_cache: false
 connection:
   client_id:
     title: Client ID
-    description: Zoom app client ID
+    description: Zoom app client ID, required for OAuth authentication
     type: credential_secret_key
-    required: true
+    required: false
     example: "9de5069c5afe602b2ea0a04b66beb2c0"
   client_secret:
     title: Client Secret
-    description: Zoom app client secret
+    description: Zoom app client secret, required for OAuth authentication
     type: credential_secret_key
-    required: true
+    required: false
     example: "9de5069c5afe602b2ea0a04b66beb2c0"
   account_id:
     title: Account ID
-    description: Zoom app account ID
+    description: Zoom app account ID, required for OAuth authentication
     type: credential_secret_key
-    required: true
+    required: false
     example: 'dBs0x4Kf7HuIK0LLbzMduW'
+  jwt_token:
+    title: JWT Token
+    description: Zoom JWT token
+    type: credential_secret_key
+    required: false
+    example: '9de5069c5afe602b2ea0a04b66beb2c0'
 
 types:
   user_activity:

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -42,7 +42,7 @@ connection:
     example: 'dBs0x4Kf7HuIK0LLbzMduW'
   jwt_token:
     title: JWT Token
-    description: Zoom JWT token
+    description: Zoom JWT token, without the Bearer prefix
     type: credential_secret_key
     required: false
     example: '9de5069c5afe602b2ea0a04b66beb2c0'

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -40,6 +40,13 @@ connection:
     type: credential_secret_key
     required: false
     example: 'dBs0x4Kf7HuIK0LLbzMduW'
+  authentication_retry_limit:
+    title: OAuth Authentication Retry Limit
+    description: How many times to retry authentication to Zoom before failing, required for OAuth authentication
+    type: integer
+    required: false
+    default: 5
+    example: 5
   jwt_token:
     title: JWT Token
     description: Zoom JWT token, without the Bearer prefix

--- a/plugins/zoom/requirements.txt
+++ b/plugins/zoom/requirements.txt
@@ -2,3 +2,4 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 parameterized==0.8.1
+PyJWT==1.7.1

--- a/plugins/zoom/requirements.txt
+++ b/plugins/zoom/requirements.txt
@@ -2,4 +2,3 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 parameterized==0.8.1
-PyJWT==1.7.1

--- a/plugins/zoom/setup.py
+++ b/plugins/zoom/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="zoom-rapid7-plugin",
-      version="2.1.0",
+      version="3.0.0",
       description="Trigger workflows on user activity while also managing your users with the Zoom plugin",
       author="rapid7",
       author_email="",

--- a/plugins/zoom/unit_test/mock.py
+++ b/plugins/zoom/unit_test/mock.py
@@ -5,7 +5,6 @@ from typing import Callable
 import requests
 
 from unittest import mock
-from unittest.mock import MagicMock
 
 from icon_zoom.actions.create_user.schema import Input
 from icon_zoom.connection.connection import Connection

--- a/plugins/zoom/unit_test/mock.py
+++ b/plugins/zoom/unit_test/mock.py
@@ -28,7 +28,7 @@ STUB_CREATE_USER = {
     Input.LAST_NAME: "LastName",
 }
 
-REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI.refresh_oauth_token"
+REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI._refresh_oauth_token"
 
 
 class Util:

--- a/plugins/zoom/unit_test/mock.py
+++ b/plugins/zoom/unit_test/mock.py
@@ -45,10 +45,11 @@ class Util:
 
 
 class MockResponse:
-    def __init__(self, filename: str, status_code: int, text: str = "") -> None:
+    def __init__(self, filename: str, status_code: int, text: str = "", headers: dict = {}) -> None:
         self.filename = filename
         self.status_code = status_code
         self.text = text
+        self.headers = headers
 
     def json(self):
         with open(

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -33,13 +33,27 @@ class TestAPI(TestCase):
 
     @patch(REFRESH_OAUTH_TOKEN_PATH)
     @patch(REQUESTS_PATH)
-    def test_unauthenticated_first_run_oauth_retry_limit_met(self, mock_request, mock_refresh):
+    def test_unauthenticated_first_run_oauth_retry_limit_met_1_attempt(self, mock_request, mock_refresh):
         mock_refresh.return_value = "blah"
         api = ZoomAPI(
             account_id="blah", client_id="blah", client_secret="blah", oauth_retry_limit=1, logger=logging.getLogger()
         )
 
         mock_request.side_effect = [MockResponse(status_code=401), MockResponse(status_code=200)]
+
+        with self.assertRaises(PluginException):
+            api._call_api(method="POST", url="http://example.com")
+
+    @patch(REFRESH_OAUTH_TOKEN_PATH)
+    @patch(REQUESTS_PATH)
+    def test_unauthenticated_first_run_oauth_retry_limit_met_50_attempts(self, mock_request, mock_refresh):
+        num_retries = 50
+        mock_refresh.return_value = "blah"
+        api = ZoomAPI(
+            account_id="blah", client_id="blah", client_secret="blah", oauth_retry_limit=num_retries, logger=logging.getLogger()
+        )
+
+        mock_request.side_effect = [MockResponse(status_code=401) for _ in range(0, num_retries)]
 
         with self.assertRaises(PluginException):
             api._call_api(method="POST", url="http://example.com")

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import TestCase
 from unittest.mock import patch
 
-from icon_zoom.util.api import ZoomAPI, BearerAuth
+from icon_zoom.util.api import ZoomAPI
 
 
 REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI._refresh_oauth_token"

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -21,7 +21,7 @@ class MockResponse:
 class MyTestCase(TestCase):
     @patch(REFRESH_OAUTH_TOKEN_PATH)
     @patch(REQUESTS_PATH)
-    def test_unauthenticated_first_run(self, mock_request, mock_refresh):
+    def test_unauthenticated_first_run_oauth(self, mock_request, mock_refresh):
         mock_refresh.return_value = "blah"
         api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", logger=logging.getLogger())
 
@@ -31,9 +31,25 @@ class MyTestCase(TestCase):
 
     @patch(REFRESH_OAUTH_TOKEN_PATH)
     @patch(REQUESTS_PATH)
-    def test_authenticated_first_run(self, mock_request, mock_refresh):
+    def test_authenticated_first_run_oauth(self, mock_request, mock_refresh):
         mock_refresh.return_value = "blah"
         api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", logger=logging.getLogger())
+
+        mock_request.side_effect = [MockResponse(status_code=200)]
+        result = api._call_api(method="POST", url="http://example.com")
+        self.assertDictEqual(result, {})
+
+    @patch(REQUESTS_PATH)
+    def test_authenticated_first_run_jwt(self, mock_request):
+        api = ZoomAPI(jwt_token="blah", logger=logging.getLogger())
+
+        mock_request.side_effect = [MockResponse(status_code=200)]
+        result = api._call_api(method="POST", url="http://example.com")
+        self.assertDictEqual(result, {})
+
+    @patch(REQUESTS_PATH)
+    def test_authenticated_first_run_no_auth(self, mock_request):
+        api = ZoomAPI(logger=logging.getLogger())
 
         mock_request.side_effect = [MockResponse(status_code=200)]
         result = api._call_api(method="POST", url="http://example.com")

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -50,7 +50,11 @@ class TestAPI(TestCase):
         num_retries = 50
         mock_refresh.return_value = "blah"
         api = ZoomAPI(
-            account_id="blah", client_id="blah", client_secret="blah", oauth_retry_limit=num_retries, logger=logging.getLogger()
+            account_id="blah",
+            client_id="blah",
+            client_secret="blah",
+            oauth_retry_limit=num_retries,
+            logger=logging.getLogger(),
         )
 
         mock_request.side_effect = [MockResponse(status_code=401) for _ in range(0, num_retries)]

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -47,14 +47,6 @@ class MyTestCase(TestCase):
         result = api._call_api(method="POST", url="http://example.com")
         self.assertDictEqual(result, {})
 
-    @patch(REQUESTS_PATH)
-    def test_authenticated_first_run_no_auth(self, mock_request):
-        api = ZoomAPI(logger=logging.getLogger())
-
-        mock_request.side_effect = [MockResponse(status_code=200)]
-        result = api._call_api(method="POST", url="http://example.com")
-        self.assertDictEqual(result, {})
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -6,7 +6,7 @@ from unittest.mock import patch
 from icon_zoom.util.api import ZoomAPI, BearerAuth
 
 
-REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI.refresh_oauth_token"
+REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI._refresh_oauth_token"
 REQUESTS_PATH = "requests.request"
 
 
@@ -26,7 +26,7 @@ class MyTestCase(TestCase):
         api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", logger=logging.getLogger())
 
         mock_request.side_effect = [MockResponse(status_code=401), MockResponse(status_code=200)]
-        result = api._call_api(method="POST", url="http://example.com", auth=BearerAuth(api.oauth_token))
+        result = api._call_api(method="POST", url="http://example.com")
         self.assertDictEqual(result, {})
 
     @patch(REFRESH_OAUTH_TOKEN_PATH)
@@ -36,7 +36,7 @@ class MyTestCase(TestCase):
         api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", logger=logging.getLogger())
 
         mock_request.side_effect = [MockResponse(status_code=200)]
-        result = api._call_api(method="POST", url="http://example.com", auth=BearerAuth(api.oauth_token))
+        result = api._call_api(method="POST", url="http://example.com")
         self.assertDictEqual(result, {})
 
 

--- a/plugins/zoom/unit_test/test_api.py
+++ b/plugins/zoom/unit_test/test_api.py
@@ -35,8 +35,9 @@ class TestAPI(TestCase):
     @patch(REQUESTS_PATH)
     def test_unauthenticated_first_run_oauth_retry_limit_met(self, mock_request, mock_refresh):
         mock_refresh.return_value = "blah"
-        api = ZoomAPI(account_id="blah", client_id="blah", client_secret="blah", oauth_retry_limit=1,
-                      logger=logging.getLogger())
+        api = ZoomAPI(
+            account_id="blah", client_id="blah", client_secret="blah", oauth_retry_limit=1, logger=logging.getLogger()
+        )
 
         mock_request.side_effect = [MockResponse(status_code=401), MockResponse(status_code=200)]
 

--- a/plugins/zoom/unit_test/test_create_user.py
+++ b/plugins/zoom/unit_test/test_create_user.py
@@ -47,7 +47,7 @@ class TestCreateUser(TestCase):
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
         ],
     )
-    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token", return_value=None)
+    @mock.patch("icon_zoom.util.api.ZoomAPI._refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request, exception, mock_refresh):
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:

--- a/plugins/zoom/unit_test/test_create_user.py
+++ b/plugins/zoom/unit_test/test_create_user.py
@@ -6,7 +6,6 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase, mock
 from icon_zoom.actions.create_user import CreateUser
-from icon_zoom.actions.create_user.schema import Input
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 from unit_test.mock import (

--- a/plugins/zoom/unit_test/test_delete_user.py
+++ b/plugins/zoom/unit_test/test_delete_user.py
@@ -47,7 +47,7 @@ class TestDeleteUser(TestCase):
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
         ]
     )
-    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token", return_value=None)
+    @mock.patch("icon_zoom.util.api.ZoomAPI._refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request, exception, mock_refresh):
         mocked_request(mock_request)
 

--- a/plugins/zoom/unit_test/test_get_user.py
+++ b/plugins/zoom/unit_test/test_get_user.py
@@ -1,7 +1,6 @@
 import sys
 import os
 from parameterized import parameterized
-import logging
 
 sys.path.append(os.path.abspath("../"))
 

--- a/plugins/zoom/unit_test/test_get_user.py
+++ b/plugins/zoom/unit_test/test_get_user.py
@@ -84,7 +84,7 @@ class TestGetUser(TestCase):
             (mock_request_404, PluginException.causes[PluginException.Preset.NOT_FOUND]),
         ],
     )
-    @mock.patch("icon_zoom.util.api.ZoomAPI.refresh_oauth_token", return_value=None)
+    @mock.patch("icon_zoom.util.api.ZoomAPI._refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request, exception, mock_refresh):
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -8,7 +8,7 @@ from icon_zoom.tasks.monitor_sign_in_out_activity.task import MonitorSignInOutAc
 from icon_zoom.connection.connection import Connection
 from unit_test.mock import STUB_CONNECTION, STUB_OAUTH_TOKEN
 
-REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI.refresh_oauth_token"
+REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI._refresh_oauth_token"
 GET_USER_ACTIVITY_EVENTS_PATH = "icon_zoom.util.api.ZoomAPI.get_user_activity_events"
 GET_DATETIME_NOW_PATH = "icon_zoom.tasks.monitor_sign_in_out_activity.task.MonitorSignInOutActivity._get_datetime_now"
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Improves OAuth authentication logic to help mitigate infinite looping
  - Adds back JWT authentication to possible connection configurations until OAuth token invalidation is fully solved. Please note: JWT auth will become unavailable in June 2023.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

Task with JWT Authentication
<img width="1265" alt="Screen Shot 2023-04-05 at 4 50 35 PM" src="https://user-images.githubusercontent.com/32079048/230220424-1b1cb1ed-3a7e-47fd-a208-e3959b30448f.png">

Task with OAuth Authentication
<img width="1278" alt="Screen Shot 2023-04-05 at 4 50 52 PM" src="https://user-images.githubusercontent.com/32079048/230220483-7cb181dd-4681-4f3f-8af9-be9e59acf2f5.png">


#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [x] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [x] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [x] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [x] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [x] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [x] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
