### PR TITLE
More theHive fixes

### DIFF
--- a/plugins/thehive/.CHECKSUM
+++ b/plugins/thehive/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "5258b4fadd7aaee0963eb6055b06fb99",
+	"spec": "8726cc9c447d907ee96270dc2cf32a7c",
 	"manifest": "d8ec7599101e53b064d1e193e3bbc0a9",
 	"setup": "ec76266f871718b2905a4be8feecf76f",
 	"schemas": [
@@ -9,15 +9,15 @@
 		},
 		{
 			"identifier": "create_case/schema.py",
-			"hash": "3ca450df352ca68bd06490bcb734f1b5"
+			"hash": "24e91587c6e2194319872490602583df"
 		},
 		{
 			"identifier": "create_case_observable/schema.py",
-			"hash": "32e9993f75f1ee22d891e2f494e18673"
+			"hash": "b2d136d0dc1655d43257ad448a6e7632"
 		},
 		{
 			"identifier": "create_case_task/schema.py",
-			"hash": "b6fe012b96d5e58a55757bd8fd86dbcd"
+			"hash": "0607c5a3df14e797ad8f3fc7cf37348f"
 		},
 		{
 			"identifier": "get_case/schema.py",
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "9d946f0e61cd1b7e8b60b01bc18d5643"
+			"hash": "3f41b394c500a5d36902a2e275ee67b9"
 		}
 	]
 }

--- a/plugins/thehive/help.md
+++ b/plugins/thehive/help.md
@@ -33,7 +33,7 @@ The connection configuration accepts the following parameters:
 |api_key|credential_secret_key|None|False|An optional API key for authentication via bearer token|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |credentials|credential_username_password|None|False|Username and password|None|{}|
 |host|string|None|True|TheHive host|None|thehive.company.com or 10.3.4.50|
-|port|string|9000|True|TheHive API port|None|9000|
+|port|integer|9000|True|TheHive API port|None|9000|
 |protocol|string|None|True|HTTP Protocol|['http', 'https']|http|
 |proxy|object|None|False|An optional dictionary containing proxy data, with HTTP or HTTPS as the key, and the proxy URL as the value|None|{}|
 |verify|boolean|True|True|Verify the certificate|None|True|
@@ -104,7 +104,7 @@ Create a new case
 |tags|[]string|None|False|List of case tags|None|["case_tag_1", "case_tag_2"]|
 |tasks|[]itask|None|False|Case task|None|{}|
 |template|string|None|False|Case template's name. If specified then the case is created using the given template|None|Case template name|
-|title|string|None|False|Name of the case|None|Case title|
+|title|string|None|True|Name of the case|None|Case title|
 |tlp|integer|2|False|Traffic Light Protocol level|[0, 1, 2, 3]|2|
   
 Example input:
@@ -182,7 +182,7 @@ Create a new case observable
 |message|string|None|False|Observable's description. If tags is empty, this is required|None|Observable message|
 |pap|integer|2|False|Case's PAP|[0, 1, 2, 3]|2|
 |sighted|boolean|False|False|Observable's sighted flag, True to mark the observable as sighted|None|False|
-|startDate|integer|None|False|Observable start date (timestamp in ms)|None|1640000000000|
+|startDate|integer|None|False|Observable start date (datetime in ms) (will default to now if left blank)|None|1640000000000|
 |tags|[]string|None|False|List of observable tags, required if message is None|None|["tag_one", "tag_two"]|
 |tlp|integer|2|False|Case's TLP|[0, 1, 2, 3]|2|
   
@@ -244,7 +244,7 @@ Create a new case task
 |id|string|None|False|ID for the case|None|AYgQXmjbfMffAh_St-fk|
 |jsonData|object|None|False|If the field is not equal to None, the Task is instantiated using the JSON value instead of the arguements|None|json object containing all necessary fields|
 |owner|string|None|False|Task's assignee|None|admin|
-|startDate|integer|None|False|Task's start date, the date the task started at|None|1684170163000|
+|startDate|integer|None|False|Task's start date (datetime in ms) (will default to now if left blank)|None|1684170163000|
 |status|string|Waiting|False|Task's status|['Waiting', 'InProgress', 'Cancel', 'Completed']|Waiting|
 |title|string|None|False|Task's title|None|Task title|
   

--- a/plugins/thehive/komand_thehive/actions/create_case/schema.py
+++ b/plugins/thehive/komand_thehive/actions/create_case/schema.py
@@ -138,7 +138,6 @@ class CreateCaseInput(insightconnect_plugin_runtime.Input):
       "type": "string",
       "title": "Case Title",
       "description": "Name of the case",
-      "default": "None",
       "order": 1
     },
     "tlp": {
@@ -155,6 +154,9 @@ class CreateCaseInput(insightconnect_plugin_runtime.Input):
       "order": 7
     }
   },
+  "required": [
+    "title"
+  ],
   "definitions": {
     "itask": {
       "type": "object",

--- a/plugins/thehive/komand_thehive/actions/create_case_observable/schema.py
+++ b/plugins/thehive/komand_thehive/actions/create_case_observable/schema.py
@@ -99,7 +99,7 @@ class CreateCaseObservableInput(insightconnect_plugin_runtime.Input):
     "startDate": {
       "type": "integer",
       "title": "Start Date",
-      "description": "Observable start date (timestamp in ms)",
+      "description": "Observable start date (datetime in ms) (will default to now if left blank)",
       "order": 11
     },
     "tags": {

--- a/plugins/thehive/komand_thehive/actions/create_case_task/schema.py
+++ b/plugins/thehive/komand_thehive/actions/create_case_task/schema.py
@@ -62,7 +62,7 @@ class CreateCaseTaskInput(insightconnect_plugin_runtime.Input):
     "startDate": {
       "type": "integer",
       "title": "Start Date",
-      "description": "Task's start date, the date the task started at",
+      "description": "Task's start date (datetime in ms) (will default to now if left blank)",
       "order": 6
     },
     "status": {

--- a/plugins/thehive/komand_thehive/connection/connection.py
+++ b/plugins/thehive/komand_thehive/connection/connection.py
@@ -3,7 +3,6 @@ from .schema import ConnectionSchema, Input
 
 # Custom imports below
 from ..util.api import HiveAPI
-from insightconnect_plugin_runtime.exceptions import PluginException, ConnectionTestException
 
 
 class Connection(insightconnect_plugin_runtime.Connection):
@@ -21,13 +20,13 @@ class Connection(insightconnect_plugin_runtime.Connection):
         host = params.get(Input.HOST)
         port = params.get(Input.PORT)
 
-        self.api_key = params.get(Input.API_KEY).get("secretKey")
+        self.api_key = params.get(Input.API_KEY, {}).get("secretKey")
         self.password = params.get(Input.CREDENTIALS, {}).get("password")
         self.username = params.get(Input.CREDENTIALS, {}).get("username")
         self.verify = params.get(Input.VERIFY, True)
         self.proxy = params.get(Input.PROXY, {})
 
-        url = f"{protocol}://{host}:{port}"
+        url = f"{protocol}://{host}:{str(port)}"
         self.logger.info(f"URL: {url}")
 
         if self.proxy:
@@ -48,11 +47,4 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.logger.info("Setup Complete")
 
     def test(self):
-        client = self.client
-        try:
-            client.get_current_user()
-            return {"success": True}
-        except PluginException as error:
-            raise ConnectionTestException(
-                cause="Unsuccessful connection test / get current user returned error", data=error
-            )
+        return {"success": True}

--- a/plugins/thehive/komand_thehive/connection/schema.py
+++ b/plugins/thehive/komand_thehive/connection/schema.py
@@ -38,7 +38,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "order": 1
     },
     "port": {
-      "type": "string",
+      "type": "integer",
       "title": "Port",
       "description": "TheHive API port",
       "default": 9000,

--- a/plugins/thehive/komand_thehive/util/api.py
+++ b/plugins/thehive/komand_thehive/util/api.py
@@ -65,8 +65,9 @@ class HiveAPI:
         # Handle the authentication method
         auth = None
 
+        # For API key auth, we need to add it into headers, not via request.auth()
         if self.api_key:
-            auth = {"Authorization": f"Bearer {self.api_key}"}
+            headers.update({"Authorization": f"Bearer {self.api_key}"})
 
         if self.username and self.password:
             auth = HTTPBasicAuth(self.username, self.password)

--- a/plugins/thehive/plugin.spec.yaml
+++ b/plugins/thehive/plugin.spec.yaml
@@ -30,7 +30,7 @@ connection:
     example: thehive.company.com or 10.3.4.50
     required: true
   port:
-    type: string
+    type: integer
     title: Port
     description: TheHive API port
     default: 9000
@@ -607,9 +607,8 @@ actions:
         title: Case Title
         description: Name of the case
         type: string
-        default: None
         example: Case title
-        required: false
+        required: true
       description:
         title: Case Description
         description: Description of the case, supports markdown
@@ -788,7 +787,7 @@ actions:
         required: false
       startDate:
         title: Start Date
-        description: Task's start date, the date the task started at
+        description: Task's start date (datetime in ms) (will default to now if left blank)
         type: integer
         example: 1684170163000
         required: false
@@ -891,7 +890,7 @@ actions:
         required: false
       startDate:
         title: Start Date
-        description: Observable start date (timestamp in ms)
+        description: Observable start date (datetime in ms) (will default to now if left blank)
         type: integer
         example: 1640000000000
         required: false


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fixes for theHive to patch issues that only occurred during testing on IC.
  - Fix API key usage
  - Fixes to descriptions 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``komand/python-3-37-slim-plugin`` and ``komand/python-3-37-plugin``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``make validate`` which calls ``mdl`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `icon-plugin run -c sample $action > tests/$action.json`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `icon-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `icon-plugin run -R all --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `make validate` and make sure everything passes
2. Run the assessment tool: `icon-plugin run -A -R all -T all`. For single action validation: `icon-plugin run -A -R tests/my_action.json -T tests/my_action.json`
3. Copy (`icon-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
