### PR TITLE
[PLGN-294] Mimecast handle messaging in cause field

### DIFF
--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -131,7 +131,9 @@ class MimecastAPI:
             )
 
     def _handle_status_code_response(self, response: requests.request, status_code: int):
-        if status_code == 403:
+        if status_code == 401:
+            raise PluginException(preset=PluginException.Preset.UNAUTHORIZED, data=response)
+        elif status_code == 403:
             raise PluginException(preset=PluginException.Preset.API_KEY, data=response)
         elif status_code == 404:
             raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response)
@@ -226,36 +228,34 @@ class MimecastAPI:
             for error in errors.get("errors", []):
                 if error.get(CODE) == XDK_BINDING_EXPIRED_ERROR:
                     raise ApiClientException(
-                        cause=ERROR_CASES.get(XDK_BINDING_EXPIRED_ERROR),
-                        assistance="Please provide a valid AccessKey.",
+                        preset=PluginException.Preset.UNAUTHORIZED,
                         data=response,
                         status_code=401,
                     )
                 elif error.get(CODE) == DEVELOPER_KEY_ERROR:
                     raise ApiClientException(
-                        cause=ERROR_CASES.get(error.get(CODE)),
-                        assistance=BASIC_ASSISTANCE_MESSAGE,
+                        preset=PluginException.Preset.UNAUTHORIZED,
                         data=response,
                         status_code=401,
                     )
                 elif error.get(CODE) in ERROR_CASES:
                     raise ApiClientException(
-                        cause=ERROR_CASES.get(error.get(CODE)),
-                        assistance=BASIC_ASSISTANCE_MESSAGE,
+                        assistance=ERROR_CASES.get(error.get(CODE)),
+                        cause=PluginException.causes[PluginException.Preset.BAD_REQUEST],
                         data=response,
                         status_code=400,
                     )
                 elif error.get(CODE) == FIELD_VALIDATION_ERROR:
                     raise ApiClientException(
-                        cause=f"This {error.get('field')} field is mandatory; it cannot be NULL.",
-                        assistance=BASIC_ASSISTANCE_MESSAGE,
+                        assistance=f"This {error.get('field')} field is mandatory; it cannot be NULL.",
+                        cause=PluginException.causes[PluginException.Preset.BAD_REQUEST],
                         data=response,
                         status_code=400,
                     )
                 elif error.get(CODE) == VALIDATION_BLANK_ERROR:
                     raise ApiClientException(
-                        cause=f"This {error.get('field')} field, if present, cannot be blank or empty.",
-                        assistance=BASIC_ASSISTANCE_MESSAGE,
+                        assistance=f"This {error.get('field')} field, if present, cannot be blank or empty.",
+                        cause=PluginException.causes[PluginException.Preset.BAD_REQUEST],
                         data=response,
                         status_code=400,
                     )


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - handled error messaging in cause field

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
