### PR TITLE
[PLGN-294] Mimecast update message for 401 and 403

### DIFF
--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -132,9 +132,9 @@ class MimecastAPI:
 
     def _handle_status_code_response(self, response: requests.request, status_code: int):
         if status_code == 401:
-            raise PluginException(preset=PluginException.Preset.UNAUTHORIZED, data=response)
-        elif status_code == 403:
             raise PluginException(preset=PluginException.Preset.API_KEY, data=response)
+        elif status_code == 403:
+            raise PluginException(preset=PluginException.Preset.UNAUTHORIZED, data=response)
         elif status_code == 404:
             raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response)
         elif status_code >= 500:
@@ -228,13 +228,13 @@ class MimecastAPI:
             for error in errors.get("errors", []):
                 if error.get(CODE) == XDK_BINDING_EXPIRED_ERROR:
                     raise ApiClientException(
-                        preset=PluginException.Preset.UNAUTHORIZED,
+                        preset=PluginException.Preset.API_KEY,
                         data=response,
                         status_code=401,
                     )
                 elif error.get(CODE) == DEVELOPER_KEY_ERROR:
                     raise ApiClientException(
-                        preset=PluginException.Preset.UNAUTHORIZED,
+                        preset=PluginException.Preset.API_KEY,
                         data=response,
                         status_code=401,
                     )

--- a/plugins/mimecast/unit_test/test_response_status_code_handling.py
+++ b/plugins/mimecast/unit_test/test_response_status_code_handling.py
@@ -31,9 +31,11 @@ class TestResponseStatusCodeHandling(TestCase):
     def test_403_response(self, mocked_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/find_groups_403.json.exp"))
-        self.assertEqual(exception.exception.cause, ConnectionTestException.causes.get(PluginException.Preset.API_KEY))
         self.assertEqual(
-            exception.exception.assistance, ConnectionTestException.assistances.get(PluginException.Preset.API_KEY)
+            exception.exception.cause, ConnectionTestException.causes.get(PluginException.Preset.UNAUTHORIZED)
+        )
+        self.assertEqual(
+            exception.exception.assistance, ConnectionTestException.assistances.get(PluginException.Preset.UNAUTHORIZED)
         )
 
     def test_404_response(self, mocked_request):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - update message when status code are 401 and 403 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
