### PR TITLE
SOAR-15612-Fix for required fields for GetUserOutput schema

### DIFF
--- a/plugins/zoom/.CHECKSUM
+++ b/plugins/zoom/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a0dc5fe901b6ac263bf8359c10048d09",
+	"spec": "5884f8d86a75ae1b8bad775e431bc682",
 	"manifest": "943bc06c0677e8d9d0dd04f52551f060",
-	"setup": "f9291a61ff05df58748ea14c14aa8830",
+	"setup": "e5b25aeb128e7edca5684d4a4b97c413",
 	"schemas": [
 		{
 			"identifier": "create_user/schema.py",
@@ -13,7 +13,7 @@
 		},
 		{
 			"identifier": "get_user/schema.py",
-			"hash": "d5351bec8f80cbb9190aec421c84cbb3"
+			"hash": "d34e02ac0f8fdf72ca6edbc928b886a8"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -302,6 +302,7 @@ Example output:
 
 # Version History
 
+* 4.1.2 - Fix required fields for GetUserOutput schema
 * 4.1.1 - Fix external pagination support for Monitor Sign in and Out Activity task
 * 4.1.0 - Implement external pagination for Monitor Sign in and Out Activity task | Update to latest plugin SDK
 * 4.0.2 - Reordered status checks to avoid JSON parsing issue with 204s | Added examples to spec file and help.md

--- a/plugins/zoom/icon_zoom/actions/get_user/schema.py
+++ b/plugins/zoom/icon_zoom/actions/get_user/schema.py
@@ -53,7 +53,6 @@ class GetUserOutput(insightconnect_plugin_runtime.Output):
     }
   },
   "required": [
-    "id",
     "user"
   ],
   "definitions": {
@@ -213,12 +212,11 @@ class GetUserOutput(insightconnect_plugin_runtime.Output):
           "title": "Status",
           "description": "Status of user",
           "order": 23
-        },
-        "required": [
-          "id",
-          "user"
-        ]
-      }
+        }
+      },
+      "required": [
+        "id"
+      ]
     }
   }
 }

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: zoom
 title: Zoom
 description: Trigger workflows on user activity while also managing your users with the Zoom plugin
-version: 4.1.1
+version: 4.1.2
 vendor: rapid7
 support: rapid7
 status: []

--- a/plugins/zoom/setup.py
+++ b/plugins/zoom/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="zoom-rapid7-plugin",
-      version="4.1.1",
+      version="4.1.2",
       description="Trigger workflows on user activity while also managing your users with the Zoom plugin",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  when the `insight-plugin refresh` command was last run for the zoom integration it had introduced a regression into the code. this error was caused by the required fields in the `icon_zoom/actions/get_user/schema.py` for the user object to be nested incorrectly into the object and require itself as required field. I have manually updated this issue as well as manually calculated and updated the hash values for this file

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

testing via postman we can see that the 
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/a5f8c1b7-89f4-40e5-b1ae-6530ed1ac20d)


#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
