### PR TITLE
[PLGN-423]Updated timestamp handling

### DIFF
--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "77beeb58071c98d64a6a6e4c1915ebd3",
-	"manifest": "01bcc6c2542999d60ebb034e89c8b1d8",
-	"setup": "cca5518b93d244c3428e098cc5a83523",
+	"spec": "7539a3a6c37bc080ff7c6ce06e35f18c",
+	"manifest": "444a5c0139f94e0618426c4d3fd2b168",
+	"setup": "588b6772ffcf7bd56254cddc2ba929c7",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/duo_admin/bin/komand_duo_admin
+++ b/plugins/duo_admin/bin/komand_duo_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Duo Admin API"
 Vendor = "rapid7"
-Version = "4.2.0"
+Version = "4.2.1"
 Description = "Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization"
 
 

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -1021,6 +1021,7 @@ A User ID can be obtained by passing a username to the Get User Status action.
 
 # Version History
 
+* 4.2.1 - Monitor Logs task: updated timestamp handling
 * 4.2.0 - Monitor Logs task: removed formatting of task output
 * 4.1.1 - Monitor Logs task: strip http/https in hostname, fix problem with generating header signature
 * 4.1.0 - Update to latest plugin SDK

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
@@ -11,6 +11,9 @@ from hashlib import sha1
 
 class MonitorLogs(insightconnect_plugin_runtime.Task):
     LAST_COLLECTION_TIMESTAMP = "last_collection_timestamp"
+    ADMIN_LOGS_LAST_LOG_TIMESTAMP = "admin_logs_last_log_timestamp"
+    AUTH_LOGS_LAST_LOG_TIMESTAMP = "auth_logs_last_log_timestamp"
+    TRUST_MONITOR_LAST_LOG_TIMESTAMP = "trust_monitor_last_log_timestamp"
     STATUS_CODE = "status_code"
     ADMIN_LOGS_NEXT_PAGE_PARAMS = "admin_logs_next_page_params"
     AUTH_LOGS_NEXT_PAGE_PARAMS = "auth_logs_next_page_params"
@@ -28,96 +31,143 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             state=MonitorLogsState(),
         )
 
+    def get_parameters_for_query(self, log_type, now, last_log_timestamp, next_page_params):
+        get_next_page = False
+        last_two_minutes = now - timedelta(minutes=2)
+        if not last_log_timestamp:
+            self.logger.info(f"First run for {log_type}")
+            last_24_hours = now - timedelta(hours=24)
+            if log_type != "admin_logs":
+                mintime = self.convert_to_milliseconds(last_24_hours)
+                maxtime = self.convert_to_milliseconds(last_two_minutes)
+            else:
+                # Use seconds for admin log endpoint
+                mintime = self.convert_to_seconds(last_24_hours)
+                maxtime = self.convert_to_seconds(last_two_minutes)
+
+        else:
+            if next_page_params:
+                self.logger.info("Getting the next page of results...")
+                get_next_page = True
+            else:
+                self.logger.info(f"Subsequent run for {log_type}")
+            if log_type != "admin_logs":
+                mintime = last_log_timestamp
+                maxtime = self.convert_to_milliseconds(last_two_minutes)
+            else:
+                # Use seconds for admin log endpoint
+                mintime = int(last_log_timestamp / 1000)
+                maxtime = self.convert_to_seconds(last_two_minutes)
+
+        self.logger.info(f"Retrieve data from {mintime} to {maxtime}. Get next page is set to {get_next_page}")
+        return mintime, maxtime, get_next_page
+
     # pylint: disable=unused-argument
     def run(self, params={}, state={}):  # noqa: C901
         self.connection.admin_api.toggle_rate_limiting = False
         has_more_pages = False
-        get_next_page = False
+
         try:
             now = self.get_current_time()
-            last_minute = now - timedelta(minutes=1)
             last_collection_timestamp = state.get(self.LAST_COLLECTION_TIMESTAMP)
             trust_monitor_next_page_params = state.get(self.TRUST_MONITOR_NEXT_PAGE_PARAMS)
             auth_logs_next_page_params = state.get(self.AUTH_LOGS_NEXT_PAGE_PARAMS)
             admin_logs_next_page_params = state.get(self.ADMIN_LOGS_NEXT_PAGE_PARAMS)
 
-            if not last_collection_timestamp:
-                self.logger.info("First run")
-                last_24_hours = now - timedelta(hours=24)
-                mintime_in_milliseconds = self.convert_to_milliseconds(last_24_hours)
-                maxtime_in_milliseconds = self.convert_to_milliseconds(last_minute)
-                mintime_in_seconds = self.convert_to_seconds(last_24_hours)
-                maxtime_in_seconds = self.convert_to_seconds(last_minute)
+            if last_collection_timestamp:
+                # Previously only one timestamp was held (the end of the collection window)
+                # This has been superceded by a latest timestamp per log type
+                self.logger.info("Backwards compatibility - update all timestamps to the last known timestamp")
+                trust_monitor_last_log_timestamp = auth_logs_last_log_timestamp = admin_logs_last_log_timestamp = last_collection_timestamp
+                # Update the old last collection timestamp to None so it is not considered in future runs
+                state[self.LAST_COLLECTION_TIMESTAMP] = None
             else:
-                if trust_monitor_next_page_params or auth_logs_next_page_params or admin_logs_next_page_params:
-                    self.logger.info("Getting the next page of results...")
-                    get_next_page = True
-                else:
-                    self.logger.info("Subsequent run")
-                mintime_in_milliseconds = last_collection_timestamp
-                maxtime_in_milliseconds = self.convert_to_milliseconds(last_minute)
-                mintime_in_seconds = int(mintime_in_milliseconds / 1000)
-                maxtime_in_seconds = int(maxtime_in_milliseconds / 1000)
+                trust_monitor_last_log_timestamp = state.get(self.TRUST_MONITOR_LAST_LOG_TIMESTAMP)
+                auth_logs_last_log_timestamp = state.get(self.AUTH_LOGS_LAST_LOG_TIMESTAMP)
+                admin_logs_last_log_timestamp = state.get(self.ADMIN_LOGS_LAST_LOG_TIMESTAMP)
+                self.logger.info(f"Previous timestamps retrieved. "
+                                 f"Auth {auth_logs_last_log_timestamp} "
+                                 f"Admin: {admin_logs_last_log_timestamp}. "
+                                 f"Trust monitor {trust_monitor_last_log_timestamp}")
             try:
                 new_logs = []
-                if not get_next_page:
-                    state[self.LAST_COLLECTION_TIMESTAMP] = maxtime_in_milliseconds
 
                 previous_trust_monitor_event_hashes = state.get(self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES, [])
                 previous_admin_log_hashes = state.get(self.PREVIOUS_ADMIN_LOG_HASHES, [])
                 previous_auth_log_hashes = state.get(self.PREVIOUS_AUTH_LOG_HASHES, [])
-                new_trust_monitor_event_hashes = []
-                new_admin_log_hashes = []
-                new_auth_log_hashes = []
+
+                new_trust_monitor_event_hashes = new_admin_log_hashes = new_auth_log_hashes =[]
+
+                # Get trust monitor events
+                mintime, maxtime, get_next_page = self.get_parameters_for_query("Trust monitor events",
+                                                                                now, trust_monitor_last_log_timestamp,
+                                                                                trust_monitor_next_page_params)
 
                 if (get_next_page and trust_monitor_next_page_params) or not get_next_page:
                     trust_monitor_events, trust_monitor_next_page_params = self.get_trust_monitor_event(
-                        mintime_in_milliseconds, maxtime_in_milliseconds, trust_monitor_next_page_params
+                        mintime, maxtime, trust_monitor_next_page_params
                     )
                     new_trust_monitor_events, new_trust_monitor_event_hashes = self.compare_hashes(
                         previous_trust_monitor_event_hashes, trust_monitor_events
                     )
                     new_logs.extend(new_trust_monitor_events)
-                if (get_next_page and admin_logs_next_page_params) or not get_next_page:
-                    admin_logs, admin_logs_next_page_params = self.get_admin_logs(
-                        mintime_in_seconds, maxtime_in_seconds, admin_logs_next_page_params
-                    )
-                    new_admin_logs, new_admin_log_hashes = self.compare_hashes(previous_admin_log_hashes, admin_logs)
-                    new_logs.extend(new_admin_logs)
-                if (get_next_page and auth_logs_next_page_params) or not get_next_page:
-                    auth_logs, auth_logs_next_page_params = self.get_auth_logs(
-                        mintime_in_milliseconds, maxtime_in_milliseconds, auth_logs_next_page_params
-                    )
-                    new_auth_logs, new_auth_log_hashes = self.compare_hashes(previous_auth_log_hashes, auth_logs)
-                    new_logs.extend(new_auth_logs)
-
+                    state[self.TRUST_MONITOR_LAST_LOG_TIMESTAMP] = self.get_highest_timestamp(new_trust_monitor_events)
+                    self.logger.info(f"{len(new_trust_monitor_events)} trust monitor events retrieved")
                 state[self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES] = (
                     previous_trust_monitor_event_hashes
                     if not new_trust_monitor_event_hashes and get_next_page
                     else new_trust_monitor_event_hashes
                 )
-                state[self.PREVIOUS_ADMIN_LOG_HASHES] = (
-                    previous_admin_log_hashes if not new_admin_log_hashes and get_next_page else new_admin_log_hashes
-                )
-                state[self.PREVIOUS_AUTH_LOG_HASHES] = (
-                    previous_auth_log_hashes if not new_auth_log_hashes and get_next_page else new_auth_log_hashes
-                )
-
                 if trust_monitor_next_page_params:
                     state[self.TRUST_MONITOR_NEXT_PAGE_PARAMS] = trust_monitor_next_page_params
                     has_more_pages = True
                 elif state.get(self.TRUST_MONITOR_NEXT_PAGE_PARAMS):
                     state.pop(self.TRUST_MONITOR_NEXT_PAGE_PARAMS)
-                if auth_logs_next_page_params:
-                    state[self.AUTH_LOGS_NEXT_PAGE_PARAMS] = auth_logs_next_page_params
-                    has_more_pages = True
-                elif state.get(self.AUTH_LOGS_NEXT_PAGE_PARAMS):
-                    state.pop(self.AUTH_LOGS_NEXT_PAGE_PARAMS)
+
+                # Get admin logs
+                mintime, maxtime, get_next_page = self.get_parameters_for_query("Admin logs", now,
+                                                                                admin_logs_last_log_timestamp,
+                                                                                admin_logs_next_page_params)
+
+                if (get_next_page and admin_logs_next_page_params) or not get_next_page:
+                    admin_logs, admin_logs_next_page_params = self.get_admin_logs(
+                        mintime, maxtime, admin_logs_next_page_params
+                    )
+                    new_admin_logs, new_admin_log_hashes = self.compare_hashes(previous_admin_log_hashes, admin_logs)
+                    new_logs.extend(new_admin_logs)
+                    state[self.ADMIN_LOGS_LAST_LOG_TIMESTAMP] = self.get_highest_timestamp(new_admin_logs)
+                    self.logger.info(f"{len(new_admin_logs)} admin logs retrieved")
+                state[self.PREVIOUS_ADMIN_LOG_HASHES] = (
+                    previous_admin_log_hashes if not new_admin_log_hashes and get_next_page else new_admin_log_hashes
+                )
+
                 if admin_logs_next_page_params:
                     state[self.ADMIN_LOGS_NEXT_PAGE_PARAMS] = admin_logs_next_page_params
                     has_more_pages = True
                 elif state.get(self.ADMIN_LOGS_NEXT_PAGE_PARAMS):
                     state.pop(self.ADMIN_LOGS_NEXT_PAGE_PARAMS)
+
+                # Get auth logs
+                mintime, maxtime, get_next_page = self.get_parameters_for_query("Auth logs", now,
+                                                                                auth_logs_last_log_timestamp,
+                                                                                auth_logs_next_page_params)
+                if (get_next_page and auth_logs_next_page_params) or not get_next_page:
+                    auth_logs, auth_logs_next_page_params = self.get_auth_logs(
+                        mintime, maxtime, auth_logs_next_page_params
+                    )
+                    new_auth_logs, new_auth_log_hashes = self.compare_hashes(previous_auth_log_hashes, auth_logs)
+                    # Grab the most recent timestamp and save it to use as min time for next run
+                    new_logs.extend(new_auth_logs)
+                    state[self.AUTH_LOGS_LAST_LOG_TIMESTAMP] = self.get_highest_timestamp(new_auth_logs)
+                    self.logger.info(f"{len(new_auth_logs)} auth logs retrieved")
+                state[self.PREVIOUS_AUTH_LOG_HASHES] = (
+                    previous_auth_log_hashes if not new_auth_log_hashes and get_next_page else new_auth_log_hashes
+                )
+                if auth_logs_next_page_params:
+                    state[self.AUTH_LOGS_NEXT_PAGE_PARAMS] = auth_logs_next_page_params
+                    has_more_pages = True
+                elif state.get(self.AUTH_LOGS_NEXT_PAGE_PARAMS):
+                    state.pop(self.AUTH_LOGS_NEXT_PAGE_PARAMS)
 
                 return new_logs, state, has_more_pages, 200, None
             except ApiException as error:
@@ -166,12 +216,24 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 logs_to_return.append(log)
         return logs_to_return, new_logs_hashes
 
+    def get_highest_timestamp(self, logs):
+        highest_timestamp = 0
+        for log in logs:
+            log_timestamp = log.get("timestamp")
+            if log_timestamp and log_timestamp > highest_timestamp:
+                highest_timestamp = log_timestamp
+        self.logger.info(f"Highest timestamp set to {highest_timestamp}")
+        return highest_timestamp
+
+
     def get_auth_logs(self, mintime: int, maxtime: int, next_page_params: dict) -> list:
         parameters = (
             next_page_params
             if next_page_params
             else {"mintime": str(mintime), "maxtime": str(maxtime), "limit": str(1000)}
         )
+        parameters.update("sort", "asc")
+        self.logger.info(f"Parameters for get auth logs set to {parameters}")
         response = self.connection.admin_api.get_auth_logs(parameters).get("response", {})
         metadata = response.get("metadata") or {}
         next_offset = metadata.get("next_offset")
@@ -184,6 +246,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
 
     def get_admin_logs(self, mintime: int, maxtime: int, next_page_params: dict) -> list:
         parameters = {"mintime": next_page_params.get("mintime") if next_page_params else str(mintime)}
+        self.logger.info(f"Parameters for get admin logs set to {parameters}")
         response = self.connection.admin_api.get_admin_logs(parameters).get("response", [])
         last_item = response[-1] if response and isinstance(response, list) else None
 
@@ -206,6 +269,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             if next_page_params
             else {"mintime": str(mintime), "maxtime": str(maxtime), "limit": str(200)}
         )
+        self.logger.info(f"Parameters for get trust monitor events set to {parameters}")
         response = self.connection.admin_api.get_trust_monitor_events(parameters).get("response", {})
         offset = response.get("metadata", {}).get("next_offset")
         if offset:

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
@@ -36,7 +36,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         last_two_minutes = now - timedelta(minutes=2)
         if not last_log_timestamp:
             self.logger.info(f"First run for {log_type}")
-            last_24_hours = now - timedelta(hours=2)
+            last_24_hours = now - timedelta(hours=24)
             if log_type != "Admin logs":
                 mintime = self.convert_to_milliseconds(last_24_hours)
                 maxtime = self.convert_to_milliseconds(last_two_minutes)
@@ -78,17 +78,21 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 # Previously only one timestamp was held (the end of the collection window)
                 # This has been superceded by a latest timestamp per log type
                 self.logger.info("Backwards compatibility - update all timestamps to the last known timestamp")
-                trust_monitor_last_log_timestamp = auth_logs_last_log_timestamp = admin_logs_last_log_timestamp = last_collection_timestamp
+                trust_monitor_last_log_timestamp = (
+                    auth_logs_last_log_timestamp
+                ) = admin_logs_last_log_timestamp = last_collection_timestamp
                 # Update the old last collection timestamp to None so it is not considered in future runs
                 state[self.LAST_COLLECTION_TIMESTAMP] = None
             else:
                 trust_monitor_last_log_timestamp = state.get(self.TRUST_MONITOR_LAST_LOG_TIMESTAMP)
                 auth_logs_last_log_timestamp = state.get(self.AUTH_LOGS_LAST_LOG_TIMESTAMP)
                 admin_logs_last_log_timestamp = state.get(self.ADMIN_LOGS_LAST_LOG_TIMESTAMP)
-                self.logger.info(f"Previous timestamps retrieved. "
-                                 f"Auth {auth_logs_last_log_timestamp} "
-                                 f"Admin: {admin_logs_last_log_timestamp}. "
-                                 f"Trust monitor {trust_monitor_last_log_timestamp}")
+                self.logger.info(
+                    f"Previous timestamps retrieved. "
+                    f"Auth {auth_logs_last_log_timestamp} "
+                    f"Admin: {admin_logs_last_log_timestamp}. "
+                    f"Trust monitor {trust_monitor_last_log_timestamp}"
+                )
             try:
                 new_logs = []
 
@@ -96,12 +100,12 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 previous_admin_log_hashes = state.get(self.PREVIOUS_ADMIN_LOG_HASHES, [])
                 previous_auth_log_hashes = state.get(self.PREVIOUS_AUTH_LOG_HASHES, [])
 
-                new_trust_monitor_event_hashes = new_admin_log_hashes = new_auth_log_hashes =[]
+                new_trust_monitor_event_hashes = new_admin_log_hashes = new_auth_log_hashes = []
 
                 # Get trust monitor events
-                mintime, maxtime, get_next_page = self.get_parameters_for_query("Trust monitor events",
-                                                                                now, trust_monitor_last_log_timestamp,
-                                                                                trust_monitor_next_page_params)
+                mintime, maxtime, get_next_page = self.get_parameters_for_query(
+                    "Trust monitor events", now, trust_monitor_last_log_timestamp, trust_monitor_next_page_params
+                )
 
                 if (get_next_page and trust_monitor_next_page_params) or not get_next_page:
                     trust_monitor_events, trust_monitor_next_page_params = self.get_trust_monitor_event(
@@ -125,9 +129,9 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                     state.pop(self.TRUST_MONITOR_NEXT_PAGE_PARAMS)
 
                 # Get admin logs
-                mintime, maxtime, get_next_page = self.get_parameters_for_query("Admin logs", now,
-                                                                                admin_logs_last_log_timestamp,
-                                                                                admin_logs_next_page_params)
+                mintime, maxtime, get_next_page = self.get_parameters_for_query(
+                    "Admin logs", now, admin_logs_last_log_timestamp, admin_logs_next_page_params
+                )
 
                 if (get_next_page and admin_logs_next_page_params) or not get_next_page:
                     admin_logs, admin_logs_next_page_params = self.get_admin_logs(
@@ -148,9 +152,9 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                     state.pop(self.ADMIN_LOGS_NEXT_PAGE_PARAMS)
 
                 # Get auth logs
-                mintime, maxtime, get_next_page = self.get_parameters_for_query("Auth logs", now,
-                                                                                auth_logs_last_log_timestamp,
-                                                                                auth_logs_next_page_params)
+                mintime, maxtime, get_next_page = self.get_parameters_for_query(
+                    "Auth logs", now, auth_logs_last_log_timestamp, auth_logs_next_page_params
+                )
 
                 if (get_next_page and auth_logs_next_page_params) or not get_next_page:
                     auth_logs, auth_logs_next_page_params = self.get_auth_logs(
@@ -225,7 +229,6 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 highest_timestamp = log_timestamp
         self.logger.info(f"Highest timestamp set to {highest_timestamp}")
         return highest_timestamp
-
 
     def get_auth_logs(self, mintime: int, maxtime: int, next_page_params: dict) -> list:
         parameters = (

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
@@ -36,8 +36,8 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         last_two_minutes = now - timedelta(minutes=2)
         if not last_log_timestamp:
             self.logger.info(f"First run for {log_type}")
-            last_24_hours = now - timedelta(hours=24)
-            if log_type != "admin_logs":
+            last_24_hours = now - timedelta(hours=2)
+            if log_type != "Admin logs":
                 mintime = self.convert_to_milliseconds(last_24_hours)
                 maxtime = self.convert_to_milliseconds(last_two_minutes)
             else:
@@ -51,7 +51,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 get_next_page = True
             else:
                 self.logger.info(f"Subsequent run for {log_type}")
-            if log_type != "admin_logs":
+            if log_type != "Admin logs":
                 mintime = last_log_timestamp
                 maxtime = self.convert_to_milliseconds(last_two_minutes)
             else:
@@ -151,6 +151,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 mintime, maxtime, get_next_page = self.get_parameters_for_query("Auth logs", now,
                                                                                 auth_logs_last_log_timestamp,
                                                                                 auth_logs_next_page_params)
+
                 if (get_next_page and auth_logs_next_page_params) or not get_next_page:
                     auth_logs, auth_logs_next_page_params = self.get_auth_logs(
                         mintime, maxtime, auth_logs_next_page_params
@@ -232,7 +233,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             if next_page_params
             else {"mintime": str(mintime), "maxtime": str(maxtime), "limit": str(1000)}
         )
-        parameters.update("sort", "asc")
+        parameters.update({"sort": "ts:asc"})
         self.logger.info(f"Parameters for get auth logs set to {parameters}")
         response = self.connection.admin_api.get_auth_logs(parameters).get("response", {})
         metadata = response.get("metadata") or {}

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
@@ -100,8 +100,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 previous_trust_monitor_event_hashes = state.get(self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES, [])
                 previous_admin_log_hashes = state.get(self.PREVIOUS_ADMIN_LOG_HASHES, [])
                 previous_auth_log_hashes = state.get(self.PREVIOUS_AUTH_LOG_HASHES, [])
-
-                new_trust_monitor_event_hashes = new_admin_log_hashes = new_auth_log_hashes = []
+                new_trust_monitor_event_hashes, new_admin_log_hashes, new_auth_log_hashes = [], [], []
 
                 # Get trust monitor events
                 mintime, maxtime, get_next_page = self.get_parameters_for_query(
@@ -120,11 +119,9 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                         trust_monitor_last_log_timestamp, new_trust_monitor_events
                     )
                     self.logger.info(f"{len(new_trust_monitor_events)} trust monitor events retrieved")
-                state[self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES] = (
-                    previous_trust_monitor_event_hashes
-                    if not new_trust_monitor_event_hashes and get_next_page
-                    else new_trust_monitor_event_hashes
-                )
+                if new_trust_monitor_event_hashes:
+                    state[self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES] = new_trust_monitor_event_hashes
+
                 if trust_monitor_next_page_params:
                     state[self.TRUST_MONITOR_NEXT_PAGE_PARAMS] = trust_monitor_next_page_params
                     has_more_pages = True
@@ -146,9 +143,9 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                         admin_logs_last_log_timestamp, new_admin_logs
                     )
                     self.logger.info(f"{len(new_admin_logs)} admin logs retrieved")
-                state[self.PREVIOUS_ADMIN_LOG_HASHES] = (
-                    previous_admin_log_hashes if not new_admin_log_hashes and get_next_page else new_admin_log_hashes
-                )
+
+                if new_admin_log_hashes:
+                    state[self.PREVIOUS_ADMIN_LOG_HASHES] = new_admin_log_hashes
 
                 if admin_logs_next_page_params:
                     state[self.ADMIN_LOGS_NEXT_PAGE_PARAMS] = admin_logs_next_page_params
@@ -172,9 +169,10 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                         auth_logs_last_log_timestamp, new_auth_logs
                     )
                     self.logger.info(f"{len(new_auth_logs)} auth logs retrieved")
-                state[self.PREVIOUS_AUTH_LOG_HASHES] = (
-                    previous_auth_log_hashes if not new_auth_log_hashes and get_next_page else new_auth_log_hashes
-                )
+
+                if new_auth_log_hashes:
+                    state[self.PREVIOUS_AUTH_LOG_HASHES] = new_auth_log_hashes
+
                 if auth_logs_next_page_params:
                     state[self.AUTH_LOGS_NEXT_PAGE_PARAMS] = auth_logs_next_page_params
                     has_more_pages = True

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -13,7 +13,7 @@ sdk:
   version: 5
   user: nobody
 description: Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization
-version: 4.2.0
+version: 4.2.1
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/duo_admin

--- a/plugins/duo_admin/setup.py
+++ b/plugins/duo_admin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="duo_admin-rapid7-plugin",
-      version="4.2.0",
+      version="4.2.1",
       description="Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description
Update handling of timestamp functionality with tasks:
- Ensure that the auth logs are ordered ascending in timestamp
- Change now time to 2 mins ago instead of 1 minute as suggested should be the case in the Duo docs 
- Split into maintaining three timestamps - one per log type
- Change the timestamp used to the latest log time instead of the max window time
- Backwards compatibility with the older one last collection timestamp method
- Add additional logging for debug purposes. 

NoteL To minimise risk, have tried to keep changes to a minimum. Also updated unit tests will come after in a subsequent PR.  Schema manually updated with ticket already raised around tooling fix required. 

