### PR TITLE
PLGN-431: only filter events when not using Okta pagination.

### DIFF
--- a/plugins/okta/.CHECKSUM
+++ b/plugins/okta/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "3ad1604efd5761d7129ee19e728efb5d",
-	"manifest": "ae6c3d90c00d8b25576f218a99b62763",
-	"setup": "f0f0aa00f602f9aa8da621bfe91e7107",
+	"spec": "4fa8814f7a1dad536a21d7e9de9751c6",
+	"manifest": "447e9671154a8344ca38101005070c84",
+	"setup": "104b67f143c716178e8c47921d6b4e0b",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",

--- a/plugins/okta/bin/komand_okta
+++ b/plugins/okta/bin/komand_okta
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Okta"
 Vendor = "rapid7"
-Version = "4.2.1"
+Version = "4.2.2"
 Description = "Secure identity management and single sign-on to any application"
 
 

--- a/plugins/okta/help.md
+++ b/plugins/okta/help.md
@@ -1612,6 +1612,7 @@ by Okta themselves, or constructed by the plugin based on the information it has
 
 # Version History
 
+* 4.2.2 - Monitor Logs task: log deduplication only applied when querying Okta using since and until parameters.
 * 4.2.1 - Monitor Logs task: filter previously returned log events | only update time checkpoint when an event is returned | update timestamp format | set cutoff time of 24 hours.
 * 4.2.0 - Monitor Logs task: return raw logs data without cleaning and use last log time as checkpoint in time for next run.
 * 4.1.1 - Monitor Logs task: strip http/https in hostname

--- a/plugins/okta/plugin.spec.yaml
+++ b/plugins/okta/plugin.spec.yaml
@@ -13,7 +13,7 @@ sdk:
   version: 5
   user: nobody
 description: Secure identity management and single sign-on to any application
-version: 4.2.1
+version: 4.2.2
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/okta

--- a/plugins/okta/setup.py
+++ b/plugins/okta/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="okta-rapid7-plugin",
-      version="4.2.1",
+      version="4.2.2",
       description="Secure identity management and single sign-on to any application",
       author="rapid7",
       author_email="",

--- a/plugins/okta/unit_test/expected/get_logs_next_page.json.exp
+++ b/plugins/okta/unit_test/expected/get_logs_next_page.json.exp
@@ -73,8 +73,9 @@
     }
   ],
   "state": {
-    "last_collection_timestamp": "2023-04-27T07:49:21.764Z"
+    "last_collection_timestamp": "2023-04-27T07:49:21.764Z",
+    "next_page_link": "https://example.com/nextLink?q=next"
   },
-  "has_more_pages": false,
+  "has_more_pages": true,
   "status_code": 200
 }

--- a/plugins/okta/unit_test/util.py
+++ b/plugins/okta/unit_test/util.py
@@ -64,7 +64,9 @@ class Util:
                 resp_args["filename"], resp_args["headers"] = "get_logs_single_event.json.resp", {"link": ""}
             return MockResponse(**resp_args)
         if url == "https://example.com/nextLink?q=next":
-            return MockResponse(200, "get_logs_next_page.json.resp", {"link": ""})
+            return MockResponse(
+                200, "get_logs_next_page.json.resp", {"link": '<https://example.com/nextLink?q=next> rel="next"'}
+            )
         if url == "https://example.com/api/v1/groups/12345/users" and first_request:
             first_request = False
             return MockResponse(200, "get_users_in_group.json.resp")


### PR DESCRIPTION
## Proposed Changes
Noticed in data comparison of Okta that there is an edge case when we encounter pagination that the next page called could still have an event that matches the last event returned, and with the old logic this would be filtered from the results. 

### Description

Describe the proposed changes:
  - only perform the comparison of logs events against the last_collection_timestamp when we have used the values since and until.
  - these params are used to make sure no data is lost between each run but will return the last ingested event, this logic was added in: #2008 but didn't take into account the next page could also contain a matching timestamp. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Edge case that was hit on production to get two events at the same time and during pagination.. Unable to test on dev instance, so I've had to rely on adding. a new unit test added to cover this edge case. The unit test uses a mocked response, to:
- test iteration 1 -> normal workflow using a saved TS that does not match the returned event. This feeds into the next iteration with the state now saving the last_collection_timestamp to be the returned log time and the next page link.
- test iteration 2: uses the state from above, but the unit test reuses the same mocked response (to save on adding more faked responses), and this event is to act as a new event in the next call, but is not filtered even though the times match. 

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
