### PR TITLE
Okta 4.2.2. Release - PLGN-431 - improved monitor log task. 

### DIFF
--- a/plugins/okta/.CHECKSUM
+++ b/plugins/okta/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "3ad1604efd5761d7129ee19e728efb5d",
-	"manifest": "ae6c3d90c00d8b25576f218a99b62763",
-	"setup": "f0f0aa00f602f9aa8da621bfe91e7107",
+	"spec": "4fa8814f7a1dad536a21d7e9de9751c6",
+	"manifest": "447e9671154a8344ca38101005070c84",
+	"setup": "104b67f143c716178e8c47921d6b4e0b",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",

--- a/plugins/okta/bin/komand_okta
+++ b/plugins/okta/bin/komand_okta
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Okta"
 Vendor = "rapid7"
-Version = "4.2.1"
+Version = "4.2.2"
 Description = "Secure identity management and single sign-on to any application"
 
 

--- a/plugins/okta/help.md
+++ b/plugins/okta/help.md
@@ -1612,6 +1612,7 @@ by Okta themselves, or constructed by the plugin based on the information it has
 
 # Version History
 
+* 4.2.2 - Monitor Logs task: log deduplication only applied when querying Okta using since and until parameters.
 * 4.2.1 - Monitor Logs task: filter previously returned log events | only update time checkpoint when an event is returned | update timestamp format | set cutoff time of 24 hours.
 * 4.2.0 - Monitor Logs task: return raw logs data without cleaning and use last log time as checkpoint in time for next run.
 * 4.1.1 - Monitor Logs task: strip http/https in hostname

--- a/plugins/okta/plugin.spec.yaml
+++ b/plugins/okta/plugin.spec.yaml
@@ -13,7 +13,7 @@ sdk:
   version: 5
   user: nobody
 description: Secure identity management and single sign-on to any application
-version: 4.2.1
+version: 4.2.2
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/okta

--- a/plugins/okta/setup.py
+++ b/plugins/okta/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="okta-rapid7-plugin",
-      version="4.2.1",
+      version="4.2.2",
       description="Secure identity management and single sign-on to any application",
       author="rapid7",
       author_email="",

--- a/plugins/okta/unit_test/expected/get_logs_next_page.json.exp
+++ b/plugins/okta/unit_test/expected/get_logs_next_page.json.exp
@@ -73,8 +73,9 @@
     }
   ],
   "state": {
-    "last_collection_timestamp": "2023-04-27T07:49:21.764Z"
+    "last_collection_timestamp": "2023-04-27T07:49:21.764Z",
+    "next_page_link": "https://example.com/nextLink?q=next"
   },
-  "has_more_pages": false,
+  "has_more_pages": true,
   "status_code": 200
 }

--- a/plugins/okta/unit_test/util.py
+++ b/plugins/okta/unit_test/util.py
@@ -64,7 +64,9 @@ class Util:
                 resp_args["filename"], resp_args["headers"] = "get_logs_single_event.json.resp", {"link": ""}
             return MockResponse(**resp_args)
         if url == "https://example.com/nextLink?q=next":
-            return MockResponse(200, "get_logs_next_page.json.resp", {"link": ""})
+            return MockResponse(
+                200, "get_logs_next_page.json.resp", {"link": '<https://example.com/nextLink?q=next> rel="next"'}
+            )
         if url == "https://example.com/api/v1/groups/12345/users" and first_request:
             first_request = False
             return MockResponse(200, "get_users_in_group.json.resp")


### PR DESCRIPTION
Release PR - Okta 4.2.2

PRs:
- #2030 

Changes:
- Only apply filtering logic if the request to Okta has not been carried out using the `next_page` value. 

Testing:
- Deployed to staging and logs are looking as expected. 
- Unable to hit new logger on staging: `next_page value used to poll from Okta. Returning x event(s) from response.` as dev instance only seems to create 8 log events per log in action and pagination is triggered at +1000 events. (verified in unit tests). 
- Unable to test edge case of two events on separate pages at the exact time. 