### PR TITLE
Mimecast 5.3.2 Release (PLGN-434)

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "4c16abce919b026aa51a6b37acd0bd57",
+	"spec": "923a6bbb21fe0ce039f39ff00014ae00",
 	"manifest": "a5513a1c36d038851b10a6226d980590",
 	"setup": "318548fa67238e900bb082347305cef6",
 	"schemas": [
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "monitor_siem_logs/schema.py",
-			"hash": "e86f21b7207b572f78132b9288843bf1"
+			"hash": "fed0e07521688fbeece2dd35abb49310"
 		}
 	]
 }

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "aec11f5ba7ccf8bb2120d71e6d1fb11d",
-	"manifest": "ec2886842e5f577654c60162b579d28e",
-	"setup": "5924e68a1548bb356a533b947e205be8",
+	"spec": "4c16abce919b026aa51a6b37acd0bd57",
+	"manifest": "a5513a1c36d038851b10a6226d980590",
+	"setup": "318548fa67238e900bb082347305cef6",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",
@@ -57,11 +57,11 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "34ebd42e8cc4eba39db8d07b843c8d63"
+			"hash": "5f2643a1df641cfac4a907361dd63556"
 		},
 		{
 			"identifier": "monitor_siem_logs/schema.py",
-			"hash": "17bfe7c53aab5e5ebc6db73d3c6e29d2"
+			"hash": "e86f21b7207b572f78132b9288843bf1"
 		}
 	]
 }

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.1"
+Version = "5.3.2"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1027,6 +1027,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information.
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 
 * 5.2.2 - Handled status code for `Monitor SIEM Logs` | Request limit set to 1 minute in `Monitor SIEM Logs` 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -729,18 +729,8 @@ Example output:
 Monitor and retrieve the latest logs
 
 ##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|token|string|None|False|Used to request the next available log file|None|9de5069c5afe602b2ea0a04b66beb2c0|
   
-Example input:
-
-```
-{
-  "token": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
+*This task does not contain any inputs.*
 
 ##### Output
 
@@ -1027,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information.
+* 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 
 * 5.2.2 - Handled status code for `Monitor SIEM Logs` | Request limit set to 1 minute in `Monitor SIEM Logs` 

--- a/plugins/mimecast/komand_mimecast/connection/schema.py
+++ b/plugins/mimecast/komand_mimecast/connection/schema.py
@@ -48,7 +48,9 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
         "ZA",
         "AU",
         "Offshore",
-        "Sandbox"
+        "Sandbox",
+        "USB",
+        "USBCOM"
       ],
       "order": 1
     },

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/schema.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/schema.py
@@ -8,7 +8,7 @@ class Component:
 
 
 class Input:
-    TOKEN = "token"
+    pass
 
 
 class State:
@@ -21,19 +21,7 @@ class Output:
 
 class MonitorSiemLogsInput(insightconnect_plugin_runtime.Input):
     schema = json.loads(r"""
-   {
-  "type": "object",
-  "title": "Variables",
-  "properties": {
-    "token": {
-      "type": "string",
-      "title": "Token",
-      "description": "Used to request the next available log file",
-      "order": 1
-    }
-  },
-  "definitions": {}
-}
+   {}
     """)
 
     def __init__(self):

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -2,12 +2,13 @@ from operator import itemgetter
 from time import time
 
 import insightconnect_plugin_runtime
-from typing import Dict, List
+from typing import Dict, List, Any
 
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import get_time_hours_ago
 
 from .schema import MonitorSiemLogsInput, MonitorSiemLogsOutput, MonitorSiemLogsState, Component
+from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
@@ -16,7 +17,6 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
     NEXT_TOKEN = "next_token"  # nosec
     HEADER_NEXT_TOKEN = "mc-siem-token"  # nosec
     STATUS_CODE = "status_code"  # nosec
-    TOKEN = "token"  # nosec
 
     def __init__(self):
         super(self.__class__, self).__init__(
@@ -27,57 +27,62 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             state=MonitorSiemLogsState(),
         )
 
-    def run(self, params={}, state={}) -> (List[Dict], Dict):
+    def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument
         try:
             has_more_pages = False
             header_next_token = state.get(self.NEXT_TOKEN, "")
+
             if not header_next_token:
                 self.logger.info("First run")
             else:
                 self.logger.info("Subsequent run")
-                params[self.TOKEN] = header_next_token
 
             limit_time = time() + 60
             while time() < limit_time:
                 try:
-                    output, headers, status_code = self.connection.client.get_siem_logs(params)
+                    output, headers, status_code = self.connection.client.get_siem_logs(header_next_token)
+                    if not output:
+                        break
                 except ApiClientException as error:
                     return [], state, has_more_pages, error.status_code, error
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
-                params[self.TOKEN] = header_next_token
-                if not output:
-                    break
                 output = self._filter_and_sort_recent_events(output)
-                if len(output) > 0:
+                if output:
                     break
 
             if header_next_token:
                 state[self.NEXT_TOKEN] = header_next_token
-                has_more_pages = True
+                has_more_pages = IS_LAST_TOKEN_FIELD not in headers
 
             return output, state, has_more_pages, status_code, None
         except Exception as error:
             return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
-    def _filter_and_sort_recent_events(self, output: List[dict]) -> List[dict]:
+    def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Filters and sorts a list of events to retrieve only the recent events.
 
-        Args:
-            events (list): A list of event objects to be filtered and sorted.
+        :param task_output: A list of dictionaries representing the task output to be filtered and sorted.
+        :type: List[Dict[str, Any]]
 
-        Returns:
-            list: The filtered and sorted list of recent events.
-
+        :return: A new list of dictionaries representing the filtered and sorted recent events.
+        :rtype: List[Dict[str, Any]]
         """
-        self.logger.info(f"Number of raw logs returned from Mimemcast: {len(output)}")
-        output = [EventLogs(data=event) for event in output]
-        output = sorted(
-            [event.get_dict() for event in output if event.compare_datetime(get_time_hours_ago(hours_ago=24))],
+
+        self.logger.info(f"Number of raw logs returned from Mimecast: {len(task_output)}")
+        task_output = sorted(
+            map(
+                lambda event: event.get_dict(),
+                filter(
+                    lambda event: event.compare_datetime(get_time_hours_ago(hours_ago=24)),
+                    [EventLogs(data=event) for event in task_output],
+                ),
+            ),
             key=itemgetter(EventLogs.FILTER_DATETIME),
         )
 
-        for event in output:
+        for event in task_output:
             event.pop(EventLogs.FILTER_DATETIME, None)
-        self.logger.info(f"Number of returned logs after filtering performed: {len(output)}")
-        return output
+        self.logger.info(f"Number of returned logs after filtering performed: {len(task_output)}")
+
+        return task_output

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -70,6 +70,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             list: The filtered and sorted list of recent events.
 
         """
+        self.logger.info(f"Number of raw logs returned from Mimemcast: {len(output)}")
         output = [EventLogs(data=event) for event in output]
         output = sorted(
             [event.get_dict() for event in output if event.compare_datetime(get_time_hours_ago(hours_ago=24))],
@@ -78,5 +79,5 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
         for event in output:
             event.pop(EventLogs.FILTER_DATETIME, None)
-
+        self.logger.info(f"Number of returned logs after filtering performed: {len(output)}")
         return output

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -37,7 +37,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             else:
                 self.logger.info("Subsequent run")
 
-            limit_time = time() + 60
+            limit_time = time() + 30
             while time() < limit_time:
                 try:
                     output, headers, status_code = self.connection.client.get_siem_logs(header_next_token)

--- a/plugins/mimecast/komand_mimecast/util/constants.py
+++ b/plugins/mimecast/komand_mimecast/util/constants.py
@@ -1,6 +1,6 @@
 API = "/api"
-REGIONS = ["EU", "DE", "US", "CA", "ZA", "AU", "Offshore", "Sandbox"]
-HOSTS = ["eu-api", "de-api", "us-api", "ca-api", "za-api", "au-api", "je-api", "sandbox-api"]
+REGIONS = ["EU", "DE", "US", "CA", "ZA", "AU", "Offshore", "Sandbox", "USB", "USBCOM"]
+HOSTS = ["eu-api", "de-api", "us-api", "ca-api", "za-api", "au-api", "je-api", "sandbox-api", "usb-api", "uspcom-api"]
 BASE_HOSTNAME_MAP = dict(zip(REGIONS, HOSTS))
 DEFAULT_REGION = "EU"
 DATA_FIELD = "data"

--- a/plugins/mimecast/komand_mimecast/util/constants.py
+++ b/plugins/mimecast/komand_mimecast/util/constants.py
@@ -8,6 +8,7 @@ META_FIELD = "meta"
 PAGINATION_FIELD = "pagination"
 TRACKED_EMAILS_FIELD = "trackedEmails"
 TRACKED_EMAILS_ADVANCED_OPTIONS = "advancedTrackAndTraceOptions"
+IS_LAST_TOKEN_FIELD = "isLastToken"  # nosec
 ID_FIELD = "id"
 DOMAIN_FIELD = "domain"
 EMAIL_FIELD = "emailAddress"

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.1
+version: 5.3.2
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7
@@ -847,6 +847,8 @@ connection:
       - AU
       - Offshore
       - Sandbox
+      - USB
+      - USBCOM
     required: true
     example: EU
     default: EU

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -1493,13 +1493,6 @@ tasks:
   monitor_siem_logs:
     title: Monitor SIEM Logs
     description: Monitor and retrieve the latest logs
-    input:
-      token:
-        title: Token
-        description: Used to request the next available log file
-        type: string
-        required: false
-        example: 9de5069c5afe602b2ea0a04b66beb2c0
     output:
       data:
         title: Data

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.1",
+      version="5.3.2",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Release of Mimecast 5.3.2. 

Changes:
- Add all regions of Mimecast: USB, and USBCOM was previously not supported. 
- Add extra logs around monitor logs task to help in future with any C2C investigation. 
- Updated pagination handler
- Removed `token` input
- Changed max request time to 30s

Notes:
- This is cloud enabled. 

Original PR:
- #2039
- #2068
- #2078