### PR TITLE
[PLGN-425] Mimecast - Updated pagination handler | Removed token input parameter

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "4c16abce919b026aa51a6b37acd0bd57",
+	"spec": "923a6bbb21fe0ce039f39ff00014ae00",
 	"manifest": "a5513a1c36d038851b10a6226d980590",
 	"setup": "318548fa67238e900bb082347305cef6",
 	"schemas": [
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "monitor_siem_logs/schema.py",
-			"hash": "e86f21b7207b572f78132b9288843bf1"
+			"hash": "fed0e07521688fbeece2dd35abb49310"
 		}
 	]
 }

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -729,18 +729,8 @@ Example output:
 Monitor and retrieve the latest logs
 
 ##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|token|string|None|False|Used to request the next available log file|None|9de5069c5afe602b2ea0a04b66beb2c0|
   
-Example input:
-
-```
-{
-  "token": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
+*This task does not contain any inputs.*
 
 ##### Output
 
@@ -1027,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information.
+* 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 
 * 5.2.2 - Handled status code for `Monitor SIEM Logs` | Request limit set to 1 minute in `Monitor SIEM Logs` 

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/schema.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/schema.py
@@ -8,7 +8,7 @@ class Component:
 
 
 class Input:
-    TOKEN = "token"
+    pass
 
 
 class State:
@@ -21,19 +21,7 @@ class Output:
 
 class MonitorSiemLogsInput(insightconnect_plugin_runtime.Input):
     schema = json.loads(r"""
-   {
-  "type": "object",
-  "title": "Variables",
-  "properties": {
-    "token": {
-      "type": "string",
-      "title": "Token",
-      "description": "Used to request the next available log file",
-      "order": 1
-    }
-  },
-  "definitions": {}
-}
+   {}
     """)
 
     def __init__(self):

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -2,12 +2,13 @@ from operator import itemgetter
 from time import time
 
 import insightconnect_plugin_runtime
-from typing import Dict, List
+from typing import Dict, List, Any
 
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import get_time_hours_ago
 
 from .schema import MonitorSiemLogsInput, MonitorSiemLogsOutput, MonitorSiemLogsState, Component
+from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
@@ -16,7 +17,6 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
     NEXT_TOKEN = "next_token"  # nosec
     HEADER_NEXT_TOKEN = "mc-siem-token"  # nosec
     STATUS_CODE = "status_code"  # nosec
-    TOKEN = "token"  # nosec
 
     def __init__(self):
         super(self.__class__, self).__init__(
@@ -27,57 +27,62 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             state=MonitorSiemLogsState(),
         )
 
-    def run(self, params={}, state={}) -> (List[Dict], Dict):
+    def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument
         try:
             has_more_pages = False
             header_next_token = state.get(self.NEXT_TOKEN, "")
+
             if not header_next_token:
                 self.logger.info("First run")
             else:
                 self.logger.info("Subsequent run")
-                params[self.TOKEN] = header_next_token
 
             limit_time = time() + 60
             while time() < limit_time:
                 try:
-                    output, headers, status_code = self.connection.client.get_siem_logs(params)
+                    output, headers, status_code = self.connection.client.get_siem_logs(header_next_token)
+                    if not output:
+                        break
                 except ApiClientException as error:
                     return [], state, has_more_pages, error.status_code, error
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
-                params[self.TOKEN] = header_next_token
-                if not output:
-                    break
                 output = self._filter_and_sort_recent_events(output)
-                if len(output) > 0:
+                if output:
                     break
 
             if header_next_token:
                 state[self.NEXT_TOKEN] = header_next_token
-                has_more_pages = True
+                has_more_pages = IS_LAST_TOKEN_FIELD not in headers
 
             return output, state, has_more_pages, status_code, None
         except Exception as error:
             return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
-    def _filter_and_sort_recent_events(self, output: List[dict]) -> List[dict]:
+    def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """
         Filters and sorts a list of events to retrieve only the recent events.
 
-        Args:
-            events (list): A list of event objects to be filtered and sorted.
+        :param task_output: A list of dictionaries representing the task output to be filtered and sorted.
+        :type: List[Dict[str, Any]]
 
-        Returns:
-            list: The filtered and sorted list of recent events.
-
+        :return: A new list of dictionaries representing the filtered and sorted recent events.
+        :rtype: List[Dict[str, Any]]
         """
-        self.logger.info(f"Number of raw logs returned from Mimemcast: {len(output)}")
-        output = [EventLogs(data=event) for event in output]
-        output = sorted(
-            [event.get_dict() for event in output if event.compare_datetime(get_time_hours_ago(hours_ago=24))],
+
+        self.logger.info(f"Number of raw logs returned from Mimecast: {len(task_output)}")
+        task_output = sorted(
+            map(
+                lambda event: event.get_dict(),
+                filter(
+                    lambda event: event.compare_datetime(get_time_hours_ago(hours_ago=24)),
+                    [EventLogs(data=event) for event in task_output],
+                ),
+            ),
             key=itemgetter(EventLogs.FILTER_DATETIME),
         )
 
-        for event in output:
+        for event in task_output:
             event.pop(EventLogs.FILTER_DATETIME, None)
-        self.logger.info(f"Number of returned logs after filtering performed: {len(output)}")
-        return output
+        self.logger.info(f"Number of returned logs after filtering performed: {len(task_output)}")
+
+        return task_output

--- a/plugins/mimecast/komand_mimecast/util/constants.py
+++ b/plugins/mimecast/komand_mimecast/util/constants.py
@@ -8,6 +8,7 @@ META_FIELD = "meta"
 PAGINATION_FIELD = "pagination"
 TRACKED_EMAILS_FIELD = "trackedEmails"
 TRACKED_EMAILS_ADVANCED_OPTIONS = "advancedTrackAndTraceOptions"
+IS_LAST_TOKEN_FIELD = "isLastToken"  # nosec
 ID_FIELD = "id"
 DOMAIN_FIELD = "domain"
 EMAIL_FIELD = "emailAddress"

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -1493,13 +1493,6 @@ tasks:
   monitor_siem_logs:
     title: Monitor SIEM Logs
     description: Monitor and retrieve the latest logs
-    input:
-      token:
-        title: Token
-        description: Used to request the next available log file
-        type: string
-        required: false
-        example: 9de5069c5afe602b2ea0a04b66beb2c0
     output:
       data:
         title: Data


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Removed `token` input parameter
  - Updated pagination handler

## Snyk validation

Snyk found a problem related to the unzipping file mechanism, which pulls the content from the response and unzips the attachment. Snyk thinks that there is a possibility that its allowed to do path traversal in this code, but its not. We pull the response content into the `BytesIO` to load the attachment into RAM, and then unzip that memory. In this case there is no access to the file system etc.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
