### PR TITLE
PLGN-251-Increasing the maximum results per call from 50 to 500 and adding in log if there is more than 500

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "7334b6d77f442d36280bd35d6ce3f34e",
-	"manifest": "0e896c3b72ca96d223dc521c31eef7b2",
-	"setup": "72ec0955651aa66bca8b39549acc1411",
+	"spec": "db3200de7f533f97a6ef37b9e03c8b68",
+	"manifest": "fcaf023d3d8e468094348803d3ecc5eb",
+	"setup": "3b83b99c77061338b639889ef7848b9b",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "218cf52cbd4460b58be9610d7cc34556"
+			"hash": "6eaefe40cdb9c88a7c2118b8574e4a99"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "db3200de7f533f97a6ef37b9e03c8b68",
+	"spec": "4e41dafa94077651418e53d24d50ab1b",
 	"manifest": "fcaf023d3d8e468094348803d3ecc5eb",
 	"setup": "3b83b99c77061338b639889ef7848b9b",
 	"schemas": [
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "6eaefe40cdb9c88a7c2118b8574e4a99"
+			"hash": "8eee4540d5732fa2be2f9a5c4cc603e0"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "4e41dafa94077651418e53d24d50ab1b",
+	"spec": "e88e03be591a773f6f06ab8f8ff72d75",
 	"manifest": "fcaf023d3d8e468094348803d3ecc5eb",
 	"setup": "3b83b99c77061338b639889ef7848b9b",
 	"schemas": [

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "6.0.0"
+Version = "6.0.1"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -110,7 +110,7 @@ Example output:
 
 #### Advanced Query on Log
   
-Realtime query an InsightIDR log. This will query individual logs for results
+Realtime query an InsightIDR log. This will query individual logs for results. Note a maximum of 500 results only will be returned from a single call, if all results are required for this query please use smaller timeranges
 
 ##### Input
 
@@ -2024,6 +2024,7 @@ Example output:
 
 # Version History
 
+* 6.0.1 - Action: `Advanced Query On Log Set` - Up the maximium events returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs
 * 5.1.1 - Action: `List Investigations` - Now receiving size input | Actions: `Advanced Query On Log` & `Advanced Query On Log Set` - Acronym LQL has been updated to LEQL

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -110,7 +110,7 @@ Example output:
 
 #### Advanced Query on Log
   
-Realtime query an InsightIDR log. This will query individual logs for results. Note a maximum of 500 results only will be returned from a single call, if all results are required for this query please use smaller timeranges
+Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges 
 
 ##### Input
 

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -88,6 +88,10 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                     self.logger.info("No results were found, returning an empty list")
                     return []
             else:
+                if results_object.get("links", [{}])[0].get("rel") == "Next":
+                    self.logger.info(
+                        "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"
+                    )
                 return log_entries
 
     def get_results_from_callback(self, callback_url: str, timeout: int) -> [object]:
@@ -137,7 +141,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         @return: (callback url, list of log entries)
         """
         endpoint = f"{self.connection.url}log_search/query/logs/{log_id}"
-        params = {"query": query, "from": time_from, "to": time_to}
+        params = {"query": query, "from": time_from, "to": time_to, "per_page": 500}
 
         self.logger.info(f"Getting logs from: {endpoint}")
         self.logger.info(f"Using parameters: {params}")
@@ -155,6 +159,11 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         potential_results = results_object.get("events", [])
         if potential_results:
             self.logger.info("Got results immediately, returning.")
+            self.logger.info("results_object.get('links', [{}])")
+            if results_object.get("links", [{}])[0].get("rel") == "Next":
+                self.logger.info(
+                    "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"
+                )
             return None, potential_results
         else:
             self.logger.info("Got a callback url. Polling results...")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results.  Note a maximum of 500 results only will be returned from a single call, if all results are required for this query please use smaller timeranges"
+    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges"
 
 
 class Input:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results"
+    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results.  Note a maximum of 500 results only will be returned from a single call, if all results are required for this query please use smaller timeranges"
 
 
 class Input:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -1242,7 +1242,7 @@ actions:
         example: {"log": {"id": "0b9a242d-d2fb-4e42-8656-eb5ff64d652f","name": "Windows Defender","tokens": ["bc38a911-65f1-4755-cca3-a330a6336b3a"],"structures": ["1238a911-65f1-4755-cca3-a330a6336b3a"],"user_data": {"platform_managed": "true"},"source_type": "token","token_seed": null,"retention_period": "default","links": [{"rel": "Related","href": "https://example.com"}],"rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:log:bc38a911-65f1-4755-cca3-a330a6336b3a","logsets_info": [{"id": "bc38a911-65f1-4755-cca3-a330a6336b3a","name": "Unparsed Data","rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:logset:bc38a911-65f1-4755-cca3-a330a6336b3a","links": [{"rel": "Self","href": "https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85"}]}]}}
   advanced_query_on_log:
     title: Advanced Query on Log
-    description: Realtime query an InsightIDR log. This will query individual logs for results. Note a maximum of 500 results only will be returned from a single call, if all results are required for this query please use smaller timeranges
+    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timerangess
     input:
       query:
         title: Query

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 6.0.0
+version: 6.0.1
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7
@@ -1242,7 +1242,7 @@ actions:
         example: {"log": {"id": "0b9a242d-d2fb-4e42-8656-eb5ff64d652f","name": "Windows Defender","tokens": ["bc38a911-65f1-4755-cca3-a330a6336b3a"],"structures": ["1238a911-65f1-4755-cca3-a330a6336b3a"],"user_data": {"platform_managed": "true"},"source_type": "token","token_seed": null,"retention_period": "default","links": [{"rel": "Related","href": "https://example.com"}],"rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:log:bc38a911-65f1-4755-cca3-a330a6336b3a","logsets_info": [{"id": "bc38a911-65f1-4755-cca3-a330a6336b3a","name": "Unparsed Data","rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:logset:bc38a911-65f1-4755-cca3-a330a6336b3a","links": [{"rel": "Self","href": "https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85"}]}]}}
   advanced_query_on_log:
     title: Advanced Query on Log
-    description: Realtime query an InsightIDR log. This will query individual logs for results
+    description: Realtime query an InsightIDR log. This will query individual logs for results. Note a maximum of 500 results only will be returned from a single call, if all results are required for this query please use smaller timeranges
     input:
       query:
         title: Query

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -1242,7 +1242,7 @@ actions:
         example: {"log": {"id": "0b9a242d-d2fb-4e42-8656-eb5ff64d652f","name": "Windows Defender","tokens": ["bc38a911-65f1-4755-cca3-a330a6336b3a"],"structures": ["1238a911-65f1-4755-cca3-a330a6336b3a"],"user_data": {"platform_managed": "true"},"source_type": "token","token_seed": null,"retention_period": "default","links": [{"rel": "Related","href": "https://example.com"}],"rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:log:bc38a911-65f1-4755-cca3-a330a6336b3a","logsets_info": [{"id": "bc38a911-65f1-4755-cca3-a330a6336b3a","name": "Unparsed Data","rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:logset:bc38a911-65f1-4755-cca3-a330a6336b3a","links": [{"rel": "Self","href": "https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85"}]}]}}
   advanced_query_on_log:
     title: Advanced Query on Log
-    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timerangess
+    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges
     input:
       query:
         title: Query

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="6.0.0",
+      version="6.0.1",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - To increase the max per page size from the default of 50 to 500
  - To add this behaviour into the documentation
  - To add in a logger message to reflect when there are more results that were not returned

https://issues.corp.rapid7.com/browse/PLGN-252

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

all unit tests passed

```
Ran 80 tests in 0.034s

OK
```

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

testing in local docker container using postman to make the call, all 500 results are returned as expected and the message is also logged

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/ab8b59cd-79cd-41f0-837b-760571a26fb4)


### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
