### PR TITLE
[SOAR-15940] InsightIDR - advanced_query_on_log_set statistical result bug fix

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,6 +1,6 @@
 {
-	"spec": "e88e03be591a773f6f06ab8f8ff72d75",
-	"manifest": "fcaf023d3d8e468094348803d3ecc5eb",
+	"spec": "0f975db262dadb06d0a90e39fc05434a",
+	"manifest": "f6c902be173f84e632cafb5b3093432e",
 	"setup": "3b83b99c77061338b639889ef7848b9b",
 	"schemas": [
 		{

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "6.0.1"
+Version = "6.0.2"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -2024,7 +2024,8 @@ Example output:
 
 # Version History
 
-* 6.0.1 - Action: `Advanced Query On Log Set` - Up the maximium events returned from 50 to 500
+* 6.0.2 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0
+* 6.0.1 - Action: `Advanced Query On Log` - Up the maximium events returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs
 * 5.1.1 - Action: `List Investigations` - Now receiving size input | Actions: `Advanced Query On Log` & `Advanced Query On Log Set` - Acronym LQL has been updated to LEQL

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -2025,7 +2025,7 @@ Example output:
 # Version History
 
 * 6.0.2 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0
-* 6.0.1 - Action: `Advanced Query On Log` - Up the maximium events returned from 50 to 500
+* 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs
 * 5.1.1 - Action: `List Investigations` - Now receiving size input | Actions: `Advanced Query On Log` & `Advanced Query On Log Set` - Acronym LQL has been updated to LEQL

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -173,7 +173,18 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
 
         results_object = response.json()
         if statistical:
-            potential_results = results_object.get("partial")
+            stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
+            self.logger.info(f"Getting statistical from: {stats_endpoint}")
+            stats_response = self.connection.session.get(stats_endpoint, params=params)
+            try:
+                stats_response.raise_for_status()
+            except Exception:
+                raise PluginException(
+                    cause="Failed to get log sets from InsightIDR\n",
+                    assistance=f"Could not get statistical info from: {stats_endpoint}\n",
+                    data=stats_response.text,
+                )
+            potential_results = stats_response.json()
         else:
             potential_results = results_object.get("events")
 

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -57,7 +57,10 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
         else:
-            return {Output.RESULTS_STATISTICAL: log_entries, Output.COUNT: log_entries.get("search_stats", {}).get("events_matched", 0)}
+            return {
+                Output.RESULTS_STATISTICAL: log_entries,
+                Output.COUNT: log_entries.get("search_stats", {}).get("events_matched", 0),
+            }
 
     @staticmethod
     def parse_query_for_statistical(query: str) -> bool:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -6,6 +6,7 @@ import time
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightidr.util.parse_dates import parse_dates
+from requests import HTTPError
 
 
 class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
@@ -181,11 +182,11 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             stats_response = self.connection.session.get(stats_endpoint, params=params)
             try:
                 stats_response.raise_for_status()
-            except Exception:
+            except HTTPError as error:
                 raise PluginException(
                     cause="Failed to get log sets from InsightIDR\n",
                     assistance=f"Could not get statistical info from: {stats_endpoint}\n",
-                    data=stats_response.text,
+                    data=f"{stats_response.text}, {error}",
                 )
             potential_results = stats_response.json()
         else:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -57,7 +57,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
         else:
-            return {Output.RESULTS_STATISTICAL: log_entries, Output.COUNT: len(log_entries)}
+            return {Output.RESULTS_STATISTICAL: log_entries, Output.COUNT: log_entries.get("search_stats", {}).get("events_matched", 0)}
 
     @staticmethod
     def parse_query_for_statistical(query: str) -> bool:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 6.0.1
+version: 6.0.2
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="6.0.1",
+      version="6.0.2",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id5.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id5.json.resp
@@ -1,0 +1,74 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "progress": 0,
+  "events": [],
+  "partial": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699567413000,
+    "to": 1699610613000,
+    "type": "count",
+    "stats": {
+      "global_timeseries": {
+        "count": 0
+      }
+    },
+    "groups": [],
+    "others": {},
+    "status": 200,
+    "timeseries": {
+      "global_timeseries": [
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        }
+      ]
+    },
+    "groups_timeseries": [],
+    "all_exact_result": null,
+    "count": 0
+  },
+  "id": "7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:",
+  "links": [
+    {
+      "rel": "Self",
+      "href": "https://us.api.insight.rapid7.com/log_search/query/7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:"
+    }
+  ],
+  "leql": {
+    "statement": "where(hostname='WindowsX64') calculate(count)",
+    "during": {
+      "from": 1699567413000,
+      "to": 1699610613000
+    }
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id6.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id6.json.resp
@@ -1,0 +1,74 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "statistics": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699567413000,
+    "to": 1699610613000,
+    "type": "count",
+    "stats": {
+      "global_timeseries": {
+        "count": 462
+      }
+    },
+    "groups": [],
+    "others": {},
+    "status": 200,
+    "timeseries": {
+      "global_timeseries": [
+        {
+          "count": 38
+        },
+        {
+          "count": 47
+        },
+        {
+          "count": 36
+        },
+        {
+          "count": 56
+        },
+        {
+          "count": 60
+        },
+        {
+          "count": 40
+        },
+        {
+          "count": 39
+        },
+        {
+          "count": 41
+        },
+        {
+          "count": 61
+        },
+        {
+          "count": 44
+        }
+      ]
+    },
+    "groups_timeseries": [],
+    "all_exact_result": null,
+    "count": 462
+  },
+  "search_stats": {
+    "bytes_checked": 3589232,
+    "index_factor": 0.4294746,
+    "events_matched": 462,
+    "events_checked": 595,
+    "duration_ms": 19,
+    "events_all": 1025,
+    "bytes_all": 6291099
+  },
+  "leql": {
+    "statement": "where(hostname='WindowsX64') calculate(count)",
+    "during": {
+      "from": 1699567413000,
+      "to": 1699610613000
+    }
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id7.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id7.json.resp
@@ -1,0 +1,36 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "progress": 0,
+  "events": [],
+  "partial": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699569260000,
+    "to": 1699612460000,
+    "type": "count",
+    "stats": {},
+    "groups": [],
+    "others": {},
+    "status": 204,
+    "timeseries": {},
+    "groups_timeseries": [],
+    "all_exact_result": true
+  },
+  "id": "b55a768a-4c0e-449a-84ae-adc70e18eb20:1:8956245765c23b46f1d20322e5c076e53a7ab662::d56c37ab761ff5e65950abd93476f02ffbcb5a45:",
+  "links": [
+    {
+      "rel": "Self",
+      "href": "https://us.api.insight.rapid7.com/log_search/query/b55a768a-4c0e-449a-84ae-adc70e18eb20:1:8956245765c23b46f1d20322e5c076e53a7ab662::d56c37ab761ff5e65950abd93476f02ffbcb5a45:"
+    }
+  ],
+  "leql": {
+    "statement": "groupby(r7_context.asset.name)",
+    "during": {
+      "from": 1699569260000,
+      "to": 1699612460000
+    }
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id8.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id8.json.resp
@@ -1,0 +1,130 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "statistics": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699569260000,
+    "to": 1699612460000,
+    "type": "count",
+    "stats": {},
+    "groups": [
+      {
+        "tomascybereasonsensor": {
+          "count": 555
+        }
+      },
+      {
+        "windowsx64": {
+          "count": 465
+        }
+      }
+    ],
+    "others": {
+      "series": []
+    },
+    "status": 200,
+    "timeseries": {},
+    "groups_timeseries": [
+      {
+        "tomascybereasonsensor": {
+          "groups_timeseries": [],
+          "series": [
+            {
+              "count": 31
+            },
+            {
+              "count": 37
+            },
+            {
+              "count": 56
+            },
+            {
+              "count": 25
+            },
+            {
+              "count": 17
+            },
+            {
+              "count": 273
+            },
+            {
+              "count": 22
+            },
+            {
+              "count": 38
+            },
+            {
+              "count": 33
+            },
+            {
+              "count": 23
+            }
+          ],
+          "totals": {
+            "count": 555
+          }
+        }
+      },
+      {
+        "windowsx64": {
+          "groups_timeseries": [],
+          "series": [
+            {
+              "count": 28
+            },
+            {
+              "count": 53
+            },
+            {
+              "count": 42
+            },
+            {
+              "count": 56
+            },
+            {
+              "count": 57
+            },
+            {
+              "count": 32
+            },
+            {
+              "count": 46
+            },
+            {
+              "count": 50
+            },
+            {
+              "count": 54
+            },
+            {
+              "count": 47
+            }
+          ],
+          "totals": {
+            "count": 465
+          }
+        }
+      }
+    ],
+    "all_exact_result": true
+  },
+  "search_stats": {
+    "index_factor": 0,
+    "bytes_checked": 6276329,
+    "events_matched": 1020,
+    "events_checked": 1022,
+    "duration_ms": 36,
+    "events_all": 1022,
+    "bytes_all": 6276329
+  },
+  "leql": {
+    "during": {
+      "from": 1699569260000,
+      "to": 1699612460000
+    },
+    "statement": "groupby(r7_context.asset.name)"
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
@@ -15,6 +15,14 @@
     {
       "name": "log_set4",
       "id": "log_id4"
+    },
+    {
+      "name": "log_set5",
+      "id": "log_id5"
+    },
+    {
+      "name": "log_set7",
+      "id": "log_id7"
     }
   ]
 }

--- a/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
@@ -1,27 +1,27 @@
 {
   "logsets": [
     {
-      "name": "log_set",
+      "name": "Advanced Malware Alert",
       "id": "log_id"
     },
     {
-      "name": "log_set2",
+      "name": "Active Directory Admin Activity",
       "id": "log_id2"
     },
     {
-      "name": "log_set3",
+      "name": "Asset Authentication",
       "id": "log_id3"
     },
     {
-      "name": "log_set4",
+      "name": "Cloud Service Admin Activity",
       "id": "log_id4"
     },
     {
-      "name": "log_set5",
+      "name": "Cloud Service Activity",
       "id": "log_id5"
     },
     {
-      "name": "log_set7",
+      "name": "DNS Query",
       "id": "log_id7"
     }
   ]

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -64,3 +64,140 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+    def test_advanced_query_on_log_statistical_result_calculate(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
+                Input.LOG_SET: "log_set5",
+            }
+        )
+        expected = {
+            "count": 4,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699567413000, "to": 1699610613000},
+                    "statement": "where(hostname='WindowsX64') calculate(count)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6291099,
+                    "bytes_checked": 3589232,
+                    "duration_ms": 19,
+                    "events_all": 1025,
+                    "events_checked": 595,
+                    "events_matched": 462,
+                    "index_factor": 0.4294746,
+                },
+                "statistics": {
+                    "all_exact_result": None,
+                    "cardinality": 0,
+                    "count": 462,
+                    "from": 1699567413000,
+                    "granularity": 4320000,
+                    "groups": [],
+                    "groups_timeseries": [],
+                    "others": {},
+                    "stats": {"global_timeseries": {"count": 462.0}},
+                    "status": 200,
+                    "timeseries": {
+                        "global_timeseries": [
+                            {"count": 38.0},
+                            {"count": 47.0},
+                            {"count": 36.0},
+                            {"count": 56.0},
+                            {"count": 60.0},
+                            {"count": 40.0},
+                            {"count": 39.0},
+                            {"count": 41.0},
+                            {"count": 61.0},
+                            {"count": 44.0},
+                        ]
+                    },
+                    "to": 1699610613000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+
+    def test_advanced_query_on_log_statistical_result_groupby(self, mock_get, mock_async_get):
+        actual = self.action.run(
+            {
+                Input.QUERY: "groupby(r7_context.asset.name)",
+                Input.LOG_SET: "log_set7",
+            }
+        )
+        expected = {
+            "count": 4,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699569260000, "to": 1699612460000},
+                    "statement": "groupby(r7_context.asset.name)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6276329,
+                    "bytes_checked": 6276329,
+                    "duration_ms": 36,
+                    "events_all": 1022,
+                    "events_checked": 1022,
+                    "events_matched": 1020,
+                    "index_factor": 0.0,
+                },
+                "statistics": {
+                    "all_exact_result": True,
+                    "cardinality": 0,
+                    "from": 1699569260000,
+                    "granularity": 4320000,
+                    "groups": [{"tomascybereasonsensor": {"count": 555.0}}, {"windowsx64": {"count": 465.0}}],
+                    "groups_timeseries": [
+                        {
+                            "tomascybereasonsensor": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 31.0},
+                                    {"count": 37.0},
+                                    {"count": 56.0},
+                                    {"count": 25.0},
+                                    {"count": 17.0},
+                                    {"count": 273.0},
+                                    {"count": 22.0},
+                                    {"count": 38.0},
+                                    {"count": 33.0},
+                                    {"count": 23.0},
+                                ],
+                                "totals": {"count": 555.0},
+                            }
+                        },
+                        {
+                            "windowsx64": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 28.0},
+                                    {"count": 53.0},
+                                    {"count": 42.0},
+                                    {"count": 56.0},
+                                    {"count": 57.0},
+                                    {"count": 32.0},
+                                    {"count": 46.0},
+                                    {"count": 50.0},
+                                    {"count": 54.0},
+                                    {"count": 47.0},
+                                ],
+                                "totals": {"count": 465.0},
+                            }
+                        },
+                    ],
+                    "others": {"series": []},
+                    "stats": {},
+                    "status": 200,
+                    "timeseries": {},
+                    "to": 1699612460000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -109,7 +109,7 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
         actual = self.action.run(test_input)
         expected = {
-            "count": 4,
+            "count": 462,
             "results_statistical": {
                 "leql": {
                     "during": {"from": 1699567413000, "to": 1699610613000},
@@ -171,7 +171,7 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
         actual = self.action.run(test_input)
         expected = {
-            "count": 4,
+            "count": 1020,
             "results_statistical": {
                 "leql": {
                     "during": {"from": 1699569260000, "to": 1699612460000},

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -5,9 +5,10 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.advanced_query_on_log_set import AdvancedQueryOnLogSet
-from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import Input, Output
+from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import Input, Output, AdvancedQueryOnLogSetInput, AdvancedQueryOnLogSetOutput
 from util import Util
 from unittest.mock import patch
+from jsonschema import validate
 
 
 @patch("requests.Session.get", side_effect=Util.mocked_requests)
@@ -18,60 +19,90 @@ class TestAdvancedQueryOnLogSet(TestCase):
         cls.action = Util.default_connector(AdvancedQueryOnLogSet())
 
     def test_advanced_query_on_log_set_one_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
+        test_input = {
                 Input.QUERY: "",
-                Input.LOG_SET: "log_set",
-            }
-        )
+                Input.LOG_SET: "Advanced Malware Alert",
+                Input.TIMEOUT: 60,
+                Input.RELATIVE_TIME: "Last 5 Minutes"
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
+
         expected = ["Out of order entry"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
 
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
     def test_advanced_query_on_log_set_two_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
+        test_input = {
                 Input.QUERY: "",
-                Input.LOG_SET: "log_set2",
-            }
-        )
+                Input.LOG_SET: "Active Directory Admin Activity",
+                Input.TIMEOUT: 60,
+                Input.RELATIVE_TIME: "Last 5 Minutes"
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
+
         expected = ["Out of order entry", "Out of events"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
 
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
     def test_advanced_query_on_log_set_without_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
+        test_input = {
                 Input.QUERY: "",
-                Input.LOG_SET: "log_set3",
-            }
-        )
+                Input.LOG_SET: "Asset Authentication",
+                Input.TIMEOUT: 60,
+                Input.RELATIVE_TIME: "Last 5 Minutes"
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
 
     def test_advanced_query_on_log_set_wrong_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
+        test_input = {
                 Input.QUERY: "",
-                Input.LOG_SET: "log_set4",
-            }
-        )
+                Input.LOG_SET: "Cloud Service Admin Activity",
+                Input.TIMEOUT: 60,
+                Input.RELATIVE_TIME: "Last 5 Minutes"
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
 
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
     def test_advanced_query_on_log_statistical_result_calculate(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
+        test_input = {
                 Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
-                Input.LOG_SET: "log_set5",
-            }
-        )
+                Input.LOG_SET: "Cloud Service Activity",
+                Input.TIMEOUT: 60,
+                Input.RELATIVE_TIME: "Last 5 Minutes"
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
         expected = {
             "count": 4,
             "results_statistical": {
@@ -121,14 +152,19 @@ class TestAdvancedQueryOnLogSet(TestCase):
         }
 
         self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
 
     def test_advanced_query_on_log_statistical_result_groupby(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
+        test_input = {
                 Input.QUERY: "groupby(r7_context.asset.name)",
-                Input.LOG_SET: "log_set7",
-            }
-        )
+                Input.LOG_SET: "DNS Query",
+                Input.TIMEOUT: 60,
+                Input.RELATIVE_TIME: "Last 5 Minutes"
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
         expected = {
             "count": 4,
             "results_statistical": {
@@ -201,3 +237,4 @@ class TestAdvancedQueryOnLogSet(TestCase):
         }
 
         self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -5,7 +5,12 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.advanced_query_on_log_set import AdvancedQueryOnLogSet
-from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import Input, Output, AdvancedQueryOnLogSetInput, AdvancedQueryOnLogSetOutput
+from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import (
+    Input,
+    Output,
+    AdvancedQueryOnLogSetInput,
+    AdvancedQueryOnLogSetOutput,
+)
 from util import Util
 from unittest.mock import patch
 from jsonschema import validate
@@ -20,10 +25,10 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
     def test_advanced_query_on_log_set_one_label(self, mock_get, mock_async_get):
         test_input = {
-                Input.QUERY: "",
-                Input.LOG_SET: "Advanced Malware Alert",
-                Input.TIMEOUT: 60,
-                Input.RELATIVE_TIME: "Last 5 Minutes"
+            Input.QUERY: "",
+            Input.LOG_SET: "Advanced Malware Alert",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
         }
 
         validate(test_input, AdvancedQueryOnLogSetInput.schema)
@@ -39,10 +44,10 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
     def test_advanced_query_on_log_set_two_label(self, mock_get, mock_async_get):
         test_input = {
-                Input.QUERY: "",
-                Input.LOG_SET: "Active Directory Admin Activity",
-                Input.TIMEOUT: 60,
-                Input.RELATIVE_TIME: "Last 5 Minutes"
+            Input.QUERY: "",
+            Input.LOG_SET: "Active Directory Admin Activity",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
         }
 
         validate(test_input, AdvancedQueryOnLogSetInput.schema)
@@ -58,10 +63,10 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
     def test_advanced_query_on_log_set_without_label(self, mock_get, mock_async_get):
         test_input = {
-                Input.QUERY: "",
-                Input.LOG_SET: "Asset Authentication",
-                Input.TIMEOUT: 60,
-                Input.RELATIVE_TIME: "Last 5 Minutes"
+            Input.QUERY: "",
+            Input.LOG_SET: "Asset Authentication",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
         }
 
         validate(test_input, AdvancedQueryOnLogSetInput.schema)
@@ -76,10 +81,10 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
     def test_advanced_query_on_log_set_wrong_label(self, mock_get, mock_async_get):
         test_input = {
-                Input.QUERY: "",
-                Input.LOG_SET: "Cloud Service Admin Activity",
-                Input.TIMEOUT: 60,
-                Input.RELATIVE_TIME: "Last 5 Minutes"
+            Input.QUERY: "",
+            Input.LOG_SET: "Cloud Service Admin Activity",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
         }
 
         validate(test_input, AdvancedQueryOnLogSetInput.schema)
@@ -94,10 +99,10 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
     def test_advanced_query_on_log_statistical_result_calculate(self, mock_get, mock_async_get):
         test_input = {
-                Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
-                Input.LOG_SET: "Cloud Service Activity",
-                Input.TIMEOUT: 60,
-                Input.RELATIVE_TIME: "Last 5 Minutes"
+            Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
+            Input.LOG_SET: "Cloud Service Activity",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
         }
 
         validate(test_input, AdvancedQueryOnLogSetInput.schema)
@@ -156,10 +161,10 @@ class TestAdvancedQueryOnLogSet(TestCase):
 
     def test_advanced_query_on_log_statistical_result_groupby(self, mock_get, mock_async_get):
         test_input = {
-                Input.QUERY: "groupby(r7_context.asset.name)",
-                Input.LOG_SET: "DNS Query",
-                Input.TIMEOUT: 60,
-                Input.RELATIVE_TIME: "Last 5 Minutes"
+            Input.QUERY: "groupby(r7_context.asset.name)",
+            Input.LOG_SET: "DNS Query",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
         }
 
         validate(test_input, AdvancedQueryOnLogSetInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -252,4 +252,24 @@ class Util:
         elif args[0] == f"{Util.STUB_URL_API}/log_search/management/logsets":
             return MockResponse("logsets", 200)
 
+        print(args)
+
+        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id5":
+            return MockResponse("log_id5", 200)
+
+        if (
+            args[0]
+            == "https://us.api.insight.rapid7.com/log_search/query/7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:"
+        ):
+            return MockResponse("log_id6", 200)
+
+        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id7":
+            return MockResponse("log_id7", 200)
+
+        if (
+            args[0]
+            == "https://us.api.insight.rapid7.com/log_search/query/b55a768a-4c0e-449a-84ae-adc70e18eb20:1:8956245765c23b46f1d20322e5c076e53a7ab662::d56c37ab761ff5e65950abd93476f02ffbcb5a45:"
+        ):
+            return MockResponse("log_id8", 200)
+
         raise Exception("Not implemented")

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -252,8 +252,6 @@ class Util:
         elif args[0] == f"{Util.STUB_URL_API}/log_search/management/logsets":
             return MockResponse("logsets", 200)
 
-        print(args)
-
         if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id5":
             return MockResponse("log_id5", 200)
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - to take the id that comes back from calling the `/query/logs` endpoint, then this ID can be used to the `/query/` endpoint to get back the correct values for the statistics, as the will not return the results we need

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

new unit test have been added and all of the old tests are passing 
```
Ran 82 tests in 0.038s

OK
```

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

testing via postman using a local docker container and showing the counts line up as expected 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/fca244a3-be52-4f2d-9d99-49b96ff8bfd4)

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/4e0068b7-22a5-4fa4-860a-bf6392c7686e)
cd

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
