### PR TITLE
[PLGN-614] InsightIDR - Adding parity between advanced_query_on_log_set and advanced_query_on_log

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "0f975db262dadb06d0a90e39fc05434a",
-	"manifest": "f6c902be173f84e632cafb5b3093432e",
-	"setup": "3b83b99c77061338b639889ef7848b9b",
+	"spec": "9c7adee28e0b9c12161fda2542f9d8d5",
+	"manifest": "9abe6edabaacd69f194daf13dde4f071",
+	"setup": "33356615b4b2f4d9999cc064148b9187",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "8eee4540d5732fa2be2f9a5c4cc603e0"
+			"hash": "351077a9ef290966fbfc0ba59991f33c"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "0b8b017708cf1a7fa5b775c9b5d78666"
+			"hash": "ddb27e90df73351cdf478e1aa245bb64"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "6.0.2"
+Version = "7.0.0"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -2253,7 +2253,7 @@ Example output:
 
 # Version History
 
-* 7.0.0 - Action: `Advanced Query On Log Set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log Set` Increase the maximum results returned from 50 to 500 | `Advanced Query On Log ` - Add new output type for statistical queries.
+* 7.0.0 - Action: `Advanced Query On Log Set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log Set` - Increase the maximum results returned from 50 to 500 |  Action: `Advanced Query On Log` - Add new output type for statistical queries.
 * 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -141,7 +141,8 @@ Example input:
 |Name|Type|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of log entries found|10|
-|results|[]events|True|Query Results|[{"labels": [], "timestamp": 1601598638768, "sequence_number": 123456789123456789, "log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313", "message": {"timestamp": "2020-10-02T00:29:14.649Z", "destination_asset": "iagent-win7", "source_asset_address": "192.168.100.50", "destination_asset_address": "example-host", "destination_local_account": "user", "logon_type": "NETWORK", "result": "SUCCESS", "new_authentication": "false", "service": "ntlmssp ", "source_json": {"sourceName": "Microsoft-Windows-Security-Auditing", "insertionStrings": ["S-1-0-0", "-", "-", "0x0", "X-X-X-XXXXXXXXXXX", "user@example.com", "example-host", "0x204f163c", "3", "NtLmSsp ", "NTLM", "", "{00000000-0000-0000-0000-000000000000}", "-", "NTLM V2", "128", "0x0", "-", "192.168.50.1", "59090"], "eventCode": 4624, "computerName": "example-host", "sid": "", "isDomainController": False, "eventData": None, "timeWritten": "2020-10-02T00:29:13.670722000Z"}}, "links": [{"rel": "Context", "href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}], "sequence_number_str": "123456789123456789"}]|
+|results_events|[]events|False|Query Results|[{"labels": [], "timestamp": 1601598638768, "sequence_number": 123456789123456789, "log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313", "message": {"timestamp": "2020-10-02T00:29:14.649Z", "destination_asset": "iagent-win7", "source_asset_address": "192.168.100.50", "destination_asset_address": "example-host", "destination_local_account": "user", "logon_type": "NETWORK", "result": "SUCCESS", "new_authentication": "false", "service": "ntlmssp ", "source_json": {"sourceName": "Microsoft-Windows-Security-Auditing", "insertionStrings": ["S-1-0-0", "-", "-", "0x0", "X-X-X-XXXXXXXXXXX", "user@example.com", "example-host", "0x204f163c", "3", "NtLmSsp ", "NTLM", "", "{00000000-0000-0000-0000-000000000000}", "-", "NTLM V2", "128", "0x0", "-", "192.168.50.1", "59090"], "eventCode": 4624, "computerName": "example-host", "sid": "", "isDomainController": False, "eventData": None, "timeWritten": "2020-10-02T00:29:13.670722000Z"}}, "links": [{"rel": "Context", "href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}], "sequence_number_str": "123456789123456789"}]|
+|results_statistical|statistics|False|Query Results|{'leql': {'during': {'from': 1699579214000, 'to': 1699622414000}, 'statement': 'groupby(r7_context.asset.name)'}, 'logs': ['123456-abcd-1234-abcd-123456abc'], 'search_stats': {'bytes_all': 9961260, 'bytes_checked': 9961260, 'duration_ms': 19, 'events_all': 1640, 'events_checked': 1640, 'events_matched': 1639, 'index_factor': 0.0}, 'statistics': {'all_exact_result': True, 'cardinality': 0, 'from': 1699579214000, 'granularity': 4320000, 'groups': [{'linux': {'count': 1163.0}}, {'windowsx64': {'count': 476.0}}], 'groups_timeseries': [{'linux': {'groups_timeseries': [], 'series': [{'count': 45.0}, {'count': 21.0}, {'count': 16.0}, {'count': 270.0}, {'count': 27.0}, {'count': 43.0}, {'count': 27.0}, {'count': 39.0}, {'count': 29.0}, {'count': 646.0}], 'totals': {'count': 1163.0}}}, {'windowsx64': {'groups_timeseries': [], 'series': [{'count': 54.0}, {'count': 40.0}, {'count': 60.0}, {'count': 37.0}, {'count': 42.0}, {'count': 62.0}, {'count': 41.0}, {'count': 47.0}, {'count': 49.0}, {'count': 44.0}], 'totals': {'count': 476.0}}}], 'others': {'series': []}, 'stats': {}, 'status': 200, 'timeseries': {}, 'to': 1699622414000, 'type': 'count'}}|
   
 Example output:
 
@@ -199,16 +200,145 @@ Example output:
       },
       "timestamp": "2020-10-02T00:29:14.649Z"
     },
-    "sequence_number": 123456789123456789,
+    "sequence_number": 123456789123456780,
     "sequence_number_str": "123456789123456789",
     "timestamp": 1601598638768
+  },
+  "results_statistical": {
+    "leql": {
+      "during": {
+        "from": 1699579214000,
+        "to": 1699622414000
+      },
+      "statement": "groupby(r7_context.asset.name)"
+    },
+    "logs": [
+      "123456-abcd-1234-abcd-123456abc"
+    ],
+    "search_stats": {
+      "bytes_all": 9961260,
+      "bytes_checked": 9961260,
+      "duration_ms": 19,
+      "events_all": 1640,
+      "events_checked": 1640,
+      "events_matched": 1639,
+      "index_factor": 0
+    },
+    "statistics": {
+      "all_exact_result": true,
+      "cardinality": 0,
+      "from": 1699579214000,
+      "granularity": 4320000,
+      "groups": [
+        {
+          "linux": {
+            "count": 1163
+          }
+        },
+        {
+          "windowsx64": {
+            "count": 476
+          }
+        }
+      ],
+      "groups_timeseries": [
+        {
+          "linux": {
+            "groups_timeseries": [],
+            "series": [
+              {
+                "count": 45
+              },
+              {
+                "count": 21
+              },
+              {
+                "count": 16
+              },
+              {
+                "count": 270
+              },
+              {
+                "count": 27
+              },
+              {
+                "count": 43
+              },
+              {
+                "count": 27
+              },
+              {
+                "count": 39
+              },
+              {
+                "count": 29
+              },
+              {
+                "count": 646
+              }
+            ],
+            "totals": {
+              "count": 1163
+            }
+          }
+        },
+        {
+          "windowsx64": {
+            "groups_timeseries": [],
+            "series": [
+              {
+                "count": 54
+              },
+              {
+                "count": 40
+              },
+              {
+                "count": 60
+              },
+              {
+                "count": 37
+              },
+              {
+                "count": 42
+              },
+              {
+                "count": 62
+              },
+              {
+                "count": 41
+              },
+              {
+                "count": 47
+              },
+              {
+                "count": 49
+              },
+              {
+                "count": 44
+              }
+            ],
+            "totals": {
+              "count": 476
+            }
+          }
+        }
+      ],
+      "others": {
+        "series": []
+      },
+      "stats": {},
+      "status": 200,
+      "timeseries": {},
+      "to": 1699622414000,
+      "type": "count"
+    }
   }
 }
 ```
 
 #### Advanced Query on Log Set
   
-Realtime query an InsightIDR log set. This will query entire log sets for results
+Realtime query an InsightIDR log set. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges
 
 ##### Input
 
@@ -240,7 +370,7 @@ Example input:
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of log entries found|10|
 |results_events|[]events|False|Query Results|[{"labels": [], "timestamp": 1601598638768, "sequence_number": 123456789123456789, "log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313", "message": {"timestamp": "2020-10-02T00:29:14.649Z", "destination_asset": "iagent-win7", "source_asset_address": "192.168.100.50", "destination_asset_address": "example-host", "destination_local_account": "user", "logon_type": "NETWORK", "result": "SUCCESS", "new_authentication": "false", "service": "ntlmssp ", "source_json": {"sourceName": "Microsoft-Windows-Security-Auditing", "insertionStrings": ["S-1-0-0", "-", "-", "0x0", "X-X-X-XXXXXXXXXXX", "user@example.com", "example-host", "0x204f163c", "3", "NtLmSsp ", "NTLM", "", "{00000000-0000-0000-0000-000000000000}", "-", "NTLM V2", "128", "0x0", "-", "192.168.50.1", "59090"], "eventCode": 4624, "computerName": "example-host", "sid": "", "isDomainController": False, "eventData": None, "timeWritten": "2020-10-02T00:29:13.670722000Z"}}, "links": [{"rel": "Context", "href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}], "sequence_number_str": "123456789123456789"}]|
-|results_statistical|statistics|False|Query Results|None|
+|results_statistical|statistics|False|Query Results|{'leql': {'during': {'from': 1699579214000, 'to': 1699622414000}, 'statement': 'groupby(r7_context.asset.name)'}, 'logs': ['123456-abcd-1234-abcd-123456abc'], 'search_stats': {'bytes_all': 9961260, 'bytes_checked': 9961260, 'duration_ms': 19, 'events_all': 1640, 'events_checked': 1640, 'events_matched': 1639, 'index_factor': 0.0}, 'statistics': {'all_exact_result': True, 'cardinality': 0, 'from': 1699579214000, 'granularity': 4320000, 'groups': [{'linux': {'count': 1163.0}}, {'windowsx64': {'count': 476.0}}], 'groups_timeseries': [{'linux': {'groups_timeseries': [], 'series': [{'count': 45.0}, {'count': 21.0}, {'count': 16.0}, {'count': 270.0}, {'count': 27.0}, {'count': 43.0}, {'count': 27.0}, {'count': 39.0}, {'count': 29.0}, {'count': 646.0}], 'totals': {'count': 1163.0}}}, {'windowsx64': {'groups_timeseries': [], 'series': [{'count': 54.0}, {'count': 40.0}, {'count': 60.0}, {'count': 37.0}, {'count': 42.0}, {'count': 62.0}, {'count': 41.0}, {'count': 47.0}, {'count': 49.0}, {'count': 44.0}], 'totals': {'count': 476.0}}}], 'others': {'series': []}, 'stats': {}, 'status': 200, 'timeseries': {}, 'to': 1699622414000, 'type': 'count'}}|
   
 Example output:
 
@@ -298,38 +428,137 @@ Example output:
       },
       "timestamp": "2020-10-02T00:29:14.649Z"
     },
-    "sequence_number": 123456789123456789,
+    "sequence_number": 123456789123456780,
     "sequence_number_str": "123456789123456789",
-    "timestamp": 1601598638768
-  },
-  "results_statistical": {
+    "timestamp": 1601598638768,
     "results_statistical": {
-      "cardinality": 0,
-      "granularity": 4320000,
-      "from": 1698023841000,
-      "to": 1698067041000,
-      "type": "count",
-      "stats": {
-        "global_timeseries": {
-          "count": 0.0
-        }
+      "leql": {
+        "during": {
+          "from": 1699579214000,
+          "to": 1699622414000
+        },
+        "statement": "groupby(r7_context.asset.name)"
       },
-      "groups": [],
-      "others": {},
-      "status": 200,
-      "timeseries": {
-        "global_timeseries": [
+      "logs": [
+        "123456-abcd-1234-abcd-123456abc"
+      ],
+      "search_stats": {
+        "bytes_all": 9961260,
+        "bytes_checked": 9961260,
+        "duration_ms": 19,
+        "events_all": 1640,
+        "events_checked": 1640,
+        "events_matched": 1639,
+        "index_factor": 0
+      },
+      "statistics": {
+        "all_exact_result": true,
+        "cardinality": 0,
+        "from": 1699579214000,
+        "granularity": 4320000,
+        "groups": [
           {
-            "count": 0.0
+            "linux": {
+              "count": 1163
+            }
           },
           {
-            "count": 0.0
+            "windowsx64": {
+              "count": 476
+            }
           }
-        ]
-      },
-      "groups_timeseries": [],
-      "all_exact_result": null,
-      "count": 0
+        ],
+        "groups_timeseries": [
+          {
+            "linux": {
+              "groups_timeseries": [],
+              "series": [
+                {
+                  "count": 45
+                },
+                {
+                  "count": 21
+                },
+                {
+                  "count": 16
+                },
+                {
+                  "count": 270
+                },
+                {
+                  "count": 27
+                },
+                {
+                  "count": 43
+                },
+                {
+                  "count": 27
+                },
+                {
+                  "count": 39
+                },
+                {
+                  "count": 29
+                },
+                {
+                  "count": 646
+                }
+              ],
+              "totals": {
+                "count": 1163
+              }
+            }
+          },
+          {
+            "windowsx64": {
+              "groups_timeseries": [],
+              "series": [
+                {
+                  "count": 54
+                },
+                {
+                  "count": 40
+                },
+                {
+                  "count": 60
+                },
+                {
+                  "count": 37
+                },
+                {
+                  "count": 42
+                },
+                {
+                  "count": 62
+                },
+                {
+                  "count": 41
+                },
+                {
+                  "count": 47
+                },
+                {
+                  "count": 49
+                },
+                {
+                  "count": 44
+                }
+              ],
+              "totals": {
+                "count": 476
+              }
+            }
+          }
+        ],
+        "others": {
+          "series": []
+        },
+        "stats": {},
+        "status": 200,
+        "timeseries": {},
+        "to": 1699622414000,
+        "type": "count"
+      }
     }
   }
 }
@@ -2024,7 +2253,7 @@ Example output:
 
 # Version History
 
-* 6.0.2 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0
+* 7.0.0 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log set` Increase the maximum results returned from 50 to 500 | `Advanced Query On Log ` - Add new output type for statistical queries.
 * 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -2253,7 +2253,7 @@ Example output:
 
 # Version History
 
-* 7.0.0 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log set` Increase the maximum results returned from 50 to 500 | `Advanced Query On Log ` - Add new output type for statistical queries.
+* 7.0.0 - Action: `Advanced Query On Log Set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log Set` Increase the maximum results returned from 50 to 500 | `Advanced Query On Log ` - Add new output type for statistical queries.
 * 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -18,7 +18,8 @@ class Input:
 
 class Output:
     COUNT = "count"
-    RESULTS = "results"
+    RESULTS_EVENTS = "results_events"
+    RESULTS_STATISTICAL = "results_statistical"
 
 
 class AdvancedQueryOnLogInput(insightconnect_plugin_runtime.Input):
@@ -103,7 +104,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "type": "integer",
       "title": "Count",
       "description": "Number of log entries found",
-      "order": 2
+      "order": 3
     },
     "results": {
       "type": "array",
@@ -113,11 +114,16 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
         "$ref": "#/definitions/events"
       },
       "order": 1
+    },
+    "results_statistical": {
+      "$ref": "#/definitions/statistics",
+      "title": "Query Results (Statistical)",
+      "description": "Query Results",
+      "order": 2
     }
   },
   "required": [
-    "count",
-    "results"
+    "count"
   ],
   "definitions": {
     "events": {
@@ -383,6 +389,96 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
           "title": "HREF",
           "description": "HREF",
           "order": 2
+        }
+      }
+    },
+    "statistics": {
+      "type": "object",
+      "title": "statistics",
+      "properties": {
+        "stats": {
+          "type": "object",
+          "title": "Stats",
+          "description": "Holds the overall result when query does not contain a 'groupby' clause",
+          "order": 1
+        },
+        "groups": {
+          "type": "array",
+          "title": "Groups",
+          "description": "Holds the overall result for each group in a 'groupby' query",
+          "items": {
+            "type": "object"
+          },
+          "order": 2
+        },
+        "granularity": {
+          "type": "integer",
+          "title": "Granularity",
+          "description": "The time window in milliseconds for each time slice in the time series",
+          "order": 3
+        },
+        "timeseries": {
+          "type": "object",
+          "title": "Time Series",
+          "description": "Holds the query results for each timeslice (each partition of the time_range), for non-'groupby' queries",
+          "order": 4
+        },
+        "groups_timeseries": {
+          "type": "array",
+          "title": "Groups Time Series",
+          "description": "For 'groupby' queries, holds the timeseries object for each group",
+          "items": {
+            "type": "object"
+          },
+          "order": 5
+        },
+        "from": {
+          "type": "integer",
+          "title": "From",
+          "description": "The start of the time range for the query, as a UNIX timestamp in milliseconds",
+          "order": 6
+        },
+        "to": {
+          "type": "integer",
+          "title": "To",
+          "description": "The end of the time range for the query, as a UNIX timestamp in milliseconds",
+          "order": 7
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The type of function performed, for example, \"count\", \"max\", \"average\", \"standarddeviation\"",
+          "order": 8
+        },
+        "key": {
+          "type": "string",
+          "title": "Key",
+          "description": "The key which the function of the 'calculate' clause is applied to",
+          "order": 9
+        },
+        "cardinality": {
+          "type": "integer",
+          "title": "Cardinality",
+          "description": "Always 0",
+          "order": 10
+        },
+        "others": {
+          "type": "object",
+          "title": "Others",
+          "description": "Not yet implemented",
+          "order": 11
+        },
+        "status": {
+          "type": "integer",
+          "title": "Status",
+          "description": "Holds a status code for the query, potentially different from the status code of the response",
+          "order": 12
+        },
+        "all_exact_results": {
+          "type": "boolean",
+          "title": "All Exact Results",
+          "description": "Boolean indicating whether groups are calculated approximately (approximated if a groupby query involves over 10,000 groups)",
+          "order": 13
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -46,7 +46,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         callback_url, log_entries = self.maybe_get_log_entries(log_set_id, query, time_from, time_to, statistical)
 
         if callback_url and not log_entries:
-            log_entries = self.get_results_from_callback(callback_url, timeout)
+            log_entries = self.get_results_from_callback(callback_url, timeout, statistical)
 
         if log_entries and not statistical:
             log_entries = ResourceHelper.get_log_entries_with_new_labels(
@@ -77,7 +77,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             if entry in query:
                 return True
 
-    def get_results_from_callback(self, callback_url: str, timeout: int) -> [object]:  # noqa: C901
+    def get_results_from_callback(self, callback_url: str, timeout: int, statistical: bool) -> [object]:  # noqa: C901
         """
         Get log entries from a callback URL
 
@@ -96,7 +96,10 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 data=response.text,
             )
         results_object = response.json()
-        log_entries = results_object.get("events")
+        if statistical:
+            log_entries = results_object
+        else:
+            log_entries = results_object.get("events", [])
 
         if results_object.get("links"):
             callback_url = results_object.get("links")[0].get("href")
@@ -129,7 +132,12 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 )
 
             results_object = response.json()
-            log_entries = results_object.get("events")
+
+            if statistical:
+                log_entries = results_object
+            else:
+                log_entries = results_object.get("events", [])
+
             if not log_entries:
                 try:
                     callback_url = results_object.get("links")[0].get("href")
@@ -137,6 +145,10 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     self.logger.info("No results were found, returning an empty list")
                     return []
             else:
+                if results_object.get("links", [{}])[0].get("rel") == "Next":
+                    self.logger.info(
+                        "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"
+                    )
                 return log_entries
 
         return log_entries
@@ -163,6 +175,9 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         endpoint = f"{self.connection.url}log_search/query/logsets/{log_id}"
         params = {"query": query, "from": time_from, "to": time_to}
 
+        if not statistical:
+            params["per_page"] = 500
+
         self.logger.info(f"Getting logs from: {endpoint}")
         self.logger.info(f"Using parameters: {params}")
         response = self.connection.session.get(endpoint, params=params)
@@ -176,6 +191,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             )
 
         results_object = response.json()
+
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
             self.logger.info(f"Getting statistical from: {stats_endpoint}")
@@ -188,12 +204,20 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     assistance=f"Could not get statistical info from: {stats_endpoint}\n",
                     data=f"{stats_response.text}, {error}",
                 )
-            potential_results = stats_response.json()
+
+            if stats_response.json().get("links"):
+                potential_results = None
+            else:
+                potential_results = stats_response.json()
         else:
             potential_results = results_object.get("events")
 
         if potential_results:
             self.logger.info("Got results immediately, returning.")
+            if results_object.get("links", [{}])[0].get("rel") == "Next":
+                self.logger.info(
+                    "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"
+                )
             return None, potential_results
         else:
             self.logger.info("Got a callback url. Polling results...")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log set. This will query entire log sets for results"
+    DESCRIPTION = "Realtime query an InsightIDR log set. This will query entire log sets for results. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges"
 
 
 class Input:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 6.0.2
+version: 7.0.0
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7
@@ -1301,12 +1301,18 @@ actions:
         required: true
         order: 6
     output:
-      results:
-        title: Query Results
+      results_events:
+        title: Query Results (Events)
         description: Query Results
         type: "[]events"
-        required: true
+        required: false
         example: [{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]
+      results_statistical:
+        title: Query Results (Statistical)
+        description: Query Results
+        type: statistics
+        required: false
+        example:  {"leql": {"during": {"from": 1699579214000,"to": 1699622414000},"statement": "groupby(r7_context.asset.name)"},"logs": ["123456-abcd-1234-abcd-123456abc"],"search_stats": {"bytes_all": 9961260,"bytes_checked": 9961260,"duration_ms": 19,"events_all": 1640,"events_checked": 1640,"events_matched": 1639,"index_factor": 0.0},"statistics": {"all_exact_result": true,"cardinality": 0,"from": 1699579214000,"granularity": 4320000,"groups": [{"linux": {"count": 1163.0}},{"windowsx64": {"count": 476.0}}],"groups_timeseries": [{"linux": {"groups_timeseries": [],"series": [{"count": 45.0},{"count": 21.0},{"count": 16.0},{"count": 270.0},{"count": 27.0},{"count": 43.0},{"count": 27.},{"count": 39.0},{"count": 29.0},{"count": 646.0}],"totals": {"count": 1163.0}}},{"windowsx64": {"groups_timeseries": [],"series": [{"count": 54.0},{"count": 40.0},{"count": 60.0},{"count": 37.0},{"count": 42.0},{"count": 62.0},{"count": 41.0},{"count": 47.0},{"count": 49.0},{"count": 44.0}],"totals": {"count": 476.0}}}],"others": {"series": []},"stats": {},"status": 200,"timeseries": {},"to": 1699622414000,"type": "count"}}
       count:
         title: Count
         description: Number of log entries found
@@ -1315,7 +1321,7 @@ actions:
         example: 10
   advanced_query_on_log_set:
     title: Advanced Query on Log Set
-    description: Realtime query an InsightIDR log set. This will query entire log sets for results
+    description: Realtime query an InsightIDR log set. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges
     input:
       query:
         title: Query
@@ -1408,6 +1414,7 @@ actions:
         description: Query Results
         type: statistics
         required: false
+        example:  {"leql": {"during": {"from": 1699579214000,"to": 1699622414000},"statement": "groupby(r7_context.asset.name)"},"logs": ["123456-abcd-1234-abcd-123456abc"],"search_stats": {"bytes_all": 9961260,"bytes_checked": 9961260,"duration_ms": 19,"events_all": 1640,"events_checked": 1640,"events_matched": 1639,"index_factor": 0.0},"statistics": {"all_exact_result": true,"cardinality": 0,"from": 1699579214000,"granularity": 4320000,"groups": [{"linux": {"count": 1163.0}},{"windowsx64": {"count": 476.0}}],"groups_timeseries": [{"linux": {"groups_timeseries": [],"series": [{"count": 45.0},{"count": 21.0},{"count": 16.0},{"count": 270.0},{"count": 27.0},{"count": 43.0},{"count": 27.},{"count": 39.0},{"count": 29.0},{"count": 646.0}],"totals": {"count": 1163.0}}},{"windowsx64": {"groups_timeseries": [],"series": [{"count": 54.0},{"count": 40.0},{"count": 60.0},{"count": 37.0},{"count": 42.0},{"count": 62.0},{"count": 41.0},{"count": 47.0},{"count": 49.0},{"count": 44.0}],"totals": {"count": 476.0}}}],"others": {"series": []},"stats": {},"status": 200,"timeseries": {},"to": 1699622414000,"type": "count"}}
       count:
         title: Count
         description: Number of log entries found

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="6.0.2",
+      version="7.0.0",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/payloads/logs.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logs.json.resp
@@ -15,6 +15,14 @@
     {
       "name": "example_log4",
       "id": "log_id4"
+    },
+    {
+      "name": "example_log5",
+      "id": "log_id5"
+    },
+    {
+      "name": "example_log7",
+      "id": "log_id7"
     }
   ]
 }

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
@@ -5,9 +5,15 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.advanced_query_on_log import AdvancedQueryOnLog
-from komand_rapid7_insightidr.actions.advanced_query_on_log.schema import Input, Output
+from komand_rapid7_insightidr.actions.advanced_query_on_log.schema import (
+    Input,
+    Output,
+    AdvancedQueryOnLogInput,
+    AdvancedQueryOnLogOutput,
+)
 from util import Util
 from unittest.mock import patch
+from jsonschema import validate
 
 
 @patch("requests.Session.get", side_effect=Util.mocked_requests)
@@ -18,45 +24,222 @@ class TestAdvancedQueryOnLog(TestCase):
         cls.action = Util.default_connector(AdvancedQueryOnLog())
 
     def test_advanced_query_on_log_one_label(self, mock_get, mock_async_get):
-        actual = self.action.run({Input.QUERY: "", Input.LOG: "example_log1"})
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log1",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
+
         self.maxDiff = None
         expected = ["Out of order entry"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
 
     def test_advanced_query_on_log_two_labels(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG: "example_log2",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log2",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
         expected = ["Out of order entry", "Out of events"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
 
     def test_advanced_query_on_log_without_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG: "example_log3",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log3",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
 
     def test_advanced_query_on_log_wrong_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG: "example_log4",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log4",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
+
+    def test_advanced_query_on_log_statistical_result_calculate(self, mock_get, mock_async_get):
+        test_input = {
+            Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
+            Input.LOG: "example_log5",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
+        expected = {
+            "count": 462,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699567413000, "to": 1699610613000},
+                    "statement": "where(hostname='WindowsX64') calculate(count)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6291099,
+                    "bytes_checked": 3589232,
+                    "duration_ms": 19,
+                    "events_all": 1025,
+                    "events_checked": 595,
+                    "events_matched": 462,
+                    "index_factor": 0.4294746,
+                },
+                "statistics": {
+                    "all_exact_result": None,
+                    "cardinality": 0,
+                    "count": 462,
+                    "from": 1699567413000,
+                    "granularity": 4320000,
+                    "groups": [],
+                    "groups_timeseries": [],
+                    "others": {},
+                    "stats": {"global_timeseries": {"count": 462.0}},
+                    "status": 200,
+                    "timeseries": {
+                        "global_timeseries": [
+                            {"count": 38.0},
+                            {"count": 47.0},
+                            {"count": 36.0},
+                            {"count": 56.0},
+                            {"count": 60.0},
+                            {"count": 40.0},
+                            {"count": 39.0},
+                            {"count": 41.0},
+                            {"count": 61.0},
+                            {"count": 44.0},
+                        ]
+                    },
+                    "to": 1699610613000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogOutput.schema)
+
+    def test_advanced_query_on_log_statistical_result_groupby(self, mock_get, mock_async_get):
+        test_input = {
+            Input.QUERY: "groupby(r7_context.asset.name)",
+            Input.LOG: "example_log7",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
+        expected = {
+            "count": 1020,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699569260000, "to": 1699612460000},
+                    "statement": "groupby(r7_context.asset.name)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6276329,
+                    "bytes_checked": 6276329,
+                    "duration_ms": 36,
+                    "events_all": 1022,
+                    "events_checked": 1022,
+                    "events_matched": 1020,
+                    "index_factor": 0.0,
+                },
+                "statistics": {
+                    "all_exact_result": True,
+                    "cardinality": 0,
+                    "from": 1699569260000,
+                    "granularity": 4320000,
+                    "groups": [{"tomascybereasonsensor": {"count": 555.0}}, {"windowsx64": {"count": 465.0}}],
+                    "groups_timeseries": [
+                        {
+                            "tomascybereasonsensor": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 31.0},
+                                    {"count": 37.0},
+                                    {"count": 56.0},
+                                    {"count": 25.0},
+                                    {"count": 17.0},
+                                    {"count": 273.0},
+                                    {"count": 22.0},
+                                    {"count": 38.0},
+                                    {"count": 33.0},
+                                    {"count": 23.0},
+                                ],
+                                "totals": {"count": 555.0},
+                            }
+                        },
+                        {
+                            "windowsx64": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 28.0},
+                                    {"count": 53.0},
+                                    {"count": 42.0},
+                                    {"count": 56.0},
+                                    {"count": 57.0},
+                                    {"count": 32.0},
+                                    {"count": 46.0},
+                                    {"count": 50.0},
+                                    {"count": 54.0},
+                                    {"count": 47.0},
+                                ],
+                                "totals": {"count": 465.0},
+                            }
+                        },
+                    ],
+                    "others": {"series": []},
+                    "stats": {},
+                    "status": 200,
+                    "timeseries": {},
+                    "to": 1699612460000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -117,6 +117,8 @@ class Util:
                     )
                 )
 
+        print(f"{args = }")
+
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:1234567890",
             "index": 0,
@@ -252,17 +254,23 @@ class Util:
         elif args[0] == f"{Util.STUB_URL_API}/log_search/management/logsets":
             return MockResponse("logsets", 200)
 
-        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id5":
+        elif (
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id5"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id5"
+        ):
             return MockResponse("log_id5", 200)
+
+        elif (
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id7"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id7"
+        ):
+            return MockResponse("log_id7", 200)
 
         if (
             args[0]
             == "https://us.api.insight.rapid7.com/log_search/query/7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:"
         ):
             return MockResponse("log_id6", 200)
-
-        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id7":
-            return MockResponse("log_id7", 200)
 
         if (
             args[0]


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

making sure that there is feature parity between `advanced_query_on_log_set` and `advanced_query_on_log` action 

  - add in params["per_page"] = 500 to `advanced_query_on_log_set` and added to documentation 
  - fix issue with `advanced_query_on_log_set` where if a call back url was used, incorrect results were returned 
  - added example for `results_statistical`  to help md 

  - add in statistical results to `advanced_query_on_log`
  - added unit tests for new functional
  - fix issue with advanced_query_on_log where if a call back url was used, incorrect results were returned 
 

Note this be released at the same time as https://github.com/rapid7/insightconnect-plugins/pull/2108, as a result the versoin number for the other pr has been overwritten to 7.0.0, rather than making this a sperate release

https://issues.corp.rapid7.com/browse/PLGN-614

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

new unit tests have been added for the new functionality 
```
----------------------------------------------------------------------
Ran 84 tests in 0.066s

OK
```

#### In-Product Tests

testing the new 500 limit in  advanced_query_on_log_set

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/d88c49c3-2b42-48ad-a49e-b8a7ad85bdce)

testing calculate query in advanced_query_on_log
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/9fab2109-5d85-46d1-8d2d-d1ee1beaafb0)


testing groupby query in advanced_query_on_log
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/7720c857-1b3d-4706-aa65-f7eb1c8a9e21)



If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
