### PR TITLE
Rapid7_Insightidr 7.0.0 release

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "0f975db262dadb06d0a90e39fc05434a",
-	"manifest": "f6c902be173f84e632cafb5b3093432e",
-	"setup": "3b83b99c77061338b639889ef7848b9b",
+	"spec": "9c7adee28e0b9c12161fda2542f9d8d5",
+	"manifest": "9abe6edabaacd69f194daf13dde4f071",
+	"setup": "33356615b4b2f4d9999cc064148b9187",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "8eee4540d5732fa2be2f9a5c4cc603e0"
+			"hash": "351077a9ef290966fbfc0ba59991f33c"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "0b8b017708cf1a7fa5b775c9b5d78666"
+			"hash": "ddb27e90df73351cdf478e1aa245bb64"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,6 +1,6 @@
 {
-	"spec": "e88e03be591a773f6f06ab8f8ff72d75",
-	"manifest": "fcaf023d3d8e468094348803d3ecc5eb",
+	"spec": "0f975db262dadb06d0a90e39fc05434a",
+	"manifest": "f6c902be173f84e632cafb5b3093432e",
 	"setup": "3b83b99c77061338b639889ef7848b9b",
 	"schemas": [
 		{

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "351077a9ef290966fbfc0ba59991f33c"
+			"hash": "00bc1cfd11f5e82bbd42a41f7bb73aa6"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "ddb27e90df73351cdf478e1aa245bb64"
+			"hash": "b5b2c8b6a3b884b33241f87004815459"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",
@@ -65,7 +65,7 @@
 		},
 		{
 			"identifier": "get_asset_information/schema.py",
-			"hash": "85365495f1c8163d9ea7bd57d6868912"
+			"hash": "64effaa9ce11a6c8a5ce9a7c549ab065"
 		},
 		{
 			"identifier": "get_attachment_information/schema.py",
@@ -77,7 +77,7 @@
 		},
 		{
 			"identifier": "get_user_information/schema.py",
-			"hash": "425c12ebf63cfbf4e33cc5062f6f79d6"
+			"hash": "97336fed8bb4500168c4e0e917207409"
 		},
 		{
 			"identifier": "list_alerts_for_investigation/schema.py",
@@ -93,7 +93,7 @@
 		},
 		{
 			"identifier": "list_investigations/schema.py",
-			"hash": "30638dbade4c0cfc4973ae8f337cf74d"
+			"hash": "efccfd5964ecf0e34d332a0be02b978f"
 		},
 		{
 			"identifier": "query/schema.py",
@@ -105,23 +105,23 @@
 		},
 		{
 			"identifier": "search_investigations/schema.py",
-			"hash": "ddc78a2fec8c00fdb0027eb106977bac"
+			"hash": "863a7464093e3172bb4c8fdfdc6ff565"
 		},
 		{
 			"identifier": "set_disposition_of_investigation/schema.py",
-			"hash": "c552a2a6b9b88ca956d0ec803820cde9"
+			"hash": "9a69bbb81a33f783e6031f2901ea1ae4"
 		},
 		{
 			"identifier": "set_priority_of_investigation/schema.py",
-			"hash": "3c2c3a618cb7706088bf8b3514840456"
+			"hash": "6a81d506bdef375ea5a0b5fd16ba8349"
 		},
 		{
 			"identifier": "set_status_of_investigation_action/schema.py",
-			"hash": "9df649243e960ecd339d2e1989b613b9"
+			"hash": "e9ac594003f3a4ef378aebdd14301439"
 		},
 		{
 			"identifier": "update_investigation/schema.py",
-			"hash": "899b1d2e69fb65d67c25af353e4b4249"
+			"hash": "59a5851e5ebf096ba9f22ed5eff1cc0b"
 		},
 		{
 			"identifier": "upload_attachment/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "6.0.1"
+Version = "6.0.2"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "6.0.2"
+Version = "7.0.0"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -141,7 +141,8 @@ Example input:
 |Name|Type|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of log entries found|10|
-|results|[]events|True|Query Results|[{"labels": [], "timestamp": 1601598638768, "sequence_number": 123456789123456789, "log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313", "message": {"timestamp": "2020-10-02T00:29:14.649Z", "destination_asset": "iagent-win7", "source_asset_address": "192.168.100.50", "destination_asset_address": "example-host", "destination_local_account": "user", "logon_type": "NETWORK", "result": "SUCCESS", "new_authentication": "false", "service": "ntlmssp ", "source_json": {"sourceName": "Microsoft-Windows-Security-Auditing", "insertionStrings": ["S-1-0-0", "-", "-", "0x0", "X-X-X-XXXXXXXXXXX", "user@example.com", "example-host", "0x204f163c", "3", "NtLmSsp ", "NTLM", "", "{00000000-0000-0000-0000-000000000000}", "-", "NTLM V2", "128", "0x0", "-", "192.168.50.1", "59090"], "eventCode": 4624, "computerName": "example-host", "sid": "", "isDomainController": False, "eventData": None, "timeWritten": "2020-10-02T00:29:13.670722000Z"}}, "links": [{"rel": "Context", "href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}], "sequence_number_str": "123456789123456789"}]|
+|results_events|[]events|False|Query Results|[{"labels": [], "timestamp": 1601598638768, "sequence_number": 123456789123456789, "log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313", "message": {"timestamp": "2020-10-02T00:29:14.649Z", "destination_asset": "iagent-win7", "source_asset_address": "192.168.100.50", "destination_asset_address": "example-host", "destination_local_account": "user", "logon_type": "NETWORK", "result": "SUCCESS", "new_authentication": "false", "service": "ntlmssp ", "source_json": {"sourceName": "Microsoft-Windows-Security-Auditing", "insertionStrings": ["S-1-0-0", "-", "-", "0x0", "X-X-X-XXXXXXXXXXX", "user@example.com", "example-host", "0x204f163c", "3", "NtLmSsp ", "NTLM", "", "{00000000-0000-0000-0000-000000000000}", "-", "NTLM V2", "128", "0x0", "-", "192.168.50.1", "59090"], "eventCode": 4624, "computerName": "example-host", "sid": "", "isDomainController": False, "eventData": None, "timeWritten": "2020-10-02T00:29:13.670722000Z"}}, "links": [{"rel": "Context", "href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}], "sequence_number_str": "123456789123456789"}]|
+|results_statistical|statistics|False|Query Results|{'leql': {'during': {'from': 1699579214000, 'to': 1699622414000}, 'statement': 'groupby(r7_context.asset.name)'}, 'logs': ['123456-abcd-1234-abcd-123456abc'], 'search_stats': {'bytes_all': 9961260, 'bytes_checked': 9961260, 'duration_ms': 19, 'events_all': 1640, 'events_checked': 1640, 'events_matched': 1639, 'index_factor': 0.0}, 'statistics': {'all_exact_result': True, 'cardinality': 0, 'from': 1699579214000, 'granularity': 4320000, 'groups': [{'linux': {'count': 1163.0}}, {'windowsx64': {'count': 476.0}}], 'groups_timeseries': [{'linux': {'groups_timeseries': [], 'series': [{'count': 45.0}, {'count': 21.0}, {'count': 16.0}, {'count': 270.0}, {'count': 27.0}, {'count': 43.0}, {'count': 27.0}, {'count': 39.0}, {'count': 29.0}, {'count': 646.0}], 'totals': {'count': 1163.0}}}, {'windowsx64': {'groups_timeseries': [], 'series': [{'count': 54.0}, {'count': 40.0}, {'count': 60.0}, {'count': 37.0}, {'count': 42.0}, {'count': 62.0}, {'count': 41.0}, {'count': 47.0}, {'count': 49.0}, {'count': 44.0}], 'totals': {'count': 476.0}}}], 'others': {'series': []}, 'stats': {}, 'status': 200, 'timeseries': {}, 'to': 1699622414000, 'type': 'count'}}|
   
 Example output:
 
@@ -199,16 +200,145 @@ Example output:
       },
       "timestamp": "2020-10-02T00:29:14.649Z"
     },
-    "sequence_number": 123456789123456789,
+    "sequence_number": 123456789123456780,
     "sequence_number_str": "123456789123456789",
     "timestamp": 1601598638768
+  },
+  "results_statistical": {
+    "leql": {
+      "during": {
+        "from": 1699579214000,
+        "to": 1699622414000
+      },
+      "statement": "groupby(r7_context.asset.name)"
+    },
+    "logs": [
+      "123456-abcd-1234-abcd-123456abc"
+    ],
+    "search_stats": {
+      "bytes_all": 9961260,
+      "bytes_checked": 9961260,
+      "duration_ms": 19,
+      "events_all": 1640,
+      "events_checked": 1640,
+      "events_matched": 1639,
+      "index_factor": 0
+    },
+    "statistics": {
+      "all_exact_result": true,
+      "cardinality": 0,
+      "from": 1699579214000,
+      "granularity": 4320000,
+      "groups": [
+        {
+          "linux": {
+            "count": 1163
+          }
+        },
+        {
+          "windowsx64": {
+            "count": 476
+          }
+        }
+      ],
+      "groups_timeseries": [
+        {
+          "linux": {
+            "groups_timeseries": [],
+            "series": [
+              {
+                "count": 45
+              },
+              {
+                "count": 21
+              },
+              {
+                "count": 16
+              },
+              {
+                "count": 270
+              },
+              {
+                "count": 27
+              },
+              {
+                "count": 43
+              },
+              {
+                "count": 27
+              },
+              {
+                "count": 39
+              },
+              {
+                "count": 29
+              },
+              {
+                "count": 646
+              }
+            ],
+            "totals": {
+              "count": 1163
+            }
+          }
+        },
+        {
+          "windowsx64": {
+            "groups_timeseries": [],
+            "series": [
+              {
+                "count": 54
+              },
+              {
+                "count": 40
+              },
+              {
+                "count": 60
+              },
+              {
+                "count": 37
+              },
+              {
+                "count": 42
+              },
+              {
+                "count": 62
+              },
+              {
+                "count": 41
+              },
+              {
+                "count": 47
+              },
+              {
+                "count": 49
+              },
+              {
+                "count": 44
+              }
+            ],
+            "totals": {
+              "count": 476
+            }
+          }
+        }
+      ],
+      "others": {
+        "series": []
+      },
+      "stats": {},
+      "status": 200,
+      "timeseries": {},
+      "to": 1699622414000,
+      "type": "count"
+    }
   }
 }
 ```
 
 #### Advanced Query on Log Set
   
-Realtime query an InsightIDR log set. This will query entire log sets for results
+Realtime query an InsightIDR log set. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges
 
 ##### Input
 
@@ -240,7 +370,7 @@ Example input:
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of log entries found|10|
 |results_events|[]events|False|Query Results|[{"labels": [], "timestamp": 1601598638768, "sequence_number": 123456789123456789, "log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313", "message": {"timestamp": "2020-10-02T00:29:14.649Z", "destination_asset": "iagent-win7", "source_asset_address": "192.168.100.50", "destination_asset_address": "example-host", "destination_local_account": "user", "logon_type": "NETWORK", "result": "SUCCESS", "new_authentication": "false", "service": "ntlmssp ", "source_json": {"sourceName": "Microsoft-Windows-Security-Auditing", "insertionStrings": ["S-1-0-0", "-", "-", "0x0", "X-X-X-XXXXXXXXXXX", "user@example.com", "example-host", "0x204f163c", "3", "NtLmSsp ", "NTLM", "", "{00000000-0000-0000-0000-000000000000}", "-", "NTLM V2", "128", "0x0", "-", "192.168.50.1", "59090"], "eventCode": 4624, "computerName": "example-host", "sid": "", "isDomainController": False, "eventData": None, "timeWritten": "2020-10-02T00:29:13.670722000Z"}}, "links": [{"rel": "Context", "href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}], "sequence_number_str": "123456789123456789"}]|
-|results_statistical|statistics|False|Query Results|None|
+|results_statistical|statistics|False|Query Results|{'leql': {'during': {'from': 1699579214000, 'to': 1699622414000}, 'statement': 'groupby(r7_context.asset.name)'}, 'logs': ['123456-abcd-1234-abcd-123456abc'], 'search_stats': {'bytes_all': 9961260, 'bytes_checked': 9961260, 'duration_ms': 19, 'events_all': 1640, 'events_checked': 1640, 'events_matched': 1639, 'index_factor': 0.0}, 'statistics': {'all_exact_result': True, 'cardinality': 0, 'from': 1699579214000, 'granularity': 4320000, 'groups': [{'linux': {'count': 1163.0}}, {'windowsx64': {'count': 476.0}}], 'groups_timeseries': [{'linux': {'groups_timeseries': [], 'series': [{'count': 45.0}, {'count': 21.0}, {'count': 16.0}, {'count': 270.0}, {'count': 27.0}, {'count': 43.0}, {'count': 27.0}, {'count': 39.0}, {'count': 29.0}, {'count': 646.0}], 'totals': {'count': 1163.0}}}, {'windowsx64': {'groups_timeseries': [], 'series': [{'count': 54.0}, {'count': 40.0}, {'count': 60.0}, {'count': 37.0}, {'count': 42.0}, {'count': 62.0}, {'count': 41.0}, {'count': 47.0}, {'count': 49.0}, {'count': 44.0}], 'totals': {'count': 476.0}}}], 'others': {'series': []}, 'stats': {}, 'status': 200, 'timeseries': {}, 'to': 1699622414000, 'type': 'count'}}|
   
 Example output:
 
@@ -298,38 +428,137 @@ Example output:
       },
       "timestamp": "2020-10-02T00:29:14.649Z"
     },
-    "sequence_number": 123456789123456789,
+    "sequence_number": 123456789123456780,
     "sequence_number_str": "123456789123456789",
-    "timestamp": 1601598638768
-  },
-  "results_statistical": {
+    "timestamp": 1601598638768,
     "results_statistical": {
-      "cardinality": 0,
-      "granularity": 4320000,
-      "from": 1698023841000,
-      "to": 1698067041000,
-      "type": "count",
-      "stats": {
-        "global_timeseries": {
-          "count": 0.0
-        }
+      "leql": {
+        "during": {
+          "from": 1699579214000,
+          "to": 1699622414000
+        },
+        "statement": "groupby(r7_context.asset.name)"
       },
-      "groups": [],
-      "others": {},
-      "status": 200,
-      "timeseries": {
-        "global_timeseries": [
+      "logs": [
+        "123456-abcd-1234-abcd-123456abc"
+      ],
+      "search_stats": {
+        "bytes_all": 9961260,
+        "bytes_checked": 9961260,
+        "duration_ms": 19,
+        "events_all": 1640,
+        "events_checked": 1640,
+        "events_matched": 1639,
+        "index_factor": 0
+      },
+      "statistics": {
+        "all_exact_result": true,
+        "cardinality": 0,
+        "from": 1699579214000,
+        "granularity": 4320000,
+        "groups": [
           {
-            "count": 0.0
+            "linux": {
+              "count": 1163
+            }
           },
           {
-            "count": 0.0
+            "windowsx64": {
+              "count": 476
+            }
           }
-        ]
-      },
-      "groups_timeseries": [],
-      "all_exact_result": null,
-      "count": 0
+        ],
+        "groups_timeseries": [
+          {
+            "linux": {
+              "groups_timeseries": [],
+              "series": [
+                {
+                  "count": 45
+                },
+                {
+                  "count": 21
+                },
+                {
+                  "count": 16
+                },
+                {
+                  "count": 270
+                },
+                {
+                  "count": 27
+                },
+                {
+                  "count": 43
+                },
+                {
+                  "count": 27
+                },
+                {
+                  "count": 39
+                },
+                {
+                  "count": 29
+                },
+                {
+                  "count": 646
+                }
+              ],
+              "totals": {
+                "count": 1163
+              }
+            }
+          },
+          {
+            "windowsx64": {
+              "groups_timeseries": [],
+              "series": [
+                {
+                  "count": 54
+                },
+                {
+                  "count": 40
+                },
+                {
+                  "count": 60
+                },
+                {
+                  "count": 37
+                },
+                {
+                  "count": 42
+                },
+                {
+                  "count": 62
+                },
+                {
+                  "count": 41
+                },
+                {
+                  "count": 47
+                },
+                {
+                  "count": 49
+                },
+                {
+                  "count": 44
+                }
+              ],
+              "totals": {
+                "count": 476
+              }
+            }
+          }
+        ],
+        "others": {
+          "series": []
+        },
+        "stats": {},
+        "status": 200,
+        "timeseries": {},
+        "to": 1699622414000,
+        "type": "count"
+      }
     }
   }
 }
@@ -2024,7 +2253,7 @@ Example output:
 
 # Version History
 
-* 6.0.2 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0
+* 7.0.0 - Action: `Advanced Query On Log Set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log Set` - Increase the maximum results returned from 50 to 500 |  Action: `Advanced Query On Log` - Add new output type for statistical queries.
 * 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -2253,7 +2253,7 @@ Example output:
 
 # Version History
 
-* 7.0.0 - Action: `Advanced Query On Log Set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log Set` - Increase the maximum results returned from 50 to 500 |  Action: `Advanced Query On Log` - Add new output type for statistical queries.
+* 7.0.0 - Action: `Advanced Query On Log Set` - Fixed error where statistical queries would always return 0.0 | Action: `Advanced Query On Log Set` - Increase the maximum results returned from 50 to 500 |  Action: `Advanced Query On Log` - Add new output type for statistical queries | Updated schemas to ensure all are correct and added new schema validation to unit tests
 * 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -2024,7 +2024,8 @@ Example output:
 
 # Version History
 
-* 6.0.1 - Action: `Advanced Query On Log Set` - Up the maximium events returned from 50 to 500
+* 6.0.2 - Action: `Advanced Query On Log set` - Fixed error where statistical queries would always return 0.0
+* 6.0.1 - Action: `Advanced Query On Log` - Increase the maximum results returned from 50 to 500
 * 6.0.0 - Action: `Advanced Query On Log Set` - Add new output type for statistical queries.
 * 5.1.2 - Action: `Advanced Query on Log Set` - Fix JSONDecoderError | Action: `Query` - Update spec and help.md to show it queries log IDs, not query IDs
 * 5.1.1 - Action: `List Investigations` - Now receiving size input | Actions: `Advanced Query On Log` & `Advanced Query On Log Set` - Acronym LQL has been updated to LEQL

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -106,9 +106,9 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "description": "Number of log entries found",
       "order": 3
     },
-    "results": {
+    "results_events": {
       "type": "array",
-      "title": "Query Results",
+      "title": "Query Results (Events)",
       "description": "Query Results",
       "items": {
         "$ref": "#/definitions/events"

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -18,7 +18,8 @@ class Input:
 
 class Output:
     COUNT = "count"
-    RESULTS = "results"
+    RESULTS_EVENTS = "results_events"
+    RESULTS_STATISTICAL = "results_statistical"
 
 
 class AdvancedQueryOnLogInput(insightconnect_plugin_runtime.Input):
@@ -103,7 +104,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "type": "integer",
       "title": "Count",
       "description": "Number of log entries found",
-      "order": 2
+      "order": 3
     },
     "results": {
       "type": "array",
@@ -113,11 +114,16 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
         "$ref": "#/definitions/events"
       },
       "order": 1
+    },
+    "results_statistical": {
+      "$ref": "#/definitions/statistics",
+      "title": "Query Results (Statistical)",
+      "description": "Query Results",
+      "order": 2
     }
   },
   "required": [
-    "count",
-    "results"
+    "count"
   ],
   "definitions": {
     "events": {
@@ -383,6 +389,96 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
           "title": "HREF",
           "description": "HREF",
           "order": 2
+        }
+      }
+    },
+    "statistics": {
+      "type": "object",
+      "title": "statistics",
+      "properties": {
+        "stats": {
+          "type": "object",
+          "title": "Stats",
+          "description": "Holds the overall result when query does not contain a 'groupby' clause",
+          "order": 1
+        },
+        "groups": {
+          "type": "array",
+          "title": "Groups",
+          "description": "Holds the overall result for each group in a 'groupby' query",
+          "items": {
+            "type": "object"
+          },
+          "order": 2
+        },
+        "granularity": {
+          "type": "integer",
+          "title": "Granularity",
+          "description": "The time window in milliseconds for each time slice in the time series",
+          "order": 3
+        },
+        "timeseries": {
+          "type": "object",
+          "title": "Time Series",
+          "description": "Holds the query results for each timeslice (each partition of the time_range), for non-'groupby' queries",
+          "order": 4
+        },
+        "groups_timeseries": {
+          "type": "array",
+          "title": "Groups Time Series",
+          "description": "For 'groupby' queries, holds the timeseries object for each group",
+          "items": {
+            "type": "object"
+          },
+          "order": 5
+        },
+        "from": {
+          "type": "integer",
+          "title": "From",
+          "description": "The start of the time range for the query, as a UNIX timestamp in milliseconds",
+          "order": 6
+        },
+        "to": {
+          "type": "integer",
+          "title": "To",
+          "description": "The end of the time range for the query, as a UNIX timestamp in milliseconds",
+          "order": 7
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The type of function performed, for example, \"count\", \"max\", \"average\", \"standarddeviation\"",
+          "order": 8
+        },
+        "key": {
+          "type": "string",
+          "title": "Key",
+          "description": "The key which the function of the 'calculate' clause is applied to",
+          "order": 9
+        },
+        "cardinality": {
+          "type": "integer",
+          "title": "Cardinality",
+          "description": "Always 0",
+          "order": 10
+        },
+        "others": {
+          "type": "object",
+          "title": "Others",
+          "description": "Not yet implemented",
+          "order": 11
+        },
+        "status": {
+          "type": "integer",
+          "title": "Status",
+          "description": "Holds a status code for the query, potentially different from the status code of the response",
+          "order": 12
+        },
+        "all_exact_results": {
+          "type": "boolean",
+          "title": "All Exact Results",
+          "description": "Boolean indicating whether groups are calculated approximately (approximated if a groupby query involves over 10,000 groups)",
+          "order": 13
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -46,7 +46,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         callback_url, log_entries = self.maybe_get_log_entries(log_set_id, query, time_from, time_to, statistical)
 
         if callback_url and not log_entries:
-            log_entries = self.get_results_from_callback(callback_url, timeout)
+            log_entries = self.get_results_from_callback(callback_url, timeout, statistical)
 
         if log_entries and not statistical:
             log_entries = ResourceHelper.get_log_entries_with_new_labels(
@@ -77,7 +77,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             if entry in query:
                 return True
 
-    def get_results_from_callback(self, callback_url: str, timeout: int) -> [object]:  # noqa: C901
+    def get_results_from_callback(self, callback_url: str, timeout: int, statistical: bool) -> [object]:  # noqa: C901
         """
         Get log entries from a callback URL
 
@@ -96,7 +96,10 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 data=response.text,
             )
         results_object = response.json()
-        log_entries = results_object.get("events")
+        if statistical:
+            log_entries = results_object
+        else:
+            log_entries = results_object.get("events", [])
 
         if results_object.get("links"):
             callback_url = results_object.get("links")[0].get("href")
@@ -129,7 +132,12 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 )
 
             results_object = response.json()
-            log_entries = results_object.get("events")
+
+            if statistical:
+                log_entries = results_object
+            else:
+                log_entries = results_object.get("events", [])
+
             if not log_entries:
                 try:
                     callback_url = results_object.get("links")[0].get("href")
@@ -137,6 +145,10 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     self.logger.info("No results were found, returning an empty list")
                     return []
             else:
+                if results_object.get("links", [{}])[0].get("rel") == "Next":
+                    self.logger.info(
+                        "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"
+                    )
                 return log_entries
 
         return log_entries
@@ -163,6 +175,9 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         endpoint = f"{self.connection.url}log_search/query/logsets/{log_id}"
         params = {"query": query, "from": time_from, "to": time_to}
 
+        if not statistical:
+            params["per_page"] = 500
+
         self.logger.info(f"Getting logs from: {endpoint}")
         self.logger.info(f"Using parameters: {params}")
         response = self.connection.session.get(endpoint, params=params)
@@ -176,6 +191,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             )
 
         results_object = response.json()
+
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
             self.logger.info(f"Getting statistical from: {stats_endpoint}")
@@ -188,12 +204,20 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     assistance=f"Could not get statistical info from: {stats_endpoint}\n",
                     data=f"{stats_response.text}, {error}",
                 )
-            potential_results = stats_response.json()
+
+            if stats_response.json().get("links"):
+                potential_results = None
+            else:
+                potential_results = stats_response.json()
         else:
             potential_results = results_object.get("events")
 
         if potential_results:
             self.logger.info("Got results immediately, returning.")
+            if results_object.get("links", [{}])[0].get("rel") == "Next":
+                self.logger.info(
+                    "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"
+                )
             return None, potential_results
         else:
             self.logger.info("Got a callback url. Polling results...")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log set. This will query entire log sets for results. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges"
+    DESCRIPTION = "Realtime query an InsightIDR log set. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges"
 
 
 class Input:
@@ -146,6 +146,9 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
       "order": 2
     }
   },
+  "required": [
+    "count"
+  ],
   "definitions": {
     "events": {
       "type": "object",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log set. This will query entire log sets for results"
+    DESCRIPTION = "Realtime query an InsightIDR log set. This will query entire log sets for results. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges"
 
 
 class Input:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/schema.py
@@ -24,7 +24,7 @@ class GetAssetInformationInput(insightconnect_plugin_runtime.Input):
   "properties": {
     "asset_rrn": {
       "type": "string",
-      "title": "asset RRN",
+      "title": "Asset RRN",
       "description": "The RRN of the asset",
       "order": 1
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/schema.py
@@ -24,7 +24,7 @@ class GetUserInformationInput(insightconnect_plugin_runtime.Input):
   "properties": {
     "user_rrn": {
       "type": "string",
-      "title": "user RRN",
+      "title": "User RRN",
       "description": "The RRN of the user",
       "order": 1
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_investigations/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_investigations/schema.py
@@ -38,10 +38,10 @@ class ListInvestigationsInput(insightconnect_plugin_runtime.Input):
     },
     "end_time": {
       "type": "string",
-      "title": "End Time",
-      "displayType": "date",
-      "description": "An optional-ISO formatted timestamp, where only investigations whose createTime is before this date will be returned",
       "format": "date-time",
+      "displayType": "date",
+      "title": "End Time",
+      "description": "An optional-ISO formatted timestamp, where only investigations whose createTime is before this date will be returned",
       "order": 3
     },
     "index": {
@@ -99,10 +99,10 @@ class ListInvestigationsInput(insightconnect_plugin_runtime.Input):
     },
     "start_time": {
       "type": "string",
-      "title": "Start Time",
-      "displayType": "date",
-      "description": "An optional ISO-formatted timestamp, where only investigations whose createTime is after this date will be returned",
       "format": "date-time",
+      "displayType": "date",
+      "title": "Start Time",
+      "description": "An optional ISO-formatted timestamp, where only investigations whose createTime is after this date will be returned",
       "order": 2
     },
     "statuses": {
@@ -154,24 +154,6 @@ class ListInvestigationsOutput(insightconnect_plugin_runtime.Output):
     "metadata"
   ],
   "definitions": {
-    "assignee": {
-      "type": "object",
-      "title": "assignee",
-      "properties": {
-        "email": {
-          "type": "string",
-          "title": "Email",
-          "description": "The email of the assigned user",
-          "order": 1
-        },
-        "name": {
-          "type": "string",
-          "title": "Name",
-          "description": "The name of the assigned user",
-          "order": 2
-        }
-      }
-    },
     "investigation": {
       "type": "object",
       "title": "investigation",
@@ -259,25 +241,23 @@ class ListInvestigationsOutput(insightconnect_plugin_runtime.Output):
         "source",
         "status",
         "title"
-      ],
-      "definitions": {
-        "assignee": {
-          "type": "object",
-          "title": "assignee",
-          "properties": {
-            "email": {
-              "type": "string",
-              "title": "Email",
-              "description": "The email of the assigned user",
-              "order": 1
-            },
-            "name": {
-              "type": "string",
-              "title": "Name",
-              "description": "The name of the assigned user",
-              "order": 2
-            }
-          }
+      ]
+    },
+    "assignee": {
+      "type": "object",
+      "title": "assignee",
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The email of the assigned user",
+          "order": 1
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the assigned user",
+          "order": 2
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/schema.py
@@ -115,24 +115,6 @@ class SearchInvestigationsOutput(insightconnect_plugin_runtime.Output):
     "metadata"
   ],
   "definitions": {
-    "assignee": {
-      "type": "object",
-      "title": "assignee",
-      "properties": {
-        "email": {
-          "type": "string",
-          "title": "Email",
-          "description": "The email of the assigned user",
-          "order": 1
-        },
-        "name": {
-          "type": "string",
-          "title": "Name",
-          "description": "The name of the assigned user",
-          "order": 2
-        }
-      }
-    },
     "investigation": {
       "type": "object",
       "title": "investigation",
@@ -220,25 +202,23 @@ class SearchInvestigationsOutput(insightconnect_plugin_runtime.Output):
         "source",
         "status",
         "title"
-      ],
-      "definitions": {
-        "assignee": {
-          "type": "object",
-          "title": "assignee",
-          "properties": {
-            "email": {
-              "type": "string",
-              "title": "Email",
-              "description": "The email of the assigned user",
-              "order": 1
-            },
-            "name": {
-              "type": "string",
-              "title": "Name",
-              "description": "The name of the assigned user",
-              "order": 2
-            }
-          }
+      ]
+    },
+    "assignee": {
+      "type": "object",
+      "title": "assignee",
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The email of the assigned user",
+          "order": 1
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the assigned user",
+          "order": 2
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_disposition_of_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_disposition_of_investigation/schema.py
@@ -69,24 +69,6 @@ class SetDispositionOfInvestigationOutput(insightconnect_plugin_runtime.Output):
     "investigation"
   ],
   "definitions": {
-    "assignee": {
-      "type": "object",
-      "title": "assignee",
-      "properties": {
-        "email": {
-          "type": "string",
-          "title": "Email",
-          "description": "The email of the assigned user",
-          "order": 1
-        },
-        "name": {
-          "type": "string",
-          "title": "Name",
-          "description": "The name of the assigned user",
-          "order": 2
-        }
-      }
-    },
     "investigation": {
       "type": "object",
       "title": "investigation",
@@ -174,25 +156,23 @@ class SetDispositionOfInvestigationOutput(insightconnect_plugin_runtime.Output):
         "source",
         "status",
         "title"
-      ],
-      "definitions": {
-        "assignee": {
-          "type": "object",
-          "title": "assignee",
-          "properties": {
-            "email": {
-              "type": "string",
-              "title": "Email",
-              "description": "The email of the assigned user",
-              "order": 1
-            },
-            "name": {
-              "type": "string",
-              "title": "Name",
-              "description": "The name of the assigned user",
-              "order": 2
-            }
-          }
+      ]
+    },
+    "assignee": {
+      "type": "object",
+      "title": "assignee",
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The email of the assigned user",
+          "order": 1
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the assigned user",
+          "order": 2
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/schema.py
@@ -71,24 +71,6 @@ class SetPriorityOfInvestigationOutput(insightconnect_plugin_runtime.Output):
     "investigation"
   ],
   "definitions": {
-    "assignee": {
-      "type": "object",
-      "title": "assignee",
-      "properties": {
-        "email": {
-          "type": "string",
-          "title": "Email",
-          "description": "The email of the assigned user",
-          "order": 1
-        },
-        "name": {
-          "type": "string",
-          "title": "Name",
-          "description": "The name of the assigned user",
-          "order": 2
-        }
-      }
-    },
     "investigation": {
       "type": "object",
       "title": "investigation",
@@ -176,25 +158,23 @@ class SetPriorityOfInvestigationOutput(insightconnect_plugin_runtime.Output):
         "source",
         "status",
         "title"
-      ],
-      "definitions": {
-        "assignee": {
-          "type": "object",
-          "title": "assignee",
-          "properties": {
-            "email": {
-              "type": "string",
-              "title": "Email",
-              "description": "The email of the assigned user",
-              "order": 1
-            },
-            "name": {
-              "type": "string",
-              "title": "Name",
-              "description": "The name of the assigned user",
-              "order": 2
-            }
-          }
+      ]
+    },
+    "assignee": {
+      "type": "object",
+      "title": "assignee",
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The email of the assigned user",
+          "order": 1
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the assigned user",
+          "order": 2
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/schema.py
@@ -69,24 +69,6 @@ class SetStatusOfInvestigationActionOutput(insightconnect_plugin_runtime.Output)
     "investigation"
   ],
   "definitions": {
-    "assignee": {
-      "type": "object",
-      "title": "assignee",
-      "properties": {
-        "email": {
-          "type": "string",
-          "title": "Email",
-          "description": "The email of the assigned user",
-          "order": 1
-        },
-        "name": {
-          "type": "string",
-          "title": "Name",
-          "description": "The name of the assigned user",
-          "order": 2
-        }
-      }
-    },
     "investigation": {
       "type": "object",
       "title": "investigation",
@@ -174,25 +156,23 @@ class SetStatusOfInvestigationActionOutput(insightconnect_plugin_runtime.Output)
         "source",
         "status",
         "title"
-      ],
-      "definitions": {
-        "assignee": {
-          "type": "object",
-          "title": "assignee",
-          "properties": {
-            "email": {
-              "type": "string",
-              "title": "Email",
-              "description": "The email of the assigned user",
-              "order": 1
-            },
-            "name": {
-              "type": "string",
-              "title": "Name",
-              "description": "The name of the assigned user",
-              "order": 2
-            }
-          }
+      ]
+    },
+    "assignee": {
+      "type": "object",
+      "title": "assignee",
+      "properties": {
+        "email": {
+          "type": "string",
+          "title": "Email",
+          "description": "The email of the assigned user",
+          "order": 1
+        },
+        "name": {
+          "type": "string",
+          "title": "Name",
+          "description": "The name of the assigned user",
+          "order": 2
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/schema.py
@@ -108,16 +108,7 @@ class UpdateInvestigationOutput(insightconnect_plugin_runtime.Output):
     }
   },
   "required": [
-    "created_time",
-    "disposition",
-    "investigation",
-    "last_accessed",
-    "organization_id",
-    "priority",
-    "rrn",
-    "source",
-    "status",
-    "title"
+    "investigation"
   ],
   "definitions": {
     "investigation": {
@@ -195,20 +186,19 @@ class UpdateInvestigationOutput(insightconnect_plugin_runtime.Output):
           "title": "Title",
           "description": "Investigation title",
           "order": 12
-        },
-        "required": [
-          "created_time",
-          "disposition",
-          "last_accessed",
-          "organization_id",
-          "priority",
-          "rrn",
-          "source",
-          "status",
-          "title",
-          "investigation"
-        ]
-      }
+        }
+      },
+      "required": [
+        "created_time",
+        "disposition",
+        "last_accessed",
+        "organization_id",
+        "priority",
+        "rrn",
+        "source",
+        "status",
+        "title"
+      ]
     },
     "assignee": {
       "type": "object",

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 6.0.2
+version: 7.0.0
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7
@@ -1301,12 +1301,18 @@ actions:
         required: true
         order: 6
     output:
-      results:
-        title: Query Results
+      results_events:
+        title: Query Results (Events)
         description: Query Results
         type: "[]events"
-        required: true
+        required: false
         example: [{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]
+      results_statistical:
+        title: Query Results (Statistical)
+        description: Query Results
+        type: statistics
+        required: false
+        example:  {"leql": {"during": {"from": 1699579214000,"to": 1699622414000},"statement": "groupby(r7_context.asset.name)"},"logs": ["123456-abcd-1234-abcd-123456abc"],"search_stats": {"bytes_all": 9961260,"bytes_checked": 9961260,"duration_ms": 19,"events_all": 1640,"events_checked": 1640,"events_matched": 1639,"index_factor": 0.0},"statistics": {"all_exact_result": true,"cardinality": 0,"from": 1699579214000,"granularity": 4320000,"groups": [{"linux": {"count": 1163.0}},{"windowsx64": {"count": 476.0}}],"groups_timeseries": [{"linux": {"groups_timeseries": [],"series": [{"count": 45.0},{"count": 21.0},{"count": 16.0},{"count": 270.0},{"count": 27.0},{"count": 43.0},{"count": 27.},{"count": 39.0},{"count": 29.0},{"count": 646.0}],"totals": {"count": 1163.0}}},{"windowsx64": {"groups_timeseries": [],"series": [{"count": 54.0},{"count": 40.0},{"count": 60.0},{"count": 37.0},{"count": 42.0},{"count": 62.0},{"count": 41.0},{"count": 47.0},{"count": 49.0},{"count": 44.0}],"totals": {"count": 476.0}}}],"others": {"series": []},"stats": {},"status": 200,"timeseries": {},"to": 1699622414000,"type": "count"}}
       count:
         title: Count
         description: Number of log entries found
@@ -1315,7 +1321,7 @@ actions:
         example: 10
   advanced_query_on_log_set:
     title: Advanced Query on Log Set
-    description: Realtime query an InsightIDR log set. This will query entire log sets for results
+    description: Realtime query an InsightIDR log set. This will query entire log sets for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges
     input:
       query:
         title: Query
@@ -1408,6 +1414,7 @@ actions:
         description: Query Results
         type: statistics
         required: false
+        example:  {"leql": {"during": {"from": 1699579214000,"to": 1699622414000},"statement": "groupby(r7_context.asset.name)"},"logs": ["123456-abcd-1234-abcd-123456abc"],"search_stats": {"bytes_all": 9961260,"bytes_checked": 9961260,"duration_ms": 19,"events_all": 1640,"events_checked": 1640,"events_matched": 1639,"index_factor": 0.0},"statistics": {"all_exact_result": true,"cardinality": 0,"from": 1699579214000,"granularity": 4320000,"groups": [{"linux": {"count": 1163.0}},{"windowsx64": {"count": 476.0}}],"groups_timeseries": [{"linux": {"groups_timeseries": [],"series": [{"count": 45.0},{"count": 21.0},{"count": 16.0},{"count": 270.0},{"count": 27.0},{"count": 43.0},{"count": 27.},{"count": 39.0},{"count": 29.0},{"count": 646.0}],"totals": {"count": 1163.0}}},{"windowsx64": {"groups_timeseries": [],"series": [{"count": 54.0},{"count": 40.0},{"count": 60.0},{"count": 37.0},{"count": 42.0},{"count": 62.0},{"count": 41.0},{"count": 47.0},{"count": 49.0},{"count": 44.0}],"totals": {"count": 476.0}}}],"others": {"series": []},"stats": {},"status": 200,"timeseries": {},"to": 1699622414000,"type": "count"}}
       count:
         title: Count
         description: Number of log entries found

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 6.0.1
+version: 6.0.2
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2022-07-20."]
 vendor: rapid7

--- a/plugins/rapid7_insightidr/requirements.txt
+++ b/plugins/rapid7_insightidr/requirements.txt
@@ -3,5 +3,5 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 python-dateutil==2.8.1
 validators==0.21.0
-aiohttp==3.8.5
+aiohttp==3.8.6
 parameterized==0.8.1

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="6.0.1",
+      version="6.0.2",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="6.0.2",
+      version="7.0.0",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/mock.py
+++ b/plugins/rapid7_insightidr/unit_test/mock.py
@@ -20,7 +20,7 @@ STUB_API_KEY = "j5740ps1cbukyk3t8kib3wa36aq2v3da"
 STUB_CONNECTION = {"api_key": {"secretKey": STUB_API_KEY}, "url": STUB_API_KEY}
 
 STUB_PRIORITY = "LOW"
-STUB_DISPOSITION = "BENING"
+STUB_DISPOSITION = "BENIGN"
 STUB_STATUS = "OPEN"
 
 STUB_USER_EMAIL = "user@example.com"

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id5.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id5.json.resp
@@ -1,0 +1,74 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "progress": 0,
+  "events": [],
+  "partial": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699567413000,
+    "to": 1699610613000,
+    "type": "count",
+    "stats": {
+      "global_timeseries": {
+        "count": 0
+      }
+    },
+    "groups": [],
+    "others": {},
+    "status": 200,
+    "timeseries": {
+      "global_timeseries": [
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        },
+        {
+          "count": 0
+        }
+      ]
+    },
+    "groups_timeseries": [],
+    "all_exact_result": null,
+    "count": 0
+  },
+  "id": "7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:",
+  "links": [
+    {
+      "rel": "Self",
+      "href": "https://us.api.insight.rapid7.com/log_search/query/7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:"
+    }
+  ],
+  "leql": {
+    "statement": "where(hostname='WindowsX64') calculate(count)",
+    "during": {
+      "from": 1699567413000,
+      "to": 1699610613000
+    }
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id6.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id6.json.resp
@@ -1,0 +1,74 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "statistics": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699567413000,
+    "to": 1699610613000,
+    "type": "count",
+    "stats": {
+      "global_timeseries": {
+        "count": 462
+      }
+    },
+    "groups": [],
+    "others": {},
+    "status": 200,
+    "timeseries": {
+      "global_timeseries": [
+        {
+          "count": 38
+        },
+        {
+          "count": 47
+        },
+        {
+          "count": 36
+        },
+        {
+          "count": 56
+        },
+        {
+          "count": 60
+        },
+        {
+          "count": 40
+        },
+        {
+          "count": 39
+        },
+        {
+          "count": 41
+        },
+        {
+          "count": 61
+        },
+        {
+          "count": 44
+        }
+      ]
+    },
+    "groups_timeseries": [],
+    "all_exact_result": null,
+    "count": 462
+  },
+  "search_stats": {
+    "bytes_checked": 3589232,
+    "index_factor": 0.4294746,
+    "events_matched": 462,
+    "events_checked": 595,
+    "duration_ms": 19,
+    "events_all": 1025,
+    "bytes_all": 6291099
+  },
+  "leql": {
+    "statement": "where(hostname='WindowsX64') calculate(count)",
+    "during": {
+      "from": 1699567413000,
+      "to": 1699610613000
+    }
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id7.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id7.json.resp
@@ -1,0 +1,36 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "progress": 0,
+  "events": [],
+  "partial": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699569260000,
+    "to": 1699612460000,
+    "type": "count",
+    "stats": {},
+    "groups": [],
+    "others": {},
+    "status": 204,
+    "timeseries": {},
+    "groups_timeseries": [],
+    "all_exact_result": true
+  },
+  "id": "b55a768a-4c0e-449a-84ae-adc70e18eb20:1:8956245765c23b46f1d20322e5c076e53a7ab662::d56c37ab761ff5e65950abd93476f02ffbcb5a45:",
+  "links": [
+    {
+      "rel": "Self",
+      "href": "https://us.api.insight.rapid7.com/log_search/query/b55a768a-4c0e-449a-84ae-adc70e18eb20:1:8956245765c23b46f1d20322e5c076e53a7ab662::d56c37ab761ff5e65950abd93476f02ffbcb5a45:"
+    }
+  ],
+  "leql": {
+    "statement": "groupby(r7_context.asset.name)",
+    "during": {
+      "from": 1699569260000,
+      "to": 1699612460000
+    }
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/log_id8.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/log_id8.json.resp
@@ -1,0 +1,130 @@
+{
+  "logs": [
+    "553048ff-e6ab-4597-a3e0-2b24032c233e",
+    "3244ed07-c3af-4bee-90b5-905a38a034b4"
+  ],
+  "statistics": {
+    "cardinality": 0,
+    "granularity": 4320000,
+    "from": 1699569260000,
+    "to": 1699612460000,
+    "type": "count",
+    "stats": {},
+    "groups": [
+      {
+        "tomascybereasonsensor": {
+          "count": 555
+        }
+      },
+      {
+        "windowsx64": {
+          "count": 465
+        }
+      }
+    ],
+    "others": {
+      "series": []
+    },
+    "status": 200,
+    "timeseries": {},
+    "groups_timeseries": [
+      {
+        "tomascybereasonsensor": {
+          "groups_timeseries": [],
+          "series": [
+            {
+              "count": 31
+            },
+            {
+              "count": 37
+            },
+            {
+              "count": 56
+            },
+            {
+              "count": 25
+            },
+            {
+              "count": 17
+            },
+            {
+              "count": 273
+            },
+            {
+              "count": 22
+            },
+            {
+              "count": 38
+            },
+            {
+              "count": 33
+            },
+            {
+              "count": 23
+            }
+          ],
+          "totals": {
+            "count": 555
+          }
+        }
+      },
+      {
+        "windowsx64": {
+          "groups_timeseries": [],
+          "series": [
+            {
+              "count": 28
+            },
+            {
+              "count": 53
+            },
+            {
+              "count": 42
+            },
+            {
+              "count": 56
+            },
+            {
+              "count": 57
+            },
+            {
+              "count": 32
+            },
+            {
+              "count": 46
+            },
+            {
+              "count": 50
+            },
+            {
+              "count": 54
+            },
+            {
+              "count": 47
+            }
+          ],
+          "totals": {
+            "count": 465
+          }
+        }
+      }
+    ],
+    "all_exact_result": true
+  },
+  "search_stats": {
+    "index_factor": 0,
+    "bytes_checked": 6276329,
+    "events_matched": 1020,
+    "events_checked": 1022,
+    "duration_ms": 36,
+    "events_all": 1022,
+    "bytes_all": 6276329
+  },
+  "leql": {
+    "during": {
+      "from": 1699569260000,
+      "to": 1699612460000
+    },
+    "statement": "groupby(r7_context.asset.name)"
+  }
+}

--- a/plugins/rapid7_insightidr/unit_test/payloads/logs.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logs.json.resp
@@ -15,6 +15,14 @@
     {
       "name": "example_log4",
       "id": "log_id4"
+    },
+    {
+      "name": "example_log5",
+      "id": "log_id5"
+    },
+    {
+      "name": "example_log7",
+      "id": "log_id7"
     }
   ]
 }

--- a/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/logsets.json.resp
@@ -1,20 +1,28 @@
 {
   "logsets": [
     {
-      "name": "log_set",
+      "name": "Advanced Malware Alert",
       "id": "log_id"
     },
     {
-      "name": "log_set2",
+      "name": "Active Directory Admin Activity",
       "id": "log_id2"
     },
     {
-      "name": "log_set3",
+      "name": "Asset Authentication",
       "id": "log_id3"
     },
     {
-      "name": "log_set4",
+      "name": "Cloud Service Admin Activity",
       "id": "log_id4"
+    },
+    {
+      "name": "Cloud Service Activity",
+      "id": "log_id5"
+    },
+    {
+      "name": "DNS Query",
+      "id": "log_id7"
     }
   ]
 }

--- a/plugins/rapid7_insightidr/unit_test/payloads/query.json.resp
+++ b/plugins/rapid7_insightidr/unit_test/payloads/query.json.resp
@@ -18,7 +18,6 @@
                "signatureVersion":"1.321.836.0",
                "unused":"null"
             },
-            "isDomainController":"false",
             "sid":"S-1-5-18",
             "sourceName":"Microsoft-Windows-Windows Defender",
             "timeWritten":"2020-08-07T21:44:12.335999900Z"

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -5,9 +5,15 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.advanced_query_on_log_set import AdvancedQueryOnLogSet
-from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import Input, Output
+from komand_rapid7_insightidr.actions.advanced_query_on_log_set.schema import (
+    Input,
+    Output,
+    AdvancedQueryOnLogSetInput,
+    AdvancedQueryOnLogSetOutput,
+)
 from util import Util
 from unittest.mock import patch
+from jsonschema import validate
 
 
 @patch("requests.Session.get", side_effect=Util.mocked_requests)
@@ -18,49 +24,222 @@ class TestAdvancedQueryOnLogSet(TestCase):
         cls.action = Util.default_connector(AdvancedQueryOnLogSet())
 
     def test_advanced_query_on_log_set_one_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG_SET: "log_set",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG_SET: "Advanced Malware Alert",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
+
         expected = ["Out of order entry"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
 
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
     def test_advanced_query_on_log_set_two_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG_SET: "log_set2",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG_SET: "Active Directory Admin Activity",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
+
         expected = ["Out of order entry", "Out of events"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
 
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
     def test_advanced_query_on_log_set_without_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG_SET: "log_set3",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG_SET: "Asset Authentication",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
 
     def test_advanced_query_on_log_set_wrong_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG_SET: "log_set4",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG_SET: "Cloud Service Admin Activity",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
         self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
+    def test_advanced_query_on_log_statistical_result_calculate(self, mock_get, mock_async_get):
+        test_input = {
+            Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
+            Input.LOG_SET: "Cloud Service Activity",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
+        expected = {
+            "count": 462,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699567413000, "to": 1699610613000},
+                    "statement": "where(hostname='WindowsX64') calculate(count)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6291099,
+                    "bytes_checked": 3589232,
+                    "duration_ms": 19,
+                    "events_all": 1025,
+                    "events_checked": 595,
+                    "events_matched": 462,
+                    "index_factor": 0.4294746,
+                },
+                "statistics": {
+                    "all_exact_result": None,
+                    "cardinality": 0,
+                    "count": 462,
+                    "from": 1699567413000,
+                    "granularity": 4320000,
+                    "groups": [],
+                    "groups_timeseries": [],
+                    "others": {},
+                    "stats": {"global_timeseries": {"count": 462.0}},
+                    "status": 200,
+                    "timeseries": {
+                        "global_timeseries": [
+                            {"count": 38.0},
+                            {"count": 47.0},
+                            {"count": 36.0},
+                            {"count": 56.0},
+                            {"count": 60.0},
+                            {"count": 40.0},
+                            {"count": 39.0},
+                            {"count": 41.0},
+                            {"count": 61.0},
+                            {"count": 44.0},
+                        ]
+                    },
+                    "to": 1699610613000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)
+
+    def test_advanced_query_on_log_statistical_result_groupby(self, mock_get, mock_async_get):
+        test_input = {
+            Input.QUERY: "groupby(r7_context.asset.name)",
+            Input.LOG_SET: "DNS Query",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogSetInput.schema)
+
+        actual = self.action.run(test_input)
+        expected = {
+            "count": 1020,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699569260000, "to": 1699612460000},
+                    "statement": "groupby(r7_context.asset.name)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6276329,
+                    "bytes_checked": 6276329,
+                    "duration_ms": 36,
+                    "events_all": 1022,
+                    "events_checked": 1022,
+                    "events_matched": 1020,
+                    "index_factor": 0.0,
+                },
+                "statistics": {
+                    "all_exact_result": True,
+                    "cardinality": 0,
+                    "from": 1699569260000,
+                    "granularity": 4320000,
+                    "groups": [{"tomascybereasonsensor": {"count": 555.0}}, {"windowsx64": {"count": 465.0}}],
+                    "groups_timeseries": [
+                        {
+                            "tomascybereasonsensor": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 31.0},
+                                    {"count": 37.0},
+                                    {"count": 56.0},
+                                    {"count": 25.0},
+                                    {"count": 17.0},
+                                    {"count": 273.0},
+                                    {"count": 22.0},
+                                    {"count": 38.0},
+                                    {"count": 33.0},
+                                    {"count": 23.0},
+                                ],
+                                "totals": {"count": 555.0},
+                            }
+                        },
+                        {
+                            "windowsx64": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 28.0},
+                                    {"count": 53.0},
+                                    {"count": 42.0},
+                                    {"count": 56.0},
+                                    {"count": 57.0},
+                                    {"count": 32.0},
+                                    {"count": 46.0},
+                                    {"count": 50.0},
+                                    {"count": 54.0},
+                                    {"count": 47.0},
+                                ],
+                                "totals": {"count": 465.0},
+                            }
+                        },
+                    ],
+                    "others": {"series": []},
+                    "stats": {},
+                    "status": 200,
+                    "timeseries": {},
+                    "to": 1699612460000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogSetOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
@@ -5,9 +5,15 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.advanced_query_on_log import AdvancedQueryOnLog
-from komand_rapid7_insightidr.actions.advanced_query_on_log.schema import Input, Output
+from komand_rapid7_insightidr.actions.advanced_query_on_log.schema import (
+    Input,
+    Output,
+    AdvancedQueryOnLogInput,
+    AdvancedQueryOnLogOutput,
+)
 from util import Util
 from unittest.mock import patch
+from jsonschema import validate
 
 
 @patch("requests.Session.get", side_effect=Util.mocked_requests)
@@ -18,45 +24,222 @@ class TestAdvancedQueryOnLog(TestCase):
         cls.action = Util.default_connector(AdvancedQueryOnLog())
 
     def test_advanced_query_on_log_one_label(self, mock_get, mock_async_get):
-        actual = self.action.run({Input.QUERY: "", Input.LOG: "example_log1"})
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log1",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
+
         self.maxDiff = None
         expected = ["Out of order entry"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
 
     def test_advanced_query_on_log_two_labels(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG: "example_log2",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log2",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
         expected = ["Out of order entry", "Out of events"]
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
 
     def test_advanced_query_on_log_without_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG: "example_log3",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log3",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
 
     def test_advanced_query_on_log_wrong_label(self, mock_get, mock_async_get):
-        actual = self.action.run(
-            {
-                Input.QUERY: "",
-                Input.LOG: "example_log4",
-            }
-        )
+        test_input = {
+            Input.QUERY: "",
+            Input.LOG: "example_log4",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
         expected = []
 
         self.assertEqual(actual.get(Output.COUNT), 1)
-        self.assertEqual(actual.get(Output.RESULTS)[0].get("labels"), expected)
+        self.assertEqual(actual.get(Output.RESULTS_EVENTS)[0].get("labels"), expected)
+
+        validate(actual, AdvancedQueryOnLogOutput.schema)
+
+    def test_advanced_query_on_log_statistical_result_calculate(self, mock_get, mock_async_get):
+        test_input = {
+            Input.QUERY: "where(hostname='WindowsX64') calculate(count)",
+            Input.LOG: "example_log5",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
+        expected = {
+            "count": 462,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699567413000, "to": 1699610613000},
+                    "statement": "where(hostname='WindowsX64') calculate(count)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6291099,
+                    "bytes_checked": 3589232,
+                    "duration_ms": 19,
+                    "events_all": 1025,
+                    "events_checked": 595,
+                    "events_matched": 462,
+                    "index_factor": 0.4294746,
+                },
+                "statistics": {
+                    "all_exact_result": None,
+                    "cardinality": 0,
+                    "count": 462,
+                    "from": 1699567413000,
+                    "granularity": 4320000,
+                    "groups": [],
+                    "groups_timeseries": [],
+                    "others": {},
+                    "stats": {"global_timeseries": {"count": 462.0}},
+                    "status": 200,
+                    "timeseries": {
+                        "global_timeseries": [
+                            {"count": 38.0},
+                            {"count": 47.0},
+                            {"count": 36.0},
+                            {"count": 56.0},
+                            {"count": 60.0},
+                            {"count": 40.0},
+                            {"count": 39.0},
+                            {"count": 41.0},
+                            {"count": 61.0},
+                            {"count": 44.0},
+                        ]
+                    },
+                    "to": 1699610613000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogOutput.schema)
+
+    def test_advanced_query_on_log_statistical_result_groupby(self, mock_get, mock_async_get):
+        test_input = {
+            Input.QUERY: "groupby(r7_context.asset.name)",
+            Input.LOG: "example_log7",
+            Input.TIMEOUT: 60,
+            Input.RELATIVE_TIME: "Last 5 Minutes",
+        }
+
+        validate(test_input, AdvancedQueryOnLogInput.schema)
+
+        actual = self.action.run(test_input)
+        expected = {
+            "count": 1020,
+            "results_statistical": {
+                "leql": {
+                    "during": {"from": 1699569260000, "to": 1699612460000},
+                    "statement": "groupby(r7_context.asset.name)",
+                },
+                "logs": ["553048ff-e6ab-4597-a3e0-2b24032c233e", "3244ed07-c3af-4bee-90b5-905a38a034b4"],
+                "search_stats": {
+                    "bytes_all": 6276329,
+                    "bytes_checked": 6276329,
+                    "duration_ms": 36,
+                    "events_all": 1022,
+                    "events_checked": 1022,
+                    "events_matched": 1020,
+                    "index_factor": 0.0,
+                },
+                "statistics": {
+                    "all_exact_result": True,
+                    "cardinality": 0,
+                    "from": 1699569260000,
+                    "granularity": 4320000,
+                    "groups": [{"tomascybereasonsensor": {"count": 555.0}}, {"windowsx64": {"count": 465.0}}],
+                    "groups_timeseries": [
+                        {
+                            "tomascybereasonsensor": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 31.0},
+                                    {"count": 37.0},
+                                    {"count": 56.0},
+                                    {"count": 25.0},
+                                    {"count": 17.0},
+                                    {"count": 273.0},
+                                    {"count": 22.0},
+                                    {"count": 38.0},
+                                    {"count": 33.0},
+                                    {"count": 23.0},
+                                ],
+                                "totals": {"count": 555.0},
+                            }
+                        },
+                        {
+                            "windowsx64": {
+                                "groups_timeseries": [],
+                                "series": [
+                                    {"count": 28.0},
+                                    {"count": 53.0},
+                                    {"count": 42.0},
+                                    {"count": 56.0},
+                                    {"count": 57.0},
+                                    {"count": 32.0},
+                                    {"count": 46.0},
+                                    {"count": 50.0},
+                                    {"count": 54.0},
+                                    {"count": 47.0},
+                                ],
+                                "totals": {"count": 465.0},
+                            }
+                        },
+                    ],
+                    "others": {"series": []},
+                    "stats": {},
+                    "status": 200,
+                    "timeseries": {},
+                    "to": 1699612460000,
+                    "type": "count",
+                },
+            },
+        }
+
+        self.assertEqual(actual, expected)
+        validate(actual, AdvancedQueryOnLogOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_assign_user_to_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_assign_user_to_investigation.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.assign_user_to_investigation import AssignUserToInvestigation
-from komand_rapid7_insightidr.actions.assign_user_to_investigation.schema import Input
+from komand_rapid7_insightidr.actions.assign_user_to_investigation.schema import (
+    Input,
+    AssignUserToInvestigationInput,
+    AssignUserToInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_put_request, STUB_INVESTIGATION_IDENTIFIER, STUB_USER_EMAIL
 from util import Util
+from jsonschema import validate
 
 
 class TestAssignUserToInvestigation(TestCase):
@@ -33,7 +38,10 @@ class TestAssignUserToInvestigation(TestCase):
 
     @patch("requests.Session.put", side_effect=mock_put_request)
     def test_assign_user_to_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.USER_EMAIL_ADDRESS: STUB_USER_EMAIL})
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.USER_EMAIL_ADDRESS: STUB_USER_EMAIL}
+        validate(test_input, AssignUserToInvestigationInput.schema)
+        actual = self.action.run(test_input)
+
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -52,3 +60,4 @@ class TestAssignUserToInvestigation(TestCase):
             "success": True,
         }
         self.assertEqual(actual, expected)
+        validate(actual, AssignUserToInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_create_comment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_create_comment.py
@@ -5,11 +5,12 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.create_comment import CreateComment
-from komand_rapid7_insightidr.actions.create_comment.schema import Input
+from komand_rapid7_insightidr.actions.create_comment.schema import Input, CreateCommentInput, CreateCommentOutput
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +21,17 @@ class TestCreateComment(TestCase):
 
     @parameterized.expand(Util.load_parameters("create_comment").get("parameters"))
     def test_create_comment(self, mock_request, name, target, body, attachments, expected):
-        actual = self.action.run({Input.TARGET: target, Input.BODY: body, Input.ATTACHMENTS: attachments})
+        test_input = {Input.TARGET: target, Input.BODY: body, Input.ATTACHMENTS: attachments}
+        validate(test_input, CreateCommentInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, CreateCommentOutput.schema)
 
     @parameterized.expand(Util.load_parameters("create_comment_bad").get("parameters"))
     def test_create_comment_bad(self, mock_request, name, target, body, attachments, cause, assistance):
+        test_input = {Input.TARGET: target, Input.BODY: body, Input.ATTACHMENTS: attachments}
+        validate(test_input, CreateCommentInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.TARGET: target, Input.BODY: body, Input.ATTACHMENTS: attachments})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_create_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_create_investigation.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.create_investigation import CreateInvestigation
-from komand_rapid7_insightidr.actions.create_investigation.schema import Input
+from komand_rapid7_insightidr.actions.create_investigation.schema import (
+    Input,
+    CreateInvestigationInput,
+    CreateInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_post_request, STUB_USER_EMAIL
 from util import Util
+from jsonschema import validate
 
 
 class TestCreateInvestigation(TestCase):
@@ -33,7 +38,9 @@ class TestCreateInvestigation(TestCase):
 
     @patch("requests.Session.post", side_effect=mock_post_request)
     def test_create_investigation(self, _mock_req):
-        actual = self.action.run({Input.TITLE: "Example Title", Input.EMAIL: STUB_USER_EMAIL})
+        test_input = {Input.TITLE: "Example Title", Input.EMAIL: STUB_USER_EMAIL}
+        validate(test_input, CreateInvestigationInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -51,3 +58,4 @@ class TestCreateInvestigation(TestCase):
             }
         }
         self.assertEqual(actual, expected)
+        validate(actual, CreateInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_delete_attachment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_delete_attachment.py
@@ -5,11 +5,16 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.delete_attachment import DeleteAttachment
-from komand_rapid7_insightidr.actions.delete_attachment.schema import Input
+from komand_rapid7_insightidr.actions.delete_attachment.schema import (
+    Input,
+    DeleteAttachmentInput,
+    DeleteAttachmentOutput,
+)
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +25,17 @@ class TestDeleteAttachment(TestCase):
 
     @parameterized.expand(Util.load_parameters("delete_comment").get("parameters"))
     def test_delete_attachment(self, mock_request, name, attachment_rrn, expected):
-        actual = self.action.run({Input.ATTACHMENT_RRN: attachment_rrn})
+        test_input = {Input.ATTACHMENT_RRN: attachment_rrn}
+        validate(test_input, DeleteAttachmentInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, DeleteAttachmentOutput.schema)
 
     @parameterized.expand(Util.load_parameters("delete_comment_bad").get("parameters"))
     def test_delete_attachment_bad(self, mock_request, name, attachment_rrn, cause, assistance):
+        test_input = {Input.ATTACHMENT_RRN: attachment_rrn}
+        validate(test_input, DeleteAttachmentInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.ATTACHMENT_RRN: attachment_rrn})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_delete_comment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_delete_comment.py
@@ -5,11 +5,12 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.delete_comment import DeleteComment
-from komand_rapid7_insightidr.actions.delete_comment.schema import Input
+from komand_rapid7_insightidr.actions.delete_comment.schema import Input, DeleteCommentInput, DeleteCommentOutput
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +21,17 @@ class TestDeleteComment(TestCase):
 
     @parameterized.expand(Util.load_parameters("delete_comment").get("parameters"))
     def test_delete_comment(self, mock_request, name, comment_rrn, expected):
-        actual = self.action.run({Input.COMMENT_RRN: comment_rrn})
+        test_input = {Input.COMMENT_RRN: comment_rrn}
+        validate(test_input, DeleteCommentInput.schema)
+        actual = self.action.run()
         self.assertEqual(actual, expected)
+        validate(actual, DeleteCommentOutput.schema)
 
     @parameterized.expand(Util.load_parameters("delete_comment_bad").get("parameters"))
     def test_delete_comment_bad(self, mock_request, name, comment_rrn, cause, assistance):
+        test_input = {Input.COMMENT_RRN: comment_rrn}
+        validate(test_input, DeleteCommentInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.COMMENT_RRN: comment_rrn})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_download_attachment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_download_attachment.py
@@ -5,11 +5,16 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.download_attachment import DownloadAttachment
-from komand_rapid7_insightidr.actions.download_attachment.schema import Input
+from komand_rapid7_insightidr.actions.download_attachment.schema import (
+    Input,
+    DownloadAttachmentInput,
+    DownloadAttachmentOutput,
+)
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +25,17 @@ class TestDownloadAttachment(TestCase):
 
     @parameterized.expand(Util.load_parameters("download_attachment").get("parameters"))
     def test_download_attachment(self, mock_request, name, attachment_rrn, expected):
-        actual = self.action.run({Input.ATTACHMENT_RRN: attachment_rrn})
+        test_input = {Input.ATTACHMENT_RRN: attachment_rrn}
+        validate(test_input, DownloadAttachmentInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, DownloadAttachmentOutput.schema)
 
     @parameterized.expand(Util.load_parameters("download_attachment_bad").get("parameters"))
     def test_download_attachment_bad(self, mock_request, name, attachment_rrn, cause, assistance):
+        test_input = {Input.ATTACHMENT_RRN: attachment_rrn}
+        validate(test_input, DownloadAttachmentInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.ATTACHMENT_RRN: attachment_rrn})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_get_all_saved_queries.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_all_saved_queries.py
@@ -7,12 +7,14 @@ from unittest import TestCase
 from unittest.mock import patch
 from komand_rapid7_insightidr.actions.get_all_saved_queries.action import GetAllSavedQueries
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
+from komand_rapid7_insightidr.actions.get_all_saved_queries.schema import GetAllSavedQueriesOutput
 from insightconnect_plugin_runtime.exceptions import PluginException
 from util import Util
 from mock import (
     mock_get_request,
 )
 import logging
+from jsonschema import validate
 
 
 class TestGetAllSavedQueries(TestCase):
@@ -62,3 +64,4 @@ class TestGetAllSavedQueries(TestCase):
             ]
         }
         self.assertEqual(actual, expected)
+        validate(actual, GetAllSavedQueriesOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_get_asset_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_asset_information.py
@@ -5,11 +5,16 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.get_asset_information import GetAssetInformation
-from komand_rapid7_insightidr.actions.get_asset_information.schema import Input
+from komand_rapid7_insightidr.actions.get_asset_information.schema import (
+    Input,
+    GetAssetInformationInput,
+    GetAssetInformationOutput,
+)
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +25,17 @@ class TestGetAssetInformation(TestCase):
 
     @parameterized.expand(Util.load_parameters("get_asset_information").get("parameters"))
     def test_get_asset_information(self, mock_request, asset_rrn, expected):
-        actual = self.action.run({Input.ASSET_RRN: asset_rrn})
+        test_input = {Input.ASSET_RRN: asset_rrn}
+        validate(test_input, GetAssetInformationInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, GetAssetInformationOutput.schema)
 
     @parameterized.expand(Util.load_parameters("get_asset_information_bad").get("parameters"))
     def test_get_asset_information_bad(self, mock_request, asset_rrn, cause, assistance):
+        test_input = {Input.ASSET_RRN: asset_rrn}
+        validate(test_input, GetAssetInformationInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.ASSET_RRN: asset_rrn})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_get_attachment_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_attachment_information.py
@@ -5,11 +5,16 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.get_attachment_information import GetAttachmentInformation
-from komand_rapid7_insightidr.actions.get_attachment_information.schema import Input
+from komand_rapid7_insightidr.actions.get_attachment_information.schema import (
+    Input,
+    GetAttachmentInformationInput,
+    GetAttachmentInformationOutput,
+)
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +25,17 @@ class TestGetAttachmentInformation(TestCase):
 
     @parameterized.expand(Util.load_parameters("get_attachment_information").get("parameters"))
     def test_get_attachment_information(self, mock_request, name, attachment_rrn, expected):
-        actual = self.action.run({Input.ATTACHMENT_RRN: attachment_rrn})
+        test_input = {Input.ATTACHMENT_RRN: attachment_rrn}
+        validate(test_input, GetAttachmentInformationInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, GetAttachmentInformationOutput.schema)
 
     @parameterized.expand(Util.load_parameters("get_attachment_information_bad").get("parameters"))
     def test_get_attachment_information_bad(self, mock_request, name, attachment_rrn, cause, assistance):
+        test_input = {Input.ATTACHMENT_RRN: attachment_rrn}
+        validate(test_input, GetAttachmentInformationInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.ATTACHMENT_RRN: attachment_rrn})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_get_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_investigation.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.get_investigation import GetInvestigation
-from komand_rapid7_insightidr.actions.get_investigation.schema import Input
+from komand_rapid7_insightidr.actions.get_investigation.schema import (
+    Input,
+    GetInvestigationInput,
+    GetInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_get_request, STUB_INVESTIGATION_IDENTIFIER
 from util import Util
+from jsonschema import validate
 
 
 class TestCreateInvestigation(TestCase):
@@ -33,7 +38,9 @@ class TestCreateInvestigation(TestCase):
 
     @patch("requests.Session.get", side_effect=mock_get_request)
     def test_get_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER})
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER}
+        validate(test_input, GetInvestigationInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -51,3 +58,4 @@ class TestCreateInvestigation(TestCase):
             }
         }
         self.assertEqual(actual, expected)
+        validate(actual, GetInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_get_user_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_user_information.py
@@ -5,11 +5,16 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.get_user_information import GetUserInformation
-from komand_rapid7_insightidr.actions.get_user_information.schema import Input
+from komand_rapid7_insightidr.actions.get_user_information.schema import (
+    Input,
+    GetUserInformationInput,
+    GetUserInformationOutput,
+)
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +25,17 @@ class TestGetUserInformation(TestCase):
 
     @parameterized.expand(Util.load_parameters("get_user_information").get("parameters"))
     def test_get_user_information(self, mock_request, user_rrn, expected):
-        actual = self.action.run({Input.USER_RRN: user_rrn})
+        test_input = {Input.USER_RRN: user_rrn}
+        validate(test_input, GetUserInformationInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, GetUserInformationOutput.schema)
 
     @parameterized.expand(Util.load_parameters("get_user_information_bad").get("parameters"))
     def test_get_user_information_bad(self, mock_request, user_rrn, cause, assistance):
+        test_input = {Input.USER_RRN: user_rrn}
+        validate(test_input, GetUserInformationInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.USER_RRN: user_rrn})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_list_alerts_for_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_alerts_for_investigation.py
@@ -8,11 +8,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.list_alerts_for_investigation import ListAlertsForInvestigation
-from komand_rapid7_insightidr.actions.list_alerts_for_investigation.schema import Input
+from komand_rapid7_insightidr.actions.list_alerts_for_investigation.schema import (
+    Input,
+    ListAlertsForInvestigationInput,
+    ListAlertsForInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_get_request, STUB_INVESTIGATION_IDENTIFIER, mock_request_for_different_rrn_object
 from util import Util
+from jsonschema import validate
 
 
 class TestCreateInvestigation(TestCase):
@@ -49,12 +54,16 @@ class TestCreateInvestigation(TestCase):
 
     @patch("requests.Session.get", side_effect=mock_get_request)
     def test_list_alerts_for_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER})
-
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.SIZE: 1, Input.INDEX: 0}
+        validate(test_input, ListAlertsForInvestigationInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, self.expected_result)
+        validate(actual, ListAlertsForInvestigationOutput.schema)
 
     @patch("requests.Session.get", side_effect=mock_request_for_different_rrn_object)
     def test_list_alerts_for_investigation_when_different_rrn_type(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER})
-
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.SIZE: 1, Input.INDEX: 0}
+        validate(test_input, ListAlertsForInvestigationInput.schema)
+        actual = self.action.run()
         self.assertEqual(actual, self.expected_result)
+        validate(actual, ListAlertsForInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_list_attachments.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_attachments.py
@@ -5,11 +5,12 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.list_attachments import ListAttachments
-from komand_rapid7_insightidr.actions.list_attachments.schema import Input
+from komand_rapid7_insightidr.actions.list_attachments.schema import Input, ListAttachmentsInput, ListAttachmentsOutput
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,11 +21,16 @@ class TestListAttachments(TestCase):
 
     @parameterized.expand(Util.load_parameters("list_attachments").get("parameters"))
     def test_list_attachments(self, mock_request, name, target, index, size, expected):
-        actual = self.action.run({Input.TARGET: target, Input.INDEX: index, Input.SIZE: size})
+        test_input = {Input.TARGET: target, Input.INDEX: index, Input.SIZE: size}
+        validate(test_input, ListAttachmentsInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, ListAttachmentsOutput.schema)
 
     @parameterized.expand(Util.load_parameters("list_attachments_bad").get("parameters"))
     def test_list_attachments_bad(self, mock_request, name, target, index, size, cause, assistance):
+        test_input = {Input.TARGET: target, Input.INDEX: index, Input.SIZE: size}
+        validate(test_input, ListAttachmentsInput.schema)
         with self.assertRaises(PluginException) as error:
             self.action.run({Input.TARGET: target, Input.INDEX: index, Input.SIZE: size})
         self.assertEqual(error.exception.cause, cause)

--- a/plugins/rapid7_insightidr/unit_test/test_list_comments.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_comments.py
@@ -5,11 +5,12 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.list_comments import ListComments
-from komand_rapid7_insightidr.actions.list_comments.schema import Input
+from komand_rapid7_insightidr.actions.list_comments.schema import Input, ListCommentsInput, ListCommentsOutput
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -20,12 +21,17 @@ class TestListComments(TestCase):
 
     @parameterized.expand(Util.load_parameters("list_comments").get("parameters"))
     def test_list_comments(self, mock_request, name, target, index, size, expected):
-        actual = self.action.run({Input.TARGET: target, Input.INDEX: index, Input.SIZE: size})
+        test_input = {Input.TARGET: target, Input.INDEX: index, Input.SIZE: size}
+        validate(test_input, ListCommentsInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, ListCommentsOutput.schema)
 
     @parameterized.expand(Util.load_parameters("list_comments_bad").get("parameters"))
     def test_list_comments_bad(self, mock_request, name, target, index, size, cause, assistance):
+        test_input = {Input.TARGET: target, Input.INDEX: index, Input.SIZE: size}
+        validate(test_input, ListCommentsInput.schema)
         with self.assertRaises(PluginException) as error:
-            self.action.run({Input.TARGET: target, Input.INDEX: index, Input.SIZE: size})
+            self.action.run(test_input)
         self.assertEqual(error.exception.cause, cause)
         self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_search_investigations.py
+++ b/plugins/rapid7_insightidr/unit_test/test_search_investigations.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.search_investigations import SearchInvestigations
-from komand_rapid7_insightidr.actions.search_investigations.schema import Input
+from komand_rapid7_insightidr.actions.search_investigations.schema import (
+    Input,
+    SearchInvestigationsInput,
+    SearchInvestigationsOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_post_request
 from util import Util
+from jsonschema import validate
 
 
 class TestSearchInvestigation(TestCase):
@@ -33,14 +38,14 @@ class TestSearchInvestigation(TestCase):
 
     @patch("requests.Session.post", side_effect=mock_post_request)
     def test_search_investigations(self, _mock_req):
-        actual = self.action.run(
-            {
-                Input.INDEX: 0,
-                Input.SIZE: 1,
-                Input.SORT: [{"field": "priority", "order": "ASC"}],
-                Input.SEARCH: [{"field": "Example Field", "operator": "EQUALS", "value": "Test"}],
-            }
-        )
+        test_input = {
+            Input.INDEX: 0,
+            Input.SIZE: 1,
+            Input.SORT: [{"field": "priority", "order": "ASC"}],
+            Input.SEARCH: [{"field": "Example Field", "operator": "EQUALS", "value": "Test"}],
+        }
+        validate(test_input, SearchInvestigationsInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigations": [
                 {
@@ -61,3 +66,4 @@ class TestSearchInvestigation(TestCase):
             "metadata": {"index": 0, "size": 1, "total_data": 1, "total_pages": 1},
         }
         self.assertEqual(actual, expected)
+        validate(actual, SearchInvestigationsOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_set_disposition_of_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_set_disposition_of_investigation.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.set_disposition_of_investigation import SetDispositionOfInvestigation
-from komand_rapid7_insightidr.actions.set_disposition_of_investigation.schema import Input
+from komand_rapid7_insightidr.actions.set_disposition_of_investigation.schema import (
+    Input,
+    SetDispositionOfInvestigationInput,
+    SetDispositionOfInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_put_request, STUB_INVESTIGATION_IDENTIFIER, STUB_DISPOSITION
 from util import Util
+from jsonschema import validate
 
 
 class TestCreateInvestigation(TestCase):
@@ -33,7 +38,9 @@ class TestCreateInvestigation(TestCase):
 
     @patch("requests.Session.put", side_effect=mock_put_request)
     def test_set_disposition_of_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.DISPOSITION: STUB_DISPOSITION})
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.DISPOSITION: STUB_DISPOSITION}
+        validate(test_input, SetDispositionOfInvestigationInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -51,3 +58,4 @@ class TestCreateInvestigation(TestCase):
             }
         }
         self.assertEqual(actual, expected)
+        validate(actual, SetDispositionOfInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_set_priority_of_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_set_priority_of_investigation.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.set_priority_of_investigation import SetPriorityOfInvestigation
-from komand_rapid7_insightidr.actions.set_priority_of_investigation.schema import Input
+from komand_rapid7_insightidr.actions.set_priority_of_investigation.schema import (
+    Input,
+    SetPriorityOfInvestigationInput,
+    SetPriorityOfInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_put_request, STUB_INVESTIGATION_IDENTIFIER, STUB_PRIORITY
 from util import Util
+from jsonschema import validate
 
 
 class TestSetPriorityOfInvestigation(TestCase):
@@ -33,7 +38,9 @@ class TestSetPriorityOfInvestigation(TestCase):
 
     @patch("requests.Session.put", side_effect=mock_put_request)
     def test_set_priority_of_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.PRIORITY: STUB_PRIORITY})
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.PRIORITY: STUB_PRIORITY}
+        validate(test_input, SetPriorityOfInvestigationInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -51,3 +58,4 @@ class TestSetPriorityOfInvestigation(TestCase):
             }
         }
         self.assertEqual(actual, expected)
+        validate(actual, SetPriorityOfInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_set_status_of_investigation_action.py
+++ b/plugins/rapid7_insightidr/unit_test/test_set_status_of_investigation_action.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.set_status_of_investigation_action import SetStatusOfInvestigationAction
-from komand_rapid7_insightidr.actions.set_status_of_investigation_action.schema import Input
+from komand_rapid7_insightidr.actions.set_status_of_investigation_action.schema import (
+    Input,
+    SetStatusOfInvestigationActionInput,
+    SetStatusOfInvestigationActionOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_put_request, STUB_INVESTIGATION_IDENTIFIER, STUB_STATUS
 from util import Util
+from jsonschema import validate
 
 
 class TestSetStatusOfInvestigationAction(TestCase):
@@ -33,7 +38,9 @@ class TestSetStatusOfInvestigationAction(TestCase):
 
     @patch("requests.Session.put", side_effect=mock_put_request)
     def test_set_status_of_investigation(self, _mock_req):
-        actual = self.action.run({Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.STATUS: STUB_STATUS})
+        test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.STATUS: STUB_STATUS}
+        validate(test_input, SetStatusOfInvestigationActionInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -51,3 +58,4 @@ class TestSetStatusOfInvestigationAction(TestCase):
             }
         }
         self.assertEqual(actual, expected)
+        validate(actual, SetStatusOfInvestigationActionOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_update_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_update_investigation.py
@@ -7,11 +7,16 @@ from unittest import TestCase
 from unittest.mock import patch
 
 from komand_rapid7_insightidr.actions.update_investigation import UpdateInvestigation
-from komand_rapid7_insightidr.actions.update_investigation.schema import Input
+from komand_rapid7_insightidr.actions.update_investigation.schema import (
+    Input,
+    UpdateInvestigationInput,
+    UpdateInvestigationOutput,
+)
 from komand_rapid7_insightidr.connection.schema import Input as ConnectionInput
 
 from mock import mock_patch_request, STUB_INVESTIGATION_IDENTIFIER, STUB_USER_EMAIL
 from util import Util
+from jsonschema import validate
 
 
 class TestCreateInvestigation(TestCase):
@@ -33,9 +38,14 @@ class TestCreateInvestigation(TestCase):
 
     @patch("requests.Session.patch", side_effect=mock_patch_request)
     def test_update_investigations(self, _mock_req):
-        actual = self.action.run(
-            {Input.TITLE: "Example Title", Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.EMAIL: STUB_USER_EMAIL}
-        )
+        test_input = {
+            Input.TITLE: "Example Title",
+            Input.ID: STUB_INVESTIGATION_IDENTIFIER,
+            Input.EMAIL: STUB_USER_EMAIL,
+        }
+
+        validate(test_input, UpdateInvestigationInput.schema)
+        actual = self.action.run(test_input)
         expected = {
             "investigation": {
                 "assignee": {"email": "user@example.com", "name": "Ellen Example"},
@@ -53,3 +63,4 @@ class TestCreateInvestigation(TestCase):
             }
         }
         self.assertEqual(actual, expected)
+        validate(actual, UpdateInvestigationOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_upload_attachment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_upload_attachment.py
@@ -5,10 +5,15 @@ sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
 from komand_rapid7_insightidr.actions.upload_attachment import UploadAttachment
-from komand_rapid7_insightidr.actions.upload_attachment.schema import Input
+from komand_rapid7_insightidr.actions.upload_attachment.schema import (
+    Input,
+    UploadAttachmentInput,
+    UploadAttachmentOutput,
+)
 from util import Util
 from unittest.mock import patch
 from parameterized import parameterized
+from jsonschema import validate
 
 
 @patch("requests.Session.request", side_effect=Util.mocked_requests)
@@ -19,5 +24,8 @@ class TestUploadAttachment(TestCase):
 
     @parameterized.expand(Util.load_parameters("upload_attachment").get("parameters"))
     def test_upload_attachment(self, mock_request, name, filename, file_content, expected):
-        actual = self.action.run({Input.FILENAME: filename, Input.FILE_CONTENT: file_content})
+        test_input = {Input.FILENAME: filename, Input.FILE_CONTENT: file_content}
+        validate(test_input, UploadAttachmentInput.schema)
+        actual = self.action.run(test_input)
         self.assertEqual(actual, expected)
+        validate(actual, UploadAttachmentOutput.schema)

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -252,4 +252,22 @@ class Util:
         elif args[0] == f"{Util.STUB_URL_API}/log_search/management/logsets":
             return MockResponse("logsets", 200)
 
+        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id5":
+            return MockResponse("log_id5", 200)
+
+        if (
+            args[0]
+            == "https://us.api.insight.rapid7.com/log_search/query/7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:"
+        ):
+            return MockResponse("log_id6", 200)
+
+        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id7":
+            return MockResponse("log_id7", 200)
+
+        if (
+            args[0]
+            == "https://us.api.insight.rapid7.com/log_search/query/b55a768a-4c0e-449a-84ae-adc70e18eb20:1:8956245765c23b46f1d20322e5c076e53a7ab662::d56c37ab761ff5e65950abd93476f02ffbcb5a45:"
+        ):
+            return MockResponse("log_id8", 200)
+
         raise Exception("Not implemented")

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -117,6 +117,8 @@ class Util:
                     )
                 )
 
+        print(f"{args = }")
+
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:1234567890",
             "index": 0,
@@ -252,17 +254,23 @@ class Util:
         elif args[0] == f"{Util.STUB_URL_API}/log_search/management/logsets":
             return MockResponse("logsets", 200)
 
-        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id5":
+        elif (
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id5"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id5"
+        ):
             return MockResponse("log_id5", 200)
+
+        elif (
+            args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id7"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id7"
+        ):
+            return MockResponse("log_id7", 200)
 
         if (
             args[0]
             == "https://us.api.insight.rapid7.com/log_search/query/7176face-f659-45a6-bd46-81fdc2b1f74b:1:85f959aecc0a7300f9ad93ddacf3454e36348348::bafefd2e9cf60c699529d5a8cf4493578b0b56dd:"
         ):
             return MockResponse("log_id6", 200)
-
-        if args[0] == "https://us.api.insight.rapid7.com/log_search/query/logsets/log_id7":
-            return MockResponse("log_id7", 200)
 
         if (
             args[0]


### PR DESCRIPTION
## Proposed Changes

### Description

The following prs will be merged in this release 

- https://github.com/rapid7/insightconnect-plugins/pull/2108
  -   to take the id that comes back from calling the /query/logs endpoint, then this ID can be used to the /query/ endpoint to get back the correct values for the statistics, as the will not return the results we need
- https://github.com/rapid7/insightconnect-plugins/pull/2110
  - add in params["per_page"] = 500 to advanced_query_on_log_set and added to documentation
  - fix issue with advanced_query_on_log_set where if a call back url was used, incorrect results were returned
  - added example for results_statistical to help md
  - add in statistical results to advanced_query_on_log
  - added unit tests for new functional
  - fix issue with advanced_query_on_log where if a call back url was used, incorrect results were returned
- https://github.com/rapid7/insightconnect-plugins/pull/2116
  - to update all of the schema files to ensure that they are now correct
  - to add in schema validation checks to all of the unit tests 
- https://github.com/rapid7/insightconnect-plugins/pull/2118
  - bumping version of aiohttp  



https://issues.corp.rapid7.com/browse/SOAR-15940
https://issues.corp.rapid7.com/browse/PLGN-614
https://issues.corp.rapid7.com/browse/PLGN-615


## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
