### PR TITLE
Plugin build workflow release

### DIFF
--- a/.github/workflows/plugin_production_build.yml
+++ b/.github/workflows/plugin_production_build.yml
@@ -1,0 +1,114 @@
+name: Create Production Release
+on:
+  workflow_dispatch:
+    inputs:
+      PLUGIN_NAME:
+        description: 'Plugin to build and tag. The name must match the plugin directory name in GitHub.'
+        required: false
+  pull_request:
+    types: [closed]
+    branches:
+      - master
+
+env:
+  PACKAGECLOUD_PYTHON_TOOLING_STABLE: ${{ secrets.PACKAGECLOUD_PYTHON_TOOLING_STABLE }}
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if merged
+        id: checkIfMerged
+        run: |
+          echo "INSIGHT_KOMAND_BRANCH=master" >> $GITHUB_ENV
+          if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            echo "Pull requst has been merged. Starting release process..."
+            echo "ROOT_BUILD_CAUSE=SCMTRIGGER" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Workflow was manually triggered. Starting release process..."
+            echo "ROOT_BUILD_CAUSE=MANUALTRIGGER" >> $GITHUB_ENV
+            echo "INSIGHT_KOMAND_PLUGIN_NAME=${{ github.event.inputs.PLUGIN_NAME || '' }}" >> $GITHUB_ENV
+          else
+            echo "Pull request has not been merged. Stopping workflow..."
+            exit 1
+          fi
+
+      - name: Checkout Repository
+        id: checkoutRepository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          ref: "refs/heads/${{ env.INSIGHT_KOMAND_BRANCH }}"
+
+      - name: Setup Python
+        id: setupPython
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Setup venv
+        id: setUpVenv
+        run: |
+          python3 -m venv .ci_venv
+          source .ci_venv/bin/activate
+          pip install --upgrade pip
+
+      - name: Set up environment variables
+        id: setUpEnvironmentVariables
+        run: |
+          # Setup environment variables from input
+          echo "BUILD_OUTPUT_DIRECTORY=builds" >> $GITHUB_ENV
+          echo "BUILD_OUTPUT_FULL_PATH=plugins/builds" >> $GITHUB_ENV
+
+      - name: Install CI/CD Tool
+        id: installCICDTool
+        run: |
+          # Install CI Tooling
+          curl -s https://${PACKAGECLOUD_PYTHON_TOOLING_STABLE}:@packagecloud.io/install/repositories/rapid7/insightconnect_internal_python_tooling/script.python.sh | bash
+          .ci_venv/bin/pip install icon-integrations-ci~=3.0
+
+      - name: Build Plugin Image
+        id: buildPluginImage
+        if: success()
+        run: |
+          cd plugins
+          ../.ci_venv/bin/icon-ci build -d {{ env.BUILD_OUTPUT_DIRECTORY }}
+
+      - name: Find Release Asset
+        id: findReleaseAsset
+        run: |
+          # Navigate to the build directory
+          cd ${{ env.BUILD_OUTPUT_FULL_PATH }}
+          # Use find to get the filename and set it as an environment variable
+          filename=$(find . -type f -maxdepth 1 | xargs basename)
+          echo "RELEASE_ASSET=${filename}" >> $GITHUB_ENV
+          echo "GIT_TAG=${filename%.tar.gz}" >> $GITHUB_ENV
+
+      - name: Create release
+        id: createRelease
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: ${{ env.GIT_TAG }}
+          body: |
+            ${{ env.GIT_TAG }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        id: uploadReleaseAsset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.createRelease.outputs.upload_url }}
+          asset_path: ${{ env.BUILD_OUTPUT_FULL_PATH }}/${{ env.RELEASE_ASSET }}
+          asset_name: ${{ env.RELEASE_ASSET }}
+          asset_content_type: application/gzip

--- a/.github/workflows/plugin_production_build.yml
+++ b/.github/workflows/plugin_production_build.yml
@@ -77,7 +77,7 @@ jobs:
         if: success()
         run: |
           cd plugins
-          ../.ci_venv/bin/icon-ci build -d {{ env.BUILD_OUTPUT_DIRECTORY }}
+          ../.ci_venv/bin/icon-ci build -d ${{ env.BUILD_OUTPUT_DIRECTORY }}
 
       - name: Find Release Asset
         id: findReleaseAsset

--- a/.github/workflows/plugin_staging_build.yml
+++ b/.github/workflows/plugin_staging_build.yml
@@ -84,18 +84,15 @@ jobs:
         if: success()
         run: |
           cd plugins
-          ../.ci_venv/bin/icon-ci build -d {{ env.BUILD_OUTPUT_DIRECTORY }}
+          ../.ci_venv/bin/icon-ci build -d ${{ env.BUILD_OUTPUT_DIRECTORY }}
 
-      - name: Find the filename
-        id: find-filename
+      - name: Find Release Asset
+        id: findReleaseAsset
         run: |
-          # Navigate to the desired directory
+          # Navigate to the build directory
           cd ${{ env.BUILD_OUTPUT_FULL_PATH }}
-
           # Use find to get the filename
           filename=$(find . -type f -maxdepth 1 | xargs basename)
-          
-          # Set the output variable for later use
           echo "RELEASE_ASSET=${filename}" >> $GITHUB_ENV
           echo "GIT_TAG=${filename%.tar.gz}" >> $GITHUB_ENV
 

--- a/.github/workflows/plugin_staging_build.yml
+++ b/.github/workflows/plugin_staging_build.yml
@@ -1,0 +1,125 @@
+name: Create Staging Release
+on:
+  workflow_dispatch:
+    inputs:
+      PLUGIN_NAME:
+        description: 'Plugin to build and tag. The name must match the plugin directory name in GitHub.'
+        required: false
+  pull_request:
+    types: [closed]
+    branches:
+      - develop
+
+env:
+  PACKAGECLOUD_PYTHON_TOOLING_STABLE: ${{ secrets.PACKAGECLOUD_PYTHON_TOOLING_STABLE }}
+
+permissions:
+  contents: write
+  actions: read
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check if merged
+        id: checkIfMerged
+        run: |
+          echo "INSIGHT_KOMAND_BRANCH=develop" >> $GITHUB_ENV
+          if [[ "${{ github.event.pull_request.merged }}" == "true" ]]; then
+            echo "Pull requst has been merged. Starting release process..."
+            echo "ROOT_BUILD_CAUSE=SCMTRIGGER" >> $GITHUB_ENV
+          elif [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "Workflow was manually triggered. Starting release process..."
+            echo "ROOT_BUILD_CAUSE=MANUALTRIGGER" >> $GITHUB_ENV
+            echo "INSIGHT_KOMAND_PLUGIN_NAME=${{ github.event.inputs.PLUGIN_NAME || '' }}" >> $GITHUB_ENV
+          else
+            echo "Pull request has not been merged. Stopping workflow..."
+            exit 1
+          fi
+
+      - name: Checkout Repository
+        id: checkoutRepository
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 5
+          ref: "refs/heads/${{ env.INSIGHT_KOMAND_BRANCH }}"
+
+      - name: Setup Python
+        id: setupPython
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+
+      - name: Setup venv
+        id: setUpVenv
+        run: |
+          python3 -m venv .ci_venv
+          source .ci_venv/bin/activate
+          pip install --upgrade pip
+
+      - name: Set up environment variables
+        id: setUpEnvironmentVariables
+        run: |
+          # Setup environment variables from input
+          echo "BUILD_OUTPUT_DIRECTORY=builds" >> $GITHUB_ENV
+          echo "BUILD_OUTPUT_FULL_PATH=plugins/builds" >> $GITHUB_ENV
+
+      - name: Prerelease Timestamp
+        id: prereleaseTimestamp
+        run: |
+            TIMESTAMP=$(date +%s%1N | cut -b1-10)
+            echo "PRERELEASE=true" >> $GITHUB_ENV
+            echo "PRERELEASE_TIMESTAMP=$TIMESTAMP" >> $GITHUB_ENV
+
+      - name: Install CI/CD Tool
+        id: installCICDTool
+        run: |
+          # Install CI Tooling
+          curl -s https://${PACKAGECLOUD_PYTHON_TOOLING_STABLE}:@packagecloud.io/install/repositories/rapid7/insightconnect_internal_python_tooling/script.python.sh | bash
+          .ci_venv/bin/pip install icon-integrations-ci~=3.0
+
+      - name: Build Plugin Image
+        id: buildPluginImage
+        if: success()
+        run: |
+          cd plugins
+          ../.ci_venv/bin/icon-ci build -d {{ env.BUILD_OUTPUT_DIRECTORY }}
+
+      - name: Find the filename
+        id: find-filename
+        run: |
+          # Navigate to the desired directory
+          cd ${{ env.BUILD_OUTPUT_FULL_PATH }}
+
+          # Use find to get the filename
+          filename=$(find . -type f -maxdepth 1 | xargs basename)
+          
+          # Set the output variable for later use
+          echo "RELEASE_ASSET=${filename}" >> $GITHUB_ENV
+          echo "GIT_TAG=${filename%.tar.gz}" >> $GITHUB_ENV
+
+      - name: Create release
+        id: createRelease
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          tag_name: ${{ env.GIT_TAG }}
+          release_name: ${{ env.GIT_TAG }}
+          body: |
+            ${{ env.GIT_TAG }}
+          draft: false
+          prerelease: false
+
+      - name: Upload release asset
+        id: uploadReleaseAsset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.createRelease.outputs.upload_url }}
+          asset_path: ${{ env.BUILD_OUTPUT_FULL_PATH }}/${{ env.RELEASE_ASSET }}
+          asset_name: ${{ env.RELEASE_ASSET }}
+          asset_content_type: application/gzip


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Add workflow to build and tag plugin images for production and staging

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
