### PR TITLE
[PLGN-45]- Rest 6.4 Release

### DIFF
--- a/plugins/rest/.CHECKSUM
+++ b/plugins/rest/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "01bf89086f7b69361309c6adf67f9ed3",
-	"manifest": "6a4dfbf514cf030c250d577eecf8ff21",
-	"setup": "0dba8c490db609ae9977ade0756dbaa6",
+	"spec": "824d8daed5906eb3eb6a7941f2b25f62",
+	"manifest": "605d494d836f7a167cc056175e8c452b",
+	"setup": "775bc205b08880dafc532003dc63eda8",
 	"schemas": [
 		{
 			"identifier": "delete/schema.py",

--- a/plugins/rest/Dockerfile
+++ b/plugins/rest/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-plugin:5
+FROM rapid7/insightconnect-python-3-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/rest/bin/komand_rest
+++ b/plugins/rest/bin/komand_rest
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "HTTP Requests"
 Vendor = "rapid7"
-Version = "6.0.3"
+Version = "6.0.4"
 Description = "The HTTP Requests plugin makes it easy to integrate with RESTful services"
 
 

--- a/plugins/rest/help.md
+++ b/plugins/rest/help.md
@@ -342,6 +342,7 @@ Any issues connecting to the remote service should be present in the log of the 
 
 # Version History
 
+* 6.0.4 - Custom Auth: Fix bug where we could not pass the API Key from the input into the Authentication header if the header value included a prefix
 * 6.0.3 - Added empty `__init__.py` file to `unit_test` folder | Refreshed with new tooling | Updated `requirements.txt`
 * 6.0.2 - Fixed a bug that would cause an incorrect error message whenever a 400 error was received and the response object was a list
 * 6.0.1 - Improved ability of 'Body Any' input to handle non-standard characters and JSON input

--- a/plugins/rest/komand_rest/util/util.py
+++ b/plugins/rest/komand_rest/util/util.py
@@ -161,7 +161,7 @@ class RestAPI(object):
     def create_headers_for_custom_auth(self, headers: dict, secret_key) -> dict:
         new_headers = {}
         for key, value in headers.items():
-            if value == self.CUSTOM_SECRET_INPUT:
+            if self.CUSTOM_SECRET_INPUT in value:
                 if not secret_key:
                     raise PluginException(
                         cause="'CUSTOM_SECRET_INPUT' used in authentication header, but no secret provided.",

--- a/plugins/rest/plugin.spec.yaml
+++ b/plugins/rest/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rest
 title: HTTP Requests
 description: The HTTP Requests plugin makes it easy to integrate with RESTful services
-version: 6.0.3
+version: 6.0.4
 vendor: rapid7
 support: community
 supported_versions: ["2023-10-19"]

--- a/plugins/rest/setup.py
+++ b/plugins/rest/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rest-rapid7-plugin",
-      version="6.0.3",
+      version="6.0.4",
       description="The HTTP Requests plugin makes it easy to integrate with RESTful services",
       author="rapid7",
       author_email="",

--- a/plugins/rest/unit_test/test_utils.py
+++ b/plugins/rest/unit_test/test_utils.py
@@ -175,6 +175,12 @@ class TestUtil(TestCase):
         api.with_credentials("Custom", secret_key="Key")
         self.assertEqual(api.default_headers["TEST"], "Key")
 
+    def test_custom_auth_with_prefix_success(self):
+        log = logging.getLogger("Test")
+        api = RestAPI("www.google.com", log, True, {"TEST": "ApiKey CUSTOM_SECRET_INPUT"})
+        api.with_credentials("Custom", secret_key="Key")
+        self.assertEqual(api.default_headers["TEST"], "Key")
+
     def test_custom_auth_not_provided(self):
         log = logging.getLogger("Test")
         api = RestAPI("www.google.com", log, True, {"TEST": "CUSTOM_SECRET_INPUT"})


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fixes bug where Custom Auth does not work if a prefix is added.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
