### PR TITLE
[PLGN-621] Add OAuth to ServiceNow Plugin (#2157)

### DIFF
--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "6520a686955bccfe3c4f0abfa94da4d0",
-	"manifest": "63c543969bbace434bce026f3f4c54eb",
-	"setup": "d9a67c8afe2d0bbbff58f5098a520a73",
+	"spec": "df27ad5510e10ae33482e15139c80a15",
+	"manifest": "82f844c95ef90916342ddc89143cff09",
+	"setup": "ef8a2606b780be57a6bd3af65a445aab",
 	"schemas": [
 		{
 			"identifier": "create_change_request/schema.py",
@@ -53,7 +53,7 @@
 		},
 		{
 			"identifier": "get_incident_comments_worknotes/schema.py",
-			"hash": "c8659d420ab2706fac8b28e1a75d35d4"
+			"hash": "85091e69b647bc7e3b8c8f27036c0a34"
 		},
 		{
 			"identifier": "get_security_incident/schema.py",
@@ -105,7 +105,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "3766dab0fb1af6d2edb2a514e3893515"
+			"hash": "bf06fa84b9beae4dda71f8ecb2946931"
 		},
 		{
 			"identifier": "incident_changed/schema.py",
@@ -117,7 +117,7 @@
 		},
 		{
 			"identifier": "vulnerability_updated/schema.py",
-			"hash": "2f8b6b4b5ae73a5f011d078ea095c067"
+			"hash": "8c92982b03b6313b57d705ba40a2916a"
 		}
 	]
 }

--- a/plugins/servicenow/Dockerfile
+++ b/plugins/servicenow/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-plugin:5
+FROM rapid7/insightconnect-python-3-slim-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/servicenow/bin/icon_servicenow
+++ b/plugins/servicenow/bin/icon_servicenow
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ServiceNow"
 Vendor = "rapid7"
-Version = "7.3.1"
+Version = "7.4.0"
 Description = "ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes"
 
 

--- a/plugins/servicenow/help.md
+++ b/plugins/servicenow/help.md
@@ -13,33 +13,44 @@ Note: This plugin affects only the underlying tables in a ServiceNow instance, n
 
 # Requirements
 
-* ServiceNow username and password
+* ServiceNow username and password (for basic authentication)
+* ServiceNow username, password, client ID, and client secret (for OAuth authentication) 
 * ServiceNow instance name
 
-# Supported Product Versions
+Please note that to use certain actions it's necessary to use scopes that have permissions on certain tables. Depending on the actions, it's necessary to add specific auth scopes:
+- Create/Read/Update/Delete Incident and Incident Attachments (table `incident` with permissions create/read/write/delete)
+- Create/Read/Update/Delete Security Incident (table `sn_si_incident` with permissions create/read/write/delete)
+- Create/Read/Update/Delete Vulnerability (table `sn_vul_vulnerable_item` with permissions create/read/write/delete)
+- Create Change Request (table `sn_chg_rest` with create permissions)
 
-* 2020-03-11 Orlando
+# Supported Product Versions
+  
+* 2023-10-28 Tokyo
 
 # Documentation
 
 ## Setup
-
-The connection configuration accepts the following parameters:
+  
+The connection configuration accepts the following parameters:  
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|client_id|string|None|False|Client ID for an application within your application registry|None|ad0bc2109c2642106907050c2ca6ef0c|
 |client_login|credential_username_password|None|True|The ServiceNow username and password for basic authentication API interaction|None|{"username":"user1", "password":"mypassword"}|
+|client_secret|credential_secret_key|None|False|Client secret for an application within your application registry|None|ad0bc2109c2642106907050c2ca6ef0c|
 |instance|string|None|True|The instance of ServiceNow from the URL, e.g. https://{instance}.service-now.com|None|instance|
 |timeout|integer|30|False|The interval in seconds before abandoning an attempt to access ServiceNow|None|30|
-
+  
 Example input:
 
 ```
 {
+  "client_id": "ad0bc2109c2642106907050c2ca6ef0c",
   "client_login": {
-    "username": "user1",
-    "password": "mypassword"
+    "password": "mypassword",
+    "username": "user1"
   },
+  "client_secret": "ad0bc2109c2642106907050c2ca6ef0c",
   "instance": "instance",
   "timeout": 30
 }
@@ -49,86 +60,153 @@ Example input:
 
 ### Actions
 
-#### Update Security Incident
 
-This action is used to update an existing security incident.
+#### Create Change Request
+  
+This action is used to creates a change request record based on the default change request record.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|additional_fields|object|None|False|JSON object containing the additional fields and values to update security incident|None|{"risk_score": 40, "risk_score_override": true, "parent_security_incident": "SIR0010010"}|
-|affected_user|string|None|False|The user ID, email or system ID of the user related to this security incident|None|jsmith|
-|assigned_to|string|None|False|The name, user ID, email or system id of the person primarily responsible for working this task|None|test_user|
-|assignment_group|string|None|False|The name or system id of the assignment group|None|Example Group|
-|caller|string|None|False|The user ID, email or system ID of the person requesting the work to be done|None|user@example.com|
-|category|string|None|False|The code of the security incident category|None|malware|
-|close_code|string|None|False|The code of the incident closure reason|None|Not resolved|
-|close_notes|string|None|False|Incident closure notes|None|Example notes|
-|cmdb_ci|string|None|False|The name or system ID of the configuration item|None|Example CI|
-|contact_type|string|None|False|The code of the security incident source|None|email|
-|description|string|None|False|Description of the security incident|None|Full description|
-|location|string|None|False|The name or system ID of the location|None|Example location|
-|priority|integer|None|False|The code of the priority in which an Incident needs to be resolved, based on impact and urgency|None|3|
-|short_description|string|None|False|Short description of the security incident|None|Example description|
-|state|integer|None|False|The code of the security incident state|None|18|
-|subcategory|string|None|False|The code of the security incident subcategory (available values depends on the `Category` field)|None|ransomware|
-|substate|integer|None|False|The code of the security incident substate|None|2|
-|sys_id|string|None|True|The system ID of the security incident to be updated|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|additional_fields|object|None|False|JSON object containing name-value pairs for the field(s) to update in the associated change request|None|{"short_description": "My example short description"}|
+  
 Example input:
 
 ```
 {
   "additional_fields": {
-    "risk_score": 40,
-    "risk_score_override": true,
-    "parent_security_incident": "SIR0010010"
-  },
-  "affected_user": "jsmith",
-  "assigned_to": "test_user",
-  "assignment_group": "Example Group",
-  "caller": "user@example.com",
-  "category": "malware",
-  "close_code": "Not resolved",
-  "close_notes": "Example notes",
-  "cmdb_ci": "Example CI",
-  "contact_type": "email",
-  "description": "Full description",
-  "location": "Example location",
-  "priority": 3,
-  "short_description": "Example description",
-  "state": 18,
-  "subcategory": "ransomware",
-  "substate": 2,
-  "sys_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+    "short_description": "My example short description"
+  }
 }
 ```
 
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|number|string|False|Number of the security incident|SIR0010044|
-|system_id|string|False|System ID of the security incident|9de5069c5afe602b2ea0a04b66beb2c0|
-
+| :--- | :--- | :--- | :--- | :--- |
+|success|boolean|True|Indicates whether the change request has been created|True|
+  
 Example output:
 
 ```
 {
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "number": "SIR0010044"
+  "success": true
+}
+```
+
+#### Create CI
+  
+This action is used to create a new ServiceNow CI record.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|create_data|object|None|True|JSON object containing the fields and values to create a new CI|None|{"Description": "Bug report", "ID": "58", "date": "2021-08-20 18:12:00"}|
+|table|string|None|True|The ServiceNow table where the new CI record will be inserted|None|catalog_category_request|
+  
+Example input:
+
+```
+{
+  "create_data": {
+    "Description": "Bug report",
+    "ID": "58",
+    "date": "2021-08-20 18:12:00"
+  },
+  "table": "catalog_category_request"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|system_id|string|True|System ID of the new CI created|45dd2115db1ebf00a7e99b3c8a9619da|
+  
+Example output:
+
+```
+{
+  "system_id": "45dd2115db1ebf00a7e99b3c8a9619da"
+}
+```
+
+#### Create Incident
+  
+This action is used to create a new ServiceNow Incident record.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|additional_fields|object|None|False|JSON object containing the additional fields and values to create incident|None|{"description": "incident description"}|
+|assigned_to|string|None|False|User ID of person assigned to the incident|None|user|
+|assignment_group|string|None|False|Assignment group name of the incident|None|Team Development Code Reviewers|
+|business_service|string|None|False|Name of business service|None|All|
+|caller|string|None|False|User ID of incident caller|None|user|
+|category|string|None|False|Category code of incident|None|software|
+|configuration_item|string|None|False|Configuration item code of the incident|None|int-jenkins|
+|contact_type|string|None|False|Contact type of the incident|None|email|
+|description|string|None|False|Full description of incident|None|Full details about new employee hire|
+|impact|string|None|False|Impact of the incident|None|Medium|
+|priority|string|None|False|Priority of the incident|None|Planning|
+|short_description|string|None|False|Short description of incident|None|New employee hire|
+|state|string|None|False|State name of the incident|None|In Progress|
+|subcategory|string|None|False|Subcategory code of incident (available values depends on the `Category` field)|None|email|
+|urgency|string|None|False|Urgency of the incident|None|Medium|
+  
+Example input:
+
+```
+{
+  "additional_fields": {
+    "description": "incident description"
+  },
+  "assigned_to": "user",
+  "assignment_group": "Team Development Code Reviewers",
+  "business_service": "All",
+  "caller": "user",
+  "category": "software",
+  "configuration_item": "int-jenkins",
+  "contact_type": "email",
+  "description": "Full details about new employee hire",
+  "impact": "Medium",
+  "priority": "Planning",
+  "short_description": "New employee hire",
+  "state": "In Progress",
+  "subcategory": "email",
+  "urgency": "Medium"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|incident_url|string|True|URL to newly created incident|https://example.service-now.com/task.do?sys_id=daa10e5ddb5ef7002e12ff00ba9619db|
+|number|string|True|Incident ticket number|123|
+|system_id|string|True|System ID of the new Incident created|daa10e5ddb5ef7002e12ff00ba9619db|
+  
+Example output:
+
+```
+{
+  "incident_url": "https://example.service-now.com/task.do?sys_id=daa10e5ddb5ef7002e12ff00ba9619db",
+  "number": 123,
+  "system_id": "daa10e5ddb5ef7002e12ff00ba9619db"
 }
 ```
 
 #### Create Security Incident
-
+  
 This action is used to create a new security incident.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |additional_fields|object|None|False|JSON object containing the additional fields and values to create security incident|None|{"risk_score": 40, "risk_score_override": true, "parent_security_incident": "SIR0010010"}|
 |affected_user|string|None|False|The user ID, email or system ID of the user related to this security incident|None|jsmith|
 |assigned_to|string|None|False|The name, user ID, email or system id of the person primarily responsible for working this task|None|test_user|
@@ -144,15 +222,15 @@ This action is used to create a new security incident.
 |state|integer|None|False|The code of the security incident state|None|18|
 |subcategory|string|None|False|The code of the security incident subcategory (available values depends on the `Category` field)|None|ransomware|
 |substate|integer|None|False|The code of the security incident substate|None|2|
-
+  
 Example input:
 
 ```
 {
   "additional_fields": {
+    "parent_security_incident": "SIR0010010",
     "risk_score": 40,
-    "risk_score_override": true,
-    "parent_security_incident": "SIR0010010"
+    "risk_score_override": true
   },
   "affected_user": "jsmith",
   "assigned_to": "test_user",
@@ -174,32 +252,813 @@ Example input:
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
+| :--- | :--- | :--- | :--- | :--- |
 |number|string|False|Number of the security incident|SIR0010044|
 |system_id|string|False|System ID of the security incident|9de5069c5afe602b2ea0a04b66beb2c0|
-
+  
 Example output:
 
 ```
 {
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "number": "SIR0010044"
+  "number": "SIR0010044",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
 }
 ```
 
-#### Search Security Incident
-
-This action returns security incidents that match the search criteria.
+#### Create Vulnerability
+  
+This action is used to creates a new vulnerability item record.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|additional_fields|object|None|False|JSON object containing the additional fields and values to create the vulnerability|None|{"description": "Example description"}|
+|assigned_to|string|None|False|User ID of person assigned to the vulnerability|None|ExampleUserID|
+|dns|string|None|False|The name of source DNS where the vulnerability was found|None|dns.example.com|
+|first_found|date|None|False|The time that represents the vulnerability was first found, in ISO format|None|2023-04-28 15:48:07|
+|ip_address|string|None|False|The IP address of the source where the vulnerability was found|None|192.168.0.1|
+|last_found|date|None|False|The time that represents when the vulnerability was last found, in ISO format|None|2023-04-30 12:14:10|
+|risk_score|integer|None|False|The risk score of the vulnerability, from 0 to 100|None|30|
+|short_description|string|None|False|Short description of the vulnerability|None|Example short description|
+|source|string|None|False|The vulnerability source|None|ExampleSource|
+|state|string|None|False|The state of the vulnerability|['Open', 'Under Investigation']|Open|
+|vulnerability|string|None|False|The reference of the found vulnerability (third-party vulnerability entry)|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "additional_fields": {
+    "description": "Example description"
+  },
+  "assigned_to": "ExampleUserID",
+  "dns": "dns.example.com",
+  "first_found": "2023-04-28 15:48:07",
+  "ip_address": "192.168.0.1",
+  "last_found": "2023-04-30 12:14:10",
+  "risk_score": 30,
+  "short_description": "Example short description",
+  "source": "ExampleSource",
+  "state": "Open",
+  "vulnerability": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|number|string|True|Vulnerability ticket number|1|
+|system_id|string|True|System ID of the new vulnerability created|9de5069c5afe602b2ea0a04b66beb2c0|
+|vulnerability_url|string|True|URL to newly created vulnerability|https://example.service-now.com/sn_vul_vulnerable_item.do?sys_id=61...|
+  
+Example output:
+
+```
+{
+  "number": 1,
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
+  "vulnerability_url": "https://example.service-now.com/sn_vul_vulnerable_item.do?sys_id=61..."
+}
+```
+
+#### Delete Incident
+  
+This action is used to remove the given ServiceNow Incident from the instance.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|system_id|string|None|True|System ID of the Incident record to delete|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|success|boolean|True|True if the deletion was successful, false otherwise|True|
+  
+Example output:
+
+```
+{
+  "success": true
+}
+```
+
+#### Delete Incident Attachment
+  
+This action is used to remove the given attachment from the ServiceNow instance.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|attachment_id|string|None|True|System ID of the attachment to delete|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "attachment_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|success|boolean|True|True if the deletion was successful, false otherwise|True|
+  
+Example output:
+
+```
+{
+  "success": true
+}
+```
+
+#### Delete Security Incident
+  
+This action is used to deletes a security incident by sys_id.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|sys_id|string|None|True|The unique system ID of the security incident to delete|None|7dbc4d558bbe4c6cb635b73b5f4a2e27|
+  
+Example input:
+
+```
+{
+  "sys_id": "7dbc4d558bbe4c6cb635b73b5f4a2e27"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|success|boolean|False|Whether the action was successful|True|
+  
+Example output:
+
+```
+{
+  "success": true
+}
+```
+
+#### Delete Vulnerability
+  
+This action is used to delete the vulnerability by ID.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|system_id|string|None|True|System ID of the vulnerability to be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|success|boolean|True|True if the deletion was successful, false otherwise|True|
+  
+Example output:
+
+```
+{
+  "success": true
+}
+```
+
+#### Get Attachments for an Incident
+  
+This action is used to search for attachments for a given incident ID.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|incident_id|string|None|False|ID of the incident|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "incident_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|incident_attachments|[]attachment_file|False|List of attachments for a given incident ID|[{"content":"9de5069c5afe602b2ea0a04b66beb2c0","content_type":"text/plain","file_name":"example.txt"}]|
+  
+Example output:
+
+```
+{
+  "incident_attachments": [
+    {
+      "content": "9de5069c5afe602b2ea0a04b66beb2c0",
+      "content_type": "text/plain",
+      "file_name": "example.txt"
+    }
+  ]
+}
+```
+
+#### Get CI
+  
+This action is used to retrieve a CI record from ServiceNow.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|system_id|string|None|True|The system ID of the record to retrieve|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|table|string|None|True|The ServiceNow table to retrieve the CI from|None|catalog_category_request|
+  
+Example input:
+
+```
+{
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
+  "table": "catalog_category_request"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|servicenow_ci|object|True|JSON object representing the CI record returned|{"firewall_status":"Intranet","operational_status":"1","sys_updated_on":"2019-06-26 20:45:21","first_discovered":"2018-05-14 18:07:23","used_for":"Production","sys_created_by":"admin","classification":"Production","can_print":"false","last_discovered":"2019-03-24 11:25:56","sys_class_name":"cmdb_ci_server","asset":{"link":"https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6","value":"ff5a6a55dbdef7002e12ff00ba9619d6"},"sys_updated_by":"admin","sys_created_on":"2019-06-26 20:45:21","sys_domain":{"link":"https://example.service-now.com/api/now/table/sys_user_group/sysdomain","value":"sysdomain"},"fqdn":"fqdntest","hardware_status":"installed","install_status":"1","name":"TEST NAME","subcategory":"Computer","u_restricted_access":"false","sys_id":"375a6a55dbdef7002e12ff00ba9619d6","sys_class_path":"/!!/!G/!!/!$","mac_address":"234324234342","u_automated_patching":"false","sys_mod_count":"0","monitor":"false","ip_address":"10.0.0.1","model_id":{"link":"https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949","value":"59d4c676db0fc700553363835b961949"},"cost_cc":"USD","location":{"link":"https://example.service-now.com/api/now/table/cmn_location/US-East","value":"US-East"},"category":"Hardware","fault_count":"0"}|
+  
+Example output:
+
+```
+{
+  "servicenow_ci": {
+    "asset": {
+      "link": "https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6",
+      "value": "ff5a6a55dbdef7002e12ff00ba9619d6"
+    },
+    "can_print": "false",
+    "category": "Hardware",
+    "classification": "Production",
+    "cost_cc": "USD",
+    "fault_count": "0",
+    "firewall_status": "Intranet",
+    "first_discovered": "2018-05-14 18:07:23",
+    "fqdn": "fqdntest",
+    "hardware_status": "installed",
+    "install_status": "1",
+    "ip_address": "10.0.0.1",
+    "last_discovered": "2019-03-24 11:25:56",
+    "location": {
+      "link": "https://example.service-now.com/api/now/table/cmn_location/US-East",
+      "value": "US-East"
+    },
+    "mac_address": "234324234342",
+    "model_id": {
+      "link": "https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949",
+      "value": "59d4c676db0fc700553363835b961949"
+    },
+    "monitor": "false",
+    "name": "TEST NAME",
+    "operational_status": "1",
+    "subcategory": "Computer",
+    "sys_class_name": "cmdb_ci_server",
+    "sys_class_path": "/!!/!G/!!/!$",
+    "sys_created_by": "admin",
+    "sys_created_on": "2019-06-26 20:45:21",
+    "sys_domain": {
+      "link": "https://example.service-now.com/api/now/table/sys_user_group/sysdomain",
+      "value": "sysdomain"
+    },
+    "sys_id": "375a6a55dbdef7002e12ff00ba9619d6",
+    "sys_mod_count": "0",
+    "sys_updated_by": "admin",
+    "sys_updated_on": "2019-06-26 20:45:21",
+    "u_automated_patching": "false",
+    "u_restricted_access": "false",
+    "used_for": "Production"
+  }
+}
+```
+
+#### Get Incident Attachment
+  
+This action is used to download the Base64-encoded contents of the given attachment.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|attachment_id|string|None|True|System ID of the attachment to copy|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "attachment_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|attachment_contents|bytes|True|The Base64-encoded contents of the downloaded attachment|[base-64 contents]|
+  
+Example output:
+
+```
+{
+  "attachment_contents": "[base-64 contents]"
+}
+```
+
+#### Get Incident Comments and Work Notes
+  
+This action is used to get comments and work notes for an incident.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|system_id|string|None|True|System ID of Incident record for which comments and work notes will be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|type|string|None|True|Type of output to be retrieved|['all', 'comments', 'work notes']|all|
+  
+Example input:
+
+```
+{
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
+  "type": "all"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|incident_comments_worknotes|[]comments_worknotes|True|List of comments and work notes for an incident|[{"sys_id":"2c6420c31b0000506a4a85507e4bcb82","sys_created_on":"2019-09-26 21:19:11","name":"incident","element_id":"965f140bdb4c8c105f6f00b5ca961922","sys_tags":"","value":"Team is actively looking into it.","sys_created_by":"admin","element":"work_notes"},{"sys_id":"4db0e8cb1bcccc106a4a85507e4bcba2","sys_created_on":"2019-09-26 21:03:07","name":"incident","element_id":"965f140bdb4c8c105f6f00b5ca961922","sys_tags":"","value":"This is Sev1 incident.","sys_created_by":"admin","element":"comments"},{"sys_id":"f92024471b0000506a4a85507e4bcb78","sys_created_on":"2019-09-26 21:00:43","name":"incident","element_id":"965f140bdb4c8c105f6f00b5ca961922","sys_tags":"","value":"Testing comments","sys_created_by":"admin","element":"comments"}]|
+  
+Example output:
+
+```
+{
+  "incident_comments_worknotes": [
+    {
+      "element": "work_notes",
+      "element_id": "965f140bdb4c8c105f6f00b5ca961922",
+      "name": "incident",
+      "sys_created_by": "admin",
+      "sys_created_on": "2019-09-26 21:19:11",
+      "sys_id": "2c6420c31b0000506a4a85507e4bcb82",
+      "sys_tags": "",
+      "value": "Team is actively looking into it."
+    },
+    {
+      "element": "comments",
+      "element_id": "965f140bdb4c8c105f6f00b5ca961922",
+      "name": "incident",
+      "sys_created_by": "admin",
+      "sys_created_on": "2019-09-26 21:03:07",
+      "sys_id": "4db0e8cb1bcccc106a4a85507e4bcba2",
+      "sys_tags": "",
+      "value": "This is Sev1 incident."
+    },
+    {
+      "element": "comments",
+      "element_id": "965f140bdb4c8c105f6f00b5ca961922",
+      "name": "incident",
+      "sys_created_by": "admin",
+      "sys_created_on": "2019-09-26 21:00:43",
+      "sys_id": "f92024471b0000506a4a85507e4bcb78",
+      "sys_tags": "",
+      "value": "Testing comments"
+    }
+  ]
+}
+```
+
+#### Get Security Incident
+  
+This action is used to retrieves a security incident by sys_id.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|sys_id|string|None|True|The unique system ID of the security incident|None|7dbc4d558bbe4c6cb635b73b5f4a2e27|
+  
+Example input:
+
+```
+{
+  "sys_id": "7dbc4d558bbe4c6cb635b73b5f4a2e27"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|security_incident|security_incident|False|Details of the security incident|{"active":false,"activity_due":"2023-07-28 10:18:55","affected_user":{"link":"example.com/1234","value":"1234"},"alert_id":"dca801f11b1cb5506bf1ed78b04bcb5f","alert_rule":"test","alert_sensor":{"link":"example.com/1234","value":"1234"},"assigned_to":{"link":"example.com/1234","value":"1234"},"assignment_group":{"link":"example.com/1234","value":"1234"},"business_criticality":3,"caller":{"link":"example.com/1234","value":"1234"},"category":"Phishing","close_code":-100,"close_notes":"test close notes","closed_at":"2023-08-01 08:03:28","closed_by":{"link":"example.com/1234","value":"1234"},"cmdb_ci":{"link":"example.com/1234","value":"1234"},"contact_type":"phone","description":"example description","location":{"link":"example.com/1234","value":"1234"},"number":"SIR00000001","opened_at":"2023-07-28 10:18:55","opened_by":{"link":"example.com/1234","value":"1234"},"opened_for":{"link":"example.com/1234","value":"1234"},"priority":4,"risk_score":38,"risk_score_override":false,"secure_notes":"﷠﷡﷢56715c0aff1331007a6dffffffffff54﷌﷍CzXu70QS9L8TfvWt92rByQ==﷎﷏","security_tags":"dca801f11b1cb5506bf1ed78b04bcb5f","short_description":"test","special_access_write":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g","state":3,"subcategory":"25","substate":1,"sys_created_by":"user","sys_created_on":"2023-07-28 10:18:55","sys_id":"g123456","sys_updated_by":"user","sys_updated_on":"2023-08-01 08:03:32","watch_list":"dca801f11b1cb5506bf1ed78b04bcb5f","work_notes_list":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"}|
+  
+Example output:
+
+```
+{
+  "security_incident": {
+    "active": false,
+    "activity_due": "2023-07-28 10:18:55",
+    "affected_user": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "alert_id": "dca801f11b1cb5506bf1ed78b04bcb5f",
+    "alert_rule": "test",
+    "alert_sensor": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "assigned_to": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "assignment_group": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "business_criticality": 3,
+    "caller": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "category": "Phishing",
+    "close_code": -100,
+    "close_notes": "test close notes",
+    "closed_at": "2023-08-01 08:03:28",
+    "closed_by": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "cmdb_ci": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "contact_type": "phone",
+    "description": "example description",
+    "location": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "number": "SIR00000001",
+    "opened_at": "2023-07-28 10:18:55",
+    "opened_by": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "opened_for": {
+      "link": "example.com/1234",
+      "value": "1234"
+    },
+    "priority": 4,
+    "risk_score": 38,
+    "risk_score_override": false,
+    "secure_notes": "\ufde0\ufde1\ufde256715c0aff1331007a6dffffffffff54\ufdcc\ufdcdCzXu70QS9L8TfvWt92rByQ==\ufdce\ufdcf",
+    "security_tags": "dca801f11b1cb5506bf1ed78b04bcb5f",
+    "short_description": "test",
+    "special_access_write": "dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g",
+    "state": 3,
+    "subcategory": "25",
+    "substate": 1,
+    "sys_created_by": "user",
+    "sys_created_on": "2023-07-28 10:18:55",
+    "sys_id": "g123456",
+    "sys_updated_by": "user",
+    "sys_updated_on": "2023-08-01 08:03:32",
+    "watch_list": "dca801f11b1cb5506bf1ed78b04bcb5f",
+    "work_notes_list": "dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"
+  }
+}
+```
+
+#### Get Vulnerability
+  
+This action is used to retrieve the vulnerability by ID.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|filtering_fields|string|None|True|Comma-separated list of fields desired in output object (e.g. opened_by,number)|None|opened_by,number|
+|system_id|string|None|True|System ID of the vulnerability to be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "filtering_fields": "opened_by,number",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|filtered_vulnerability|object|True|JSON object representing the vulnerability containing the given fields|{"number":"1","opened_by":{"link":"https://example.service-now.com/api/now/table/sys...","value":""},"state":"1"}|
+  
+Example output:
+
+```
+{
+  "filtered_vulnerability": {
+    "number": "1",
+    "opened_by": {
+      "link": "https://example.service-now.com/api/now/table/sys...",
+      "value": ""
+    },
+    "state": "1"
+  }
+}
+```
+
+#### Put Incident Attachment
+  
+This action is used to associate a file with a ServiceNow Incident.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|attachment_name|string|None|True|Name of the attachment in the ServiceNow instance|None|Example name|
+|base64_content|bytes|None|True|Content of the attachment, encoded into Base64|None|UmFwaWQ3IEluc2lnaHRDb25uZWN0Cg==|
+|mime_type|string|None|True|MIME type (a.k.a. content type) of the file to be attached|['text/plain (.txt)', 'text/html (.html)', 'application/rtf (.rtf)', 'application/pdf (.pdf)', 'application/msword (.doc)', 'application/vnd.ms-powerpoint (.ppt)', 'image/bmp (.bmp)', 'image/gif (.gif)', 'image/jpeg (.jpg)', 'image/png (.png)', 'image/tiff (.tiff)', 'OTHER']|text/plain (.txt)|
+|other_mime_type|string|None|False|User-specified MIME type not in the enumerated list|None|.avi|
+|system_id|string|None|True|System ID of the Incident record to which the file will be attached|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "attachment_name": "Example name",
+  "base64_content": "UmFwaWQ3IEluc2lnaHRDb25uZWN0Cg==",
+  "mime_type": "text/plain (.txt)",
+  "other_mime_type": ".avi",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|attachment_id|string|True|System ID of the newly created attachment|b5b24a5ddb1ebf00a7e99b3c8a96197d|
+  
+Example output:
+
+```
+{
+  "attachment_id": "b5b24a5ddb1ebf00a7e99b3c8a96197d"
+}
+```
+
+#### Read Incident
+  
+This action is used to populate a JSON object with the specified fields of the given Incident.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|filtering_fields|string|None|True|Comma-separated list of fields desired in output object (e.g. opened_by,number)|None|opened_by,number|
+|system_id|string|None|True|System ID of the Incident record from which to read|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "filtering_fields": "opened_by,number",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|filtered_incident|object|True|JSON object representing the incident containing the given fields|{"short_description":"Short description test","description":"Description test"}|
+  
+Example output:
+
+```
+{
+  "filtered_incident": {
+    "description": "Description test",
+    "short_description": "Short description test"
+  }
+}
+```
+
+#### Search CI
+  
+This action is used to retrieve CI record(s) from ServiceNow based on the provided query.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|query|string|None|True|Non-encoded query string for retrieving ServiceNow CI record(s) (e.g. number=INC0000055^ORshort_description=New bug)|None|number=INC0000055^ORshort_description=New bug|
+|table|string|None|True|The ServiceNow table to execute the query against|None|catalog_category_request|
+  
+Example input:
+
+```
+{
+  "query": "number=INC0000055^ORshort_description=New bug",
+  "table": "catalog_category_request"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|servicenow_cis|[]object|True|List of JSON objects representing the CI record(s) returned by the query|[{"firewall_status":"Intranet","operational_status":"1","sys_updated_on":"2019-06-26 20:45:21","first_discovered":"2018-05-14 18:07:23","used_for":"Production","sys_created_by":"admin","classification":"Production","can_print":"false","last_discovered":"2019-03-24 11:25:56","sys_class_name":"cmdb_ci_server","cd_rom":"false","unverified":"false","asset":{"link":"https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6","value":"ff5a6a55dbdef7002e12ff00ba9619d6"},"skip_sync":"false","sys_updated_by":"admin","sys_created_on":"2019-06-26 20:45:21","sys_domain":{"link":"https://example.service-now.com/api/now/table/sys_user_group/sysdomain","value":"sysdomain"},"fqdn":"fqdntest","hardware_status":"installed","install_status":"1","name":"TEST NAME","subcategory":"Computer","u_restricted_access":"false","virtual":"false","sys_id":"375a6a55dbdef7002e12ff00ba9619d6","sys_class_path":"/!!/!G/!!/!$","mac_address":"234324234342","u_automated_patching":"false","sys_mod_count":"0","monitor":"false","ip_address":"10.0.0.1","model_id":{"link":"https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949","value":"59d4c676db0fc700553363835b961949"},"cost_cc":"USD","location":{"link":"https://example.service-now.com/api/now/table/cmn_location/US-East","value":"US-East"},"category":"Hardware","fault_count":"0"}]|
+  
+Example output:
+
+```
+{
+  "servicenow_cis": [
+    {
+      "asset": {
+        "link": "https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6",
+        "value": "ff5a6a55dbdef7002e12ff00ba9619d6"
+      },
+      "can_print": "false",
+      "category": "Hardware",
+      "cd_rom": "false",
+      "classification": "Production",
+      "cost_cc": "USD",
+      "fault_count": "0",
+      "firewall_status": "Intranet",
+      "first_discovered": "2018-05-14 18:07:23",
+      "fqdn": "fqdntest",
+      "hardware_status": "installed",
+      "install_status": "1",
+      "ip_address": "10.0.0.1",
+      "last_discovered": "2019-03-24 11:25:56",
+      "location": {
+        "link": "https://example.service-now.com/api/now/table/cmn_location/US-East",
+        "value": "US-East"
+      },
+      "mac_address": "234324234342",
+      "model_id": {
+        "link": "https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949",
+        "value": "59d4c676db0fc700553363835b961949"
+      },
+      "monitor": "false",
+      "name": "TEST NAME",
+      "operational_status": "1",
+      "skip_sync": "false",
+      "subcategory": "Computer",
+      "sys_class_name": "cmdb_ci_server",
+      "sys_class_path": "/!!/!G/!!/!$",
+      "sys_created_by": "admin",
+      "sys_created_on": "2019-06-26 20:45:21",
+      "sys_domain": {
+        "link": "https://example.service-now.com/api/now/table/sys_user_group/sysdomain",
+        "value": "sysdomain"
+      },
+      "sys_id": "375a6a55dbdef7002e12ff00ba9619d6",
+      "sys_mod_count": "0",
+      "sys_updated_by": "admin",
+      "sys_updated_on": "2019-06-26 20:45:21",
+      "u_automated_patching": "false",
+      "u_restricted_access": "false",
+      "unverified": "false",
+      "used_for": "Production",
+      "virtual": "false"
+    }
+  ]
+}
+```
+
+#### Search Incident
+  
+This action is used to search for Incidents satisfying the given query.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|query|string|None|True|Non-encoded query string (e.g. number=INC0000055^ORshort_description=New bug)|None|number=INC0000055^ORshort_description=Newbug|
+  
+Example input:
+
+```
+{
+  "query": "number=INC0000055^ORshort_description=Newbug"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|system_ids|[]string|True|List of System IDs of Incidents satisfying the given query|["b5aadf6cdb16b7002e12ff00ba96193c","90db5f20db967f00a7e99b3c8a96190c","28869809db12bf00a7e99b3c8a9619de","e5a14141db92f7002e12ff00ba961962","38aa01d9dbdaf7002e12ff00ba96196a","daa10e5ddb5ef7002e12ff00ba9619db"]|
+  
+Example output:
+
+```
+{
+  "system_ids": [
+    "b5aadf6cdb16b7002e12ff00ba96193c",
+    "90db5f20db967f00a7e99b3c8a96190c",
+    "28869809db12bf00a7e99b3c8a9619de",
+    "e5a14141db92f7002e12ff00ba961962",
+    "38aa01d9dbdaf7002e12ff00ba96196a",
+    "daa10e5ddb5ef7002e12ff00ba9619db"
+  ]
+}
+```
+
+#### Search Incident Attachment
+  
+This action is used to search for attachment files with the given name.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|name|string|None|True|Name of the attachment, i.e. the base file name used to create it|None|Example name|
+  
+Example input:
+
+```
+{
+  "name": "Example name"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|attachment_ids|[]string|True|List of System IDs of attachment records with the given name|["7bbbc15ddbdaf7002e12ff00ba96196c","b5b24a5ddb1ebf00a7e99b3c8a96197d","46c14941db92bf00a7e99b3c8a9619b6"]|
+  
+Example output:
+
+```
+{
+  "attachment_ids": [
+    "7bbbc15ddbdaf7002e12ff00ba96196c",
+    "b5b24a5ddb1ebf00a7e99b3c8a96197d",
+    "46c14941db92bf00a7e99b3c8a9619b6"
+  ]
+}
+```
+
+#### Search Security Incident
+  
+This action is used to returns security incidents that match the search criteria.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |fields|string|None|False|A comma-separated list of fields to return in the response|None|number,sys_id|
 |limit|integer|None|False|Maximum number of records to return|None|10|
 |offset|integer|None|False|Starting record index for which to begin retrieving records|None|5|
 |query|string|None|False|An encoded query string used to filter the results|None|number=SIR0000001|
-
+  
 Example input:
 
 ```
@@ -214,9 +1073,9 @@ Example input:
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|security_incidents|[]security_incident|False|Details of the matching security incidents|[]|
-
+| :--- | :--- | :--- | :--- | :--- |
+|security_incidents|[]security_incident|False|Details of the matching security incidents|[{"active":false,"activity_due":"2023-07-28 10:18:55","affected_user":{"link":"example.com/1234","value":"1234"},"alert_id":"dca801f11b1cb5506bf1ed78b04bcb5f","alert_rule":"test","alert_sensor":{"link":"example.com/1234","value":"1234"},"assigned_to":{"link":"example.com/1234","value":"1234"},"assignment_group":{"link":"example.com/1234","value":"1234"},"business_criticality":3,"caller":{"link":"example.com/1234","value":"1234"},"category":"Phishing","close_code":-100,"close_notes":"test close notes","closed_at":"2023-08-01 08:03:28","closed_by":{"link":"example.com/1234","value":"1234"},"cmdb_ci":{"link":"example.com/1234","value":"1234"},"contact_type":"phone","description":"example description","location":{"link":"example.com/1234","value":"1234"},"number":"SIR00000002","opened_at":"2023-07-28 10:18:55","opened_by":{"link":"example.com/1234","value":"1234"},"opened_for":{"link":"example.com/1234","value":"1234"},"priority":3,"risk_score":38,"risk_score_override":false,"secure_notes":"﷠﷡﷢56715c0aff1331007a6dffffffffff54﷌﷍CzXu70QS9L8TfvWt92rByQ==﷎﷏","security_tags":"dca801f11b1cb5506bf1ed78b04bcb5f","short_description":"test","special_access_write":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g","state":3,"subcategory":"25","substate":1,"sys_created_by":"user","sys_created_on":"2023-07-28 10:18:55","sys_id":"g12345678","sys_updated_by":"user","sys_updated_on":"2023-08-01 08:03:32","watch_list":"dca801f11b1cb5506bf1ed78b04bcb5f","work_notes_list":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"},{"active":false,"activity_due":"2023-07-28 10:18:55","affected_user":{"link":"example.com/1234","value":"1234"},"alert_id":"dca801f11b1cb5506bf1ed78b04bcb5f","alert_rule":"test","alert_sensor":{"link":"example.com/1234","value":"1234"},"assigned_to":{"link":"example.com/1234","value":"1234"},"assignment_group":{"link":"example.com/1234","value":"1234"},"business_criticality":3,"caller":{"link":"example.com/1234","value":"1234"},"category":"Phishing","close_code":-100,"close_notes":"test close notes","closed_at":"2023-08-01 08:03:28","closed_by":{"link":"example.com/1234","value":"1234"},"cmdb_ci":{"link":"example.com/1234","value":"1234"},"contact_type":"phone","description":"example description","location":{"link":"example.com/1234","value":"1234"},"number":"SIR00000003","opened_at":"2023-07-28 10:18:55","opened_by":{"link":"example.com/1234","value":"1234"},"opened_for":{"link":"example.com/1234","value":"1234"},"priority":3,"risk_score":38,"risk_score_override":false,"secure_notes":"﷠﷡﷢56715c0aff1331007a6dffffffffff54﷌﷍CzXu70QS9L8TfvWt92rByQ==﷎﷏","security_tags":"dca801f11b1cb5506bf1ed78b04bcb5f","short_description":"test","special_access_write":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g","state":3,"subcategory":"25","substate":1,"sys_created_by":"user","sys_created_on":"2023-07-28 10:18:55","sys_id":"g123456789","sys_updated_by":"user","sys_updated_on":"2023-08-01 08:03:32","watch_list":"dca801f11b1cb5506bf1ed78b04bcb5f","work_notes_list":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"}]|
+  
 Example output:
 
 ```
@@ -368,934 +1227,20 @@ Example output:
     }
   ]
 }
-
-```
-
-#### Get Security Incident
-
-This action retrieves a security incident by sys_id or number.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|sys_id|string|None|True|The unique system ID of the security incident|None|7dbc4d558bbe4c6cb635b73b5f4a2e27|
-
-Example input:
-
-```
-{
-  "sys_id": "7dbc4d558bbe4c6cb635b73b5f4a2e27"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|security_incident|security_incident|False|Details of the security incident|{}|
-
-Example output:
-
-```
-{
-  "security_incident": {
-    "active": false,
-    "activity_due": "2023-07-28 10:18:55",
-    "affected_user": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "alert_id": "dca801f11b1cb5506bf1ed78b04bcb5f",
-    "alert_rule": "test",
-    "alert_sensor": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "assigned_to": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "assignment_group": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "business_criticality": 3,
-    "caller": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "category": "Phishing",
-    "close_code": -100,
-    "close_notes": "test close notes",
-    "closed_at": "2023-08-01 08:03:28",
-    "closed_by": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "cmdb_ci": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "contact_type": "phone",
-    "description": "example description",
-    "location": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "number": "SIR00000001",
-    "opened_at": "2023-07-28 10:18:55",
-    "opened_by": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "opened_for": {
-      "link": "example.com/1234",
-      "value": "1234"
-    },
-    "priority": 4,
-    "risk_score": 38,
-    "risk_score_override": false,
-    "secure_notes": "\ufde0\ufde1\ufde256715c0aff1331007a6dffffffffff54\ufdcc\ufdcdCzXu70QS9L8TfvWt92rByQ==\ufdce\ufdcf",
-    "security_tags": "dca801f11b1cb5506bf1ed78b04bcb5f",
-    "short_description": "test",
-    "special_access_write": "dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g",
-    "state": 3,
-    "subcategory": "25",
-    "substate": 1,
-    "sys_created_by": "user",
-    "sys_created_on": "2023-07-28 10:18:55",
-    "sys_id": "g123456",
-    "sys_updated_by": "user",
-    "sys_updated_on": "2023-08-01 08:03:32",
-    "watch_list": "dca801f11b1cb5506bf1ed78b04bcb5f",
-    "work_notes_list": "dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"
-  }
-}
-
-```
-
-#### Delete Security Incident
-
-This action deletes a security incident by sys_id.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|sys_id|string|None|True|The unique system ID of the security incident to delete|None|7dbc4d558bbe4c6cb635b73b5f4a2e27|
-
-Example input:
-
-```
-{
-  "sys_id": "7dbc4d558bbe4c6cb635b73b5f4a2e27"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|success|boolean|False|Whether the action was successful|True|
-
-Example output:
-
-```
-{
-  "success": true
-}
-```
-
-#### Update Vulnerability
-
-This action is used to update the vulnerability by ID.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|additional_fields|object|None|False|JSON object containing the additional fields and values to update the vulnerability item|None|{"description": "Example description"}|
-|assigned_to|string|None|False|User ID of person assigned to the vulnerability|None|ExampleUserID|
-|dns|string|None|False|The name of the source DNS where the vulnerability was found|None|dns.example.com|
-|first_found|date|None|False|The time that represents the vulnerability was first found, in ISO format|None|2023-04-28T15:48:07|
-|ip_address|string|None|False|The IP address of the source where the vulnerability was found|None|192.168.0.1|
-|last_found|date|None|False|The time that represents when the vulnerability was last found, in ISO format|None|2023-04-30T12:14:10|
-|short_description|string|None|False|Short description of the vulnerability|None|Example short description|
-|source|string|None|False|The vulnerability source|None|ExampleSource|
-|state|string|None|False|The state of the vulnerability|['', 'Open', 'Under Investigation']|Open|
-|system_id|string|None|True|System ID of the vulnerability to be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|vulnerability|string|None|False|The reference of the found vulnerability|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "additional_fields": {
-    "description": "Example description"
-  },
-  "assigned_to": "ExampleUserID",
-  "dns": "dns.example.com",
-  "first_found": "2023-04-28T15:48:07",
-  "ip_address": "192.168.0.1",
-  "last_found": "2023-04-30T12:14:10",
-  "short_description": "Example short description",
-  "source": "ExampleSource",
-  "state": "Open",
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "vulnerability": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|success|boolean|True|True if the update was successful, false otherwise|True|
-
-Example output:
-
-```
-{
-  "success": true
-}
-```
-
-#### Get Vulnerability
-
-This action is used to retrieve the vulnerability by ID.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|filtering_fields|string|None|True|Comma-separated list of fields desired in output object (e.g. opened_by,number)|None|opened_by,number|
-|system_id|string|None|True|System ID of the vulnerability to be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "filtering_fields": "opened_by,number",
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|filtered_vulnerability|object|True|JSON object representing the vulnerability containing the given fields|{"number":"1","opened_by":{"link":"https://example.service-now.com/api/now/table/sys...","value":""},"state":"1"}|
-
-Example output:
-
-```
-{
-  "filtered_vulnerability": {
-    "number": "1",
-    "opened_by": {
-      "link": "https://example.service-now.com/api/now/table/sys...",
-      "value": ""
-    },
-    "state": "1"
-  }
-}
-```
-
-#### Delete Vulnerability
-
-This action is used to delete the vulnerability by ID.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|system_id|string|None|True|System ID of the vulnerability to be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|success|boolean|True|True if the deletion was successful, false otherwise|True|
-
-Example output:
-
-```
-{
-  "success": true
-}
-```
-
-#### Create Vulnerability
-
-This action creates a new vulnerability record.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|additional_fields|object|None|False|JSON object containing the additional fields and values to create the vulnerability|None|{"description": "Example description"}|
-|assigned_to|string|None|False|User ID of person assigned to the vulnerability|None|ExampleUserID|
-|dns|string|None|False|The name of source DNS where the vulnerability was found|None|dns.example.com|
-|first_found|date|None|False|The time that represents the vulnerability was first found, in ISO format|None|2023-04-28T15:48:07|
-|ip_address|string|None|False|The IP address of the source where the vulnerability was found|None|192.168.0.1|
-|last_found|date|None|False|The time that represents when the vulnerability was last found, in ISO format|None|2023-04-30T12:14:10|
-|risk_score|integer|None|False|The risk score of the vulnerability, from 0 to 100|None|30|
-|short_description|string|None|False|Short description of the vulnerability|None|Example short description|
-|source|string|None|False|The vulnerability source|None|ExampleSource|
-|state|string|None|False|The state of the vulnerability|['Open', 'Under Investigation']|Open|
-|vulnerability|string|None|False|The reference of the found vulnerability (third-party vulnerability entry)|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "additional_fields": {
-    "description": "Example description"
-  },
-  "assigned_to": "ExampleUserID",
-  "dns": "dns.example.com",
-  "first_found": "2023-04-28T15:48:07",
-  "ip_address": "192.168.0.1",
-  "last_found": "2023-04-30T12:14:10",
-  "risk_score": 30,
-  "short_description": "Example short description",
-  "source": "ExampleSource",
-  "state": "Open",
-  "vulnerability": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|number|string|True|Vulnerability ticket number|1|
-|system_id|string|True|System ID of the new vulnerability created|9de5069c5afe602b2ea0a04b66beb2c0|
-|vulnerability_url|string|True|URL to newly created vulnerability|https://example.service-now.com/sn_vul_vulnerable_item.do?sys_id=61...|
-
-Example output:
-
-```
-{
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "vulnerability_url": "https://example.service-now.com/sn_vul_vulnerable_item.do?sys_id=61...",
-  "number": "1"
-}
-```
-
-#### Create Change Request
-
-This action creates a change request record based on the default change request record.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|additional_fields|object|None|False|JSON object containing name-value pairs for the field(s) to update in the associated change request|None|{"short_description": "My example short description"}|
-
-Example input:
-
-```
-{
-  "additional_fields": {
-    "short_description": "My example short description"
-  }
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|success|boolean|True|Indicates whether the change request has been created|True|
-
-Example output:
-
-```
-{
-  "success": true
-}
-```
-
-#### Get Attachments for an Incident
-
-This action is used to search for attachments for a given incident ID.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|incident_id|string|None|False|ID of the incident|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "incident_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident_attachments|[]attachment_file|False|List of attachments for a given incident ID|[{"content":"9de5069c5afe602b2ea0a04b66beb2c0","content_type":"text/plain","file_name":"example.txt"}]|
-
-Example output:
-
-```
-{
-  "incident_attachments": [
-    {
-      "content": "9de5069c5afe602b2ea0a04b66beb2c0",
-      "content_type": "text/plain",
-      "file_name": "example.txt"
-    }
-  ]
-}
-```
-
-#### Create CI
-
-This action is used to create a new ServiceNow CI record.
-
-For more information about the **query** input, please refer to [InsightConnect ServiceNow Query Syntax documentation](http://docs.rapid7.com/insightconnect/servicenow#query-syntax).
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|create_data|object|None|True|JSON object containing the fields and values to create a new CI|None|{"Description": "Bug report", "ID": "58", "date": "2021-08-20 18:12:00"}|
-|table|string|None|True|The ServiceNow table where the new CI record will be inserted|None|catalog_category_request|
-
-Example input:
-
-```
-{
-  "create_data": {
-    "Description": "Bug report",
-    "ID": "58",
-    "date": "2021-08-20 18:12:00"
-  },
-  "table": "catalog_category_request"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|system_id|string|True|System ID of the new CI created|45dd2115db1ebf00a7e99b3c8a9619da|
-
-Example output:
-
-```
-{
-  "system_id": "45dd2115db1ebf00a7e99b3c8a9619da"
-}
-```
-
-#### Create Incident
-
-This action is used to create a new ServiceNow Incident record.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|additional_fields|object|None|False|JSON object containing the additional fields and values to create incident|None|{"description": "incident description"}|
-|assigned_to|string|None|False|User ID of person assigned to the incident|None|user|
-|assignment_group|string|None|False|Assignment group name of the incident|None|Team Development Code Reviewers|
-|business_service|string|None|False|Name of business service|None|All|
-|caller|string|None|False|User ID of incident caller|None|user|
-|category|string|None|False|Category code of incident|None|software|
-|configuration_item|string|None|False|Configuration item code of the incident|None|int-jenkins|
-|contact_type|string|None|False|Contact type of the incident|None|email|
-|description|string|None|False|Full description of incident|None|Full details about new employee hire|
-|impact|string|None|False|Impact of the incident|None|Medium|
-|priority|string|None|False|Priority of the incident|None|Planning|
-|short_description|string|None|False|Short description of incident|None|New employee hire|
-|state|string|None|False|State name of the incident|None|In Progress|
-|subcategory|string|None|False|Subcategory code of incident (available values depends on the `Category` field)|None|email|
-|urgency|string|None|False|Urgency of the incident|None|Medium|
-
-Example input:
-
-```
-{
-  "additional_fields": {
-    "description": "incident description"
-  },
-  "assigned_to": "user",
-  "assignment_group": "Team Development Code Reviewers",
-  "business_service": "All",
-  "caller": "user",
-  "category": "software",
-  "configuration_item": "int-jenkins",
-  "contact_type": "email",
-  "description": "Full details about new employee hire",
-  "impact": "Medium",
-  "priority": "Planning",
-  "short_description": "New employee hire",
-  "state": "In Progress",
-  "subcategory": "email",
-  "urgency": "Medium"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident_url|string|True|URL to newly created incident|https://example.service-now.com/task.do?sys_id=daa10e5ddb5ef7002e12ff00ba9619db|
-|number|string|True|Incident ticket number|123|
-|system_id|string|True|System ID of the new Incident created|daa10e5ddb5ef7002e12ff00ba9619db|
-
-Example output:
-
-```
-{
-  "number": "123",
-  "system_id": "daa10e5ddb5ef7002e12ff00ba9619db",
-  "incident_url": "https://example.service-now.com/task.do?sys_id=daa10e5ddb5ef7002e12ff00ba9619db"
-}
-```
-
-#### Delete Incident
-
-This action is used to remove the given ServiceNow Incident from the instance.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|system_id|string|None|True|System ID of the Incident record to delete|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|success|boolean|True|True if the deletion was successful, false otherwise|True|
-
-Example output:
-
-```
-{
-  "success": true
-}
-```
-
-#### Delete Incident Attachment
-
-This action is used to remove the given attachment from the ServiceNow instance.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|attachment_id|string|None|True|System ID of the attachment to delete|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "attachment_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|success|boolean|True|True if the deletion was successful, false otherwise|True|
-
-Example output:
-
-```
-{
-  "success": true
-}
-```
-
-#### Get CI
-
-This action is used to retrieve a ServiceNow CI record based on provided query.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|system_id|string|None|True|The system ID of the record to retrieve|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|table|string|None|True|The ServiceNow table to retrieve the CI from|None|catalog_category_request|
-
-Example input:
-
-```
-{
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "table": "catalog_category_request"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|servicenow_ci|object|True|JSON object representing the CI record returned|{"firewall_status":"Intranet","operational_status":"1","sys_updated_on":"2019-06-26 20:45:21","first_discovered":"2018-05-14 18:07:23","used_for":"Production","sys_created_by":"admin","classification":"Production","can_print":"false","last_discovered":"2019-03-24 11:25:56","sys_class_name":"cmdb_ci_server","asset":{"link":"https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6","value":"ff5a6a55dbdef7002e12ff00ba9619d6"},"sys_updated_by":"admin","sys_created_on":"2019-06-26 20:45:21","sys_domain":{"link":"https://example.service-now.com/api/now/table/sys_user_group/sysdomain","value":"sysdomain"},"fqdn":"fqdntest","hardware_status":"installed","install_status":"1","name":"TEST NAME","subcategory":"Computer","u_restricted_access":"false","sys_id":"375a6a55dbdef7002e12ff00ba9619d6","sys_class_path":"/!!/!G/!!/!$","mac_address":"234324234342","u_automated_patching":"false","sys_mod_count":"0","monitor":"false","ip_address":"10.0.0.1","model_id":{"link":"https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949","value":"59d4c676db0fc700553363835b961949"},"cost_cc":"USD","location":{"link":"https://example.service-now.com/api/now/table/cmn_location/US-East","value":"US-East"},"category":"Hardware","fault_count":"0"}|
-
-Example output:
-
-```
-{
-  "servicenow_ci": {
-    "firewall_status": "Intranet",
-    "operational_status": "1",
-    "sys_updated_on": "2019-06-26 20:45:21",
-    "first_discovered": "2018-05-14 18:07:23",
-    "used_for": "Production",
-    "sys_created_by": "admin",
-    "classification": "Production",
-    "can_print": "false",
-    "last_discovered": "2019-03-24 11:25:56",
-    "sys_class_name": "cmdb_ci_server",
-    "asset": {
-      "link": "https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6",
-      "value": "ff5a6a55dbdef7002e12ff00ba9619d6"
-    },
-    "sys_updated_by": "admin",
-    "sys_created_on": "2019-06-26 20:45:21",
-    "sys_domain": {
-      "link": "https://example.service-now.com/api/now/table/sys_user_group/sysdomain",
-      "value": "sysdomain"
-    },
-    "fqdn": "fqdntest",
-    "hardware_status": "installed",
-    "install_status": "1",
-    "name": "TEST NAME",
-    "subcategory": "Computer",
-    "u_restricted_access": "false",
-    "sys_id": "375a6a55dbdef7002e12ff00ba9619d6",
-    "sys_class_path": "/!!/!G/!!/!$",
-    "mac_address": "234324234342",
-    "u_automated_patching": "false",
-    "sys_mod_count": "0",
-    "monitor": "false",
-    "ip_address": "10.0.0.1",
-    "model_id": {
-      "link": "https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949",
-      "value": "59d4c676db0fc700553363835b961949"
-    },
-    "cost_cc": "USD",
-    "location": {
-      "link": "https://example.service-now.com/api/now/table/cmn_location/US-East",
-      "value": "US-East"
-    },
-    "category": "Hardware",
-    "fault_count": "0"
-  }
-}
-```
-
-#### Get Incident Attachment
-
-This action is used to download the Base64-encoded contents of the given attachment.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|attachment_id|string|None|True|System ID of the attachment to copy|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "attachment_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|attachment_contents|bytes|True|The Base64-encoded contents of the downloaded attachment|[base-64 contents]|
-
-Example output:
-
-```
-{
-  "attachment_contents": "[base-64 contents]"
-}
-```
-
-#### Put Incident Attachment
-
-This action is used to associate a file with a ServiceNow Incident.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|attachment_name|string|None|True|Name of the attachment in the ServiceNow instance|None|Example name|
-|base64_content|bytes|None|True|Content of the attachment, encoded into Base64|None|UmFwaWQ3IEluc2lnaHRDb25uZWN0Cg==|
-|mime_type|string|None|True|MIME type (a.k.a. content type) of the file to be attached|['text/plain (.txt)', 'text/html (.html)', 'application/rtf (.rtf)', 'application/pdf (.pdf)', 'application/msword (.doc)', 'application/vnd.ms-powerpoint (.ppt)', 'image/bmp (.bmp)', 'image/gif (.gif)', 'image/jpeg (.jpg)', 'image/png (.png)', 'image/tiff (.tiff)', 'OTHER']|text/plain (.txt)|
-|other_mime_type|string|None|False|User-specified MIME type not in the enumerated list|None|.avi|
-|system_id|string|None|True|System ID of the Incident record to which the file will be attached|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "attachment_name": "Example name",
-  "base64_content": "UmFwaWQ3IEluc2lnaHRDb25uZWN0Cg==",
-  "mime_type": "text/plain (.txt)",
-  "other_mime_type": ".avi",
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|attachment_id|string|True|System ID of the newly created attachment|b5b24a5ddb1ebf00a7e99b3c8a96197d|
-
-Example output:
-
-```
-{
-  "attachment_id": "b5b24a5ddb1ebf00a7e99b3c8a96197d"
-}
-```
-
-#### Read Incident
-
-This action is used to populate a JSON object with the specified fields of the given Incident.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|filtering_fields|string|None|True|Comma-separated list of fields desired in output object (e.g. opened_by,number)|None|opened_by,number|
-|system_id|string|None|True|System ID of the Incident record from which to read|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "filtering_fields": "opened_by,number",
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|filtered_incident|object|True|JSON object representing the incident containing the given fields|{"short_description":"Short description test","description":"Description test"}|
-
-Example output:
-
-```
-{
-  "filtered_incident": {
-    "short_description": "Short description test",
-    "description": "Description test"
-  }
-}
-```
-
-#### Search CI
-
-This action is used to retrieve CI record(s) from ServiceNow based on the provided query.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|query|string|None|True|Non-encoded query string for retrieving ServiceNow CI record(s) (e.g. number=INC0000055^ORshort_description=New bug)|None|number=INC0000055^ORshort_description=New bug|
-|table|string|None|True|The ServiceNow table to execute the query against|None|catalog_category_request|
-
-Example input:
-
-```
-{
-  "query": "number=INC0000055^ORshort_description=New bug",
-  "table": "catalog_category_request"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|servicenow_cis|[]object|True|List of JSON objects representing the CI record(s) returned by the query|[{"firewall_status":"Intranet","operational_status":"1","sys_updated_on":"2019-06-26 20:45:21","first_discovered":"2018-05-14 18:07:23","used_for":"Production","sys_created_by":"admin","classification":"Production","can_print":"false","last_discovered":"2019-03-24 11:25:56","sys_class_name":"cmdb_ci_server","cd_rom":"false","unverified":"false","asset":{"link":"https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6","value":"ff5a6a55dbdef7002e12ff00ba9619d6"},"skip_sync":"false","sys_updated_by":"admin","sys_created_on":"2019-06-26 20:45:21","sys_domain":{"link":"https://example.service-now.com/api/now/table/sys_user_group/sysdomain","value":"sysdomain"},"fqdn":"fqdntest","hardware_status":"installed","install_status":"1","name":"TEST NAME","subcategory":"Computer","u_restricted_access":"false","virtual":"false","sys_id":"375a6a55dbdef7002e12ff00ba9619d6","sys_class_path":"/!!/!G/!!/!$","mac_address":"234324234342","u_automated_patching":"false","sys_mod_count":"0","monitor":"false","ip_address":"10.0.0.1","model_id":{"link":"https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949","value":"59d4c676db0fc700553363835b961949"},"cost_cc":"USD","location":{"link":"https://example.service-now.com/api/now/table/cmn_location/US-East","value":"US-East"},"category":"Hardware","fault_count":"0"}]|
-
-Example output:
-
-```
-{
-  "servicenow_cis": [
-    {
-      "firewall_status": "Intranet",
-      "operational_status": "1",
-      "sys_updated_on": "2019-06-26 20:45:21",
-      "first_discovered": "2018-05-14 18:07:23",
-      "used_for": "Production",
-      "sys_created_by": "admin",
-      "classification": "Production",
-      "can_print": "false",
-      "last_discovered": "2019-03-24 11:25:56",
-      "sys_class_name": "cmdb_ci_server",
-      "cd_rom": "false",
-      "unverified": "false",
-      "asset": {
-        "link": "https://example.service-now.com/api/now/table/alm_asset/ff5a6a55dbdef7002e12ff00ba9619d6",
-        "value": "ff5a6a55dbdef7002e12ff00ba9619d6"
-      },
-      "skip_sync": "false",
-      "sys_updated_by": "admin",
-      "sys_created_on": "2019-06-26 20:45:21",
-      "sys_domain": {
-        "link": "https://example.service-now.com/api/now/table/sys_user_group/sysdomain",
-        "value": "sysdomain"
-      },
-      "fqdn": "fqdntest",
-      "hardware_status": "installed",
-      "install_status": "1",
-      "name": "TEST NAME",
-      "subcategory": "Computer",
-      "u_restricted_access": "false",
-      "virtual": "false",
-      "sys_id": "375a6a55dbdef7002e12ff00ba9619d6",
-      "sys_class_path": "/!!/!G/!!/!$",
-      "mac_address": "234324234342",
-      "u_automated_patching": "false",
-      "sys_mod_count": "0",
-      "monitor": "false",
-      "ip_address": "10.0.0.1",
-      "model_id": {
-        "link": "https://example.service-now.com/api/now/table/cmdb_model/59d4c676db0fc700553363835b961949",
-        "value": "59d4c676db0fc700553363835b961949"
-      },
-      "cost_cc": "USD",
-      "location": {
-        "link": "https://example.service-now.com/api/now/table/cmn_location/US-East",
-        "value": "US-East"
-      },
-      "category": "Hardware",
-      "fault_count": "0"
-    }
-  ]
-}
-```
-
-#### Search Incident
-
-This action is used to search for Incidents satisfying the given query.
-
-For more information about the **query** input, please refer to [InsightConnect ServiceNow Query Syntax documentation](http://docs.rapid7.com/insightconnect/servicenow#query-syntax).
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|query|string|None|True|Non-encoded query string (e.g. number=INC0000055^ORshort_description=New bug)|None|number=INC0000055^ORshort_description=Newbug|
-
-Example input:
-
-```
-{
-  "query": "number=INC0000055^ORshort_description=Newbug"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|system_ids|[]string|True|List of System IDs of Incidents satisfying the given query|["b5aadf6cdb16b7002e12ff00ba96193c","90db5f20db967f00a7e99b3c8a96190c","28869809db12bf00a7e99b3c8a9619de","e5a14141db92f7002e12ff00ba961962","38aa01d9dbdaf7002e12ff00ba96196a","daa10e5ddb5ef7002e12ff00ba9619db"]|
-
-Example output:
-
-```
-{
-  "system_ids": [
-    "b5aadf6cdb16b7002e12ff00ba96193c",
-    "90db5f20db967f00a7e99b3c8a96190c",
-    "28869809db12bf00a7e99b3c8a9619de",
-    "e5a14141db92f7002e12ff00ba961962",
-    "38aa01d9dbdaf7002e12ff00ba96196a",
-    "daa10e5ddb5ef7002e12ff00ba9619db"
-  ]
-}
-```
-
-#### Search Incident Attachment
-
-This action is used to search for attachment files with the given name.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|name|string|None|True|Name of the attachment, i.e. the base file name used to create it|None|Example name|
-
-Example input:
-
-```
-{
-  "name": "Example name"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|attachment_ids|[]string|True|List of System IDs of attachment records with the given name|["7bbbc15ddbdaf7002e12ff00ba96196c","b5b24a5ddb1ebf00a7e99b3c8a96197d","46c14941db92bf00a7e99b3c8a9619b6"]|
-
-Example output:
-
-```
-{
-  "attachment_ids": [
-    "7bbbc15ddbdaf7002e12ff00ba96196c",
-    "b5b24a5ddb1ebf00a7e99b3c8a96197d",
-    "46c14941db92bf00a7e99b3c8a9619b6"
-  ]
-}
 ```
 
 #### Update CI
-
+  
 This action is used to update an existing ServiceNow CI record.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |system_id|string|None|True|System ID of the CI record to update|None|9de5069c5afe602b2ea0a04b66beb2c0|
 |table|string|None|True|The ServiceNow table where the CI record will be updated|None|catalog_category_request|
 |update_data|object|None|True|JSON object containing the fields and values to perform a CI update|None|{"Description": "Bug report", "ID": "58"}|
-
+  
 Example input:
 
 ```
@@ -1312,9 +1257,9 @@ Example input:
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
+| :--- | :--- | :--- | :--- | :--- |
 |success|boolean|True|True if the update was successful|True|
-
+  
 Example output:
 
 ```
@@ -1324,13 +1269,13 @@ Example output:
 ```
 
 #### Update Incident
-
+  
 This action is used to update a ServiceNow Incident with the given data.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |additional_fields|object|None|False|JSON object containing the additional fields and values to update incident|None|{"description": "incident description"}|
 |assigned_to|string|None|False|User ID of person assigned to the incident|None|user|
 |assignment_group|string|None|False|Assignment group name of the incident|None|Recommendation Admin|
@@ -1347,7 +1292,7 @@ This action is used to update a ServiceNow Incident with the given data.
 |subcategory|string|None|False|Subcategory code of incident (available values depends on the `Category` field)|None|monitor|
 |system_id|string|None|True|System ID of the Incident record to update|None|ee7e6b24dbf4e450e9faa5730596192b|
 |urgency|string|None|False|Urgency of the incident|None|Medium|
-
+  
 Example input:
 
 ```
@@ -1376,9 +1321,9 @@ Example input:
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
+| :--- | :--- | :--- | :--- | :--- |
 |success|boolean|True|True if the update was successful|True|
-
+  
 Example output:
 
 ```
@@ -1387,85 +1332,221 @@ Example output:
 }
 ```
 
-#### Get Incident Comments and Work Notes
-
-This action is used to get comments and work notes for an incident.
+#### Update Security Incident
+  
+This action is used to update an existing security incident.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|system_id|string|None|True|System ID of Incident record for which comments and work notes will be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|type|string|None|True|Type of output to be retrieved|['all', 'comments', 'work notes']|all|
-
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|additional_fields|object|None|False|JSON object containing the additional fields and values to update security incident|None|{"risk_score": 40, "risk_score_override": true, "parent_security_incident": "SIR0010010"}|
+|affected_user|string|None|False|The user ID, email or system ID of the user related to this security incident|None|jsmith|
+|assigned_to|string|None|False|The name, user ID, email or system id of the person primarily responsible for working this task|None|test_user|
+|assignment_group|string|None|False|The name or system id of the assignment group|None|Example Group|
+|caller|string|None|False|The user ID, email or system ID of the person requesting the work to be done|None|user@example.com|
+|category|string|None|False|The code of the security incident category|None|malware|
+|close_code|string|None|False|The code of the incident closure reason|None|Not resolved|
+|close_notes|string|None|False|Incident closure notes|None|Example notes|
+|cmdb_ci|string|None|False|The name or system ID of the configuration item|None|Example CI|
+|contact_type|string|None|False|The code of the security incident source|None|email|
+|description|string|None|False|Description of the security incident|None|Full description|
+|location|string|None|False|The name or system ID of the location|None|Example location|
+|priority|integer|None|False|The code of the priority in which an Incident needs to be resolved, based on impact and urgency|None|3|
+|short_description|string|None|False|Short description of the security incident|None|Example description|
+|state|integer|None|False|The code of the security incident state|None|18|
+|subcategory|string|None|False|The code of the security incident subcategory (available values depends on the `Category` field)|None|ransomware|
+|substate|integer|None|False|The code of the security incident substate|None|2|
+|sys_id|string|None|True|The system ID of the security incident to be updated|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
 Example input:
 
 ```
 {
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "type": "all"
+  "additional_fields": {
+    "parent_security_incident": "SIR0010010",
+    "risk_score": 40,
+    "risk_score_override": true
+  },
+  "affected_user": "jsmith",
+  "assigned_to": "test_user",
+  "assignment_group": "Example Group",
+  "caller": "user@example.com",
+  "category": "malware",
+  "close_code": "Not resolved",
+  "close_notes": "Example notes",
+  "cmdb_ci": "Example CI",
+  "contact_type": "email",
+  "description": "Full description",
+  "location": "Example location",
+  "priority": 3,
+  "short_description": "Example description",
+  "state": 18,
+  "subcategory": "ransomware",
+  "substate": 2,
+  "sys_id": "9de5069c5afe602b2ea0a04b66beb2c0"
 }
 ```
 
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|incident_comments_worknotes|[]comments_worknotes|True|List of comments and work notes for an incident|[{"sys_id":"2c6420c31b0000506a4a85507e4bcb82","sys_created_on":"2019-09-26 21:19:11","name":"incident","element_id":"965f140bdb4c8c105f6f00b5ca961922","sys_tags":"","value":"Team is actively looking into it.","sys_created_by":"admin","element":"work_notes"},{"sys_id":"4db0e8cb1bcccc106a4a85507e4bcba2","sys_created_on":"2019-09-26 21:03:07","name":"incident","element_id":"965f140bdb4c8c105f6f00b5ca961922","sys_tags":"","value":"This is Sev1 incident.","sys_created_by":"admin","element":"comments"},{"sys_id":"f92024471b0000506a4a85507e4bcb78","sys_created_on":"2019-09-26 21:00:43","name":"incident","element_id":"965f140bdb4c8c105f6f00b5ca961922","sys_tags":"","value":"Testing comments","sys_created_by":"admin","element":"comments"}]|
-
+| :--- | :--- | :--- | :--- | :--- |
+|number|string|False|Number of the security incident|SIR0010044|
+|system_id|string|False|System ID of the security incident|9de5069c5afe602b2ea0a04b66beb2c0|
+  
 Example output:
 
 ```
 {
-  "incident_comments_worknotes": [
-    {
-      "sys_id": "2c6420c31b0000506a4a85507e4bcb82",
-      "sys_created_on": "2019-09-26 21:19:11",
-      "name": "incident",
-      "element_id": "965f140bdb4c8c105f6f00b5ca961922",
-      "sys_tags": "",
-      "value": "Team is actively looking into it.",
-      "sys_created_by": "admin",
-      "element": "work_notes"
-    },
-    {
-      "sys_id": "4db0e8cb1bcccc106a4a85507e4bcba2",
-      "sys_created_on": "2019-09-26 21:03:07",
-      "name": "incident",
-      "element_id": "965f140bdb4c8c105f6f00b5ca961922",
-      "sys_tags": "",
-      "value": "This is Sev1 incident.",
-      "sys_created_by": "admin",
-      "element": "comments"
-    },
-    {
-      "sys_id": "f92024471b0000506a4a85507e4bcb78",
-      "sys_created_on": "2019-09-26 21:00:43",
-      "name": "incident",
-      "element_id": "965f140bdb4c8c105f6f00b5ca961922",
-      "sys_tags": "",
-      "value": "Testing comments",
-      "sys_created_by": "admin",
-      "element": "comments"
-    }
-  ]
+  "number": "SIR0010044",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
 }
 ```
 
-### Triggers
-
-#### Vulnerability Updated
-
-This trigger identifies if a vulnerability has been updated.
+#### Update Vulnerability
+  
+This action is used to update the vulnerability by ID.
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|additional_fields|object|None|False|JSON object containing the additional fields and values to update the vulnerability item|None|{"description": "Example description"}|
+|assigned_to|string|None|False|User ID of person assigned to the vulnerability|None|ExampleUserID|
+|dns|string|None|False|The name of the source DNS where the vulnerability was found|None|dns.example.com|
+|first_found|date|None|False|The time that represents the vulnerability was first found, in ISO format|None|2023-04-28 15:48:07|
+|ip_address|string|None|False|The IP address of the source where the vulnerability was found|None|192.168.0.1|
+|last_found|date|None|False|The time that represents when the vulnerability was last found, in ISO format|None|2023-04-30 12:14:10|
+|short_description|string|None|False|Short description of the vulnerability|None|Example short description|
+|source|string|None|False|The vulnerability source|None|ExampleSource|
+|state|string|None|False|The state of the vulnerability|['', 'Open', 'Under Investigation']|Open|
+|system_id|string|None|True|System ID of the vulnerability to be retrieved|None|9de5069c5afe602b2ea0a04b66beb2c0|
+|vulnerability|string|None|False|The reference of the found vulnerability|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "additional_fields": {
+    "description": "Example description"
+  },
+  "assigned_to": "ExampleUserID",
+  "dns": "dns.example.com",
+  "first_found": "2023-04-28 15:48:07",
+  "ip_address": "192.168.0.1",
+  "last_found": "2023-04-30 12:14:10",
+  "short_description": "Example short description",
+  "source": "ExampleSource",
+  "state": "Open",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
+  "vulnerability": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|success|boolean|True|True if the update was successful, false otherwise|True|
+  
+Example output:
+
+```
+{
+  "success": true
+}
+```
+### Triggers
+
+
+#### Incident Changed
+  
+This action is used to reports changes of the given fields in the given Incident.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|interval|integer|5|False|How often to detect changes to the given Incident (in minutes)|None|5|
+|monitored_fields|string|None|True|Comma-separated list of fields to be monitored (e.g. resolved,resolved_by)|None|resolved,resolved_by|
+|system_id|string|None|True|System ID of the Incident record to monitor|None|9de5069c5afe602b2ea0a04b66beb2c0|
+  
+Example input:
+
+```
+{
+  "interval": 5,
+  "monitored_fields": "resolved,resolved_by",
+  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|changed_fields|object|True|JSON object representing changed fields (map of field name to previous and current values)|{"description":{"previous":"Description 1","current":"Description 2"}}|
+  
+Example output:
+
+```
+{
+  "changed_fields": {
+    "description": {
+      "current": "Description 2",
+      "previous": "Description 1"
+    }
+  }
+}
+```
+
+#### Incident Created
+  
+This action is used to identifies if a new incident has been created.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|frequency|integer|5|True|How often to poll for new incidents (in seconds)|None|5|
+|query|string|None|False|Non-encoded query string to match new incident records (will poll for any new incident if query is omitted)|None|short_description=Newbug|
+  
+Example input:
+
+```
+{
+  "frequency": 5,
+  "query": "short_description=Newbug"
+}
+```
+
+##### Output
+
+|Name|Type|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- |
+|system_id|string|True|System ID of new incident|280b3cb71b9f1450c9768622dd4bcb32|
+  
+Example output:
+
+```
+{
+  "system_id": "280b3cb71b9f1450c9768622dd4bcb32"
+}
+```
+
+#### Vulnerability Updated
+  
+This action is used to identifies if a vulnerability has been updated.
+
+##### Input
+
+|Name|Type|Default|Required|Description|Enum|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |interval|integer|5|True|How often to detect changes to the given Incident (in seconds)|None|5|
 |monitored_fields|string|None|True|Comma-separated list of fields to be monitored (e.g. resolved,resolved_by)|None|resolved,resolved_by|
 |system_ids|[]string|None|True|List of system IDs of the vulnerability record to monitor|None|["9de5069c5afe602b2ea0a04b66beb2c0"]|
-
+  
 Example input:
 
 ```
@@ -1481,205 +1562,126 @@ Example input:
 ##### Output
 
 |Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
+| :--- | :--- | :--- | :--- | :--- |
 |updated_vulnerabilities|[]updated_vulnerability|True|List of JSON objects containing the system ID of the updated vulnerability and representation of the changed fields (map of field name from previous to current values)|{"updated_vulnerabilities": [{"system_id": "9de5069c5afe602b2ea0a04b66beb2c0", "changed_fields": {"description":{"previous":"Description 1","current":"Description 2"}}}]}|
-
+  
 Example output:
 
 ```
 {
-  "updated_vulnerabilities": [
-    {
-      "system_id": "9de5069c5afe602b2ea0a04b66beb2c0",
-      "changed_fields": {
-        "description": {
-          "previous": "Description 1",
-          "current": "Description 2"
-        }
+  "updated_vulnerabilities": {
+    "updated_vulnerabilities": [
+      {
+        "changed_fields": {
+          "description": {
+            "current": "Description 2",
+            "previous": "Description 1"
+          }
+        },
+        "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
       }
-    }
-  ]
-}
-```
-
-#### Incident Created
-
-This trigger identifies if a new incident has been created.
-
-For more information about the **query** input, please refer to [InsightConnect ServiceNow Query Syntax documentation](http://docs.rapid7.com/insightconnect/servicenow#query-syntax).
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|frequency|integer|5|True|How often to poll for new incidents (in seconds)|None|5|
-|query|string|None|False|Non-encoded query string to match new incident records (will poll for any new incident if query is omitted)|None|short_description=Newbug|
-
-Example input:
-
-```
-{
-  "frequency": 5,
-  "query": "short_description=Newbug"
-}
-```
-
-Example input (advanced query):
-```
-{
-  "frequency": 10,
-  "query": "short_description='Description with quotes'^active=true^priority=5"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|system_id|string|True|System ID of new incident|280b3cb71b9f1450c9768622dd4bcb32|
-
-Example output:
-
-```
-{
-  "system_id": "280b3cb71b9f1450c9768622dd4bcb32"
-}
-```
-
-#### Incident Changed
-
-This trigger reports changes of the given fields in the given Incident.
-
-##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|
-|----|----|-------|--------|-----------|----|-------|
-|interval|integer|5|False|How often to detect changes to the given Incident (in minutes)|None|5|
-|monitored_fields|string|None|True|Comma-separated list of fields to be monitored (e.g. resolved,resolved_by)|None|resolved,resolved_by|
-|system_id|string|None|True|System ID of the Incident record to monitor|None|9de5069c5afe602b2ea0a04b66beb2c0|
-
-Example input:
-
-```
-{
-  "interval": 5,
-  "monitored_fields": "resolved,resolved_by",
-  "system_id": "9de5069c5afe602b2ea0a04b66beb2c0"
-}
-```
-
-##### Output
-
-|Name|Type|Required|Description|Example|
-|----|----|--------|-----------|-------|
-|changed_fields|object|True|JSON object representing changed fields (map of field name to previous and current values)|{"description":{"previous":"Description 1","current":"Description 2"}}|
-
-Example output:
-
-```
-{
-  "changed_fields": {
-    "description": {
-      "previous": "Description 1",
-      "current": "Description 2"
-    }
+    ]
   }
 }
 ```
+### Tasks
+  
+*This plugin does not contain any tasks.*
 
-### Custom Output Types
+### Custom Types
+  
+**updated_vulnerability**
 
-#### attachment_file
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Changed Fields|object|None|True|JSON object representing changed fields (map of field name to previous and current values)|None|
+|System ID|string|None|True|System ID of the vulnerability|None|
+  
+**comments_worknotes**
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|Content|string|False|File content encoded with base64|
-|Content Type|string|False|Content type|
-|File Name|string|False|File name|
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Element|string|None|True|Either 'comments' or 'work_notes'|None|
+|Element ID|string|None|True|System ID of an incident|None|
+|Name|string|None|True|Type of record|None|
+|Created By|string|None|True|User who added the comment|None|
+|Creation date|string|None|True|Comment or work notes creation date|None|
+|System ID|string|None|True|System ID of comment or worknotes|None|
+|System Tags|string|None|True|System tags|None|
+|Value|string|None|True|Value of comment or worknotes|None|
+  
+**attachment_file**
 
-#### comments_worknotes
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Content|string|None|False|File content encoded with base64|None|
+|Content Type|string|None|False|Content type|None|
+|File Name|string|None|False|File name|None|
+  
+**link_value**
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|Element|string|True|Either 'comments' or 'work_notes'|
-|Element ID|string|True|System ID of an incident|
-|Name|string|True|Type of record|
-|Created By|string|True|User who added the comment|
-|Creation date|string|True|Comment or work notes creation date|
-|System ID|string|True|System ID of comment or worknotes|
-|System Tags|string|True|System tags|
-|Value|string|True|Value of comment or worknotes|
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Link|string|None|False|Link to the resource|None|
+|Value|string|None|False|Identifier of the resource|None|
+  
+**security_incident**
 
-#### link_value
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Active|boolean|None|False|Whether the security incident is active|None|
+|Activity Due|string|None|False|Date by which the Inactivity Monitor expects the task to be updated|None|
+|Affected User|link_value|None|False|The user related to this security incident|None|
+|Alert ID|string|None|False|The identifier of the alert|None|
+|Alert Rule|string|None|False|The rule of the alert|None|
+|Assigned To|link_value|None|False|Person primarily responsible for working this task|None|
+|Assignment Group|link_value|None|False|Group responsible for working this task|None|
+|Business Impact|integer|None|False|The business impact of this incident|None|
+|Requested By|link_value|None|False|Person requesting the work to be done. Determines suggested Location if no Affected CI is defined|None|
+|Category|string|None|False|Category of the incident|None|
+|Change Request|link_value|None|False|The change request related to this security incident|None|
+|Close Code|integer|None|False|Code indicating why the incident is being closed|None|
+|Close Notes|string|None|False|Notes explaining why the incident is being closed|None|
+|Closed At|string|None|False|Time when the security incident was closed|None|
+|Closed By|link_value|None|False|The person who closed the security incident|None|
+|Configuration Item|link_value|None|False|Item or service affected|None|
+|Source|string|None|False|Source of the security incident|None|
+|Description|string|None|False|Description of the security incident|None|
+|Incident|link_value|None|False|The incident related to this security incident|None|
+|Location|link_value|None|False|Where the caller or service is located|None|
+|Number|string|None|False|Identification number of the security incident|None|
+|Opened At|string|None|False|Time when the security incident was opened|None|
+|Opened By|link_value|None|False|The person who opened the security incident|None|
+|Opened For|link_value|None|False|Person this request was opened for|None|
+|Parent|link_value|None|False|The parent of this security incident|None|
+|Parent Security Incident|link_value|None|False|The parent security incident to this security incident|None|
+|Priority|integer|None|False|Sequence in which the security incident needs to be resolved, based on impact and urgency|None|
+|Problem|link_value|None|False|The problem related to this security incident|None|
+|Risk Score|integer|None|False|Score of the risk|None|
+|Risk Score Override|boolean|None|False|When checked, risk score will not be updated automatically|None|
+|Secure Notes|string|None|False|Encrypted note of the security incident|None|
+|Security Tags|string|None|False|Security tags applied to this security incident|None|
+|Short Description|string|None|False|Short description of the security incident|None|
+|Special Access Write|string|None|False|Users in the 'Privileged access' list will be able to see the Security Incident, data related to it and edit all data fields on it|None|
+|State|integer|None|False|State of the security incident|None|
+|Subcategory|string|None|False|Subcategory of the security incident|None|
+|Substate|integer|None|False|Substate of the security incident|None|
+|System Created By|string|None|False|Person this security incident was created by|None|
+|System Created On|string|None|False|Time when the security incident was created|None|
+|System ID|string|None|False|The unique system ID of the security incident|None|
+|System Updated By|string|None|False|Person this security incident was updated by|None|
+|System Updated On|string|None|False|Time when the security incident was updated|None|
+|Watch List|string|None|False|List of users that are interested on the security incident|None|
+|Work Notes List|string|None|False|Users interested in work notes|None|
 
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|Link|string|False|Link to the resource|
-|Value|string|False|Identifier of the resource|
-
-#### security_incident
-
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|Active|boolean|False|Whether the security incident is active|
-|Activity Due|string|False|Date by which the Inactivity Monitor expects the task to be updated|
-|Affected User|link_value|False|The user related to this security incident|
-|Alert ID|string|False|The identifier of the alert|
-|Alert Rule|string|False|The rule of the alert|
-|Assigned To|link_value|False|Person primarily responsible for working this task|
-|Assignment Group|link_value|False|Group responsible for working this task|
-|Business Criticality|integer|False|The code of the business impact of this incident|
-|Business Impact|integer|False|The business impact of this incident|
-|Requested By|link_value|False|Person requesting the work to be done. Determines suggested Location if no Affected CI is defined|
-|Category|string|False|Category of the incident|
-|Change Request|link_value|False|The change request related to this security incident|
-|Close Code|integer|False|Code indicating why the incident is being closed|
-|Close Notes|string|False|Notes explaining why the incident is being closed|
-|Closed At|string|False|Time when the security incident was closed|
-|Closed By|link_value|False|The person who closed the security incident|
-|Configuration Item|link_value|False|Item or service affected|
-|Source|string|False|Source of the security incident|
-|Description|string|False|Description of the security incident|
-|Incident|link_value|False|The incident related to this security incident|
-|Location|link_value|False|Where the caller or service is located|
-|Number|string|False|Identification number of the security incident|
-|Opened At|string|False|Time when the security incident was opened|
-|Opened By|link_value|False|The person who opened the security incident|
-|Opened For|link_value|False|Person this request was opened for|
-|Parent|link_value|False|The parent of this security incident|
-|Parent Security Incident|link_value|False|The parent security incident to this security incident|
-|Priority|integer|False|Sequence in which the security incident needs to be resolved, based on impact and urgency|
-|Problem|link_value|False|The problem related to this security incident|
-|Risk Score|integer|False|Score of the risk|
-|Risk Score Override|boolean|False|When checked, risk score will not be updated automatically|
-|Secure Notes|string|False|Encrypted note of the security incident|
-|Security Tags|string|False|Security tags applied to this security incident|
-|Short Description|string|False|Short description of the security incident|
-|Special Access Write|string|False|Users in the 'Privileged access' list will be able to see the Security Incident, data related to it and edit all data fields on it|
-|State|integer|False|State of the security incident|
-|Subcategory|string|False|Subcategory of the security incident|
-|Substate|integer|False|Substate of the security incident|
-|System Created By|string|False|Person this security incident was created by|
-|System Created On|string|False|Time when the security incident was created|
-|System ID|string|False|The unique system ID of the security incident|
-|System Updated By|string|False|Person this security incident was updated by|
-|System Updated On|string|False|Time when the security incident was updated|
-|Watch List|string|False|List of users that are interested on the security incident|
-|Work Notes List|string|False|Users interested in work notes|
-
-#### updated_vulnerability
-
-|Name|Type|Required|Description|
-|----|----|--------|-----------|
-|Changed Fields|object|True|JSON object representing changed fields (map of field name to previous and current values)|
-|System ID|string|True|System ID of the vulnerability|
 
 ## Troubleshooting
-
-_This plugin does not contain any troubleshooting information._
+  
+*There is no troubleshooting for this plugin.*
 
 # Version History
 
+* 7.4.0 - Add ability to use OAuth for API authentication (requires OAuth Client ID and OAuth Client Secret in connection)
 * 7.3.1 - `Incident Created`: Resolved issue related to object parsing
 * 7.3.0 - Add new actions Create Security Incident, Update Security Incident, Delete Security Incident, Get Security Incident and Search Security Incident
 * 7.2.0 - Added new actions: Create Vulnerability, Get Vulnerability, Update Vulnerability, Delete Vulnerability | Added new trigger: Vulnerability Updated

--- a/plugins/servicenow/icon_servicenow/actions/get_incident_comments_worknotes/schema.py
+++ b/plugins/servicenow/icon_servicenow/actions/get_incident_comments_worknotes/schema.py
@@ -125,16 +125,16 @@ class GetIncidentCommentsWorknotesOutput(insightconnect_plugin_runtime.Output):
           "order": 8
         }
       },
-    "required": [
-      "element",
-      "element_id",
-      "name",
-      "sys_created_by",
-      "sys_created_on",
-      "sys_id",
-      "sys_tags",
-      "value"
-    ]
+      "required": [
+        "element",
+        "element_id",
+        "name",
+        "sys_created_by",
+        "sys_created_on",
+        "sys_id",
+        "sys_tags",
+        "value"
+      ]
     }
   }
 }

--- a/plugins/servicenow/icon_servicenow/connection/connection.py
+++ b/plugins/servicenow/icon_servicenow/connection/connection.py
@@ -4,7 +4,7 @@ from .schema import ConnectionSchema, Input
 # Custom imports below
 import requests
 from requests.auth import HTTPBasicAuth
-from icon_servicenow.util.request_helper import RequestHelper
+from icon_servicenow.util.request_helper import RequestHelper, AuthenticationType
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
 
 
@@ -26,10 +26,29 @@ class Connection(insightconnect_plugin_runtime.Connection):
         username = params[Input.CLIENT_LOGIN].get("username", "")
         password = params[Input.CLIENT_LOGIN].get("password", "")
 
-        self.session = requests.Session()
-        self.session.auth = HTTPBasicAuth(username, password)
-        self.request = RequestHelper(self.session, self.logger)
+        oauth_client_id = params.get(Input.CLIENT_ID)
+        oauth_client_secret = params[Input.CLIENT_SECRET].get("secretKey")
 
+        if not oauth_client_id or not oauth_client_secret:
+            self.logger.info(
+                "Either client ID or client secret (or both) were not provided, using basic authentication"
+            )
+            authentication_type = AuthenticationType.basic
+        else:
+            self.logger.info("Client ID and secret were provided, using OAuth for API authentication")
+            authentication_type = AuthenticationType.oauth
+
+        self.request = RequestHelper(
+            username=username,
+            password=password,
+            client_id=oauth_client_id,
+            client_secret=oauth_client_secret,
+            auth_type=authentication_type,
+            base_url=self.base_url,
+            logger=self.logger,
+        )
+
+        self.oauth_url = f"{self.base_url}oauth_token.do"
         self.table_url = f"{self.base_url}{api_route}table/"
         self.incident_url = f"{self.table_url}{incident_table}"
         self.security_incident_url = f"{self.table_url}{security_incident_table}"
@@ -44,8 +63,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         query = {"sysparm_limit": 1}
         method = "get"
 
-        request = RequestHelper(self.session, self.logger)
-        response = request.make_request(url, method, params=query)
+        response = self.request.make_request(url, method, params=query)
 
         if response.get("status", 0) in range(200, 299):
             return {"success": True}

--- a/plugins/servicenow/icon_servicenow/connection/connection.py
+++ b/plugins/servicenow/icon_servicenow/connection/connection.py
@@ -23,11 +23,11 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
         self.base_url = f"https://{params.get(Input.INSTANCE, '')}.service-now.com/"
 
-        username = params[Input.CLIENT_LOGIN].get("username", "")
-        password = params[Input.CLIENT_LOGIN].get("password", "")
+        username = params.get(Input.CLIENT_LOGIN, {}).get("username", "")
+        password = params.get(Input.CLIENT_LOGIN, {}).get("password", "")
 
         oauth_client_id = params.get(Input.CLIENT_ID)
-        oauth_client_secret = params[Input.CLIENT_SECRET].get("secretKey")
+        oauth_client_secret = params.get(Input.CLIENT_SECRET, {}).get("secretKey")
 
         if not oauth_client_id or not oauth_client_secret:
             self.logger.info(

--- a/plugins/servicenow/icon_servicenow/connection/schema.py
+++ b/plugins/servicenow/icon_servicenow/connection/schema.py
@@ -4,7 +4,9 @@ import json
 
 
 class Input:
+    CLIENT_ID = "client_id"
     CLIENT_LOGIN = "client_login"
+    CLIENT_SECRET = "client_secret"
     INSTANCE = "instance"
     TIMEOUT = "timeout"
 
@@ -15,11 +17,23 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "client_id": {
+      "type": "string",
+      "title": "OAuth Client ID",
+      "description": "Client ID for an application within your application registry",
+      "order": 3
+    },
     "client_login": {
       "$ref": "#/definitions/credential_username_password",
       "title": "Client Login Information",
       "description": "The ServiceNow username and password for basic authentication API interaction",
       "order": 2
+    },
+    "client_secret": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "OAuth Client Secret",
+      "description": "Client secret for an application within your application registry",
+      "order": 4
     },
     "instance": {
       "type": "string",
@@ -32,7 +46,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "title": "Timeout",
       "description": "The interval in seconds before abandoning an attempt to access ServiceNow",
       "default": 30,
-      "order": 3
+      "order": 5
     }
   },
   "required": [
@@ -65,6 +79,24 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
         "username",
         "password"
       ]
+    },
+    "credential_secret_key": {
+      "id": "credential_secret_key",
+      "type": "object",
+      "title": "Credential: Secret Key",
+      "description": "A shared secret key",
+      "required": [
+        "secretKey"
+      ],
+      "properties": {
+        "secretKey": {
+          "type": "string",
+          "title": "Secret Key",
+          "description": "The shared secret key",
+          "format": "password",
+          "displayType": "password"
+        }
+      }
     }
   }
 }

--- a/plugins/servicenow/icon_servicenow/triggers/incident_created/trigger.py
+++ b/plugins/servicenow/icon_servicenow/triggers/incident_created/trigger.py
@@ -31,9 +31,9 @@ class IncidentCreated(insightconnect_plugin_runtime.Trigger):
         incidents = [
             (result.get("sys_created_on"), result.get("sys_id"))
             for result in results
-            if result.get("sys_created_on") is not None
+            if isinstance(result, dict)
+            and result.get("sys_created_on") is not None
             and result.get("sys_id") is not None
-            and isinstance(result, dict)
         ]
 
         # Incidents stored from least to most recent date

--- a/plugins/servicenow/icon_servicenow/util/request_helper.py
+++ b/plugins/servicenow/icon_servicenow/util/request_helper.py
@@ -1,33 +1,82 @@
-import requests
-import json
-from insightconnect_plugin_runtime.exceptions import PluginException
 import base64
+from enum import Enum
+import json
+from logging import Logger
+from typing import Optional
+
+import requests
+from requests.auth import HTTPBasicAuth, AuthBase
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+
+class BearerAuth(AuthBase):
+    """
+    Authentication class for Bearer auth
+    """
+
+    def __init__(self, access_token: str):
+        self.access_token = access_token
+
+    def __call__(self, request: requests.Request) -> requests.Request:
+        request.headers["Authorization"] = f"Bearer {self.access_token}"
+        return request
+
+
+class AuthenticationType(Enum):
+    basic = "basic"
+    oauth = "oauth"
 
 
 class RequestHelper(object):
-    def __init__(self, session, logger):
+    def __init__(
+        self,
+        username: str,
+        password: str,
+        client_id: Optional[str],
+        client_secret: Optional[str],
+        auth_type: AuthenticationType,
+        base_url: str,
+        logger: Logger,
+    ):
         """
         Creates a new instance of RequestHelper
-        :param session: Session object available to Komand actions/triggers, usually self.connection.session
+        :param username: Username for ServiceNow
+        :param password: Password for ServiceNow
+        :param client_id: Client ID for OAuth app
+        :param client_secret: Client Secret for OAuth app
+        :param auth_type: Authentication type to use for requests
+        :param base_url: Base URL for API
         :param logger: Logger object available to Komand actions/triggers, usually self.logger
         :return: RequestHelper object
         """
-
+        self.username = username
+        self.password = password
+        self.client_id = client_id
+        self.client_secret = client_secret
+        self.auth_type = auth_type
+        self.base_url = base_url
         self.logger = logger
-        self.session = session
 
     def make_request(  # noqa: C901
         self, endpoint, method, payload=None, params=None, data=None, content_type="application/json"
     ):
         try:
-            request_method = getattr(self.session, method.lower())
+            request_method = getattr(requests, method.lower())
 
             headers = {"Content-Type": content_type, "Accept": "application/json"}
 
             if not params:
                 params = {}
+
+            if self.auth_type == AuthenticationType.basic:
+                auth_mechanism = HTTPBasicAuth(username=self.username, password=self.password)
+            else:
+                oauth_token = self._get_oauth_token()
+                auth_mechanism = BearerAuth(access_token=oauth_token)
+
             response = request_method(
-                url=endpoint, headers=headers, params=params, json=payload, data=data, verify=False
+                url=endpoint, headers=headers, params=params, json=payload, data=data, auth=auth_mechanism, verify=False
             )
         except requests.RequestException as error:
             self.logger.error(error)
@@ -78,3 +127,33 @@ class RequestHelper(object):
             raise PluginException(PluginException.Preset.UNKNOWN, data=resource)
 
         return str(base64.b64encode(result), "utf-8")
+
+    def _get_oauth_token(self) -> str:
+        response = requests.post(
+            url=f"{self.base_url}oauth_token.do",
+            data={
+                "grant_type": "password",
+                "client_id": self.client_id,
+                "client_secret": self.client_secret,
+                "username": self.username,
+                "password": self.password,
+            },
+            timeout=30,
+        )
+
+        if response.status_code != 200:
+            error_message = "unknown"
+            if response.status_code == 401:
+                error_message = response.json().get("error_description", "unauthorized")
+            raise PluginException(
+                cause=f"Error while trying to retrieve new OAuth token: {error_message}",
+                assistance="Ensure credentials and ServiceNow endpoint are correct.",
+            )
+        try:
+            access_token = response.json()["access_token"]
+        except KeyError:
+            raise PluginException(
+                cause="Access token was not present in OAuth token response!", assistance="API may have changed"
+            )
+
+        return access_token

--- a/plugins/servicenow/plugin.spec.yaml
+++ b/plugins/servicenow/plugin.spec.yaml
@@ -4,9 +4,9 @@ products: ["insightconnect"]
 name: servicenow
 title: ServiceNow
 description: ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes
-version: 7.3.1
+version: 7.4.0
 connection_version: 7
-supported_versions: ["2020-03-11 Orlando"]
+supported_versions: ["2023-10-28 Tokyo"]
 vendor: rapid7
 support: rapid7
 status: []
@@ -24,7 +24,7 @@ hub_tags:
   keywords: [servicenow, incidents, cmdb, cloud_enabled]
   features: []
 sdk:
-  type: full
+  type: slim
   version: 5
   user: nobody
 types:
@@ -342,6 +342,19 @@ connection:
     type: credential_username_password
     required: true
     example: '{"username":"user1", "password":"mypassword"}'
+  client_id:
+    title: OAuth Client ID
+    description: Client ID for an application within your application registry
+    type: string
+    required: false
+    example: ad0bc2109c2642106907050c2ca6ef0c
+  client_secret:
+    title: OAuth Client Secret
+    description: Client secret for an application within your application registry
+    type: credential_secret_key
+    required: false
+    example: ad0bc2109c2642106907050c2ca6ef0c
+
   timeout:
     title: Timeout
     description: The interval in seconds before abandoning an attempt to access ServiceNow
@@ -1124,7 +1137,7 @@ actions:
         description: Details of the security incident
         type: security_incident
         required: false
-        example: {}
+        example: '{"active":false,"activity_due":"2023-07-28 10:18:55","affected_user":{"link":"example.com/1234","value":"1234"},"alert_id":"dca801f11b1cb5506bf1ed78b04bcb5f","alert_rule":"test","alert_sensor":{"link":"example.com/1234","value":"1234"},"assigned_to":{"link":"example.com/1234","value":"1234"},"assignment_group":{"link":"example.com/1234","value":"1234"},"business_criticality":3,"caller":{"link":"example.com/1234","value":"1234"},"category":"Phishing","close_code":-100,"close_notes":"test close notes","closed_at":"2023-08-01 08:03:28","closed_by":{"link":"example.com/1234","value":"1234"},"cmdb_ci":{"link":"example.com/1234","value":"1234"},"contact_type":"phone","description":"example description","location":{"link":"example.com/1234","value":"1234"},"number":"SIR00000001","opened_at":"2023-07-28 10:18:55","opened_by":{"link":"example.com/1234","value":"1234"},"opened_for":{"link":"example.com/1234","value":"1234"},"priority":4,"risk_score":38,"risk_score_override":false,"secure_notes":"﷠﷡﷢56715c0aff1331007a6dffffffffff54﷌﷍CzXu70QS9L8TfvWt92rByQ==﷎﷏","security_tags":"dca801f11b1cb5506bf1ed78b04bcb5f","short_description":"test","special_access_write":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g","state":3,"subcategory":"25","substate":1,"sys_created_by":"user","sys_created_on":"2023-07-28 10:18:55","sys_id":"g123456","sys_updated_by":"user","sys_updated_on":"2023-08-01 08:03:32","watch_list":"dca801f11b1cb5506bf1ed78b04bcb5f","work_notes_list":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"}'
   delete_security_incident:
     title: Delete Security Incident
     description: Deletes a security incident by sys_id
@@ -1176,7 +1189,7 @@ actions:
         description: Details of the matching security incidents
         type: '[]security_incident'
         required: false
-        example: []
+        example: '[{"active":false,"activity_due":"2023-07-28 10:18:55","affected_user":{"link":"example.com/1234","value":"1234"},"alert_id":"dca801f11b1cb5506bf1ed78b04bcb5f","alert_rule":"test","alert_sensor":{"link":"example.com/1234","value":"1234"},"assigned_to":{"link":"example.com/1234","value":"1234"},"assignment_group":{"link":"example.com/1234","value":"1234"},"business_criticality":3,"caller":{"link":"example.com/1234","value":"1234"},"category":"Phishing","close_code":-100,"close_notes":"test close notes","closed_at":"2023-08-01 08:03:28","closed_by":{"link":"example.com/1234","value":"1234"},"cmdb_ci":{"link":"example.com/1234","value":"1234"},"contact_type":"phone","description":"example description","location":{"link":"example.com/1234","value":"1234"},"number":"SIR00000002","opened_at":"2023-07-28 10:18:55","opened_by":{"link":"example.com/1234","value":"1234"},"opened_for":{"link":"example.com/1234","value":"1234"},"priority":3,"risk_score":38,"risk_score_override":false,"secure_notes":"﷠﷡﷢56715c0aff1331007a6dffffffffff54﷌﷍CzXu70QS9L8TfvWt92rByQ==﷎﷏","security_tags":"dca801f11b1cb5506bf1ed78b04bcb5f","short_description":"test","special_access_write":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g","state":3,"subcategory":"25","substate":1,"sys_created_by":"user","sys_created_on":"2023-07-28 10:18:55","sys_id":"g12345678","sys_updated_by":"user","sys_updated_on":"2023-08-01 08:03:32","watch_list":"dca801f11b1cb5506bf1ed78b04bcb5f","work_notes_list":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"},{"active":false,"activity_due":"2023-07-28 10:18:55","affected_user":{"link":"example.com/1234","value":"1234"},"alert_id":"dca801f11b1cb5506bf1ed78b04bcb5f","alert_rule":"test","alert_sensor":{"link":"example.com/1234","value":"1234"},"assigned_to":{"link":"example.com/1234","value":"1234"},"assignment_group":{"link":"example.com/1234","value":"1234"},"business_criticality":3,"caller":{"link":"example.com/1234","value":"1234"},"category":"Phishing","close_code":-100,"close_notes":"test close notes","closed_at":"2023-08-01 08:03:28","closed_by":{"link":"example.com/1234","value":"1234"},"cmdb_ci":{"link":"example.com/1234","value":"1234"},"contact_type":"phone","description":"example description","location":{"link":"example.com/1234","value":"1234"},"number":"SIR00000003","opened_at":"2023-07-28 10:18:55","opened_by":{"link":"example.com/1234","value":"1234"},"opened_for":{"link":"example.com/1234","value":"1234"},"priority":3,"risk_score":38,"risk_score_override":false,"secure_notes":"﷠﷡﷢56715c0aff1331007a6dffffffffff54﷌﷍CzXu70QS9L8TfvWt92rByQ==﷎﷏","security_tags":"dca801f11b1cb5506bf1ed78b04bcb5f","short_description":"test","special_access_write":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g","state":3,"subcategory":"25","substate":1,"sys_created_by":"user","sys_created_on":"2023-07-28 10:18:55","sys_id":"g123456789","sys_updated_by":"user","sys_updated_on":"2023-08-01 08:03:32","watch_list":"dca801f11b1cb5506bf1ed78b04bcb5f","work_notes_list":"dca801f11b1cb5506bf1ed78b04bcb5f,dca801f11b1cb5506bf1ed78b04bcb5g"}]'
   create_security_incident:
     title: Create Security Incident
     description: Create a new security incident

--- a/plugins/servicenow/setup.py
+++ b/plugins/servicenow/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="servicenow-rapid7-plugin",
-      version="7.3.1",
+      version="7.4.0",
       description="ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes",
       author="rapid7",
       author_email="",

--- a/plugins/servicenow/unit_test/payloads/get_oauth_token.json.resp
+++ b/plugins/servicenow/unit_test/payloads/get_oauth_token.json.resp
@@ -1,0 +1,7 @@
+{
+    "access_token": "BPtX7Lt7L8cmsn9eMTkDVjWDPkN6Sm9uu35S6uCCHAFLCio7LAevrBnXroo3-Xzu-2Qgcnnyqg2M58n3PEXFk7",
+    "refresh_token": "HyM2vQK6RadNu3Jsw8YHNkDiyuMDfFmCyppHeVwDV66NFxQibEyWCSh7PJd9vAiWz8aVoZt6GXzPfSeTQsDC4g",
+    "scope": "useraccount",
+    "token_type": "Bearer",
+    "expires_in": 1799
+}

--- a/plugins/servicenow/unit_test/test_create_change_request.py
+++ b/plugins/servicenow/unit_test/test_create_change_request.py
@@ -21,7 +21,7 @@ class TestCreateChangeRequest(TestCase):
         cls.action = Util.default_connector(CreateChangeRequest())
 
     @parameterized.expand([({},), ({"short_description": "ExampleTest"})])
-    @patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
     def test_create_change_request(self, additional_fields: Dict[str, Any], mock_post: MagicMock) -> None:
         actual = self.action.run({Input.ADDITIONAL_FIELDS: additional_fields})
         expected = {"success": True}

--- a/plugins/servicenow/unit_test/test_create_security_incident.py
+++ b/plugins/servicenow/unit_test/test_create_security_incident.py
@@ -15,7 +15,7 @@ from parameterized import parameterized
 from util import Util
 
 
-@patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
+@patch("requests.post", side_effect=Util.mocked_requests)
 class TestCreateSecurityIncident(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/servicenow/unit_test/test_create_vulnerability.py
+++ b/plugins/servicenow/unit_test/test_create_vulnerability.py
@@ -28,7 +28,7 @@ class TestCreateVulnerability(TestCase):
         cls.action = Util.default_connector(CreateVulnerability())
 
     @parameterized.expand([(STUB_INPUT_PARAMETERS,)])
-    @patch("requests.sessions.Session.post", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
     def test_create_vulnerability(self, input_parameters: Dict[str, Any], mock_post: MagicMock) -> None:
         actual = self.action.run(input_parameters)
         expected = {
@@ -37,5 +37,5 @@ class TestCreateVulnerability(TestCase):
             Output.VULNERABILITY_URL: "https://rapid7.service-now.com/sn_vul_vulnerable_item.do?sys_id=12345",
         }
         validate(actual, CreateVulnerabilityOutput.schema)
-        mock_post.assert_called_once()
+        mock_post.assert_called()
         self.assertEqual(actual, expected)

--- a/plugins/servicenow/unit_test/test_delete_security_incident.py
+++ b/plugins/servicenow/unit_test/test_delete_security_incident.py
@@ -3,8 +3,9 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
+from typing import Any, Dict
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from icon_servicenow.actions.delete_security_incident import DeleteSecurityIncident
 from icon_servicenow.actions.delete_security_incident.schema import DeleteSecurityIncidentOutput
@@ -15,7 +16,8 @@ from parameterized import parameterized
 from util import Util
 
 
-@patch("requests.sessions.Session.delete", side_effect=Util.mocked_requests)
+@patch("requests.delete", side_effect=Util.mocked_requests)
+@patch("requests.post", side_effect=Util.mocked_requests)
 class TestDeleteSecurityIncident(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -30,7 +32,14 @@ class TestDeleteSecurityIncident(TestCase):
             ],
         ]
     )
-    def test_delete_security_incident(self, mock_request, test_name, input_params, expected):
+    def test_delete_security_incident(
+        self,
+        mock_request: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        expected: Dict[str, Any],
+    ) -> None:
         actual = self.action.run(input_params)
         validate(actual, DeleteSecurityIncidentOutput.schema)
         self.assertDictEqual(actual, expected)
@@ -45,7 +54,15 @@ class TestDeleteSecurityIncident(TestCase):
             ],
         ]
     )
-    def test_delete_security_incident_raise_exception(self, mock_request, test_name, input_params, cause, assistance):
+    def test_delete_security_incident_raise_exception(
+        self,
+        mock_request: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        cause: str,
+        assistance: str,
+    ) -> None:
         with self.assertRaises(PluginException) as error:
             self.action.run(input_params)
         self.assertEqual(error.exception.cause, cause)

--- a/plugins/servicenow/unit_test/test_delete_vulnerability.py
+++ b/plugins/servicenow/unit_test/test_delete_vulnerability.py
@@ -25,10 +25,13 @@ class TestDeleteVulnerability(TestCase):
         cls.action = Util.default_connector(DeleteVulnerability())
 
     @parameterized.expand([(STUB_INPUT_PARAMETERS,)])
-    @patch("requests.sessions.Session.delete", side_effect=Util.mocked_requests)
-    def test_delete_vulnerability(self, input_parameters: Dict[str, Any], mock_post: MagicMock) -> None:
+    @patch("requests.delete", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_delete_vulnerability(
+        self, input_parameters: Dict[str, Any], mock_delete: MagicMock, mock_post: MagicMock
+    ) -> None:
         actual = self.action.run(input_parameters)
         expected = {Output.SUCCESS: True}
         validate(actual, DeleteVulnerabilityOutput.schema)
-        mock_post.assert_called_once()
+        mock_delete.assert_called_once()
         self.assertEqual(actual, expected)

--- a/plugins/servicenow/unit_test/test_get_attachments_for_an_incident.py
+++ b/plugins/servicenow/unit_test/test_get_attachments_for_an_incident.py
@@ -4,7 +4,7 @@ import sys
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from icon_servicenow.actions.get_attachments_for_an_incident import GetAttachmentsForAnIncident
 from icon_servicenow.actions.get_attachments_for_an_incident.schema import GetAttachmentsForAnIncidentOutput, Input
@@ -18,8 +18,9 @@ class TestGetAttachmentsForAnIncident(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetAttachmentsForAnIncident())
 
-    @patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
-    def test_get_attachments_for_an_incident(self, mock_post):
+    @patch("requests.get", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_get_attachments_for_an_incident(self, mock_get: MagicMock, mock_post: MagicMock) -> None:
         actual = self.action.run({Input.INCIDENT_ID: "3072d01d07a552f6d0ea83ef29c936be"})
         expected = {
             "incident_attachments": [
@@ -33,8 +34,9 @@ class TestGetAttachmentsForAnIncident(TestCase):
         validate(actual, GetAttachmentsForAnIncidentOutput.schema)
         self.assertEqual(actual, expected)
 
-    @patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
-    def test_get_attachments_for_an_incident_many(self, mock_post):
+    @patch("requests.get", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_get_attachments_for_an_incident_many(self, mock_get, mock_post):
         actual = self.action.run({Input.INCIDENT_ID: "51e4a8abb1b66fc04ba11001955e7dcb"})
         expected = {
             "incident_attachments": [
@@ -53,8 +55,9 @@ class TestGetAttachmentsForAnIncident(TestCase):
         validate(actual, GetAttachmentsForAnIncidentOutput.schema)
         self.assertEqual(actual, expected)
 
-    @patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
-    def test_get_attachments_for_an_incident_empty(self, mock_post):
+    @patch("requests.get", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_get_attachments_for_an_incident_empty(self, mock_get: MagicMock, mock_post: MagicMock) -> None:
         actual = self.action.run({Input.INCIDENT_ID: "c1565da4456c2df374793d471d6ae8dd"})
         expected = {"incident_attachments": []}
         validate(actual, GetAttachmentsForAnIncidentOutput.schema)

--- a/plugins/servicenow/unit_test/test_get_incident_attachment.py
+++ b/plugins/servicenow/unit_test/test_get_incident_attachment.py
@@ -20,8 +20,9 @@ class TestGetIncidentAttachment(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetIncidentAttachment())
 
-    @patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
-    def test_manage_threat_remediate(self, mock_post: Mock) -> None:
+    @patch("requests.get", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_manage_threat_remediate(self, mock_get: Mock, mock_post: Mock) -> None:
         actual = self.action.run({Input.ATTACHMENT_ID: "b259f4062d9f78f9ffdd6efd05c492c7"})
         expected = {Output.ATTACHMENT_CONTENTS: "ImNtRndhV1EzWVhSMFlXTm9iV1Z1ZEhSbGN6ZzNOalF6TWpKMCI="}
         validate(actual, GetIncidentAttachmentOutput.schema)

--- a/plugins/servicenow/unit_test/test_get_security_incident.py
+++ b/plugins/servicenow/unit_test/test_get_security_incident.py
@@ -3,8 +3,9 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
+from typing import Any, Dict
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from icon_servicenow.actions.get_security_incident import GetSecurityIncident
 from icon_servicenow.actions.get_security_incident.schema import GetSecurityIncidentOutput
@@ -15,7 +16,8 @@ from parameterized import parameterized
 from util import Util
 
 
-@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.get", side_effect=Util.mocked_requests)
+@patch("requests.post", side_effect=Util.mocked_requests)
 class TestGetSecurityIncident(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -30,7 +32,14 @@ class TestGetSecurityIncident(TestCase):
             ],
         ]
     )
-    def test_get_security_incident(self, mock_request, test_name, input_params, expected):
+    def test_get_security_incident(
+        self,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        expected: Dict[str, Any],
+    ) -> None:
         actual = self.action.run(input_params)
         validate(actual, GetSecurityIncidentOutput.schema)
         self.assertDictEqual(actual, expected)
@@ -45,7 +54,15 @@ class TestGetSecurityIncident(TestCase):
             ],
         ]
     )
-    def test_get_security_incident_raise_exception(self, mock_request, test_name, input_params, cause, assistance):
+    def test_get_security_incident_raise_exception(
+        self,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        cause: str,
+        assistance: str,
+    ) -> None:
         with self.assertRaises(PluginException) as error:
             self.action.run(input_params)
         self.assertEqual(error.exception.cause, cause)

--- a/plugins/servicenow/unit_test/test_get_vulnerability.py
+++ b/plugins/servicenow/unit_test/test_get_vulnerability.py
@@ -23,10 +23,13 @@ class TestGetVulnerability(TestCase):
         cls.action = Util.default_connector(GetVulnerability())
 
     @parameterized.expand([(STUB_INPUT_PARAMETERS,)])
-    @patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
-    def test_get_vulnerability(self, input_parameters: Dict[str, Any], mock_post: MagicMock) -> None:
+    @patch("requests.get", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_get_vulnerability(
+        self, input_parameters: Dict[str, Any], mock_get: MagicMock, mock_post: MagicMock
+    ) -> None:
         actual = self.action.run(input_parameters)
         expected = {Output.FILTERED_VULNERABILITY: {"risk_rating": "3", "last_opened": "2023-04-28"}}
         validate(actual, GetVulnerabilityOutput.schema)
-        mock_post.assert_called_once()
+        mock_get.assert_called_once()
         self.assertEqual(actual, expected)

--- a/plugins/servicenow/unit_test/test_search_security_incident.py
+++ b/plugins/servicenow/unit_test/test_search_security_incident.py
@@ -3,8 +3,9 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
+from typing import Any, Dict
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from icon_servicenow.actions.search_security_incident import SearchSecurityIncident
 from icon_servicenow.actions.search_security_incident.schema import SearchSecurityIncidentOutput
@@ -14,7 +15,8 @@ from parameterized import parameterized
 from util import Util
 
 
-@patch("requests.sessions.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.get", side_effect=Util.mocked_requests)
+@patch("requests.post", side_effect=Util.mocked_requests)
 class TestSearchSecurityIncident(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -49,7 +51,14 @@ class TestSearchSecurityIncident(TestCase):
             ],
         ]
     )
-    def test_get_security_incident(self, mock_request, test_name, input_params, expected):
+    def test_get_security_incident(
+        self,
+        mock_get: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        expected: Dict[str, Any],
+    ) -> None:
         actual = self.action.run(input_params)
         validate(actual, SearchSecurityIncidentOutput.schema)
         self.assertDictEqual(actual, expected)

--- a/plugins/servicenow/unit_test/test_update_security_incident.py
+++ b/plugins/servicenow/unit_test/test_update_security_incident.py
@@ -3,8 +3,9 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
+from typing import Any, Dict
 from unittest import TestCase
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 from icon_servicenow.actions.update_security_incident import UpdateSecurityIncident
 from icon_servicenow.actions.update_security_incident.schema import UpdateSecurityIncidentOutput
@@ -15,7 +16,8 @@ from parameterized import parameterized
 from util import Util
 
 
-@patch("requests.sessions.Session.patch", side_effect=Util.mocked_requests)
+@patch("requests.patch", side_effect=Util.mocked_requests)
+@patch("requests.post", side_effect=Util.mocked_requests)
 class TestUpdateSecurityIncident(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -35,7 +37,14 @@ class TestUpdateSecurityIncident(TestCase):
             ],
         ]
     )
-    def test_update_security_incident(self, mock_request, test_name, input_params, expected):
+    def test_update_security_incident(
+        self,
+        mock_patch: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        expected: Dict[str, Any],
+    ) -> None:
         actual = self.action.run(input_params)
         validate(actual, UpdateSecurityIncidentOutput.schema)
         self.assertEqual(actual, expected)
@@ -50,7 +59,15 @@ class TestUpdateSecurityIncident(TestCase):
             ]
         ]
     )
-    def test_update_security_incident_raise_exception(self, mock_request, test_name, input_params, cause, assistance):
+    def test_update_security_incident_raise_exception(
+        self,
+        mock_patch: MagicMock,
+        mock_post: MagicMock,
+        test_name: str,
+        input_params: Dict[str, Any],
+        cause: str,
+        assistance: str,
+    ) -> None:
         with self.assertRaises(PluginException) as error:
             self.action.run(input_params)
         self.assertEqual(error.exception.cause, cause)

--- a/plugins/servicenow/unit_test/test_update_vulnerability.py
+++ b/plugins/servicenow/unit_test/test_update_vulnerability.py
@@ -28,10 +28,13 @@ class TestUpdateVulnerability(TestCase):
         cls.action = Util.default_connector(UpdateVulnerability())
 
     @parameterized.expand([(STUB_INPUT_PARAMETERS,)])
-    @patch("requests.sessions.Session.put", side_effect=Util.mocked_requests)
-    def test_update_vulnerability(self, input_parameters: Dict[str, Any], mock_post: MagicMock) -> None:
+    @patch("requests.put", side_effect=Util.mocked_requests)
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def test_update_vulnerability(
+        self, input_parameters: Dict[str, Any], mock_put: MagicMock, mock_post: MagicMock
+    ) -> None:
         actual = self.action.run(input_parameters)
         expected = {Output.SUCCESS: True}
         validate(actual, UpdateVulnerabilityOutput.schema)
-        mock_post.assert_called_once()
+        mock_put.assert_called_once()
         self.assertEqual(actual, expected)

--- a/plugins/servicenow/unit_test/util.py
+++ b/plugins/servicenow/unit_test/util.py
@@ -17,6 +17,8 @@ class Util:
             params = {
                 Input.INSTANCE: "rapid7",
                 Input.CLIENT_LOGIN: {"username": "user1", "password": "mypassword"},
+                Input.CLIENT_ID: "blah",
+                Input.CLIENT_SECRET: {"secretKey": "blah"},
             }
         default_connection.connect(params)
         action.connection = default_connection
@@ -60,6 +62,8 @@ class Util:
             "https://rapid7.service-now.com/api/now/attachment/53e4a8abb1b66fc04ba11001955e7dcb/file",
         ]:
             return MockResponse("get_attachment_file", 200, {})
+        elif kwargs["url"] == "https://rapid7.service-now.com/oauth_token.do":
+            return MockResponse("get_oauth_token.json", 200)
         elif (
             kwargs["url"]
             == "https://rapid7.service-now.com/api/now/attachment?sysparm_query=table_sys_id=3072d01d07a552f6d0ea83ef29c936be"


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Added `OAuth` authentication to the plugin

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
