### PR TITLE
PLGN-633: add exception logging and bump SDK.

### DIFF
--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "af7f5046784c4bd506fbbc797d403782",
-	"manifest": "9aa65831ac901c7273abd96248e1a709",
-	"setup": "f61170938f3b53095c861c44ae7ee7e7",
+	"spec": "0e194226a0a67c2991b7ebe933c04179",
+	"manifest": "12bfb11fd6e00d799e9313f4ecb798d8",
+	"setup": "1a27dce355f442c87d53c0de3639fd11",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",
@@ -49,7 +49,7 @@
 		},
 		{
 			"identifier": "monitor_logs/schema.py",
-			"hash": "ff4f7adf6cbae20cd793af79e763a06d"
+			"hash": "dfdca5153b3d9ee8fe8a20fdb5ad4e59"
 		}
 	]
 }

--- a/plugins/duo_admin/Dockerfile
+++ b/plugins/duo_admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/duo_admin/bin/komand_duo_admin
+++ b/plugins/duo_admin/bin/komand_duo_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Duo Admin API"
 Vendor = "rapid7"
-Version = "4.3.0"
+Version = "4.3.1"
 Description = "Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization"
 
 

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -1033,6 +1033,7 @@ A User ID can be obtained by passing a username to the Get User Status action.
 
 # Version History
 
+* 4.3.1 - Monitor Logs task: Added exception logging and use latest plugin SDK (`5.3.1`).
 * 4.3.0 - Monitor Logs task: Added inputs for collecting events and logs. Updated 403 error handling 
 * 4.2.2 - Monitor Logs task: updated unit tests
 * 4.2.1 - Monitor Logs task: updated timestamp handling

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
@@ -241,11 +241,13 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
 
                 return new_logs, state, has_more_pages, 200, None
             except ApiException as error:
+                self.logger.info(f"An API Exception has been raised. Status code: {error.status_code}. Error: {error}")
                 state[self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES] = []
                 state[self.PREVIOUS_ADMIN_LOG_HASHES] = []
                 state[self.PREVIOUS_AUTH_LOG_HASHES] = []
                 return [], state, False, error.status_code, error
         except Exception as error:
+            self.logger.info(f"An Exception has been raised. Error: {error}")
             state[self.PREVIOUS_TRUST_MONITOR_EVENT_HASHES] = []
             state[self.PREVIOUS_ADMIN_LOG_HASHES] = []
             state[self.PREVIOUS_AUTH_LOG_HASHES] = []

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -13,7 +13,7 @@ sdk:
   version: 5
   user: nobody
 description: Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization
-version: 4.3.0
+version: 4.3.1
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/duo_admin

--- a/plugins/duo_admin/setup.py
+++ b/plugins/duo_admin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="duo_admin-rapid7-plugin",
-      version="4.3.0",
+      version="4.3.1",
       description="Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - add logs when we raise an exception so we can trace this back if needed. 
  - bump SDK version so that we log when the task has started/finished. 
  - fixed md5sum for schema as was failing validation. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Action testing <- to be done on staging.
- [X] Local testing for logs


Logging evidence of exception raised from plugin (AnAPI Exception has been raised) and SDK (plugin exception instantiated):
```
Plugin task beginning execution...
Connect: Connecting...
rapid7/Duo Admin API:4.3.1. Step name: monitor_logs
Previous timestamps retrieved. Auth None. Admin: None. Trust monitor None.
First run for Trust monitor events
Retrieve data from 1702383994832 to 1702470274832. Get next page is set to False
Parameters for get trust monitor events set to {'mintime': '1702383994832', 'maxtime': '1702470274832', 'limit': '200'}
Request to path: /admin/v1/trust_monitor/events
Response returned from get trust monitor events: {'events': [], 'metadata': {}}
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 0
Highest timestamp set to 0 for Trust monitor events
0 trust monitor events retrieved
First run for Admin logs
Retrieve data from 1702383994 to 1702470274. Get next page is set to False
Get admin logs: mintime:1702383994, maxtime:1702470274, next_page_params:None
Parameters for get admin logs set to {'mintime': '1702383994'}
Request to path: /admin/v1/logs/administrator
Parameters to return from get admin logs set to {}. Return 1 logs
Original number of logs:1. Number of logs after de-duplication:1
Previous highest recorded timestamp is 0
Highest timestamp set to 1702470024 for Admin logs
1 admin logs retrieved
First run for Auth logs
Retrieve data from 1702383994832 to 1702470274832. Get next page is set to False
Get auth logs: mintime:1702383994832, maxtime:1702470274832, next_page_params:None
Parameters for get auth logs set to {'mintime': '1702383994832', 'maxtime': '1702470274832', 'limit': '1000', 'sort': 'ts:asc'}
Request to path: /admin/v2/logs/authentication
Plugin exception instantiated. cause='The account configured in your plugin connection is currently rate-limited.', assistance='Adjust the time between requests if possible.', data='{"code": 42901, "message": "Too Many Requests", "stat": "FAIL"}', preset='rate_limit'
An API Exception has been raised. Status code: 429. Error: An error occurred during plugin execution!

The account configured in your plugin connection is currently rate-limited. Adjust the time between requests if possible. Response was: {"code": 42901, "message": "Too Many Requests", "stat": "FAIL"}
Plugin task finished execution...
```

Happy path with no exceptions/rate limited:
```
Plugin task beginning execution...
rapid7/Duo Admin API:4.3.1. Step name: monitor_logs
Previous timestamps retrieved. Auth None. Admin: None. Trust monitor None.
First run for Trust monitor events
Retrieve data from 1702384160676 to 1702470440676. Get next page is set to False
Parameters for get trust monitor events set to {'mintime': '1702384160676', 'maxtime': '1702470440676', 'limit': '200'}
Request to path: /admin/v1/trust_monitor/events
Response returned from get trust monitor events: {'events': [], 'metadata': {}}
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 0
Highest timestamp set to 0 for Trust monitor events
0 trust monitor events retrieved
First run for Admin logs
Retrieve data from 1702384160 to 1702470440. Get next page is set to False
Get admin logs: mintime:1702384160, maxtime:1702470440, next_page_params:None
Parameters for get admin logs set to {'mintime': '1702384160'}
Request to path: /admin/v1/logs/administrator
Parameters to return from get admin logs set to {}. Return 1 logs
Original number of logs:1. Number of logs after de-duplication:1
Previous highest recorded timestamp is 0
Highest timestamp set to 1702470024 for Admin logs
1 admin logs retrieved
First run for Auth logs
Retrieve data from 1702384160676 to 1702470440676. Get next page is set to False
Get auth logs: mintime:1702384160676, maxtime:1702470440676, next_page_params:None
Parameters for get auth logs set to {'mintime': '1702384160676', 'maxtime': '1702470440676', 'limit': '1000', 'sort': 'ts:asc'}
Request to path: /admin/v2/logs/authentication
Get auth logs: parameters to return {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 0
Highest timestamp set to 0 for Auth logs
0 auth logs retrieved
Plugin task finished execution...

```

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional <- no options below are needed for this change. 
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
