### PR TITLE
[PLGN-629] Active Directory LDAP - Fix problem where some ASCII characters were not escaped properly

### DIFF
--- a/plugins/active_directory_ldap/.CHECKSUM
+++ b/plugins/active_directory_ldap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d5dfdb03974651b69e5a02256df71e03",
-	"manifest": "5d016144fec71b932d8182d5c1a7f81d",
-	"setup": "def3e06498eabadbc9aaa7270aff8be6",
+	"spec": "7ccbd3e54069b451819765d331a5e422",
+	"manifest": "eec2dabd6adf20679bf09da7cda157b5",
+	"setup": "c2867f07c815fafae59884272249fe1e",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/active_directory_ldap/Dockerfile
+++ b/plugins/active_directory_ldap/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/active_directory_ldap/bin/komand_active_directory_ldap
+++ b/plugins/active_directory_ldap/bin/komand_active_directory_ldap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Active Directory LDAP"
 Vendor = "rapid7"
-Version = "9.0.0"
+Version = "9.0.1"
 Description = "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
 
 

--- a/plugins/active_directory_ldap/help.md
+++ b/plugins/active_directory_ldap/help.md
@@ -57,7 +57,7 @@ Example input:
 
 #### Add User
   
-Adds the specified Active Directory user
+This action is used to add the specified Active Directory user
 
 ##### Input
 
@@ -107,7 +107,7 @@ Example output:
 
 #### Delete
   
-Deletes the LDAP object specified
+This action is used to delete the LDAP object specified
 
 ##### Input
 
@@ -139,7 +139,7 @@ Example output:
 
 #### Disable User
   
-Disable an account
+This action is used to disable an account
 
 ##### Input
 
@@ -171,7 +171,7 @@ Example output:
 
 #### Disable Users
   
-Disable multiple accounts
+This action is used to disable multiple accounts
 
 ##### Input
 
@@ -214,7 +214,7 @@ Example output:
 
 #### Enable User
   
-Enable an account
+This action is used to enable an account
 
 ##### Input
 
@@ -246,7 +246,7 @@ Example output:
 
 #### Enable Users
   
-Enable multiple accounts
+This action is used to enable multiple accounts
 
 ##### Input
 
@@ -289,7 +289,7 @@ Example output:
 
 #### Force Password Reset
   
-Force a user to reset their password on next login
+This action is used to force a user to reset their password on next login
 
 ##### Input
 
@@ -321,7 +321,7 @@ Example output:
 
 #### Add or Remove an Object from Group
   
-Add or remove an object from an Active Directory group
+This action is used to add or remove an object from an Active Directory group
 
 ##### Input
 
@@ -357,7 +357,7 @@ Example output:
 
 #### Modify Object
   
-Modify the attributes for an Active Directory object
+This action is used to modify the attributes for an Active Directory object
 
 ##### Input
 
@@ -393,7 +393,7 @@ Example output:
 
 #### Move Object
   
-Move an Active Directory object from one organizational unit to another
+This action is used to move an Active Directory object from one organizational unit to another
 
 ##### Input
 
@@ -427,7 +427,7 @@ Example output:
 
 #### Query
   
-Run an LDAP query
+This action is used to run an LDAP query
 
 ##### Input
 
@@ -455,7 +455,7 @@ Example input:
 |Name|Type|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|False|Number of results|1|
-|results|[]result|False|Results returned|[ { "dn": string, "attributes": { "pwdLastSet": date, "objectClass": [ string, string, string, string ], "memberOf": [ string ], "sAMAccountType": int, "uSNChanged": int, "givenName": string, "userPrincipalName": string, "countryCode": int, "lastLogon": date, "sAMAccountName": string, "name": string, "primaryGroupID": int, "dSCorePropagationData": [ date ], "displayName": string, "logonCount": int, "cn": string, "objectSid": string, "codePage": int, "badPwdCount": int, "objectGUID": string, "distinguishedName": string, "whenChanged": date, "badPasswordTime": date, "instanceType": int, "uSNCreated": int, "sn": string, "whenCreated": date, "accountExpires": date, "userAccountControl": int, "lastLogoff": date, "objectCategory": "string" } } ]|
+|results|[]result|False|Results returned|[{"dn":"string","attributes":{"pwdLastSet":"date","objectClass":["string","string","string","string"],"memberOf":["string"],"sAMAccountType":"int","uSNChanged":"int","givenName":"string","userPrincipalName":"string","countryCode":"int","lastLogon":"date","sAMAccountName":"string","name":"string","primaryGroupID":"int","dSCorePropagationData":["date"],"displayName":"string","logonCount":"int","cn":"string","objectSid":"string","codePage":"int","badPwdCount":"int","objectGUID":"string","distinguishedName":"string","whenChanged":"date","badPasswordTime":"date","instanceType":"int","uSNCreated":"int","sn":"string","whenCreated":"date","accountExpires":"date","userAccountControl":"int","lastLogoff":"date","objectCategory":"string"}}]|
   
 Example output:
 
@@ -464,49 +464,49 @@ Example output:
   "count": 1,
   "results": [
     {
-      "dn": "string",
       "attributes": {
-        "pwdLastSet": "date",
+        "accountExpires": "date",
+        "badPasswordTime": "date",
+        "badPwdCount": "int",
+        "cn": "string",
+        "codePage": "int",
+        "countryCode": "int",
+        "dSCorePropagationData": [
+          "date"
+        ],
+        "displayName": "string",
+        "distinguishedName": "string",
+        "givenName": "string",
+        "instanceType": "int",
+        "lastLogoff": "date",
+        "lastLogon": "date",
+        "logonCount": "int",
+        "memberOf": [
+          "string"
+        ],
+        "name": "string",
+        "objectCategory": "string",
         "objectClass": [
           "string",
           "string",
           "string",
           "string"
         ],
-        "memberOf": [
-          "string"
-        ],
-        "sAMAccountType": "int",
-        "uSNChanged": "int",
-        "givenName": "string",
-        "userPrincipalName": "string",
-        "countryCode": "int",
-        "lastLogon": "date",
-        "sAMAccountName": "string",
-        "name": "string",
-        "primaryGroupID": "int",
-        "dSCorePropagationData": [
-          "date"
-        ],
-        "displayName": "string",
-        "logonCount": "int",
-        "cn": "string",
-        "objectSid": "string",
-        "codePage": "int",
-        "badPwdCount": "int",
         "objectGUID": "string",
-        "distinguishedName": "string",
-        "whenChanged": "date",
-        "badPasswordTime": "date",
-        "instanceType": "int",
-        "uSNCreated": "int",
+        "objectSid": "string",
+        "primaryGroupID": "int",
+        "pwdLastSet": "date",
+        "sAMAccountName": "string",
+        "sAMAccountType": "int",
         "sn": "string",
-        "whenCreated": "date",
-        "accountExpires": "date",
+        "uSNChanged": "int",
+        "uSNCreated": "int",
         "userAccountControl": "int",
-        "lastLogoff": "date",
-        "objectCategory": "string"
-      }
+        "userPrincipalName": "string",
+        "whenChanged": "date",
+        "whenCreated": "date"
+      },
+      "dn": "string"
     }
   ]
 }
@@ -514,7 +514,7 @@ Example output:
 
 #### Query Group Membership
   
-Return users and groups that belonging to the specific group
+This action is used to return users and groups that belonging to the specific group
 
 ##### Input
 
@@ -604,7 +604,7 @@ Example output:
 
 #### Reset Password
   
-Reset a users password
+This action is used to reset a users password
 
 ##### Input
 
@@ -638,7 +638,7 @@ Example output:
 
 #### Unlock User
   
-Unlock an account
+This action is used to unlock an account
 
 ##### Input
 
@@ -667,11 +667,9 @@ Example output:
   "success": true
 }
 ```
-
 ### Triggers
   
 *This plugin does not contain any triggers.*
-
 ### Tasks
   
 *This plugin does not contain any tasks.*
@@ -762,6 +760,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 9.0.1 - Fix problem where some ASCII characters were not escaped properly
 * 9.0.0 - Action: `Disable User` & `Enable User` - Rename title of actions from `Disable` & `Enable` to `Disable Users` & `Enable Users` on the front-end.
 * 8.0.0 - Update actions Enable Users and Enable Users to add outputs Completed and Failed and remove output All Operations Succeeded
 * 7.0.0 - Update actions Enable Users and Enable Users to replace output Success with All Operations Succeeded True/False
@@ -809,10 +808,11 @@ the query results, and then using the variable step $item.dn
 * 1.0.0 - Revise input names, bugfixes for missing attributes and character escaping, fix security issue
 * 0.1.0 - Initial plugin
 
-
 # Links
 
 [Learn Azure Active Directory](https://learn.microsoft.com/en-us/azure/active-directory/)
+[AD LDAP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3c5916a9-f1a0-429d-b937-f8fe672d777c)
+[Microsoft's Active Directory service](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx)
 
 ## References
 

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/disable_user/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/disable_user/action.py
@@ -1,7 +1,9 @@
 import insightconnect_plugin_runtime
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 # Custom imports below
 from .schema import DisableUserInput, DisableUserOutput, Input, Output
+from komand_active_directory_ldap.util.utils import ADUtils
 
 
 class DisableUser(insightconnect_plugin_runtime.Action):
@@ -14,4 +16,16 @@ class DisableUser(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        return {Output.SUCCESS: self.connection.client.manage_user(params.get(Input.DISTINGUISHED_NAME), False)}
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_name = params.get(Input.DISTINGUISHED_NAME)
+        # END INPUT BINDING - DO NOT REMOVE
+
+        try:
+            return {Output.SUCCESS: self.connection.client.manage_user(distinguished_name, False)}
+        except PluginException:
+            self.logger.info("Escaping non-ascii characters...")
+            return {
+                Output.SUCCESS: self.connection.client.manage_user(
+                    ADUtils.escape_non_ascii_characters(distinguished_name), False
+                )
+            }

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/disable_users/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/disable_users/action.py
@@ -3,6 +3,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from .schema import DisableUsersInput, DisableUsersOutput, Input, Output, Component
 
 # Custom imports below
+from komand_active_directory_ldap.util.utils import ADUtils
 
 
 class DisableUsers(insightconnect_plugin_runtime.Action):
@@ -15,14 +16,17 @@ class DisableUsers(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        if not params.get(Input.DISTINGUISHED_NAMES):
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_names = params.get(Input.DISTINGUISHED_NAMES)
+        # END INPUT BINDING - DO NOT REMOVE
+
+        if not distinguished_names:
             raise PluginException(
                 cause="Distinguished Names must contain at least one entry",
                 assistance="Please enter one or more Distinguished Names",
             )
 
-        disabled_users = self.connection.client.manage_users(params.get(Input.DISTINGUISHED_NAMES), False)
-
+        disabled_users = self.connection.client.manage_users(distinguished_names, False)
         return {
             Output.COMPLETED: disabled_users.get("successes"),
             Output.FAILED: disabled_users.get("failures"),

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/enable_user/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/enable_user/action.py
@@ -1,7 +1,9 @@
 import insightconnect_plugin_runtime
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 # Custom imports below
 from .schema import EnableUserInput, EnableUserOutput, Input, Output
+from komand_active_directory_ldap.util.utils import ADUtils
 
 
 class EnableUser(insightconnect_plugin_runtime.Action):
@@ -14,4 +16,16 @@ class EnableUser(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        return {Output.SUCCESS: self.connection.client.manage_user(params.get(Input.DISTINGUISHED_NAME), True)}
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_name = params.get(Input.DISTINGUISHED_NAME)
+        # END INPUT BINDING - DO NOT REMOVE
+
+        try:
+            return {Output.SUCCESS: self.connection.client.manage_user(distinguished_name, True)}
+        except PluginException:
+            self.logger.info("Escaping non-ascii characters...")
+            return {
+                Output.SUCCESS: self.connection.client.manage_user(
+                    ADUtils.escape_non_ascii_characters(distinguished_name), True
+                )
+            }

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/enable_users/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/enable_users/action.py
@@ -12,14 +12,17 @@ class EnableUsers(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        if not params.get(Input.DISTINGUISHED_NAMES):
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_names = params.get(Input.DISTINGUISHED_NAMES)
+        # END INPUT BINDING - DO NOT REMOVE
+
+        if not distinguished_names:
             raise PluginException(
                 cause="Distinguished Names must contain at least one entry",
                 assistance="Please enter one or more Distinguished Names",
             )
 
-        enabled_users = self.connection.client.manage_users(params.get(Input.DISTINGUISHED_NAMES), True)
-
+        enabled_users = self.connection.client.manage_users(distinguished_names, True)
         return {
             Output.COMPLETED: enabled_users.get("successes"),
             Output.FAILED: enabled_users.get("failures"),

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/force_password_reset/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/force_password_reset/action.py
@@ -1,4 +1,5 @@
 import insightconnect_plugin_runtime
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 # Custom imports below
 from komand_active_directory_ldap.util.utils import ADUtils
@@ -15,10 +16,21 @@ class ForcePasswordReset(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        formatter = ADUtils()
-        dn = params.get(Input.DISTINGUISHED_NAME)
-        dn = formatter.format_dn(dn)[0]
-        dn = formatter.unescape_asterisk(dn)
-        self.logger.info(f"Escaped DN {dn}")
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_name = params.get(Input.DISTINGUISHED_NAME)
+        # END INPUT BINDING - DO NOT REMOVE
+
+        distinguished_name = ADUtils.format_dn(distinguished_name)[0]
+        distinguished_name = ADUtils.unescape_asterisk(distinguished_name)
+        self.logger.info(f"Escaped DN {distinguished_name}")
         password_expire = {"pwdLastSet": ("MODIFY_REPLACE", [0])}
-        return {Output.SUCCESS: self.connection.client.force_password_reset(dn, password_expire)}
+
+        try:
+            return {Output.SUCCESS: self.connection.client.force_password_reset(distinguished_name, password_expire)}
+        except PluginException:
+            self.logger.info("Escaping non-ascii characters...")
+            return {
+                Output.SUCCESS: self.connection.client.force_password_reset(
+                    ADUtils.escape_non_ascii_characters(distinguished_name), password_expire
+                )
+            }

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/move_object/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/move_object/action.py
@@ -2,6 +2,7 @@
 import re
 
 import insightconnect_plugin_runtime
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 from komand_active_directory_ldap.util.utils import ADUtils
 from .schema import MoveObjectInput, MoveObjectOutput, Output, Input
@@ -17,18 +18,29 @@ class MoveObject(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        formatter = ADUtils()
-        dn = params.get(Input.DISTINGUISHED_NAME)
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_name = params.get(Input.DISTINGUISHED_NAME)
         new_ou = params.get(Input.NEW_OU)
-        relative_dn = ""
-        dn = formatter.format_dn(dn)[0]
-        dn = formatter.unescape_asterisk(dn)
-        self.logger.info(f"Escaped DN {dn}")
+        # END INPUT BINDING - DO NOT REMOVE
 
-        pattern = re.search(r"CN=[^,]*,", dn)
+        relative_dn = ""
+        distinguished_name = ADUtils.format_dn(distinguished_name)[0]
+        distinguished_name = ADUtils.unescape_asterisk(distinguished_name)
+        self.logger.info(f"Escaped DN {distinguished_name}")
+
+        pattern = re.search(r"CN=[^,]*,", distinguished_name)
         self.logger.debug(pattern)
         if pattern:
             relative_dn = pattern.group()
             relative_dn = relative_dn[:-1]
             self.logger.debug(relative_dn)
-        return {Output.SUCCESS: self.connection.client.move_object(dn, relative_dn, new_ou)}
+
+        try:
+            return {Output.SUCCESS: self.connection.client.move_object(distinguished_name, relative_dn, new_ou)}
+        except PluginException:
+            self.logger.info("Escaping non-ascii characters...")
+            return {
+                Output.SUCCESS: self.connection.client.move_object(
+                    ADUtils.escape_non_ascii_characters(distinguished_name), relative_dn, new_ou
+                )
+            }

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/query/action.py
@@ -2,6 +2,7 @@ import insightconnect_plugin_runtime
 import ldap3
 
 # Custom imports below
+from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.util.utils import ADUtils
 from .schema import QueryInput, QueryOutput, Input, Output
 
@@ -13,22 +14,27 @@ class Query(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        formatter = ADUtils()
-        query = params.get(Input.SEARCH_FILTER)
-
-        query = query.replace("\\>=", ">=")
-        query = query.replace("\\<=", "<=")
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        query = params.get(Input.SEARCH_FILTER, "").replace("\\>=", ">=").replace("\\<=", "<=")
+        search_base = params.get(Input.SEARCH_BASE)
+        attributes = params.get(Input.ATTRIBUTES, [])
+        # END INPUT BINDING - DO NOT REMOVE
 
         # replace ( and ) when they are part of a name rather than a search parameter
-        escaped_query = formatter.escape_brackets_for_query(query)
-        self.logger.info("Escaped query: %s", escaped_query)
+        escaped_query = ADUtils.escape_brackets_for_query(query)
+        self.logger.info(f"Escaped query: {escaped_query}")
 
-        attributes = params.get(Input.ATTRIBUTES, [])
         if not attributes:
             attributes = [ldap3.ALL_ATTRIBUTES, ldap3.ALL_OPERATIONAL_ATTRIBUTES]
 
-        entries = self.connection.client.query(params.get(Input.SEARCH_BASE), escaped_query, attributes)
+        try:
+            entries = self.connection.client.query(search_base, escaped_query, attributes)
+        except PluginException:
+            self.logger.info("Escaping non-ascii characters...")
+            entries = self.connection.client.query(
+                search_base, ADUtils.escape_non_ascii_characters(escaped_query), attributes
+            )
+
         if entries:
             return {Output.RESULTS: entries, Output.COUNT: len(entries)}
-        else:
-            return {Output.RESULTS: [], Output.COUNT: 0}
+        return {Output.RESULTS: [], Output.COUNT: 0}

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/query_group_membership/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/query_group_membership/action.py
@@ -1,6 +1,7 @@
 import insightconnect_plugin_runtime
 
 # Custom imports below
+from insightconnect_plugin_runtime.exceptions import PluginException
 from .schema import QueryGroupMembershipInput, QueryGroupMembershipOutput, Input, Output, Component
 
 
@@ -14,10 +15,12 @@ class QueryGroupMembership(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         base = params.get(Input.SEARCH_BASE)
+        group_name = params.get(Input.GROUP_NAME)
         include_groups = params.get(Input.INCLUDE_GROUPS)
         expand_nested_groups = params.get(Input.EXPAND_NESTED_GROUPS)
-        entries = self.connection.client.query_group_membership(
-            base, params.get(Input.GROUP_NAME), include_groups, expand_nested_groups
-        )
+        # END INPUT BINDING - DO NOT REMOVE
+
+        entries = self.connection.client.query_group_membership(base, group_name, include_groups, expand_nested_groups)
         return {Output.RESULTS: entries, Output.COUNT: len(entries)}

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/actions/unlock_user/action.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/actions/unlock_user/action.py
@@ -1,7 +1,8 @@
 import insightconnect_plugin_runtime
 
 # Custom imports below
-from komand_active_directory_ldap.util.utils import UserAccountFlags
+from insightconnect_plugin_runtime.exceptions import PluginException
+from komand_active_directory_ldap.util.utils import UserAccountFlags, ADUtils
 from .schema import UnlockUserInput, UnlockUserOutput, Input, Output, Component
 
 
@@ -12,8 +13,16 @@ class UnlockUser(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        return {
-            Output.SUCCESS: self.connection.client.unblock_user(
-                params.get(Input.DISTINGUISHED_NAME), UserAccountFlags.LOCKOUT
-            )
-        }
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        distinguished_name = params.get(Input.DISTINGUISHED_NAME)
+        # END INPUT BINDING - DO NOT REMOVE
+
+        try:
+            return {Output.SUCCESS: self.connection.client.unblock_user(distinguished_name, UserAccountFlags.LOCKOUT)}
+        except PluginException:
+            self.logger.info("Escaping non-ascii characters...")
+            return {
+                Output.SUCCESS: self.connection.client.unblock_user(
+                    ADUtils.escape_non_ascii_characters(distinguished_name), UserAccountFlags.LOCKOUT
+                )
+            }

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/util/api.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/util/api.py
@@ -176,15 +176,21 @@ class ActiveDirectoryLdapAPI:
         :return: Dictionary containing two lists, one for successfully modified Distinguishes Names and another for
         unsuccessfully modified Distinguishes Names and the cause of the failure
         """
+
         successes = []
         failures = []
         for dn in dns:
             try:
                 ADUtils.change_account_status(conn, dn, status, self.logger)
                 successes.append(dn)
-            except Exception as exception:
-                failures.append({"dn": dn, "error": str(exception)})
-                self.logger.error(f"Error: Failed to modify user {dn}")
+            except Exception:
+                try:
+                    escaped_dn = ADUtils.escape_non_ascii_characters(dn)
+                    ADUtils.change_account_status(conn, escaped_dn, status, self.logger)
+                    successes.append(dn)
+                except Exception as error:
+                    failures.append({"dn": dn, "error": str(error)})
+                    self.logger.error(f"Error: Failed to modify user {dn}")
         return {"successes": successes, "failures": failures}
 
     @with_connection

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/util/utils.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/util/utils.py
@@ -8,9 +8,24 @@ from logging import Logger
 
 class ADUtils:
     @staticmethod
+    def escape_non_ascii_characters(input_string: str) -> str:
+        non_ascii_list = {
+            "á": "\\E1",
+            "é": "\\E9",
+            "í": "\\ED",
+            "ó": "\\F3",
+            "ú": "\\FA",
+            "ñ": "\\F1",
+        }
+
+        for non_ascii, escaped_character in non_ascii_list.items():
+            input_string = input_string.replace(non_ascii, escaped_character)
+        return input_string
+
+    @staticmethod
     def dn_normalize(dn: str) -> str:
         """
-        This method normalizes dn keys so that inputs are not case sensitive
+        This method normalizes dn keys so that inputs are not case-sensitive
         :param dn: A dn
         :return: A normalized dn
         """
@@ -33,16 +48,16 @@ class ADUtils:
 
         # Ensure that special characters and non ascii characters are escaped
         character_list = [",", "#", "+", "<", ">", ";", '"']
-        non_ascii_list = {
-            "á": "\\E1",
-            "é": "\\E9",
-            "í": "\\ED",
-            "ó": "\\F3",
-            "ú": "\\FA",
-            "ñ": "\\F1",
-        }
 
-        # These are legal characters that some times need to be escaped and sometimes do not
+        # non_ascii_list = {
+        #     "á": "\\E1",
+        #     "é": "\\E9",
+        #     "í": "\\ED",
+        #     "ó": "\\F3",
+        #     "ú": "\\FA",
+        #     "ñ": "\\F1",
+        # }
+        # These are legal characters that sometimes need to be escaped and sometimes do not
         # We make the use escape them correctly in their inputs if they want to use them
         manual_escape = ["*", "="]
 
@@ -51,9 +66,6 @@ class ADUtils:
             for escaped_char in character_list:
                 if f"\\{escaped_char}" not in value:
                     dn_list[idx] = dn_list[idx].replace(escaped_char, f"\\{escaped_char}")
-            # Escape non ascii characters
-            for non_ascii_char, escaped_char in non_ascii_list.items():
-                dn_list[idx] = dn_list[idx].replace(non_ascii_char, escaped_char)
         # escape \\ as needed
         for idx, value in enumerate(dn_list):
             location = value.find("\\")

--- a/plugins/active_directory_ldap/plugin.spec.yaml
+++ b/plugins/active_directory_ldap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: active_directory_ldap
 title: Active Directory LDAP
 description: "This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network"
-version: 9.0.0
+version: 9.0.1
 supported_versions: ["Azure Active Directory 2.0.89.0"]
 vendor: rapid7
 support: rapid7
@@ -14,15 +14,15 @@ resources:
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
   vendor_url: https://www.microsoft.com
 tags:
-- ldap
-- active directory
-- microsoft
+  - ldap
+  - active directory
+  - microsoft
 hub_tags:
   use_cases: [user_management, credential_management, application_management, threat_detection_and_response]
   keywords: [ldap, microsoft]
   features: []
 sdk:
-  type: full
+  type: slim
   version: 5
   user: nobody
 types:
@@ -274,7 +274,7 @@ actions:
         description: Results returned
         type: '[]result'
         required: false
-        example: '[ { "dn": string, "attributes": { "pwdLastSet": date, "objectClass": [ string, string, string, string ], "memberOf": [ string ], "sAMAccountType": int, "uSNChanged": int, "givenName": string, "userPrincipalName": string, "countryCode": int, "lastLogon": date, "sAMAccountName": string, "name": string, "primaryGroupID": int, "dSCorePropagationData": [ date ], "displayName": string, "logonCount": int, "cn": string, "objectSid": string, "codePage": int, "badPwdCount": int, "objectGUID": string, "distinguishedName": string, "whenChanged": date, "badPasswordTime": date, "instanceType": int, "uSNCreated": int, "sn": string, "whenCreated": date, "accountExpires": date, "userAccountControl": int, "lastLogoff": date, "objectCategory": "string" } } ]'
+        example: '[{"dn":"string","attributes":{"pwdLastSet":"date","objectClass":["string","string","string","string"],"memberOf":["string"],"sAMAccountType":"int","uSNChanged":"int","givenName":"string","userPrincipalName":"string","countryCode":"int","lastLogon":"date","sAMAccountName":"string","name":"string","primaryGroupID":"int","dSCorePropagationData":["date"],"displayName":"string","logonCount":"int","cn":"string","objectSid":"string","codePage":"int","badPwdCount":"int","objectGUID":"string","distinguishedName":"string","whenChanged":"date","badPasswordTime":"date","instanceType":"int","uSNCreated":"int","sn":"string","whenCreated":"date","accountExpires":"date","userAccountControl":"int","lastLogoff":"date","objectCategory":"string"}}]'
       count:
         title: Count
         description: Number of results

--- a/plugins/active_directory_ldap/setup.py
+++ b/plugins/active_directory_ldap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="active_directory_ldap-rapid7-plugin",
-      version="9.0.0",
+      version="9.0.1",
       description="This plugin utilizes Microsoft's Active Directory service to create and manage domains, users, and objects within a network",
       author="rapid7",
       author_email="",

--- a/plugins/active_directory_ldap/unit_test/common.py
+++ b/plugins/active_directory_ldap/unit_test/common.py
@@ -3,15 +3,11 @@ import json
 import logging
 
 import ldap3
-from ldap3.core.connection import SyncStrategy
-from ldap3.core.exceptions import LDAPInvalidDnError
-from ldap3.core.exceptions import LDAPObjectClassError
-from ldap3.core.exceptions import LDAPOperationsErrorResult
-from ldap3.core.results import RESULT_OPERATIONS_ERROR
-from ldap3.core.results import RESULT_SUCCESS
-
 from komand_active_directory_ldap import connection
 from komand_active_directory_ldap.connection.schema import Input
+from ldap3.core.connection import SyncStrategy
+from ldap3.core.exceptions import LDAPInvalidDnError, LDAPObjectClassError, LDAPOperationsErrorResult
+from ldap3.core.results import RESULT_OPERATIONS_ERROR, RESULT_SUCCESS
 
 
 class MockConnection:

--- a/plugins/active_directory_ldap/unit_test/test_add_user.py
+++ b/plugins/active_directory_ldap/unit_test/test_add_user.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.add_user import AddUser
 from komand_active_directory_ldap.actions.add_user.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionAddUser(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_delete.py
+++ b/plugins/active_directory_ldap/unit_test/test_delete.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.delete import Delete
 from komand_active_directory_ldap.actions.delete.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionDelete(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_disable_user.py
+++ b/plugins/active_directory_ldap/unit_test/test_disable_user.py
@@ -1,17 +1,17 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
-from komand_active_directory_ldap.actions.enable_user import EnableUser
-from komand_active_directory_ldap.actions.enable_user.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+from komand_active_directory_ldap.actions.disable_user import DisableUser
+from komand_active_directory_ldap.actions.disable_user.schema import Input, Output
+
+from common import MockConnection, MockServer, default_connector
 
 
-class TestActionEnableUser(TestCase):
+class TestActionDisableUser(TestCase):
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=EnableUser())
-    def test_enable_user(self, action):
+    @default_connector(action=DisableUser())
+    def test_disable_user(self, action):
         actual = action.run({Input.DISTINGUISHED_NAME: "CN=Users,DC=example,DC=com"})
         expected = {Output.SUCCESS: True}
 
@@ -19,8 +19,8 @@ class TestActionEnableUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=EnableUser())
-    def test_enable_user_empty_search(self, action):
+    @default_connector(action=DisableUser())
+    def test_disable_user_empty_search(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=empty_search,DC=example,DC=com"})
 
@@ -29,8 +29,8 @@ class TestActionEnableUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=EnableUser())
-    def test_enable_user_raise(self, action):
+    @default_connector(action=DisableUser())
+    def test_disable_user_raise(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=LDAPInvalidDnError,DC=example,DC=com"})
 
@@ -49,8 +49,8 @@ class TestActionEnableUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=EnableUser())
-    def test_enable_user_wrong_result(self, action):
+    @default_connector(action=DisableUser())
+    def test_disable_user_wrong_result(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=wrong_result,DC=example,DC=com"})
 

--- a/plugins/active_directory_ldap/unit_test/test_disable_users.py
+++ b/plugins/active_directory_ldap/unit_test/test_disable_users.py
@@ -1,14 +1,14 @@
-from parameterized import parameterized
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
-from komand_active_directory_ldap.actions.enable_users import EnableUsers
-from komand_active_directory_ldap.actions.enable_users.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+from komand_active_directory_ldap.actions.disable_users import DisableUsers
+from komand_active_directory_ldap.actions.disable_users.schema import Input, Output
+from parameterized import parameterized
+
+from common import MockConnection, MockServer, default_connector
 
 
-class TestActionEnableUsers(TestCase):
+class TestActionDisableUsers(TestCase):
     @parameterized.expand(
         [
             (
@@ -50,20 +50,20 @@ class TestActionEnableUsers(TestCase):
             (
                 {Input.DISTINGUISHED_NAMES: ["CN=Users,DC=example,DC=com"]},
                 {
-                    Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
                     Output.FAILED: [],
+                    Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
                 },
             ),
         ]
     )
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=EnableUsers())
-    def test_enable_users(self, _input, expected, action):
+    @default_connector(action=DisableUsers())
+    def test_disable_users(self, _input, expected, action):
         actual = action.run(_input)
         self.assertEqual(expected, actual)
 
-    @default_connector(action=EnableUsers())
+    @default_connector(action=DisableUsers())
     def test_empty_input(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAMES: []})

--- a/plugins/active_directory_ldap/unit_test/test_enable_user.py
+++ b/plugins/active_directory_ldap/unit_test/test_enable_user.py
@@ -1,19 +1,17 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
-from komand_active_directory_ldap.actions.unlock_user import UnlockUser
+from komand_active_directory_ldap.actions.enable_user import EnableUser
 from komand_active_directory_ldap.actions.enable_user.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
-from komand_active_directory_ldap.connection import Connection
-import logging
+
+from common import MockConnection, MockServer, default_connector
 
 
-class TestActionUnlockUser(TestCase):
+class TestActionEnableUser(TestCase):
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=UnlockUser())
-    def test_unlock_user(self, action):
+    @default_connector(action=EnableUser())
+    def test_enable_user(self, action):
         actual = action.run({Input.DISTINGUISHED_NAME: "CN=Users,DC=example,DC=com"})
         expected = {Output.SUCCESS: True}
 
@@ -21,8 +19,8 @@ class TestActionUnlockUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=UnlockUser())
-    def test_unlock_user_empty_search(self, action):
+    @default_connector(action=EnableUser())
+    def test_enable_user_empty_search(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=empty_search,DC=example,DC=com"})
 
@@ -31,8 +29,8 @@ class TestActionUnlockUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=UnlockUser())
-    def test_unlock_user_raise(self, action):
+    @default_connector(action=EnableUser())
+    def test_enable_user_raise(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=LDAPInvalidDnError,DC=example,DC=com"})
 
@@ -51,35 +49,10 @@ class TestActionUnlockUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=UnlockUser())
-    def test_unlock_user_wrong_result(self, action):
+    @default_connector(action=EnableUser())
+    def test_enable_user_wrong_result(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=wrong_result,DC=example,DC=com"})
 
         self.assertEqual("The DN CN=wrong_result,DC=example,DC=com was not found.", context.exception.cause)
         self.assertEqual("Please provide a valid DN and try again.", context.exception.assistance)
-
-    def test_unlock_user_integration(self):
-        log = logging.getLogger("Test")
-        test_conn = Connection()
-        test_action = UnlockUser()
-
-        test_conn.logger = log
-        test_action.logger = log
-        # Uncomment when you have a valid JSON file. Allows for debugging of the plugin and won't fail tests otherwise
-        """
-        try:
-            with open("../tests/unlock_user.json") as file:
-                test_json = json.loads(file.read()).get("body")
-                connection_params = test_json.get("connection")
-                action_params = test_json.get("input")
-        except Exception as e:
-            message = "Could not find or read sample tests from /tests directory"
-            self.fail(message)
-
-        test_conn.connect(connection_params)
-        test_action.connection = test_conn
-        results = test_action.run(action_params)
-        
-        # self.assertEquals(True, results.get("success"))
-        """

--- a/plugins/active_directory_ldap/unit_test/test_enable_users.py
+++ b/plugins/active_directory_ldap/unit_test/test_enable_users.py
@@ -1,15 +1,14 @@
+from unittest import TestCase, mock
+
+from insightconnect_plugin_runtime.exceptions import PluginException
+from komand_active_directory_ldap.actions.enable_users import EnableUsers
+from komand_active_directory_ldap.actions.enable_users.schema import Input, Output
 from parameterized import parameterized
 
-from unittest import TestCase, mock
-from insightconnect_plugin_runtime.exceptions import PluginException
-from komand_active_directory_ldap.actions.disable_users import DisableUsers
-from komand_active_directory_ldap.actions.disable_users.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+from common import MockConnection, MockServer, default_connector
 
 
-class TestActionDisableUsers(TestCase):
+class TestActionEnableUsers(TestCase):
     @parameterized.expand(
         [
             (
@@ -51,20 +50,20 @@ class TestActionDisableUsers(TestCase):
             (
                 {Input.DISTINGUISHED_NAMES: ["CN=Users,DC=example,DC=com"]},
                 {
-                    Output.FAILED: [],
                     Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
+                    Output.FAILED: [],
                 },
             ),
         ]
     )
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=DisableUsers())
-    def test_disable_users(self, _input, expected, action):
+    @default_connector(action=EnableUsers())
+    def test_enable_users(self, _input, expected, action):
         actual = action.run(_input)
         self.assertEqual(expected, actual)
 
-    @default_connector(action=DisableUsers())
+    @default_connector(action=EnableUsers())
     def test_empty_input(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAMES: []})

--- a/plugins/active_directory_ldap/unit_test/test_escape_brackets_formatter.py
+++ b/plugins/active_directory_ldap/unit_test/test_escape_brackets_formatter.py
@@ -1,6 +1,5 @@
 from unittest import TestCase
 
-
 from komand_active_directory_ldap.util.utils import ADUtils
 from parameterized import parameterized
 

--- a/plugins/active_directory_ldap/unit_test/test_force_password_reset.py
+++ b/plugins/active_directory_ldap/unit_test/test_force_password_reset.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.force_password_reset import ForcePasswordReset
 from komand_active_directory_ldap.actions.force_password_reset.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionForcePasswordReset(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_host_formatter.py
+++ b/plugins/active_directory_ldap/unit_test/test_host_formatter.py
@@ -4,8 +4,8 @@ from unittest import TestCase, mock
 from komand_active_directory_ldap import connection
 from komand_active_directory_ldap.connection.schema import Input
 from komand_active_directory_ldap.util.api import ActiveDirectoryLdapAPI
-from common import MockConnection
-from common import MockServer
+
+from common import MockConnection, MockServer
 
 
 class TestHostFormatter(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_modify_groups.py
+++ b/plugins/active_directory_ldap/unit_test/test_modify_groups.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.modify_groups import ModifyGroups
 from komand_active_directory_ldap.actions.modify_groups.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionModifyGroups(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_modify_object.py
+++ b/plugins/active_directory_ldap/unit_test/test_modify_object.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.modify_object import ModifyObject
 from komand_active_directory_ldap.actions.modify_object.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionModifyObject(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_move_object.py
+++ b/plugins/active_directory_ldap/unit_test/test_move_object.py
@@ -1,9 +1,9 @@
 from unittest import TestCase, mock
+
 from komand_active_directory_ldap.actions.move_object import MoveObject
 from komand_active_directory_ldap.actions.move_object.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionMoveObject(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_query.py
+++ b/plugins/active_directory_ldap/unit_test/test_query.py
@@ -1,9 +1,9 @@
 from unittest import TestCase, mock
+
 from komand_active_directory_ldap.actions.query import Query
 from komand_active_directory_ldap.actions.query.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionQuery(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_query_group_membership.py
+++ b/plugins/active_directory_ldap/unit_test/test_query_group_membership.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.query_group_membership import QueryGroupMembership
 from komand_active_directory_ldap.actions.query_group_membership.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionQueryGroupMembership(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_reset_password.py
+++ b/plugins/active_directory_ldap/unit_test/test_reset_password.py
@@ -1,10 +1,10 @@
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_active_directory_ldap.actions.reset_password import ResetPassword
 from komand_active_directory_ldap.actions.reset_password.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+
+from common import MockConnection, MockServer, default_connector
 
 
 class TestActionResetPassword(TestCase):

--- a/plugins/active_directory_ldap/unit_test/test_unlock_user.py
+++ b/plugins/active_directory_ldap/unit_test/test_unlock_user.py
@@ -1,17 +1,19 @@
+import logging
 from unittest import TestCase, mock
+
 from insightconnect_plugin_runtime.exceptions import PluginException
-from komand_active_directory_ldap.actions.disable_user import DisableUser
-from komand_active_directory_ldap.actions.disable_user.schema import Input, Output
-from common import MockConnection
-from common import MockServer
-from common import default_connector
+from komand_active_directory_ldap.actions.enable_user.schema import Input, Output
+from komand_active_directory_ldap.actions.unlock_user import UnlockUser
+from komand_active_directory_ldap.connection import Connection
+
+from common import MockConnection, MockServer, default_connector
 
 
-class TestActionDisableUser(TestCase):
+class TestActionUnlockUser(TestCase):
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=DisableUser())
-    def test_disable_user(self, action):
+    @default_connector(action=UnlockUser())
+    def test_unlock_user(self, action):
         actual = action.run({Input.DISTINGUISHED_NAME: "CN=Users,DC=example,DC=com"})
         expected = {Output.SUCCESS: True}
 
@@ -19,8 +21,8 @@ class TestActionDisableUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=DisableUser())
-    def test_disable_user_empty_search(self, action):
+    @default_connector(action=UnlockUser())
+    def test_unlock_user_empty_search(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=empty_search,DC=example,DC=com"})
 
@@ -29,8 +31,8 @@ class TestActionDisableUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=DisableUser())
-    def test_disable_user_raise(self, action):
+    @default_connector(action=UnlockUser())
+    def test_unlock_user_raise(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=LDAPInvalidDnError,DC=example,DC=com"})
 
@@ -49,10 +51,35 @@ class TestActionDisableUser(TestCase):
 
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
-    @default_connector(action=DisableUser())
-    def test_disable_user_wrong_result(self, action):
+    @default_connector(action=UnlockUser())
+    def test_unlock_user_wrong_result(self, action):
         with self.assertRaises(PluginException) as context:
             action.run({Input.DISTINGUISHED_NAME: "CN=wrong_result,DC=example,DC=com"})
 
         self.assertEqual("The DN CN=wrong_result,DC=example,DC=com was not found.", context.exception.cause)
         self.assertEqual("Please provide a valid DN and try again.", context.exception.assistance)
+
+    def test_unlock_user_integration(self):
+        log = logging.getLogger("Test")
+        test_conn = Connection()
+        test_action = UnlockUser()
+
+        test_conn.logger = log
+        test_action.logger = log
+        # Uncomment when you have a valid JSON file. Allows for debugging of the plugin and won't fail tests otherwise
+        """
+        try:
+            with open("../tests/unlock_user.json") as file:
+                test_json = json.loads(file.read()).get("body")
+                connection_params = test_json.get("connection")
+                action_params = test_json.get("input")
+        except Exception as e:
+            message = "Could not find or read sample tests from /tests directory"
+            self.fail(message)
+
+        test_conn.connect(connection_params)
+        test_action.connection = test_conn
+        results = test_action.run(action_params)
+        
+        # self.assertEquals(True, results.get("success"))
+        """


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Fix problem where some ASCII characters were not escaped properly

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [X] Screenshot of job output with the plugin changes
- [X] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
