### PR TITLE
[PLGN-651] Abnormal Security-Fixing issue where toTime should be lte

### DIFF
--- a/plugins/abnormal_security/.CHECKSUM
+++ b/plugins/abnormal_security/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "4466a331c3bbae9c1348cf7731663cec",
-	"manifest": "a0e1a881d85289d7af7e124b259fc21d",
-	"setup": "be1d36c398425feb179b65aa612a265b",
+	"spec": "54821dd0f7e13a2ff4d93f0c05db1108",
+	"manifest": "42a45d3adc43907a028ba7ac0a2b3059",
+	"setup": "8447e8fc54f08c59ec4e4c585e395d88",
 	"schemas": [
 		{
 			"identifier": "get_case_details/schema.py",

--- a/plugins/abnormal_security/bin/icon_abnormal_security
+++ b/plugins/abnormal_security/bin/icon_abnormal_security
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Abnormal Security"
 Vendor = "rapid7"
-Version = "2.0.1"
+Version = "2.0.2"
 Description = "Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks"
 
 

--- a/plugins/abnormal_security/help.md
+++ b/plugins/abnormal_security/help.md
@@ -452,8 +452,7 @@ Example output:
 
 # Version History
 
-* 2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and 
-`get_threats` actions  
+* 2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions  
 * 2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions  
 * 2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version  
 * 1.3.0 - New logo and requirements update  

--- a/plugins/abnormal_security/help.md
+++ b/plugins/abnormal_security/help.md
@@ -452,7 +452,9 @@ Example output:
 
 # Version History
 
-* 2.0.1 - To remove formatting of the fromTime or toTome values used in the `get_cases` and `get_threats` actions  
+* 2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and 
+`get_threats` actions  
+* 2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions  
 * 2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version  
 * 1.3.0 - New logo and requirements update  
 * 1.2.0 - New actions Manage Case and Manage Threat  

--- a/plugins/abnormal_security/icon_abnormal_security/util/api.py
+++ b/plugins/abnormal_security/icon_abnormal_security/util/api.py
@@ -93,7 +93,7 @@ class AbnormalSecurityAPI:
             if from_date:
                 params["filter"] = f"{params.get('filter', '')} gte {from_date}"
             if to_date:
-                params["filter"] = f"{params.get('filter', '')} gte {to_date}"
+                params["filter"] = f"{params.get('filter', '')} lte {to_date}"
         self.logger.info(f"Paramters used for the api call - {params}")
         return params
 

--- a/plugins/abnormal_security/plugin.spec.yaml
+++ b/plugins/abnormal_security/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: abnormal_security
 title: Abnormal Security
 description: Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks
-version: 2.0.1
+version: 2.0.2
 supported_versions: ["abnormal-security API abx v1.4.2"]
 vendor: rapid7
 support: rapid7
@@ -20,7 +20,8 @@ resources:
   vendor_url: https://abnormalsecurity.com/
 enable_cache: true
 version_history:
-  - '2.0.1 - To remove formatting of the fromTime or toTome values used in the `get_cases` and `get_threats` actions'
+  - '2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions'
+  - '2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions'
   - '2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version'
   - '1.3.0 - New logo and requirements update'
   - '1.2.0 - New actions Manage Case and Manage Threat'

--- a/plugins/abnormal_security/setup.py
+++ b/plugins/abnormal_security/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="abnormal_security-rapid7-plugin",
-      version="2.0.1",
+      version="2.0.2",
       description="Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

After a change made in https://github.com/rapid7/insightconnect-plugins/pull/2196 toTime had went is gte, but should be lte
  
  - Update gte to lte


https://issues.corp.rapid7.com/browse/PLGN-651

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

testing on docker with the following input 
`
"input": {
      "from_date": "2023-12-01T00:00:00Z",
      "to_date": "2023-12-31T00:00:00Z"
  }
`

`rapid7/Abnormal Security:2.0.2. Step name: get_threats 
Paramters used for the api call - {'filter': 'receivedTime gte 2023-12-01T00:00:00Z lte 2023-12-31T00:00:00Z'}`

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
