### PR TITLE
Abnormal Security v2.0.2 release

### DIFF
--- a/plugins/abnormal_security/.CHECKSUM
+++ b/plugins/abnormal_security/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "4466a331c3bbae9c1348cf7731663cec",
-	"manifest": "a0e1a881d85289d7af7e124b259fc21d",
-	"setup": "be1d36c398425feb179b65aa612a265b",
+	"spec": "54821dd0f7e13a2ff4d93f0c05db1108",
+	"manifest": "42a45d3adc43907a028ba7ac0a2b3059",
+	"setup": "8447e8fc54f08c59ec4e4c585e395d88",
 	"schemas": [
 		{
 			"identifier": "get_case_details/schema.py",

--- a/plugins/abnormal_security/bin/icon_abnormal_security
+++ b/plugins/abnormal_security/bin/icon_abnormal_security
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Abnormal Security"
 Vendor = "rapid7"
-Version = "2.0.1"
+Version = "2.0.2"
 Description = "Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks"
 
 

--- a/plugins/abnormal_security/help.md
+++ b/plugins/abnormal_security/help.md
@@ -452,7 +452,8 @@ Example output:
 
 # Version History
 
-* 2.0.1 - To remove formatting of the fromTime or toTome values used in the `get_cases` and `get_threats` actions  
+* 2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions  
+* 2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions  
 * 2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version  
 * 1.3.0 - New logo and requirements update  
 * 1.2.0 - New actions Manage Case and Manage Threat  

--- a/plugins/abnormal_security/icon_abnormal_security/util/api.py
+++ b/plugins/abnormal_security/icon_abnormal_security/util/api.py
@@ -93,7 +93,7 @@ class AbnormalSecurityAPI:
             if from_date:
                 params["filter"] = f"{params.get('filter', '')} gte {from_date}"
             if to_date:
-                params["filter"] = f"{params.get('filter', '')} gte {to_date}"
+                params["filter"] = f"{params.get('filter', '')} lte {to_date}"
         self.logger.info(f"Paramters used for the api call - {params}")
         return params
 

--- a/plugins/abnormal_security/plugin.spec.yaml
+++ b/plugins/abnormal_security/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: abnormal_security
 title: Abnormal Security
 description: Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks
-version: 2.0.1
+version: 2.0.2
 supported_versions: ["abnormal-security API abx v1.4.2"]
 vendor: rapid7
 support: rapid7
@@ -20,7 +20,8 @@ resources:
   vendor_url: https://abnormalsecurity.com/
 enable_cache: true
 version_history:
-  - '2.0.1 - To remove formatting of the fromTime or toTome values used in the `get_cases` and `get_threats` actions'
+  - '2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions'
+  - '2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions'
   - '2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version'
   - '1.3.0 - New logo and requirements update'
   - '1.2.0 - New actions Manage Case and Manage Threat'

--- a/plugins/abnormal_security/setup.py
+++ b/plugins/abnormal_security/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="abnormal_security-rapid7-plugin",
-      version="2.0.1",
+      version="2.0.2",
       description="Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - https://github.com/rapid7/insightconnect-plugins/pull/2196
    - Update gte to lte for the fromTime used to query the abnormal security endpoint 


https://issues.corp.rapid7.com/browse/PLGN-651



testing on stging using the following input 

`{
  "from_date": "2023-12-01T00:00:00Z",
  "to_date": "2023-12-31T00:00:00Z"
}
`

the time string will now be correct 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/e87c4fc9-aafc-47a2-8889-fca7924d4951)

