### PR TITLE
[PLGN-646] Correct Automox check failures

### DIFF
--- a/plugins/automox/.CHECKSUM
+++ b/plugins/automox/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "78226b5c9b4bf0bc2671383f7d6bf49c",
+	"spec": "cd79984176d8b69301ff2c9be6362cab",
 	"manifest": "2c6036c8148029801d83cb235746f4e5",
 	"setup": "3bdb2f139da45cd18003c8b107df72b8",
 	"schemas": [

--- a/plugins/automox/help.md
+++ b/plugins/automox/help.md
@@ -1062,7 +1062,6 @@ This action is used to retrieve the issues identified for a specified vulnerabil
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |action_set_id|integer|None|True|Identifier of the action set|None|1234|
-|issue_type_in|[]string|None|False|Filter by issue type|None|['unknown-host']|
 |org_id|integer|None|True|Identifier of organization|None|1234|
 |issue_type_in|[]string|None|False|Filter by issue type|None|["unknown-host"]|
   
@@ -1115,7 +1114,6 @@ This action is used to retrieve a list of vulnerability sync remediations
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |action_set_id|integer|None|True|Filter by action set identifier|None|1234|
 |org_id|integer|None|True|Identifier of organization|None|1234|
-|remediation_type_in|[]string|None|False|Filter by remediation type|None|['patch-now', 'patch-with-worklet']|
 |severity_in|[]string|None|False|Filter by severity|None|["critical", "high", "medium", "low", "unknown"]|
 |vulnerability_in|[]string|None|False|Filter by vulnerability|None|["CVE-2020-1234", "CVE-2020-5678"]|
 |remediation_type_in|[]string|None|False|Filter by remediation type|None|["patch-now", "patch-with-worklet"]|
@@ -1204,7 +1202,7 @@ This action is used to retrieve list of vulnerability sync batches
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum| Example                                                           |
-| :--- | :--- | :--- | :--- | :--- | :--- |:------------------------------------------------------------------|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |configuration_id_equals|string|None|False|Filter by configuration ID|None|00000000-0000-0000-0000-000000000000|
 |configuration_id_is_set|boolean|None|False|Filter based on whether the configuration ID is set|None|True|
 |group_sort|string|None|False|Sort results by field|['asc', 'desc', 'latest_updated_at:asc', 'latest_updated_at:desc', 'source:asc', 'source:desc', '']|latest_updated_at:desc|
@@ -1295,7 +1293,7 @@ This action is used to run a command on a device
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :-- |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |command|string|None|True|Command to run on device|['GetOS', 'InstallUpdate', 'InstallAllUpdates', 'PolicyTest', 'PolicyRemediate', 'Reboot']|GetOS|
 |device_id|integer|None|True|Identifier of device|None|1234|
 |org_id|integer|None|False|Identifier of organization|None|1234|

--- a/plugins/automox/help.md
+++ b/plugins/automox/help.md
@@ -1201,7 +1201,7 @@ This action is used to retrieve list of vulnerability sync batches
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum| Example                                                           |
+|Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |configuration_id_equals|string|None|False|Filter by configuration ID|None|00000000-0000-0000-0000-000000000000|
 |configuration_id_is_set|boolean|None|False|Filter based on whether the configuration ID is set|None|True|

--- a/plugins/automox/help.md
+++ b/plugins/automox/help.md
@@ -1064,6 +1064,7 @@ This action is used to retrieve the issues identified for a specified vulnerabil
 |action_set_id|integer|None|True|Identifier of the action set|None|1234|
 |issue_type_in|[]string|None|False|Filter by issue type|None|['unknown-host']|
 |org_id|integer|None|True|Identifier of organization|None|1234|
+|issue_type_in|[]string|None|False|Filter by issue type|None|["unknown-host"]|
   
 Example input:
 
@@ -1115,8 +1116,9 @@ This action is used to retrieve a list of vulnerability sync remediations
 |action_set_id|integer|None|True|Filter by action set identifier|None|1234|
 |org_id|integer|None|True|Identifier of organization|None|1234|
 |remediation_type_in|[]string|None|False|Filter by remediation type|None|['patch-now', 'patch-with-worklet']|
-|severity_in|[]string|None|False|Filter by severity|None|['critical', 'high', 'medium', 'low', 'unknown']|
-|vulnerability_in|[]string|None|False|Filter by vulnerability|None|['CVE-2020-1234', 'CVE-2020-5678']|
+|severity_in|[]string|None|False|Filter by severity|None|["critical", "high", "medium", "low", "unknown"]|
+|vulnerability_in|[]string|None|False|Filter by vulnerability|None|["CVE-2020-1234", "CVE-2020-5678"]|
+|remediation_type_in|[]string|None|False|Filter by remediation type|None|["patch-now", "patch-with-worklet"]|
   
 Example input:
 
@@ -1201,17 +1203,17 @@ This action is used to retrieve list of vulnerability sync batches
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|Name|Type|Default|Required|Description|Enum| Example                                                           |
+| :--- | :--- | :--- | :--- | :--- | :--- |:------------------------------------------------------------------|
 |configuration_id_equals|string|None|False|Filter by configuration ID|None|00000000-0000-0000-0000-000000000000|
 |configuration_id_is_set|boolean|None|False|Filter based on whether the configuration ID is set|None|True|
 |group_sort|string|None|False|Sort results by field|['asc', 'desc', 'latest_updated_at:asc', 'latest_updated_at:desc', 'source:asc', 'source:desc', '']|latest_updated_at:desc|
 |include_all_runs_equals|boolean|None|False|Whether to include all runs in the response|None|True|
 |org_id|integer|None|True|Identifier of organization|None|1234|
 |sort|string|None|False|Sort results by field|['created_at', 'updated_at', 'status', 'source_type', 'source_name', 'configuration_id', '']|created_at|
-|source_type_in|[]string|None|False|Filter by source type|None|['Generic Report', 'CrowdStrike', 'Rapid7', 'TenableIO', 'Qualys']|
-|status_in|[]string|None|False|Filter by status|None|['building', 'ready', 'error']|
-|status_not_in|[]string|None|False|Filter by status|None|['building', 'ready', 'error']|
+|source_type_in|[]string|None|False|Filter by source type|None|["Generic Report", "CrowdStrike", "Rapid7", "TenableIO", "Qualys"]|
+|status_in|[]string|None|False|Filter by status|None|["building", "ready", "error"]|
+|status_not_in|[]string|None|False|Filter by status|None|["building", "ready", "error"]|
   
 Example input:
 
@@ -1293,11 +1295,11 @@ This action is used to run a command on a device
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| :--- | :--- | :--- | :--- | :--- | :--- | :-- |
 |command|string|None|True|Command to run on device|['GetOS', 'InstallUpdate', 'InstallAllUpdates', 'PolicyTest', 'PolicyRemediate', 'Reboot']|GetOS|
 |device_id|integer|None|True|Identifier of device|None|1234|
 |org_id|integer|None|False|Identifier of organization|None|1234|
-|patches|[]string|None|False|List of patches to be installed by name (Note: this only works with the InstallUpdate command)|None|['Security Update (KB4549947)']|
+|patches|[]string|None|False|List of patches to be installed by name (Note: this only works with the InstallUpdate command)|None|["Security Update (KB4549947)"]|
 |policy_id|integer|None|False|Identifier of policy|None|1234|
   
 Example input:
@@ -1339,7 +1341,7 @@ This action is used to update Automox device
 |exception|boolean|False|True|Exclude the device from reports and statistics|None|False|
 |org_id|integer|None|False|Identifier of organization|None|1234|
 |server_group_id|integer|None|False|Identifier of server group|None|1234|
-|tags|[]string|None|False|List of tags|None|['tag1', 'tag2']|
+|tags|[]string|None|False|List of tags|None|["tag1", "tag2"]|
   
 Example input:
 

--- a/plugins/automox/icon_automox/actions/execute_vulnerability_sync_actions/action.py
+++ b/plugins/automox/icon_automox/actions/execute_vulnerability_sync_actions/action.py
@@ -25,9 +25,7 @@ class ExecuteVulnerabilitySyncActions(insightconnect_plugin_runtime.Action):
         action_set_id = params.get(Input.ACTION_SET_ID)
         actions = params.get(Input.ACTIONS)
         if actions is None or len(actions) == 0:
-            raise PluginException(
-                cause="Invalid input", assistance="Actions cannot be empty."
-            )
+            raise PluginException(cause="Invalid input", assistance="Actions cannot be empty.")
         formatted_actions = []
         for action in actions:
             fa = {

--- a/plugins/automox/icon_automox/actions/list_vulnerability_sync_action_set_solutions/action.py
+++ b/plugins/automox/icon_automox/actions/list_vulnerability_sync_action_set_solutions/action.py
@@ -30,8 +30,9 @@ class ListVulnerabilitySyncActionSetSolutions(insightconnect_plugin_runtime.Acti
                 "vulnerability_id:in[]": params.get(Input.VULNERABILITY_IN),
             }
         )
-        solutions = self.connection.automox_api.list_vulnerability_sync_action_set_solutions(org_id, action_set_id,
-                                                                                             params)
+        solutions = self.connection.automox_api.list_vulnerability_sync_action_set_solutions(
+            org_id, action_set_id, params
+        )
         # Set the device_ids field for each solution as a helper in workflows
         for solution in solutions:
             solution["device_ids"] = [device["id"] for device in solution["devices"]]

--- a/plugins/automox/icon_automox/actions/update_group/action.py
+++ b/plugins/automox/icon_automox/actions/update_group/action.py
@@ -21,7 +21,7 @@ class UpdateGroup(insightconnect_plugin_runtime.Action):
             "name": params.get(Input.NAME) or current_group_settings["name"],
             "refresh_interval": params.get(Input.REFRESH_INTERVAL) or current_group_settings["refresh_interval"],
             "parent_server_group_id": params.get(Input.PARENT_SERVER_GROUP_ID)
-                                      or current_group_settings["parent_server_group_id"],
+            or current_group_settings["parent_server_group_id"],
             "ui_color": params.get(Input.COLOR) or current_group_settings["ui_color"],
             "notes": params.get(Input.NOTES) or current_group_settings["notes"],
             "enable_os_auto_update": None,

--- a/plugins/automox/icon_automox/util/api_client.py
+++ b/plugins/automox/icon_automox/util/api_client.py
@@ -112,12 +112,17 @@ class ApiClient:
     # Remove Null from response to avoid type issues
     def remove_null_values(self, item: Collection):
         if isinstance(item, dict):
-            return dict((key, self.remove_null_values(value))
-                        for key, value in item.items() if self._is_value_or_number(value) and
-                        self._is_value_or_number(self.remove_null_values(value)))
+            return dict(
+                (key, self.remove_null_values(value))
+                for key, value in item.items()
+                if self._is_value_or_number(value) and self._is_value_or_number(self.remove_null_values(value))
+            )
         elif isinstance(item, list):
-            return [self.remove_null_values(value) for value in item if self._is_value_or_number(value) and
-                    self._is_value_or_number(self.remove_null_values(value))]
+            return [
+                self.remove_null_values(value)
+                for value in item
+                if self._is_value_or_number(value) and self._is_value_or_number(self.remove_null_values(value))
+            ]
         else:
             return item
 
@@ -165,9 +170,7 @@ class ApiClient:
         :param org_id: Organization ID
         :return: Dict of users
         """
-        return self.remove_null_values(
-            self._page_results(f"{self.endpoint}/users", self._org_param(org_id))
-        )
+        return self.remove_null_values(self._page_results(f"{self.endpoint}/users", self._org_param(org_id)))
 
     # Devices/Endpoints
     def get_device(self, org_id: int, device_id: int) -> Dict:
@@ -352,7 +355,7 @@ class ApiClient:
                     raise PluginException(
                         preset=PluginException.Preset.SERVER_ERROR,
                         assistance=f"Failed to upload file to Vulnerability Sync - Response code: {response.status_code}, "
-                                   f"Content: {response.text}",
+                        f"Content: {response.text}",
                     )
             except PluginException:
                 raise
@@ -360,13 +363,13 @@ class ApiClient:
                 raise PluginException(
                     preset=PluginException.Preset.INVALID_JSON,
                     assistance=f"Failed to upload file to Vulnerability Sync - Response code: {response.status_code}, "
-                               f"Content: {response.text}, Error: {str(error)}"
+                    f"Content: {response.text}, Error: {str(error)}",
                 )
             except Exception as error:
                 raise PluginException(
                     preset=PluginException.Preset.UNKNOWN,
                     assistance=f"Failed to upload file to Vulnerability Sync - Response code: {response.status_code}, "
-                               f"Content: {response.text}, Error: {str(error)}"
+                    f"Content: {response.text}, Error: {str(error)}",
                 )
 
     def list_vulnerability_sync_action_sets(self, org_id: int, params=None) -> List[Dict]:
@@ -381,23 +384,29 @@ class ApiClient:
         if params is None:
             params = {}
         params.update(self._org_param(org_id))
-        return self.remove_null_values(self._page_results_data(
-            f"{self.endpoint}/orgs/{org_id}/remediations/action-sets/{action_set_id}/issues", params=params
-        ))
+        return self.remove_null_values(
+            self._page_results_data(
+                f"{self.endpoint}/orgs/{org_id}/remediations/action-sets/{action_set_id}/issues", params=params
+            )
+        )
 
     def list_vulnerability_sync_action_set_solutions(self, org_id: int, action_set_id: int, params=None) -> List[Dict]:
         if params is None:
             params = {}
         params.update(self._org_param(org_id))
-        return self.remove_null_values(self._page_results_data(
-            f"{self.endpoint}/orgs/{org_id}/remediations/action-sets/{action_set_id}/solutions", params=params
-        ))
+        return self.remove_null_values(
+            self._page_results_data(
+                f"{self.endpoint}/orgs/{org_id}/remediations/action-sets/{action_set_id}/solutions", params=params
+            )
+        )
 
     def get_vulnerability_sync_action_set(self, org_id: int, action_set_id: int) -> Dict:
         params = self._org_param(org_id)
-        return self.remove_null_values(self._call_api(
-            "GET", f"{self.endpoint}/orgs/{org_id}/remediations/action-sets/{action_set_id}", params=params
-        ))
+        return self.remove_null_values(
+            self._call_api(
+                "GET", f"{self.endpoint}/orgs/{org_id}/remediations/action-sets/{action_set_id}", params=params
+            )
+        )
 
     def delete_vulnerability_sync_action_set(self, org_id: int, action_set_id: int) -> bool:
         params = self._org_param(org_id)

--- a/plugins/automox/plugin.spec.yaml
+++ b/plugins/automox/plugin.spec.yaml
@@ -7,25 +7,6 @@ title: Automox
 description: Automox is modernizing IT operations with continuous visibility, insight,
   and agility for your entire IT environment
 version: 3.0.0
-version_history:
-  - '3.0.0 - `Action`: Fixed -  Get Vulnerability Sync Action Set | `Action`: Fixed
-    - List Vulnerability Sync Action Sets | `Action`: Updated - List Organization Users'
-  - '2.0.0 - Fix Vulnerability Sync API Actions | `Action`: Added - Delete Vulnerability
-    Sync Action Set | `Action`: Added - Execute Vulnerability Sync Actions | `Action`:
-    Added - List Vulnerability Sync Action Set Issues | `Action`: Added - List Vulnerability
-    Sync Action Set Solutions | `Action`: Added - List Vulnerability Sync Action Sets
-    | `Action`: Added - Get Vulnerability Sync Action Set | `Action`: Updated - Upload
-    Vulnerability Sync File | `Action`: Updated - Get Devices | `Action`: Deleted -
-    Action on Vulnerability Sync Batch | `Action`: Deleted - Vulnerability Sync Task
-    | `Action`: Deleted - Get Vulnerability Sync Batch | `Action`: Deleted - List Vulnerability
-    Sync Batches | `Action`: Deleted - List Vulnerability Sync Tasks'
-  - '1.2.0 - Get device by IP and Get device by hostname: fix validation issue when
-    IP or hostname not found | Add unit tests'
-  - '1.1.1 - Fix undefined org ID passed to actions when not required | Record outcome
-    of connection tests'
-  - '1.1.0 - Add `report source` as optional input parameter to Upload Vulnerability
-    Sync File action | Add report source to batch type'
-  - '1.0.0 - Initial plugin'
 supported_versions: [All as of 12/29/2023]
 support: partner
 status: []

--- a/plugins/automox/plugin.spec.yaml
+++ b/plugins/automox/plugin.spec.yaml
@@ -7,6 +7,7 @@ title: Automox
 description: Automox is modernizing IT operations with continuous visibility, insight,
   and agility for your entire IT environment
 version: 3.0.0
+connection_version: 3
 supported_versions: [All as of 12/29/2023]
 support: partner
 status: []

--- a/plugins/automox/unit_test/test_create_group.py
+++ b/plugins/automox/unit_test/test_create_group.py
@@ -47,11 +47,9 @@ class TestCreateGroup(TestCase):
                     "is_managed": True,
                     "server_url": "string",
                     "created_at": "string",
-                    "updated_at": "string"
+                    "updated_at": "string",
                 },
-                "policies": [
-                    1234
-                ]
+                "policies": [1234],
             },
         }
 

--- a/plugins/automox/unit_test/test_delete_vulnerability_sync_action_set.py
+++ b/plugins/automox/unit_test/test_delete_vulnerability_sync_action_set.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath("../"))
 
 from parameterized import parameterized
 from unittest.mock import patch, Mock

--- a/plugins/automox/unit_test/test_execute_vulnerability_sync_actions.py
+++ b/plugins/automox/unit_test/test_execute_vulnerability_sync_actions.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath("../"))
 
 from parameterized import parameterized
 from unittest.mock import patch, Mock
@@ -26,16 +26,11 @@ from icon_automox.actions.execute_vulnerability_sync_actions.schema import Input
 class TestExecuteVulnerabilitySyncActions(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(ExecuteVulnerabilitySyncActions())
-        self.params = {Input.ORG_ID: ORG_ID, Input.ACTION_SET_ID: ACTION_SET_ID, Input.ACTIONS: [
-            {
-                "action": "patch-with-worklet",
-                "worklet_id": 2062699,
-                "device_ids": [
-                    1769272,
-                    1768969
-                ]
-            }
-        ]}
+        self.params = {
+            Input.ORG_ID: ORG_ID,
+            Input.ACTION_SET_ID: ACTION_SET_ID,
+            Input.ACTIONS: [{"action": "patch-with-worklet", "worklet_id": 2062699, "device_ids": [1769272, 1768969]}],
+        }
 
     @patch("requests.Session.request", side_effect=mock_request_204)
     def test_execute_vulnerability_sync_actions_ok(self, mock: Mock) -> None:

--- a/plugins/automox/unit_test/test_get_device_by_hostname.py
+++ b/plugins/automox/unit_test/test_get_device_by_hostname.py
@@ -47,9 +47,7 @@ class TestGetDeviceByIp(TestCase):
                             "DEVICE": "en0",
                             "TYPE": "enet",
                             "MAC": "00:00:00:00:00:00",
-                            "IPS": [
-                                "192.168.1.1"
-                            ]
+                            "IPS": ["192.168.1.1"],
                         }
                     ],
                     "VOLUME": [
@@ -59,7 +57,7 @@ class TestGetDeviceByIp(TestCase):
                             "AVAIL": "62704803840",
                             "FREE": "21316517888",
                             "IS_SYSTEM_DISK": "true",
-                            "VOLUME": "/dev/disk1s5s1"
+                            "VOLUME": "/dev/disk1s5s1",
                         },
                         {
                             "VOLUME": "/dev/disk1s3",
@@ -67,43 +65,25 @@ class TestGetDeviceByIp(TestCase):
                             "LABEL": "Recovery",
                             "AVAIL": "62704803840",
                             "FREE": "21316517888",
-                            "IS_SYSTEM_DISK": "false"
-                        }
+                            "IS_SYSTEM_DISK": "false",
+                        },
                     ],
                     "VENDOR": "Apple",
                     "MDM_PROFILE_INSTALLED": "false",
-                    "LAST_USER_LOGON": {
-                        "SRC": "console",
-                        "USER": "root",
-                        "TIME": "2023-04-14 16:05"
-                    },
-                    "UPDATE_SOURCE_CHECK": {
-                        "CONNECTED": "true",
-                        "ERROR": "Succeded"
-                    },
+                    "LAST_USER_LOGON": {"SRC": "console", "USER": "root", "TIME": "2023-04-14 16:05"},
+                    "UPDATE_SOURCE_CHECK": {"CONNECTED": "true", "ERROR": "Succeded"},
                     "SERIAL": "C00000000001",
-                    "DISKS": [
-                        {
-                            "TYPE": "VMware Virtual NVMe Disk",
-                            "SIZE": "62914560000"
-                        }
-                    ],
-                    "IPS": [
-                        "192.168.1.1"
-                    ],
+                    "DISKS": [{"TYPE": "VMware Virtual NVMe Disk", "SIZE": "62914560000"}],
+                    "IPS": ["192.168.1.1"],
                     "MODEL": "MacBook Pro",
                     "AUTO_UPDATE_OPTIONS": {
                         "OPTIONS": "Automatic Check for Updates, Install system data updates, Install system security updates",
-                        "ENABLED": "0"
-                    }
+                        "ENABLED": "0",
+                    },
                 },
                 "display_name": "apple",
-                "ip_addrs": [
-                    "0.0.0.0"
-                ],
-                "ip_addrs_private": [
-                    "192.168.1.1"
-                ],
+                "ip_addrs": ["0.0.0.0"],
+                "ip_addrs_private": ["192.168.1.1"],
                 "is_compatible": True,
                 "last_disconnect_time": "2023-04-14T23:07:04+0000",
                 "last_logged_in_user": "root",
@@ -120,15 +100,11 @@ class TestGetDeviceByIp(TestCase):
                 "refresh_interval": 1440,
                 "serial_number": "C00000000001",
                 "server_group_id": 1234,
-                "status": {
-                    "device_status": "not-ready",
-                    "agent_status": "disconnected",
-                    "policy_status": "unmanaged"
-                },
+                "status": {"device_status": "not-ready", "agent_status": "disconnected", "policy_status": "unmanaged"},
                 "timezone": "UTC-0700",
                 "total_count": 5,
                 "uptime": "88632",
-                "uuid": "00000000-0000-0000-0000-000000000000"
+                "uuid": "00000000-0000-0000-0000-000000000000",
             },
         }
 

--- a/plugins/automox/unit_test/test_get_device_by_ip.py
+++ b/plugins/automox/unit_test/test_get_device_by_ip.py
@@ -47,9 +47,7 @@ class TestGetDeviceByIp(TestCase):
                             "DEVICE": "en0",
                             "TYPE": "enet",
                             "MAC": "00:00:00:00:00:00",
-                            "IPS": [
-                                "192.168.1.1"
-                            ]
+                            "IPS": ["192.168.1.1"],
                         }
                     ],
                     "VOLUME": [
@@ -59,7 +57,7 @@ class TestGetDeviceByIp(TestCase):
                             "AVAIL": "62704803840",
                             "FREE": "21316517888",
                             "IS_SYSTEM_DISK": "true",
-                            "VOLUME": "/dev/disk1s5s1"
+                            "VOLUME": "/dev/disk1s5s1",
                         },
                         {
                             "VOLUME": "/dev/disk1s3",
@@ -67,43 +65,25 @@ class TestGetDeviceByIp(TestCase):
                             "LABEL": "Recovery",
                             "AVAIL": "62704803840",
                             "FREE": "21316517888",
-                            "IS_SYSTEM_DISK": "false"
-                        }
+                            "IS_SYSTEM_DISK": "false",
+                        },
                     ],
                     "VENDOR": "Apple",
                     "MDM_PROFILE_INSTALLED": "false",
-                    "LAST_USER_LOGON": {
-                        "SRC": "console",
-                        "USER": "root",
-                        "TIME": "2023-04-14 16:05"
-                    },
-                    "UPDATE_SOURCE_CHECK": {
-                        "CONNECTED": "true",
-                        "ERROR": "Succeded"
-                    },
+                    "LAST_USER_LOGON": {"SRC": "console", "USER": "root", "TIME": "2023-04-14 16:05"},
+                    "UPDATE_SOURCE_CHECK": {"CONNECTED": "true", "ERROR": "Succeded"},
                     "SERIAL": "C00000000001",
-                    "DISKS": [
-                        {
-                            "TYPE": "VMware Virtual NVMe Disk",
-                            "SIZE": "62914560000"
-                        }
-                    ],
-                    "IPS": [
-                        "192.168.1.1"
-                    ],
+                    "DISKS": [{"TYPE": "VMware Virtual NVMe Disk", "SIZE": "62914560000"}],
+                    "IPS": ["192.168.1.1"],
                     "MODEL": "MacBook Pro",
                     "AUTO_UPDATE_OPTIONS": {
                         "OPTIONS": "Automatic Check for Updates, Install system data updates, Install system security updates",
-                        "ENABLED": "0"
-                    }
+                        "ENABLED": "0",
+                    },
                 },
                 "display_name": "apple",
-                "ip_addrs": [
-                    "0.0.0.0"
-                ],
-                "ip_addrs_private": [
-                    "192.168.1.1"
-                ],
+                "ip_addrs": ["0.0.0.0"],
+                "ip_addrs_private": ["192.168.1.1"],
                 "is_compatible": True,
                 "last_disconnect_time": "2023-04-14T23:07:04+0000",
                 "last_logged_in_user": "root",
@@ -120,15 +100,11 @@ class TestGetDeviceByIp(TestCase):
                 "refresh_interval": 1440,
                 "serial_number": "C00000000001",
                 "server_group_id": 1234,
-                "status": {
-                    "device_status": "not-ready",
-                    "agent_status": "disconnected",
-                    "policy_status": "unmanaged"
-                },
+                "status": {"device_status": "not-ready", "agent_status": "disconnected", "policy_status": "unmanaged"},
                 "timezone": "UTC-0700",
                 "total_count": 5,
                 "uptime": "88632",
-                "uuid": "00000000-0000-0000-0000-000000000000"
+                "uuid": "00000000-0000-0000-0000-000000000000",
             },
         }
 

--- a/plugins/automox/unit_test/test_get_device_software.py
+++ b/plugins/automox/unit_test/test_get_device_software.py
@@ -47,7 +47,7 @@ class TestGetDeviceSoftware(TestCase):
                     "os_version": "12.2",
                     "os_version_id": 1234,
                     "create_time": "2021-12-20T16:21:21+0000",
-                    "organization_id": 1234
+                    "organization_id": 1234,
                 },
                 {
                     "id": 1234,
@@ -64,10 +64,9 @@ class TestGetDeviceSoftware(TestCase):
                     "os_version": "12.2",
                     "os_version_id": 1234,
                     "create_time": "2021-12-26T17:23:19+0000",
-                    "organization_id": 1234
-                }
+                    "organization_id": 1234,
+                },
             ]
-
         }
         self.assertEqual(response, expected_response)
 

--- a/plugins/automox/unit_test/test_get_vulnerability_sync_action_set.py
+++ b/plugins/automox/unit_test/test_get_vulnerability_sync_action_set.py
@@ -37,32 +37,17 @@ class TestGetVulnerabilitySyncActionSet(TestCase):
                     "email": "user@example.com",
                     "firstname": "User",
                     "id": 1234,
-                    "lastname": "Example"
+                    "lastname": "Example",
                 },
                 "id": 1234,
                 "organization_id": 1234,
-                "source": {
-                    "name": "example.csv",
-                    "type": "generic"
-                },
+                "source": {"name": "example.csv", "type": "generic"},
                 "statistics": {
-                    "issues": {
-                        "unknown-host": {
-                            "count": 1
-                        }
-                    },
+                    "issues": {"unknown-host": {"count": 1}},
                     "solutions": {
-                        "patch-now": {
-                            "count": 0,
-                            "device_count": 0,
-                            "vulnerability_count": 0
-                        },
-                        "patch-with-worklet": {
-                            "count": 0,
-                            "device_count": 0,
-                            "vulnerability_count": 0
-                        }
-                    }
+                        "patch-now": {"count": 0, "device_count": 0, "vulnerability_count": 0},
+                        "patch-with-worklet": {"count": 0, "device_count": 0, "vulnerability_count": 0},
+                    },
                 },
                 "status": "ready",
                 "updated_at": "2023-10-04T02:56:00+0000",
@@ -70,8 +55,8 @@ class TestGetVulnerabilitySyncActionSet(TestCase):
                     "email": "user@example.com",
                     "firstname": "User",
                     "id": 1234,
-                    "lastname": "Example"
-                }
+                    "lastname": "Example",
+                },
             }
         }
         self.assertEqual(response, expected_response)

--- a/plugins/automox/unit_test/test_list_devices.py
+++ b/plugins/automox/unit_test/test_list_devices.py
@@ -49,9 +49,7 @@ class TestListDevices(TestCase):
                                 "DEVICE": "en0",
                                 "TYPE": "enet",
                                 "MAC": "00:00:00:00:00:00",
-                                "IPS": [
-                                    "192.168.1.1"
-                                ]
+                                "IPS": ["192.168.1.1"],
                             }
                         ],
                         "VOLUME": [
@@ -61,7 +59,7 @@ class TestListDevices(TestCase):
                                 "AVAIL": "62704803840",
                                 "FREE": "21316517888",
                                 "IS_SYSTEM_DISK": "true",
-                                "VOLUME": "/dev/disk1s5s1"
+                                "VOLUME": "/dev/disk1s5s1",
                             },
                             {
                                 "VOLUME": "/dev/disk1s3",
@@ -69,43 +67,25 @@ class TestListDevices(TestCase):
                                 "LABEL": "Recovery",
                                 "AVAIL": "62704803840",
                                 "FREE": "21316517888",
-                                "IS_SYSTEM_DISK": "false"
-                            }
+                                "IS_SYSTEM_DISK": "false",
+                            },
                         ],
                         "VENDOR": "Apple",
                         "MDM_PROFILE_INSTALLED": "false",
-                        "LAST_USER_LOGON": {
-                            "SRC": "console",
-                            "USER": "root",
-                            "TIME": "2023-04-14 16:05"
-                        },
-                        "UPDATE_SOURCE_CHECK": {
-                            "CONNECTED": "true",
-                            "ERROR": "Succeded"
-                        },
+                        "LAST_USER_LOGON": {"SRC": "console", "USER": "root", "TIME": "2023-04-14 16:05"},
+                        "UPDATE_SOURCE_CHECK": {"CONNECTED": "true", "ERROR": "Succeded"},
                         "SERIAL": "C00000000001",
-                        "DISKS": [
-                            {
-                                "TYPE": "VMware Virtual NVMe Disk",
-                                "SIZE": "62914560000"
-                            }
-                        ],
-                        "IPS": [
-                            "192.168.1.1"
-                        ],
+                        "DISKS": [{"TYPE": "VMware Virtual NVMe Disk", "SIZE": "62914560000"}],
+                        "IPS": ["192.168.1.1"],
                         "MODEL": "MacBook Pro",
                         "AUTO_UPDATE_OPTIONS": {
                             "OPTIONS": "Automatic Check for Updates, Install system data updates, Install system security updates",
-                            "ENABLED": "0"
-                        }
+                            "ENABLED": "0",
+                        },
                     },
                     "display_name": "apple",
-                    "ip_addrs": [
-                        "0.0.0.0"
-                    ],
-                    "ip_addrs_private": [
-                        "192.168.1.1"
-                    ],
+                    "ip_addrs": ["0.0.0.0"],
+                    "ip_addrs_private": ["192.168.1.1"],
                     "is_compatible": True,
                     "last_disconnect_time": "2023-04-14T23:07:04+0000",
                     "last_logged_in_user": "root",
@@ -125,12 +105,12 @@ class TestListDevices(TestCase):
                     "status": {
                         "device_status": "not-ready",
                         "agent_status": "disconnected",
-                        "policy_status": "unmanaged"
+                        "policy_status": "unmanaged",
                     },
                     "timezone": "UTC-0700",
                     "total_count": 5,
                     "uptime": "88632",
-                    "uuid": "00000000-0000-0000-0000-000000000000"
+                    "uuid": "00000000-0000-0000-0000-000000000000",
                 }
             ]
         }

--- a/plugins/automox/unit_test/test_list_groups.py
+++ b/plugins/automox/unit_test/test_list_groups.py
@@ -43,12 +43,9 @@ class TestListGroups(TestCase):
                         "id": 1234,
                         "server_group_id": 1234,
                         "created_at": "2022-09-13T14:26:19+0000",
-                        "updated_at": "2022-09-13T14:26:19+0000"
+                        "updated_at": "2022-09-13T14:26:19+0000",
                     },
-                    "policies": [
-                        1234,
-                        1235
-                    ]
+                    "policies": [1234, 1235],
                 },
                 {
                     "id": 1235,
@@ -62,12 +59,10 @@ class TestListGroups(TestCase):
                         "id": 1234,
                         "server_group_id": 1234,
                         "created_at": "2022-09-13T14:26:32+0000",
-                        "updated_at": "2022-09-13T14:26:32+0000"
+                        "updated_at": "2022-09-13T14:26:32+0000",
                     },
-                    "policies": [
-                        0
-                    ]
-                }
+                    "policies": [0],
+                },
             ]
         }
         self.assertEqual(response, expected_response)

--- a/plugins/automox/unit_test/test_list_organization_users.py
+++ b/plugins/automox/unit_test/test_list_organization_users.py
@@ -31,18 +31,41 @@ class TestListOrganizationUsers(TestCase):
         response = self.action.run(self.params)
         expected_response = {
             Output.USERS: [
-                {"id": 1234, "uuid": "00000000-0000-0000-0000-000000000000", "firstname": "User", "lastname": "Example",
-                 "email": "user@example.com",
-                 "prefs": [{"user_id": 1234, "pref_name": "notify.system.add", "value": "false"},
-                           {"user_id": 1234, "pref_name": "notify.weeklydigest", "value": "true"},
-                           {"user_id": 1234, "pref_name": "user.tfa", "value": "email"}], "orgs": [
-                    {"id": 1234, "zone_id": "00000000-0000-0000-0000-000000000000", "name": "Global Zone",
-                     "trial_end_time": "2024-02-03T00:00:00+00:00", "create_time": "2021-10-20T04:03:25+0000",
-                     "plan": "manage", "access_key": "00000000-0000-0000-0000-000000000000"},
-                    {"id": 1235, "zone_id": "00000000-0000-0000-0000-000000000000", "name": "Local Zone",
-                     "trial_end_time": "2021-11-03T00:00:00+00:00", "trial_expired": True,
-                     "create_time": "2021-10-26T08:14:25+0000", "plan": "manage", "parent_id": 1234,
-                     "access_key": "00000000-0000-0000-0000-000000000000"}]}]
+                {
+                    "id": 1234,
+                    "uuid": "00000000-0000-0000-0000-000000000000",
+                    "firstname": "User",
+                    "lastname": "Example",
+                    "email": "user@example.com",
+                    "prefs": [
+                        {"user_id": 1234, "pref_name": "notify.system.add", "value": "false"},
+                        {"user_id": 1234, "pref_name": "notify.weeklydigest", "value": "true"},
+                        {"user_id": 1234, "pref_name": "user.tfa", "value": "email"},
+                    ],
+                    "orgs": [
+                        {
+                            "id": 1234,
+                            "zone_id": "00000000-0000-0000-0000-000000000000",
+                            "name": "Global Zone",
+                            "trial_end_time": "2024-02-03T00:00:00+00:00",
+                            "create_time": "2021-10-20T04:03:25+0000",
+                            "plan": "manage",
+                            "access_key": "00000000-0000-0000-0000-000000000000",
+                        },
+                        {
+                            "id": 1235,
+                            "zone_id": "00000000-0000-0000-0000-000000000000",
+                            "name": "Local Zone",
+                            "trial_end_time": "2021-11-03T00:00:00+00:00",
+                            "trial_expired": True,
+                            "create_time": "2021-10-26T08:14:25+0000",
+                            "plan": "manage",
+                            "parent_id": 1234,
+                            "access_key": "00000000-0000-0000-0000-000000000000",
+                        },
+                    ],
+                }
+            ]
         }
         self.assertEqual(response, expected_response)
 

--- a/plugins/automox/unit_test/test_list_organizations.py
+++ b/plugins/automox/unit_test/test_list_organizations.py
@@ -40,7 +40,7 @@ class TestListOrganizations(TestCase):
                     "billing_name": "Test",
                     "billing_email": "example@automox.com",
                     "uuid": "00000000-0000-0000-0000-0000000000000",
-                    "device_count": 2
+                    "device_count": 2,
                 },
                 {
                     "id": 1235,
@@ -52,10 +52,9 @@ class TestListOrganizations(TestCase):
                     "sub_plan": "FULL",
                     "rate_id": 1,
                     "parent_id": 1234,
-                    "uuid": "00000000-0000-0000-0000-000000000000"
-                }
+                    "uuid": "00000000-0000-0000-0000-000000000000",
+                },
             ]
-
         }
         self.assertEqual(response, expected_response)
 

--- a/plugins/automox/unit_test/test_list_policies.py
+++ b/plugins/automox/unit_test/test_list_policies.py
@@ -15,7 +15,7 @@ from util import (
     mock_request_404,
     mocked_request,
     mock_request_200_invalid_json,
-    ORG_ID
+    ORG_ID,
 )
 from icon_automox.actions.list_policies import ListPolicies
 from icon_automox.actions.list_policies.schema import Input, Output
@@ -46,19 +46,13 @@ class TestListPolicies(TestCase):
                         "notify_deferred_reboot_user_message_timeout": 15,
                         "custom_pending_reboot_notification_max_delays": 3,
                         "custom_pending_reboot_notification_message_mac": "Updates require restart: Please save your work.",
-                        "custom_pending_reboot_notification_deferment_periods": [
-                            1,
-                            4,
-                            8
-                        ]
+                        "custom_pending_reboot_notification_deferment_periods": [1, 4, 8],
                     },
                     "schedule_time": "00:00",
                     "create_time": "2023-10-25T21:56:48+0000",
-                    "server_groups": [
-                        1234
-                    ],
+                    "server_groups": [1234],
                     "server_count": 5,
-                    "status": "inactive"
+                    "status": "inactive",
                 }
             ]
         }

--- a/plugins/automox/unit_test/test_list_vulnerability_sync_action_set_issues.py
+++ b/plugins/automox/unit_test/test_list_vulnerability_sync_action_set_issues.py
@@ -16,7 +16,7 @@ from util import (
     mocked_request,
     mock_request_200_invalid_json,
     ORG_ID,
-    ACTION_SET_ID
+    ACTION_SET_ID,
 )
 from icon_automox.actions.list_vulnerability_sync_action_set_issues import ListVulnerabilitySyncActionSetIssues
 from icon_automox.actions.list_vulnerability_sync_action_set_issues.schema import Input, Output
@@ -32,20 +32,8 @@ class TestListVulnerabilitySyncActionSetIssues(TestCase):
         response = self.action.run(self.params)
         expected_response = {
             Output.ISSUES: [
-                {
-                    "id": 1234,
-                    "issue_details": {
-                        "hostname": "WINDOWS-1234"
-                    },
-                    "issue_type": "unknown-host"
-                },
-                {
-                    "id": 1234,
-                    "issue_details": {
-                        "hostname": "example-test-1234"
-                    },
-                    "issue_type": "unknown-host"
-                }
+                {"id": 1234, "issue_details": {"hostname": "WINDOWS-1234"}, "issue_type": "unknown-host"},
+                {"id": 1234, "issue_details": {"hostname": "example-test-1234"}, "issue_type": "unknown-host"},
             ]
         }
         self.assertEqual(response, expected_response)

--- a/plugins/automox/unit_test/test_list_vulnerability_sync_action_set_solutions.py
+++ b/plugins/automox/unit_test/test_list_vulnerability_sync_action_set_solutions.py
@@ -16,7 +16,7 @@ from util import (
     mocked_request,
     mock_request_200_invalid_json,
     ORG_ID,
-    ACTION_SET_ID
+    ACTION_SET_ID,
 )
 from icon_automox.actions.list_vulnerability_sync_action_set_solutions import ListVulnerabilitySyncActionSetSolutions
 from icon_automox.actions.list_vulnerability_sync_action_set_solutions.schema import Input, Output
@@ -33,42 +33,29 @@ class TestListVulnerabilitySyncActionSetSolutions(TestCase):
         expected_response = {
             Output.SOLUTIONS: [
                 {
-                    "device_ids": [
-                        1,
-                        2,
-                        3
-                    ],
+                    "device_ids": [1, 2, 3],
                     "devices": [
                         {
                             "custom_name": "example1",
                             "id": 1,
-                            "ip_addrs_private": [
-                                "10.0.0.1",
-                                "ffff::ffff:ffff:ffff:ffff"
-                            ],
+                            "ip_addrs_private": ["10.0.0.1", "ffff::ffff:ffff:ffff:ffff"],
                             "name": "example1",
-                            "status": "pending"
+                            "status": "pending",
                         },
                         {
                             "custom_name": "example2",
                             "id": 2,
-                            "ip_addrs_private": [
-                                "10.0.0.2",
-                                "ffff::ffff:ffff:ffff:ffff"
-                            ],
+                            "ip_addrs_private": ["10.0.0.2", "ffff::ffff:ffff:ffff:ffff"],
                             "name": "example2",
-                            "status": "pending"
+                            "status": "pending",
                         },
                         {
                             "custom_name": "example3",
                             "id": 3,
-                            "ip_addrs_private": [
-                                "10.0.0.3",
-                                "ffff::ffff:ffff:ffff:ffff"
-                            ],
+                            "ip_addrs_private": ["10.0.0.3", "ffff::ffff:ffff:ffff:ffff"],
                             "name": "example3",
-                            "status": "pending"
-                        }
+                            "status": "pending",
+                        },
                     ],
                     "id": 1234,
                     "organization_id": 1234,
@@ -78,9 +65,9 @@ class TestListVulnerabilitySyncActionSetSolutions(TestCase):
                         {
                             "id": "CVE-2021-24111",
                             "severity": "high",
-                            "title": ".NET Framework Denial of Service Vulnerability"
+                            "title": ".NET Framework Denial of Service Vulnerability",
                         }
-                    ]
+                    ],
                 }
             ]
         }

--- a/plugins/automox/unit_test/test_list_vulnerability_sync_action_sets.py
+++ b/plugins/automox/unit_test/test_list_vulnerability_sync_action_sets.py
@@ -15,7 +15,7 @@ from util import (
     mock_request_404,
     mocked_request,
     mock_request_200_invalid_json,
-    ORG_ID
+    ORG_ID,
 )
 from icon_automox.actions.list_vulnerability_sync_action_sets import ListVulnerabilitySyncActionSets
 from icon_automox.actions.list_vulnerability_sync_action_sets.schema import Input, Output
@@ -37,32 +37,17 @@ class TestListVulnerabilitySyncActionSets(TestCase):
                         "email": "user@example.com",
                         "firstname": "User",
                         "id": 1234,
-                        "lastname": "Example"
+                        "lastname": "Example",
                     },
                     "id": 1234,
                     "organization_id": 1234,
-                    "source": {
-                        "name": "example.csv",
-                        "type": "generic"
-                    },
+                    "source": {"name": "example.csv", "type": "generic"},
                     "statistics": {
-                        "issues": {
-                            "unknown-host": {
-                                "count": 1
-                            }
-                        },
+                        "issues": {"unknown-host": {"count": 1}},
                         "solutions": {
-                            "patch-now": {
-                                "count": 0,
-                                "device_count": 0,
-                                "vulnerability_count": 0
-                            },
-                            "patch-with-worklet": {
-                                "count": 0,
-                                "device_count": 0,
-                                "vulnerability_count": 0
-                            }
-                        }
+                            "patch-now": {"count": 0, "device_count": 0, "vulnerability_count": 0},
+                            "patch-with-worklet": {"count": 0, "device_count": 0, "vulnerability_count": 0},
+                        },
                     },
                     "status": "ready",
                     "updated_at": "2023-10-04T02:56:00+0000",
@@ -70,8 +55,8 @@ class TestListVulnerabilitySyncActionSets(TestCase):
                         "email": "user@example.com",
                         "firstname": "User",
                         "id": 1234,
-                        "lastname": "Example"
-                    }
+                        "lastname": "Example",
+                    },
                 }
             ]
         }

--- a/plugins/automox/unit_test/test_run_command.py
+++ b/plugins/automox/unit_test/test_run_command.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath("../"))
 
 from parameterized import parameterized
 from unittest.mock import patch, Mock
@@ -17,7 +17,7 @@ from util import (
     mock_request_200_invalid_json,
     ORG_ID,
     DEVICE_ID,
-    POLICY_ID
+    POLICY_ID,
 )
 
 from icon_automox.actions.run_command import RunCommand
@@ -33,7 +33,7 @@ class TestRunCommand(TestCase):
             Input.DEVICE_ID: DEVICE_ID,
             Input.PATCHES: [1234],
             Input.POLICY_ID: POLICY_ID,
-            }
+        }
 
     @patch("requests.Session.request", side_effect=mock_request_204)
     def test_run_command_ok(self, mock: Mock) -> None:

--- a/plugins/automox/unit_test/test_update_device.py
+++ b/plugins/automox/unit_test/test_update_device.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath("../"))
 
 from parameterized import parameterized
 from unittest.mock import patch, Mock
@@ -18,7 +18,7 @@ from util import (
     mock_request_200_invalid_json,
     ORG_ID,
     DEVICE_ID,
-    POLICY_ID
+    POLICY_ID,
 )
 
 from icon_automox.actions.update_device import UpdateDevice
@@ -34,8 +34,8 @@ class TestUpdateDevice(TestCase):
             Input.DEVICE_ID: DEVICE_ID,
             Input.EXCEPTION: False,
             Input.SERVER_GROUP_ID: 1234,
-            Input.TAGS: ["apple", "banana"]
-            }
+            Input.TAGS: ["apple", "banana"],
+        }
 
     @patch("requests.Session.request", side_effect=mock_request_200)
     @patch("requests.Session.request", side_effect=mock_request_204)

--- a/plugins/automox/unit_test/test_update_group.py
+++ b/plugins/automox/unit_test/test_update_group.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath("../"))
 
 from parameterized import parameterized
 from unittest.mock import patch, Mock
@@ -17,7 +17,7 @@ from util import (
     mocked_request,
     mock_request_200_invalid_json,
     ORG_ID,
-    GROUP_ID
+    GROUP_ID,
 )
 
 from icon_automox.actions.update_group import UpdateGroup
@@ -35,7 +35,7 @@ class TestUpdateGroup(TestCase):
             Input.COLOR: "#000000",
             Input.PARENT_SERVER_GROUP_ID: 12345,
             Input.REFRESH_INTERVAL: 6000,
-            }
+        }
 
     @patch("requests.Session.request", side_effect=mock_request_200)
     @patch("requests.Session.request", side_effect=mock_request_204)

--- a/plugins/automox/unit_test/test_upload_vulnerability_sync_file.py
+++ b/plugins/automox/unit_test/test_upload_vulnerability_sync_file.py
@@ -1,7 +1,7 @@
 import sys
 import os
 
-sys.path.append(os.path.abspath('../'))
+sys.path.append(os.path.abspath("../"))
 
 from parameterized import parameterized
 from unittest.mock import patch, Mock
@@ -15,7 +15,8 @@ from util import (
     mock_request_post_404,
     mock_request_post_201,
     mock_request_post_201_invalid_json,
-    ORG_ID, mock_request_post_500
+    ORG_ID,
+    mock_request_post_500,
 )
 
 from icon_automox.actions.upload_vulnerability_sync_file import UploadVulnerabilitySyncFile
@@ -30,7 +31,6 @@ class TestUploadVulnerabilitySyncFile(TestCase):
             Input.CSV_FILE: "SG9zdCxDVkUKaG9zdDEsQ1ZFLTIwMjAtMTIzNApob3N0MixDVkUtMjAyMC0xMjM0Cg==",
             Input.CSV_FILE_NAME: "test.txt",
             Input.REPORT_SOURCE: "generic",
-
         }
 
     def test_upload_vulnerability_sync_file_ok(self) -> None:

--- a/plugins/automox/unit_test/util.py
+++ b/plugins/automox/unit_test/util.py
@@ -182,4 +182,3 @@ def mock_request_500(*args, **kwargs) -> MockResponse:
 
 def mock_request_post_500(*args, **kwargs) -> MockResponse:
     return mock_conditions("POST", args[0], 500, **kwargs)
-


### PR DESCRIPTION
## Proposed Changes

### Description
Correct a couple of automated check failures on Automox e.g. linter failures and help.md examples.
Note there is one failing plugin validator check - this is a known validator issue (with a ticket raised to fix) around a failure when no connection version previously exists - it shows up as the error:
```
INFO:root:Found the following directories for validation: {'automox'}
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```
This can be ignored for now. 