### PR TITLE
PLGN- 642: sdk bump and logger improvements.

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "923a6bbb21fe0ce039f39ff00014ae00",
-	"manifest": "a5513a1c36d038851b10a6226d980590",
-	"setup": "318548fa67238e900bb082347305cef6",
+	"spec": "4232d7bba45c9b6fe506a9ec94b305d6",
+	"manifest": "3a6f785a66ed07111301f9bf8e5ad1d6",
+	"setup": "4167aab8af34af2b7a0e8324d5621363",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "monitor_siem_logs/schema.py",
-			"hash": "fed0e07521688fbeece2dd35abb49310"
+			"hash": "5ec87a10ad6a0a1b37c33e45f025e469"
 		}
 	]
 }

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.2"
+Version = "5.3.3"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -32,7 +32,7 @@ The connection configuration accepts the following parameters:
 |access_key|credential_secret_key|None|True|The application access key|None|eWtOL3XZCOwG96BOiFTZRiC5rdvDmP4FFdwU2Y1DC1Us-gh7KyL5trUrZ9aEuzQMV7pPWWxTnPVtsJ6x3fajAh3cRskP0w8hNjaFFVkZB6G9dOytLM2ssQ7HY-p7gJoi|
 |app_id|string|None|True|Application ID|None|78d2e4b1-8cc2-4806-nt79-6ef332a47374|
 |app_key|credential_secret_key|None|True|The application key|None|475x54c6-4f61-4fab-8be7-a0710f3859e3|
-|region|string|EU|True|The region for the Mimecast server|['EU', 'DE', 'US', 'CA', 'ZA', 'AU', 'Offshore', 'Sandbox']|EU|
+|region|string|EU|True|The region for the Mimecast server| ['EU', 'DE', 'US', 'CA', 'ZA', 'AU', 'Offshore', 'Sandbox', 'USB', 'USBCOM']|EU|
 |secret_key|credential_secret_key|None|True|The application secret key|None|FgHrtydiP4TynI+rTZF42Qu0FtGuhJtuNM5bDh82goJQHed9kJZ5t/ORwGnI5r2hkl/bzCosZ+KVapJFeaf3Yw==|
   
 Example input:

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.3 - Task `monitor_siem_logs` improved error logging and SDK bump.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -35,7 +35,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             if not header_next_token:
                 self.logger.info("First run...")
             else:
-                self.logger.info(f"Subsequent run using header_next_token...")
+                self.logger.info("Subsequent run using header_next_token...")
 
             limit_time = time() + 30
             while time() < limit_time:

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -28,14 +28,14 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
         )
 
     def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument
+        has_more_pages = False
         try:
-            has_more_pages = False
             header_next_token = state.get(self.NEXT_TOKEN, "")
 
             if not header_next_token:
-                self.logger.info("First run")
+                self.logger.info("First run...")
             else:
-                self.logger.info("Subsequent run")
+                self.logger.info(f"Subsequent run using header_next_token...")
 
             limit_time = time() + 30
             while time() < limit_time:
@@ -44,6 +44,10 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     if not output:
                         break
                 except ApiClientException as error:
+                    self.logger.error(
+                        f"An API client exception has been raised. Status code: {error.status_code}. Error: {error}"
+                        f"returning state={state}, has_more_pages={has_more_pages}"
+                    )
                     return [], state, has_more_pages, error.status_code, error
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
                 output = self._filter_and_sort_recent_events(output)
@@ -56,6 +60,10 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
             return output, state, has_more_pages, status_code, None
         except Exception as error:
+            self.logger.error(
+                f"An exception has been raised. Error: {error}, returning state={state}, "
+                f"has_more_pages={has_more_pages}"
+            )
             return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
     def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -99,7 +99,6 @@ class MimecastAPI:
             method="POST", url=f"{self.url}{uri}", headers=self._prepare_header(uri), data=str(payload)
         )
         self._check_rate_limiting(request)
-
         if "attachment" in request.headers.get("Content-Disposition", "") or self._is_last_token(request):
             combined_json_list = self._handle_zip_file(request)
             return combined_json_list, request.headers, request.status_code
@@ -132,9 +131,9 @@ class MimecastAPI:
         """
 
         try:
-            last_token = IS_LAST_TOKEN_FIELD in json.dumps(request.json())
+            last_token = request.json().get("meta", {}).get(IS_LAST_TOKEN_FIELD, False)
             request.headers.update({IS_LAST_TOKEN_FIELD: last_token})
-            return True
+            return last_token
         except json.JSONDecodeError:
             return False
 

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.2
+version: 5.3.3
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.2",
+      version="5.3.3",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -1,14 +1,14 @@
 import datetime
 import os
 import sys
+from insightconnect_plugin_runtime.exceptions import PluginException
 from unittest import TestCase
 from unittest.mock import patch
-
-from dateutil.parser import parse
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.util.event import EventLogs
+from komand_mimecast.util.exceptions import ApiClientException
 from komand_mimecast.tasks import MonitorSiemLogs
 from util import Util, FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, SIEM_LOGS_HEADERS_RESPONSE
 
@@ -18,16 +18,33 @@ class TestMonitorSiemLogs(TestCase):
     def setUp(self) -> None:
         self.task = Util.default_connector(MonitorSiemLogs())
 
-    def test_monitor_siem_logs(self, mock_data):
-        response, new_state, has_more_pages, status_code, _ = self.task.run()
+    def test_monitor_siem_logs_success(self, _mock_data):
+        content = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2]
+        token = SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")
+        tests = [
+            {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
+            {"next_token": "force_json_error", "resp": content, "has_more_pages": True, "token": token},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
+        ]
+        for test in tests:
+            with self.subTest(f"Success test with token: {test.get('next_token')}"):
+                test_state = {"next_token": test.get("next_token")}
+                response, new_state, has_more_pages, status_code, _ = self.task.run(params={}, state=test_state)
 
-        expected_response = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2]
-        expected_state = {"next_token": SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")}
+                self.assertEqual(has_more_pages, test.get("has_more_pages"))
+                self.assertEqual(response, test.get("resp"))
+                self.assertEqual(new_state, {"next_token": test.get("token")})
+                self.assertEqual(status_code, 200)
 
-        self.assertEqual(has_more_pages, True)
-        self.assertEqual(response, expected_response)
-        self.assertEqual(new_state, expected_state)
-        self.assertEqual(status_code, 200)
+    def test_monitor_siem_logs_raises_401(self, _mock_data):
+        state_params = {"next_token": "force_401"}
+
+        response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=state_params)
+
+        self.assertEqual(status_code, 401)
+        self.assertEqual(response, [])
+        self.assertEqual(new_state, state_params)  # we shouldn't change the state if we encounter an error
+        self.assertEqual(type(error), ApiClientException)
 
 
 class TestEventLogs(TestCase):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Bump SDK version so that we pull in exception and task started/finished logging. 
  - Add direct logging when we catch an exception.
  - Small changes to `_is_last_token` to check this value is `True`. noticed when testing 401 code path this gets returned as `False` and was masking the error by going into the condition and trying to parse zip content and resulting in returning `[]` as output instead of the following through to the exception being raised. 
  - Update help.md to include all supported regions (PLGN-415). 

Lint failing because of automox. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Log examples
```
# Clean run - pulling in events.
Plugin task beginning execution...
https://usb-api.mimecast.com
rapid7/Mimecast:5.3.3. Step name: monitor_siem_logs
Subsequent run using header_next_token...
Number of raw logs returned from Mimecast: 99
Number of returned logs after filtering performed: 96
Plugin task finished execution...

# Clean run using next_token with no new results
Plugin task beginning execution...
rapid7/Mimecast:5.3.3. Step name: monitor_siem_logs
Subsequent run using header_next_token...
Plugin task finished execution...

# using next token value but hitting 401 error. 
Plugin task beginning execution...
https://usb-api.mimecast.com
rapid7/Mimecast:5.3.3. Step name: monitor_siem_logs
Subsequent run using header_next_token...
Plugin exception instantiated. cause='Invalid API key provided.', assistance='Verify your API key configured in your connection is correct.', data='{'meta': {'status': 401}, 'data': [], 'fail': [{'errors': [{'code': 'err_xdk_invalid_signature', 'message': '0004 Invalid Signature', 'retryable': False}]}]}', preset='api_key'
Plugin exception instantiated. cause='Invalid API key provided.', assistance='Verify your API key configured in your connection is correct.', data='{'meta': {'status': 401}, 'data': [], 'fail': [{'errors': [{'code': 'err_xdk_invalid_signature', 'message': '0004 Invalid Signature', 'retryable': False}]}]}', preset='api_key'
An API client exception has been raised. Status code: 401. Error: An error occurred during plugin execution!

Invalid API key provided. Verify your API key configured in your connection is correct. Response was: {'meta': {'status': 401}, 'data': [], 'fail': [{'errors': [{'code': 'err_xdk_invalid_signature', 'message': '0004 Invalid Signature', 'retryable': False}]}]}returning state={'next_token': 'eNo9jk1vgkAUAP_LO5PIArqriQdAMZQmlfhtvJDt0yzCvoZl26Lxv0t78DyTydzBoLQNqk-YgFwe8nS5eQ_VUV2uKYv3HSs9VXuZSMssMVL-hhUllnxMRGzzW7cq6lvo7UqNWs6qeZT7b4dZXl0XZBfbbEiafSTqNBBEdv0T7eJ9sc2YnWseTMEBOp8NtjBhDhiFdUWXvw3fHwd85DkgGyxaXKsae4W7geDc5S4bBS-97b565jrwjY1RpP9ThZRkdZ-FeLOK2DhkAh5Pv4dJ1g'}, has_more_pages=False
Plugin task finished execution...

# hitting 401 with no next token provided. 
Plugin task beginning execution...
rapid7/Mimecast:5.3.3. Step name: monitor_siem_logs
First run...
Plugin exception instantiated. cause='Invalid API key provided.', assistance='Verify your API key configured in your connection is correct.', data='{'meta': {'status': 401}, 'data': [], 'fail': [{'errors': [{'code': 'err_xdk_invalid_signature', 'message': '0004 Invalid Signature', 'retryable': False}]}]}', preset='api_key'
Plugin exception instantiated. cause='Invalid API key provided.', assistance='Verify your API key configured in your connection is correct.', data='{'meta': {'status': 401}, 'data': [], 'fail': [{'errors': [{'code': 'err_xdk_invalid_signature', 'message': '0004 Invalid Signature', 'retryable': False}]}]}', preset='api_key'
An API client exception has been raised. Status code: 401. Error: An error occurred during plugin execution!

Invalid API key provided. Verify your API key configured in your connection is correct. Response was: {'meta': {'status': 401}, 'data': [], 'fail': [{'errors': [{'code': 'err_xdk_invalid_signature', 'message': '0004 Invalid Signature', 'retryable': False}]}]}returning state={'next_token': ''}, has_more_pages=False
Plugin task finished execution...
```


#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
