### PR TITLE
[PLGN-642] [Mimecast] - Fix schema for find_groups action. 

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -33,7 +33,7 @@
 		},
 		{
 			"identifier": "find_groups/schema.py",
-			"hash": "8c1accc62ed9cb95451422d4f54df476"
+			"hash": "0991456d139c291460b81704916dfe90"
 		},
 		{
 			"identifier": "get_audit_events/schema.py",

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.3 - Task `monitor_siem_logs` improved error logging and SDK bump.
+* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix output schema for `find_groups`.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/komand_mimecast/actions/find_groups/schema.py
+++ b/plugins/mimecast/komand_mimecast/actions/find_groups/schema.py
@@ -80,32 +80,32 @@ class FindGroupsOutput(insightconnect_plugin_runtime.Output):
         },
         "source": {
           "type": "string",
-          "title": null,
-          "description": null,
+          "title": "source",
+          "description": "Source of the group, either cloud or ldap",
           "order": 2
         },
         "folder_count": {
           "type": "integer",
-          "title": null,
-          "description": null,
+          "title": "folderCount",
+          "description": "Number of folders allocated to this group",
           "order": 3
         },
         "parent_id": {
           "type": "string",
-          "title": null,
-          "description": null,
+          "title": "parentID",
+          "description": "The parent ID",
           "order": 4
         },
         "id": {
           "type": "string",
-          "title": null,
-          "description": null,
+          "title": "id",
+          "description": "ID of the group",
           "order": 5
         },
         "user_count": {
           "type": "integer",
-          "title": null,
-          "description": null,
+          "title": "userCount",
+          "description": "Number of users in the group",
           "order": 6
         }
       }


### PR DESCRIPTION
Small change to fix the schema for `find_groups`. When I began testing all actions for my last PR I was getting validation errors. 

Last PR:
- #2220

Updated to fix the schema and action now passing on local docker image. Checked schema for other actions and couldn't see any other schemas with a similar invalid schema. 

Test:
<img width="1310" alt="Screenshot 2024-01-10 at 16 17 02" src="https://github.com/rapid7/insightconnect-plugins/assets/139136675/4a375e3b-befb-465e-a3e8-0e338935d8ae">
