### PR TITLE
[PLGN-642] [Mimecast] Schema changes/unit testing and bump validators version.

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "get_audit_events/schema.py",
-			"hash": "cdeee44f1cb87b304c5e5284c3ff1053"
+			"hash": "d732699946e1ef41e47bf30354e202a3"
 		},
 		{
 			"identifier": "get_managed_url/schema.py",

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix output schema for `find_groups`.
+* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/komand_mimecast/actions/get_audit_events/schema.py
+++ b/plugins/mimecast/komand_mimecast/actions/get_audit_events/schema.py
@@ -36,6 +36,9 @@ class GetAuditEventsInput(insightconnect_plugin_runtime.Input):
       "order": 2
     }
   },
+  "required": [
+    "audit_events_data"
+  ],
   "definitions": {
     "audit_events_data": {
       "type": "object",
@@ -67,13 +70,12 @@ class GetAuditEventsInput(insightconnect_plugin_runtime.Input):
             "type": "string"
           },
           "order": 4
-        },
-        "required": [
-          "endDateTime",
-          "startDateTime",
-          "audit_events_data"
-        ]
-      }
+        }
+      },
+      "required": [
+        "endDateTime",
+        "startDateTime"
+      ]
     },
     "audit_events_request_pagination": {
       "type": "object",
@@ -124,6 +126,9 @@ class GetAuditEventsOutput(insightconnect_plugin_runtime.Output):
       "order": 1
     }
   },
+  "required": [
+    "response"
+  ],
   "definitions": {
     "audit_events_response": {
       "type": "object",

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -1,6 +1,7 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-validators==0.18.2
+validators==0.21.0
 parameterized==0.8.1
 python-dateutil==2.6.1
+jsonschema==3.2.0

--- a/plugins/mimecast/unit_test/test_add_group_member.py
+++ b/plugins/mimecast/unit_test/test_add_group_member.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 from komand_mimecast.actions import AddGroupMember
+from komand_mimecast.actions.add_group_member.schema import AddGroupMemberOutput, AddGroupMemberInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, GROUP_MEMBER_ALREADY_EXISTS_ERROR
 
 from util import Util
@@ -18,12 +20,15 @@ class TestAddGroupMember(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(AddGroupMember())
 
-    def test_add_group_member(self, mock_request):
-        actual = self.action.run(Util.load_json("inputs/add_group_member.json.exp"))
+    def test_add_group_member(self, _mock_request):
+        input_data = Util.load_json("inputs/add_group_member.json.exp")
+        actual = self.action.run(input_data)
+        validate(input_data, AddGroupMemberInput.schema)
         expect = Util.load_json("expected/add_group_member_exp.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, AddGroupMemberOutput.schema)
 
-    def test_bad_add_group_member(self, mock_request):
+    def test_bad_add_group_member(self, _mock_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/add_group_member_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(GROUP_MEMBER_ALREADY_EXISTS_ERROR))

--- a/plugins/mimecast/unit_test/test_create_blocked_sender_policy.py
+++ b/plugins/mimecast/unit_test/test_create_blocked_sender_policy.py
@@ -1,12 +1,16 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import CreateBlockedSenderPolicy
-
+from komand_mimecast.actions.create_blocked_sender_policy.schema import (
+    CreateBlockedSenderPolicyOutput,
+    CreateBlockedSenderPolicyInput,
+)
 from util import Util
 
 
@@ -16,7 +20,10 @@ class TestCreateBlockedSenderPolicy(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(CreateBlockedSenderPolicy())
 
-    def test_create_blocked_sender_policy(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/create_blocked_sender_policy.json.exp"))
+    def test_create_blocked_sender_policy(self, _mocked_request):
+        input_data = Util.load_json("inputs/create_blocked_sender_policy.json.exp")
+        actual = self.action.run(input_data)
+        validate(input_data, CreateBlockedSenderPolicyInput.schema)
         expect = Util.load_json("expected/create_blocked_sender_policy.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, CreateBlockedSenderPolicyOutput.schema)

--- a/plugins/mimecast/unit_test/test_create_managed_url.py
+++ b/plugins/mimecast/unit_test/test_create_managed_url.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -8,6 +9,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 from komand_mimecast.actions import CreateManagedUrl
+from komand_mimecast.actions.create_managed_url.schema import CreateManagedUrlOutput, CreateManagedUrlInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, MANAGED_URL_EXISTS_ERROR
 
 from util import Util
@@ -19,12 +21,15 @@ class TestCreateManagedURl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(CreateManagedUrl())
 
-    def test_create_managed_url(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/create_managed_url.json.exp"))
+    def test_create_managed_url(self, _mocked_request):
+        input_data = Util.load_json("inputs/create_managed_url.json.exp")
+        validate(input_data, CreateManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/create_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, CreateManagedUrlOutput.schema)
 
-    def test_bad_create_managed_url(self, mocked_request):
+    def test_bad_create_managed_url(self, _mocked_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/create_managed_url_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(MANAGED_URL_EXISTS_ERROR))

--- a/plugins/mimecast/unit_test/test_decode_url.py
+++ b/plugins/mimecast/unit_test/test_decode_url.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import DecodeUrl
+from komand_mimecast.actions.decode_url.schema import DecodeUrlOutput, DecodeUrlInput
 
 from util import Util
 
@@ -16,7 +18,10 @@ class TestDecodeURL(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DecodeUrl())
 
-    def test_decode_url(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/decode_url.json.exp"))
+    def test_decode_url(self, _mocked_request):
+        input_data = Util.load_json("inputs/decode_url.json.exp")
+        validate(input_data, DecodeUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/decode_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DecodeUrlOutput.schema)

--- a/plugins/mimecast/unit_test/test_delete_blocked_sender_policy.py
+++ b/plugins/mimecast/unit_test/test_delete_blocked_sender_policy.py
@@ -1,12 +1,16 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import DeleteBlockedSenderPolicy
-from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, MANAGED_URL_NOT_FOUND_ERROR
+from komand_mimecast.actions.delete_blocked_sender_policy.schema import (
+    DeleteBlockedSenderPolicyOutput,
+    DeleteBlockedSenderPolicyInput,
+)
 
 from util import Util
 
@@ -17,12 +21,15 @@ class TestDeleteBlockedSenderPolicy(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DeleteBlockedSenderPolicy())
 
-    def test_delete_blocked_sender_policy(self, mocked_request: MagicMock):
-        actual = self.action.run(Util.load_json("inputs/delete_blocked_sender_policy.json.exp"))
+    def test_delete_blocked_sender_policy(self, _mocked_request: MagicMock):
+        input_data = Util.load_json("inputs/delete_blocked_sender_policy.json.exp")
+        validate(input_data, DeleteBlockedSenderPolicyInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/delete_blocked_sender_policy.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DeleteBlockedSenderPolicyOutput.schema)
 
-    def test_bad_delete_blocked_sender_policy(self, mocked_request: MagicMock):
+    def test_bad_delete_blocked_sender_policy(self, _mocked_request: MagicMock):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/delete_blocked_sender_policy_bad.json.exp"))
         self.assertEqual(exception.exception.cause, PluginException.causes[PluginException.Preset.NOT_FOUND])

--- a/plugins/mimecast/unit_test/test_delete_group_member.py
+++ b/plugins/mimecast/unit_test/test_delete_group_member.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import DeleteGroupMember
+from komand_mimecast.actions.delete_group_member.schema import DeleteGroupMemberOutput, DeleteGroupMemberInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, FOLDER_EMAIL_NOT_FOUND_ERROR
 
 from util import Util
@@ -17,10 +19,13 @@ class TestDeleteGroupMember(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DeleteGroupMember())
 
-    def test_delete_group_member(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/delete_group_member.json.exp"))
+    def test_delete_group_member(self, _mocked_request):
+        input_data = Util.load_json("inputs/delete_group_member.json.exp")
+        validate(input_data, DeleteGroupMemberInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/delete_group_member.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DeleteGroupMemberOutput.schema)
 
     def test_bad_delete_group_member(self, mocked_request):
         with self.assertRaises(PluginException) as exception:

--- a/plugins/mimecast/unit_test/test_delete_managed_url.py
+++ b/plugins/mimecast/unit_test/test_delete_managed_url.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import DeleteManagedUrl
+from komand_mimecast.actions.delete_managed_url.schema import DeleteManagedUrlOutput, DeleteManagedUrlInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, MANAGED_URL_NOT_FOUND_ERROR
 
 from util import Util
@@ -17,12 +19,15 @@ class TestDeleteManagedURl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DeleteManagedUrl())
 
-    def test_delete_managed_url(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/delete_managed_url.json.exp"))
+    def test_delete_managed_url(self, _mocked_request):
+        input_data = Util.load_json("inputs/delete_managed_url.json.exp")
+        validate(input_data, DeleteManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/delete_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DeleteManagedUrlOutput.schema)
 
-    def test_bad_delete_managed_url(self, mocked_request):
+    def test_bad_delete_managed_url(self, _mocked_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/delete_managed_url_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(MANAGED_URL_NOT_FOUND_ERROR))

--- a/plugins/mimecast/unit_test/test_find_groups.py
+++ b/plugins/mimecast/unit_test/test_find_groups.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import FindGroups
+from komand_mimecast.actions.find_groups.schema import FindGroupsOutput, FindGroupsInput
 
 from util import Util
 
@@ -16,12 +18,15 @@ class TestFindGroups(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(FindGroups())
 
-    def test_find_group(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/find_groups.json.exp"))
+    def test_find_group(self, _mocked_request):
+        input_data = Util.load_json("inputs/find_groups.json.exp")
+        validate(input_data, FindGroupsInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/find_groups.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, FindGroupsOutput.schema)
 
-    def test_empty_response(self, mocked_request):
+    def test_empty_response(self, _mocked_request):
         actual = self.action.run(Util.load_json("inputs/find_groups_with_filter.json.exp"))
         expect = Util.load_json("expected/find_groups_empty_groups.json.exp")
         self.assertEqual(expect, actual)

--- a/plugins/mimecast/unit_test/test_get_audit_event.py
+++ b/plugins/mimecast/unit_test/test_get_audit_event.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import GetAuditEvents
+from komand_mimecast.actions.get_audit_events.schema import GetAuditEventsOutput, GetAuditEventsInput
 
 from util import Util
 
@@ -16,7 +18,10 @@ class TestGetAuditEvent(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetAuditEvents())
 
-    def test_get_audit_event(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_audit_events.json.exp"))
+    def test_get_audit_event(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_audit_events.json.exp")
+        validate(input_data, GetAuditEventsInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_audit_events.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetAuditEventsOutput.schema)

--- a/plugins/mimecast/unit_test/test_get_managed_url.py
+++ b/plugins/mimecast/unit_test/test_get_managed_url.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import GetManagedUrl
+from komand_mimecast.actions.get_managed_url.schema import GetManagedUrlOutput, GetManagedUrlInput
 
 from util import Util
 
@@ -16,37 +18,58 @@ class TestGetManagedUrl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetManagedUrl())
 
-    def test_get_managed_url_no_filter(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url.json.exp"))
+    def test_get_managed_url_no_filter(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_action(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_action.json.exp"))
+    def test_get_managed_url_filtered_by_action(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_action.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_filtered_by_action.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_scheme(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_schema.json.exp"))
+    def test_get_managed_url_filtered_by_scheme(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_schema.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_filtered_by_scheme.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_math_type(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_mathtype.json.exp"))
+    def test_get_managed_url_filtered_by_math_type(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_mathtype.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_empty_response.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_disabled(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_disabled.json.exp"))
+    def test_get_managed_url_filtered_by_disabled(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_disabled.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_id(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_id.json.exp"))
+    def test_get_managed_url_filtered_by_id(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_id.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_filtered_by_id.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_empty_response(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_with_filter.json.exp"))
+    def test_empty_response(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_with_filter.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_empty_response.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)

--- a/plugins/mimecast/unit_test/test_get_ttp_url_logs.py
+++ b/plugins/mimecast/unit_test/test_get_ttp_url_logs.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import GetTtpUrlLogs
+from komand_mimecast.actions.get_ttp_url_logs.schema import GetTtpUrlLogsOutput, GetTtpUrlLogsInput
 
 from util import Util
 
@@ -16,7 +18,10 @@ class TestGetManagedUrl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetTtpUrlLogs())
 
-    def test_get_ttp_url_logs(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_ttp_url_logs.json.exp"))
+    def test_get_ttp_url_logs(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_ttp_url_logs.json.exp")
+        validate(input_data, GetTtpUrlLogsInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_ttp_url_logs.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetTtpUrlLogsOutput.schema)

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import sys
-from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -10,6 +10,7 @@ sys.path.append(os.path.abspath("../"))
 from komand_mimecast.util.event import EventLogs
 from komand_mimecast.util.exceptions import ApiClientException
 from komand_mimecast.tasks import MonitorSiemLogs
+from komand_mimecast.tasks.monitor_siem_logs.schema import MonitorSiemLogsOutput
 from util import Util, FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, SIEM_LOGS_HEADERS_RESPONSE
 
 
@@ -35,6 +36,7 @@ class TestMonitorSiemLogs(TestCase):
                 self.assertEqual(response, test.get("resp"))
                 self.assertEqual(new_state, {"next_token": test.get("token")})
                 self.assertEqual(status_code, 200)
+                validate(response, MonitorSiemLogsOutput.schema)
 
     def test_monitor_siem_logs_raises_401(self, _mock_data):
         state_params = {"next_token": "force_401"}

--- a/plugins/mimecast/unit_test/test_permit_or_block_sender.py
+++ b/plugins/mimecast/unit_test/test_permit_or_block_sender.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 from komand_mimecast.actions import PermitOrBlockSender
+from komand_mimecast.actions.permit_or_block_sender.schema import PermitOrBlockSenderOutput, PermitOrBlockSenderInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, VALIDATION_INVALID_EMAIL_ADDRESS_ERROR
 
 from util import Util
@@ -18,17 +20,23 @@ class TestPermitOrBlockSender(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(PermitOrBlockSender())
 
-    def test_permit_user(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/permit_or_block_sender.json.exp"))
+    def test_permit_user(self, _mocked_request):
+        input_data = Util.load_json("inputs/permit_or_block_sender.json.exp")
+        validate(input_data, PermitOrBlockSenderInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/permit_or_block_sender.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, PermitOrBlockSenderOutput.schema)
 
-    def test_block_user(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/block_sender.json.exp"))
+    def test_block_user(self, _mocked_request):
+        input_data = Util.load_json("inputs/block_sender.json.exp")
+        validate(input_data, PermitOrBlockSenderInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/block_sender.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, PermitOrBlockSenderOutput.schema)
 
-    def test_bad_email(self, mock_request):
+    def test_bad_email(self, _mock_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/permit_or_block_sender_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(VALIDATION_INVALID_EMAIL_ADDRESS_ERROR))

--- a/plugins/mimecast/unit_test/test_track_messages.py
+++ b/plugins/mimecast/unit_test/test_track_messages.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import TrackMessages
+from komand_mimecast.actions.track_messages.schema import TrackMessagesOutput, TrackMessagesInput
 from komand_mimecast.util.constants import (
     TRACKED_EMAILS_ADVANCED_CAUSE,
     TRACKED_EMAILS_REQUIRED_CAUSE,
@@ -22,10 +24,13 @@ class TestTrackMessages(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(TrackMessages())
 
-    def test_track_messages(self, mocked_request: MagicMock):
-        actual = self.action.run(Util.load_json("inputs/search_message_tracking.json.exp"))
+    def test_track_messages(self, _mocked_request: MagicMock):
+        input_data = Util.load_json("inputs/search_message_tracking.json.exp")
+        validate(input_data, TrackMessagesInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/search_message_tracking.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, TrackMessagesOutput.schema)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Hit schema validation error when testing get_audit_events action on staging, fixed broken schema from an old refresh. 
  - Added `validate(..)` into all unit tests to catch this happening again. 
  - Noticed snyk vulnerability so bumped package.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Tested get_audit_events locally and passing. 
- following failing on staging but passing locally: get_ttp_url_logs and track_messages, will confirm after deploy all working ok. 
- `delete_group_member` failing on local image, staging and python shell: mimecast throwing 500 even when copy sample python code from their docs. 

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code
