### PR TITLE
[PLGN-642] Mimecast 5.3.3 release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "get_audit_events/schema.py",
-			"hash": "cdeee44f1cb87b304c5e5284c3ff1053"
+			"hash": "d732699946e1ef41e47bf30354e202a3"
 		},
 		{
 			"identifier": "get_managed_url/schema.py",

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "923a6bbb21fe0ce039f39ff00014ae00",
-	"manifest": "a5513a1c36d038851b10a6226d980590",
-	"setup": "318548fa67238e900bb082347305cef6",
+	"spec": "4232d7bba45c9b6fe506a9ec94b305d6",
+	"manifest": "3a6f785a66ed07111301f9bf8e5ad1d6",
+	"setup": "4167aab8af34af2b7a0e8324d5621363",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "monitor_siem_logs/schema.py",
-			"hash": "fed0e07521688fbeece2dd35abb49310"
+			"hash": "5ec87a10ad6a0a1b37c33e45f025e469"
 		}
 	]
 }

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -33,7 +33,7 @@
 		},
 		{
 			"identifier": "find_groups/schema.py",
-			"hash": "8c1accc62ed9cb95451422d4f54df476"
+			"hash": "0991456d139c291460b81704916dfe90"
 		},
 		{
 			"identifier": "get_audit_events/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.2"
+Version = "5.3.3"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.3 - Task `monitor_siem_logs` improved error logging and SDK bump.
+* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix output schema for `find_groups`.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix output schema for `find_groups`.
+* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -32,7 +32,7 @@ The connection configuration accepts the following parameters:
 |access_key|credential_secret_key|None|True|The application access key|None|eWtOL3XZCOwG96BOiFTZRiC5rdvDmP4FFdwU2Y1DC1Us-gh7KyL5trUrZ9aEuzQMV7pPWWxTnPVtsJ6x3fajAh3cRskP0w8hNjaFFVkZB6G9dOytLM2ssQ7HY-p7gJoi|
 |app_id|string|None|True|Application ID|None|78d2e4b1-8cc2-4806-nt79-6ef332a47374|
 |app_key|credential_secret_key|None|True|The application key|None|475x54c6-4f61-4fab-8be7-a0710f3859e3|
-|region|string|EU|True|The region for the Mimecast server|['EU', 'DE', 'US', 'CA', 'ZA', 'AU', 'Offshore', 'Sandbox']|EU|
+|region|string|EU|True|The region for the Mimecast server| ['EU', 'DE', 'US', 'CA', 'ZA', 'AU', 'Offshore', 'Sandbox', 'USB', 'USBCOM']|EU|
 |secret_key|credential_secret_key|None|True|The application secret key|None|FgHrtydiP4TynI+rTZF42Qu0FtGuhJtuNM5bDh82goJQHed9kJZ5t/ORwGnI5r2hkl/bzCosZ+KVapJFeaf3Yw==|
   
 Example input:
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.3 - Task `monitor_siem_logs` improved error logging and SDK bump.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
+* 5.3.3 - Task `monitor_siem_logs` improved error logging and sanitization of filenames | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/komand_mimecast/actions/find_groups/schema.py
+++ b/plugins/mimecast/komand_mimecast/actions/find_groups/schema.py
@@ -80,32 +80,32 @@ class FindGroupsOutput(insightconnect_plugin_runtime.Output):
         },
         "source": {
           "type": "string",
-          "title": null,
-          "description": null,
+          "title": "source",
+          "description": "Source of the group, either cloud or ldap",
           "order": 2
         },
         "folder_count": {
           "type": "integer",
-          "title": null,
-          "description": null,
+          "title": "folderCount",
+          "description": "Number of folders allocated to this group",
           "order": 3
         },
         "parent_id": {
           "type": "string",
-          "title": null,
-          "description": null,
+          "title": "parentID",
+          "description": "The parent ID",
           "order": 4
         },
         "id": {
           "type": "string",
-          "title": null,
-          "description": null,
+          "title": "id",
+          "description": "ID of the group",
           "order": 5
         },
         "user_count": {
           "type": "integer",
-          "title": null,
-          "description": null,
+          "title": "userCount",
+          "description": "Number of users in the group",
           "order": 6
         }
       }

--- a/plugins/mimecast/komand_mimecast/actions/get_audit_events/schema.py
+++ b/plugins/mimecast/komand_mimecast/actions/get_audit_events/schema.py
@@ -36,6 +36,9 @@ class GetAuditEventsInput(insightconnect_plugin_runtime.Input):
       "order": 2
     }
   },
+  "required": [
+    "audit_events_data"
+  ],
   "definitions": {
     "audit_events_data": {
       "type": "object",
@@ -67,13 +70,12 @@ class GetAuditEventsInput(insightconnect_plugin_runtime.Input):
             "type": "string"
           },
           "order": 4
-        },
-        "required": [
-          "endDateTime",
-          "startDateTime",
-          "audit_events_data"
-        ]
-      }
+        }
+      },
+      "required": [
+        "endDateTime",
+        "startDateTime"
+      ]
     },
     "audit_events_request_pagination": {
       "type": "object",
@@ -124,6 +126,9 @@ class GetAuditEventsOutput(insightconnect_plugin_runtime.Output):
       "order": 1
     }
   },
+  "required": [
+    "response"
+  ],
   "definitions": {
     "audit_events_response": {
       "type": "object",

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -28,14 +28,14 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
         )
 
     def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument
+        has_more_pages = False
         try:
-            has_more_pages = False
             header_next_token = state.get(self.NEXT_TOKEN, "")
 
             if not header_next_token:
-                self.logger.info("First run")
+                self.logger.info("First run...")
             else:
-                self.logger.info("Subsequent run")
+                self.logger.info("Subsequent run using header_next_token...")
 
             limit_time = time() + 30
             while time() < limit_time:
@@ -44,6 +44,10 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     if not output:
                         break
                 except ApiClientException as error:
+                    self.logger.error(
+                        f"An API client exception has been raised. Status code: {error.status_code}. Error: {error}"
+                        f"returning state={state}, has_more_pages={has_more_pages}"
+                    )
                     return [], state, has_more_pages, error.status_code, error
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
                 output = self._filter_and_sort_recent_events(output)
@@ -56,6 +60,10 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
             return output, state, has_more_pages, status_code, None
         except Exception as error:
+            self.logger.error(
+                f"An exception has been raised. Error: {error}, returning state={state}, "
+                f"has_more_pages={has_more_pages}"
+            )
             return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
     def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -99,7 +99,6 @@ class MimecastAPI:
             method="POST", url=f"{self.url}{uri}", headers=self._prepare_header(uri), data=str(payload)
         )
         self._check_rate_limiting(request)
-
         if "attachment" in request.headers.get("Content-Disposition", "") or self._is_last_token(request):
             combined_json_list = self._handle_zip_file(request)
             return combined_json_list, request.headers, request.status_code
@@ -132,9 +131,9 @@ class MimecastAPI:
         """
 
         try:
-            last_token = IS_LAST_TOKEN_FIELD in json.dumps(request.json())
+            last_token = request.json().get("meta", {}).get(IS_LAST_TOKEN_FIELD, False)
             request.headers.update({IS_LAST_TOKEN_FIELD: last_token})
-            return True
+            return last_token
         except json.JSONDecodeError:
             return False
 

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -170,12 +170,16 @@ class MimecastAPI:
             List[Dict]: A list of dictionaries, where each dictionary represents a log entry extracted from the ZIP file
         """
         try:
-            with ZipFile(BytesIO(request.content)) as my_zip:
+            content = self.sanitise_content(request.content)
+            with ZipFile(BytesIO(content)) as my_zip:
                 combined_json_list = [
                     log for file_name in my_zip.namelist() for log in json.loads(my_zip.read(file_name)).get("data")
                 ]
             return combined_json_list
-        except BadZipFile:
+        except BadZipFile as error:
+            # empty response from Mimecast can hit this, which we know is not an error, don't log it
+            if error.args[0] != "File is not a zip file":
+                self.logger.error(f"Hit BadZipFile, returning []. Error: {error}")
             return []
 
     def _prepare_header(self, uri: str) -> dict:
@@ -323,3 +327,12 @@ class MimecastAPI:
             return response
 
         self._handle_status_code_response(response, status_code)
+
+    @staticmethod
+    def sanitise_content(request_content: bytes) -> bytes:
+        # Sanitise file names to help guard against path traversal
+        sanitised_content = request_content.replace(b"%2e%2e%2f", b"../")
+        sanitised_content = sanitised_content.replace(b"../", b"")
+        sanitised_content = sanitised_content.replace(b"%2e%2e%5C", b"..\\")
+        sanitised_content = sanitised_content.replace(b"..\\", b"")
+        return sanitised_content

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.2
+version: 5.3.3
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -1,6 +1,7 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-validators==0.18.2
+validators==0.21.0
 parameterized==0.8.1
 python-dateutil==2.6.1
+jsonschema==3.2.0

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.2",
+      version="5.3.3",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_add_group_member.py
+++ b/plugins/mimecast/unit_test/test_add_group_member.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 from komand_mimecast.actions import AddGroupMember
+from komand_mimecast.actions.add_group_member.schema import AddGroupMemberOutput, AddGroupMemberInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, GROUP_MEMBER_ALREADY_EXISTS_ERROR
 
 from util import Util
@@ -18,12 +20,15 @@ class TestAddGroupMember(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(AddGroupMember())
 
-    def test_add_group_member(self, mock_request):
-        actual = self.action.run(Util.load_json("inputs/add_group_member.json.exp"))
+    def test_add_group_member(self, _mock_request):
+        input_data = Util.load_json("inputs/add_group_member.json.exp")
+        actual = self.action.run(input_data)
+        validate(input_data, AddGroupMemberInput.schema)
         expect = Util.load_json("expected/add_group_member_exp.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, AddGroupMemberOutput.schema)
 
-    def test_bad_add_group_member(self, mock_request):
+    def test_bad_add_group_member(self, _mock_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/add_group_member_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(GROUP_MEMBER_ALREADY_EXISTS_ERROR))

--- a/plugins/mimecast/unit_test/test_create_blocked_sender_policy.py
+++ b/plugins/mimecast/unit_test/test_create_blocked_sender_policy.py
@@ -1,12 +1,16 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import CreateBlockedSenderPolicy
-
+from komand_mimecast.actions.create_blocked_sender_policy.schema import (
+    CreateBlockedSenderPolicyOutput,
+    CreateBlockedSenderPolicyInput,
+)
 from util import Util
 
 
@@ -16,7 +20,10 @@ class TestCreateBlockedSenderPolicy(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(CreateBlockedSenderPolicy())
 
-    def test_create_blocked_sender_policy(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/create_blocked_sender_policy.json.exp"))
+    def test_create_blocked_sender_policy(self, _mocked_request):
+        input_data = Util.load_json("inputs/create_blocked_sender_policy.json.exp")
+        actual = self.action.run(input_data)
+        validate(input_data, CreateBlockedSenderPolicyInput.schema)
         expect = Util.load_json("expected/create_blocked_sender_policy.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, CreateBlockedSenderPolicyOutput.schema)

--- a/plugins/mimecast/unit_test/test_create_managed_url.py
+++ b/plugins/mimecast/unit_test/test_create_managed_url.py
@@ -1,6 +1,7 @@
 import json
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -8,6 +9,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 from komand_mimecast.actions import CreateManagedUrl
+from komand_mimecast.actions.create_managed_url.schema import CreateManagedUrlOutput, CreateManagedUrlInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, MANAGED_URL_EXISTS_ERROR
 
 from util import Util
@@ -19,12 +21,15 @@ class TestCreateManagedURl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(CreateManagedUrl())
 
-    def test_create_managed_url(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/create_managed_url.json.exp"))
+    def test_create_managed_url(self, _mocked_request):
+        input_data = Util.load_json("inputs/create_managed_url.json.exp")
+        validate(input_data, CreateManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/create_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, CreateManagedUrlOutput.schema)
 
-    def test_bad_create_managed_url(self, mocked_request):
+    def test_bad_create_managed_url(self, _mocked_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/create_managed_url_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(MANAGED_URL_EXISTS_ERROR))

--- a/plugins/mimecast/unit_test/test_decode_url.py
+++ b/plugins/mimecast/unit_test/test_decode_url.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import DecodeUrl
+from komand_mimecast.actions.decode_url.schema import DecodeUrlOutput, DecodeUrlInput
 
 from util import Util
 
@@ -16,7 +18,10 @@ class TestDecodeURL(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DecodeUrl())
 
-    def test_decode_url(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/decode_url.json.exp"))
+    def test_decode_url(self, _mocked_request):
+        input_data = Util.load_json("inputs/decode_url.json.exp")
+        validate(input_data, DecodeUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/decode_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DecodeUrlOutput.schema)

--- a/plugins/mimecast/unit_test/test_delete_blocked_sender_policy.py
+++ b/plugins/mimecast/unit_test/test_delete_blocked_sender_policy.py
@@ -1,12 +1,16 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import DeleteBlockedSenderPolicy
-from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, MANAGED_URL_NOT_FOUND_ERROR
+from komand_mimecast.actions.delete_blocked_sender_policy.schema import (
+    DeleteBlockedSenderPolicyOutput,
+    DeleteBlockedSenderPolicyInput,
+)
 
 from util import Util
 
@@ -17,12 +21,15 @@ class TestDeleteBlockedSenderPolicy(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DeleteBlockedSenderPolicy())
 
-    def test_delete_blocked_sender_policy(self, mocked_request: MagicMock):
-        actual = self.action.run(Util.load_json("inputs/delete_blocked_sender_policy.json.exp"))
+    def test_delete_blocked_sender_policy(self, _mocked_request: MagicMock):
+        input_data = Util.load_json("inputs/delete_blocked_sender_policy.json.exp")
+        validate(input_data, DeleteBlockedSenderPolicyInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/delete_blocked_sender_policy.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DeleteBlockedSenderPolicyOutput.schema)
 
-    def test_bad_delete_blocked_sender_policy(self, mocked_request: MagicMock):
+    def test_bad_delete_blocked_sender_policy(self, _mocked_request: MagicMock):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/delete_blocked_sender_policy_bad.json.exp"))
         self.assertEqual(exception.exception.cause, PluginException.causes[PluginException.Preset.NOT_FOUND])

--- a/plugins/mimecast/unit_test/test_delete_group_member.py
+++ b/plugins/mimecast/unit_test/test_delete_group_member.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import DeleteGroupMember
+from komand_mimecast.actions.delete_group_member.schema import DeleteGroupMemberOutput, DeleteGroupMemberInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, FOLDER_EMAIL_NOT_FOUND_ERROR
 
 from util import Util
@@ -17,10 +19,13 @@ class TestDeleteGroupMember(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DeleteGroupMember())
 
-    def test_delete_group_member(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/delete_group_member.json.exp"))
+    def test_delete_group_member(self, _mocked_request):
+        input_data = Util.load_json("inputs/delete_group_member.json.exp")
+        validate(input_data, DeleteGroupMemberInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/delete_group_member.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DeleteGroupMemberOutput.schema)
 
     def test_bad_delete_group_member(self, mocked_request):
         with self.assertRaises(PluginException) as exception:

--- a/plugins/mimecast/unit_test/test_delete_managed_url.py
+++ b/plugins/mimecast/unit_test/test_delete_managed_url.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import DeleteManagedUrl
+from komand_mimecast.actions.delete_managed_url.schema import DeleteManagedUrlOutput, DeleteManagedUrlInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, MANAGED_URL_NOT_FOUND_ERROR
 
 from util import Util
@@ -17,12 +19,15 @@ class TestDeleteManagedURl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(DeleteManagedUrl())
 
-    def test_delete_managed_url(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/delete_managed_url.json.exp"))
+    def test_delete_managed_url(self, _mocked_request):
+        input_data = Util.load_json("inputs/delete_managed_url.json.exp")
+        validate(input_data, DeleteManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/delete_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, DeleteManagedUrlOutput.schema)
 
-    def test_bad_delete_managed_url(self, mocked_request):
+    def test_bad_delete_managed_url(self, _mocked_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/delete_managed_url_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(MANAGED_URL_NOT_FOUND_ERROR))

--- a/plugins/mimecast/unit_test/test_find_groups.py
+++ b/plugins/mimecast/unit_test/test_find_groups.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import FindGroups
+from komand_mimecast.actions.find_groups.schema import FindGroupsOutput, FindGroupsInput
 
 from util import Util
 
@@ -16,12 +18,15 @@ class TestFindGroups(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(FindGroups())
 
-    def test_find_group(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/find_groups.json.exp"))
+    def test_find_group(self, _mocked_request):
+        input_data = Util.load_json("inputs/find_groups.json.exp")
+        validate(input_data, FindGroupsInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/find_groups.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, FindGroupsOutput.schema)
 
-    def test_empty_response(self, mocked_request):
+    def test_empty_response(self, _mocked_request):
         actual = self.action.run(Util.load_json("inputs/find_groups_with_filter.json.exp"))
         expect = Util.load_json("expected/find_groups_empty_groups.json.exp")
         self.assertEqual(expect, actual)

--- a/plugins/mimecast/unit_test/test_get_audit_event.py
+++ b/plugins/mimecast/unit_test/test_get_audit_event.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import GetAuditEvents
+from komand_mimecast.actions.get_audit_events.schema import GetAuditEventsOutput, GetAuditEventsInput
 
 from util import Util
 
@@ -16,7 +18,10 @@ class TestGetAuditEvent(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetAuditEvents())
 
-    def test_get_audit_event(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_audit_events.json.exp"))
+    def test_get_audit_event(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_audit_events.json.exp")
+        validate(input_data, GetAuditEventsInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_audit_events.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetAuditEventsOutput.schema)

--- a/plugins/mimecast/unit_test/test_get_managed_url.py
+++ b/plugins/mimecast/unit_test/test_get_managed_url.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import GetManagedUrl
+from komand_mimecast.actions.get_managed_url.schema import GetManagedUrlOutput, GetManagedUrlInput
 
 from util import Util
 
@@ -16,37 +18,58 @@ class TestGetManagedUrl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetManagedUrl())
 
-    def test_get_managed_url_no_filter(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url.json.exp"))
+    def test_get_managed_url_no_filter(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_action(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_action.json.exp"))
+    def test_get_managed_url_filtered_by_action(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_action.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_filtered_by_action.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_scheme(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_schema.json.exp"))
+    def test_get_managed_url_filtered_by_scheme(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_schema.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_filtered_by_scheme.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_math_type(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_mathtype.json.exp"))
+    def test_get_managed_url_filtered_by_math_type(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_mathtype.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_empty_response.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_disabled(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_disabled.json.exp"))
+    def test_get_managed_url_filtered_by_disabled(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_disabled.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_get_managed_url_filtered_by_id(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_filtered_by_id.json.exp"))
+    def test_get_managed_url_filtered_by_id(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_filtered_by_id.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_filtered_by_id.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)
 
-    def test_empty_response(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_managed_url_with_filter.json.exp"))
+    def test_empty_response(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_managed_url_with_filter.json.exp")
+        validate(input_data, GetManagedUrlInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_managed_url_empty_response.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetManagedUrlOutput.schema)

--- a/plugins/mimecast/unit_test/test_get_ttp_url_logs.py
+++ b/plugins/mimecast/unit_test/test_get_ttp_url_logs.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.actions import GetTtpUrlLogs
+from komand_mimecast.actions.get_ttp_url_logs.schema import GetTtpUrlLogsOutput, GetTtpUrlLogsInput
 
 from util import Util
 
@@ -16,7 +18,10 @@ class TestGetManagedUrl(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetTtpUrlLogs())
 
-    def test_get_ttp_url_logs(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/get_ttp_url_logs.json.exp"))
+    def test_get_ttp_url_logs(self, _mocked_request):
+        input_data = Util.load_json("inputs/get_ttp_url_logs.json.exp")
+        validate(input_data, GetTtpUrlLogsInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/get_ttp_url_logs.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, GetTtpUrlLogsOutput.schema)

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -1,7 +1,7 @@
 import datetime
 import os
 import sys
-from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -10,6 +10,7 @@ sys.path.append(os.path.abspath("../"))
 from komand_mimecast.util.event import EventLogs
 from komand_mimecast.util.exceptions import ApiClientException
 from komand_mimecast.tasks import MonitorSiemLogs
+from komand_mimecast.tasks.monitor_siem_logs.schema import MonitorSiemLogsOutput
 from util import Util, FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, SIEM_LOGS_HEADERS_RESPONSE
 
 
@@ -35,6 +36,7 @@ class TestMonitorSiemLogs(TestCase):
                 self.assertEqual(response, test.get("resp"))
                 self.assertEqual(new_state, {"next_token": test.get("token")})
                 self.assertEqual(status_code, 200)
+                validate(response, MonitorSiemLogsOutput.schema)
 
     def test_monitor_siem_logs_raises_401(self, _mock_data):
         state_params = {"next_token": "force_401"}

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -1,14 +1,14 @@
 import datetime
 import os
 import sys
+from insightconnect_plugin_runtime.exceptions import PluginException
 from unittest import TestCase
 from unittest.mock import patch
-
-from dateutil.parser import parse
 
 sys.path.append(os.path.abspath("../"))
 
 from komand_mimecast.util.event import EventLogs
+from komand_mimecast.util.exceptions import ApiClientException
 from komand_mimecast.tasks import MonitorSiemLogs
 from util import Util, FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, SIEM_LOGS_HEADERS_RESPONSE
 
@@ -18,16 +18,33 @@ class TestMonitorSiemLogs(TestCase):
     def setUp(self) -> None:
         self.task = Util.default_connector(MonitorSiemLogs())
 
-    def test_monitor_siem_logs(self, mock_data):
-        response, new_state, has_more_pages, status_code, _ = self.task.run()
+    def test_monitor_siem_logs_success(self, _mock_data):
+        content = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2]
+        token = SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")
+        tests = [
+            {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
+            {"next_token": "force_json_error", "resp": content, "has_more_pages": True, "token": token},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
+        ]
+        for test in tests:
+            with self.subTest(f"Success test with token: {test.get('next_token')}"):
+                test_state = {"next_token": test.get("next_token")}
+                response, new_state, has_more_pages, status_code, _ = self.task.run(params={}, state=test_state)
 
-        expected_response = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2]
-        expected_state = {"next_token": SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")}
+                self.assertEqual(has_more_pages, test.get("has_more_pages"))
+                self.assertEqual(response, test.get("resp"))
+                self.assertEqual(new_state, {"next_token": test.get("token")})
+                self.assertEqual(status_code, 200)
 
-        self.assertEqual(has_more_pages, True)
-        self.assertEqual(response, expected_response)
-        self.assertEqual(new_state, expected_state)
-        self.assertEqual(status_code, 200)
+    def test_monitor_siem_logs_raises_401(self, _mock_data):
+        state_params = {"next_token": "force_401"}
+
+        response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=state_params)
+
+        self.assertEqual(status_code, 401)
+        self.assertEqual(response, [])
+        self.assertEqual(new_state, state_params)  # we shouldn't change the state if we encounter an error
+        self.assertEqual(type(error), ApiClientException)
 
 
 class TestEventLogs(TestCase):

--- a/plugins/mimecast/unit_test/test_permit_or_block_sender.py
+++ b/plugins/mimecast/unit_test/test_permit_or_block_sender.py
@@ -1,5 +1,6 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -7,6 +8,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 sys.path.append(os.path.abspath("../"))
 from komand_mimecast.actions import PermitOrBlockSender
+from komand_mimecast.actions.permit_or_block_sender.schema import PermitOrBlockSenderOutput, PermitOrBlockSenderInput
 from komand_mimecast.util.constants import BASIC_ASSISTANCE_MESSAGE, ERROR_CASES, VALIDATION_INVALID_EMAIL_ADDRESS_ERROR
 
 from util import Util
@@ -18,17 +20,23 @@ class TestPermitOrBlockSender(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(PermitOrBlockSender())
 
-    def test_permit_user(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/permit_or_block_sender.json.exp"))
+    def test_permit_user(self, _mocked_request):
+        input_data = Util.load_json("inputs/permit_or_block_sender.json.exp")
+        validate(input_data, PermitOrBlockSenderInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/permit_or_block_sender.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, PermitOrBlockSenderOutput.schema)
 
-    def test_block_user(self, mocked_request):
-        actual = self.action.run(Util.load_json("inputs/block_sender.json.exp"))
+    def test_block_user(self, _mocked_request):
+        input_data = Util.load_json("inputs/block_sender.json.exp")
+        validate(input_data, PermitOrBlockSenderInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/block_sender.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, PermitOrBlockSenderOutput.schema)
 
-    def test_bad_email(self, mock_request):
+    def test_bad_email(self, _mock_request):
         with self.assertRaises(PluginException) as exception:
             self.action.run(Util.load_json("inputs/permit_or_block_sender_bad.json.exp"))
         self.assertEqual(exception.exception.cause, ERROR_CASES.get(VALIDATION_INVALID_EMAIL_ADDRESS_ERROR))

--- a/plugins/mimecast/unit_test/test_track_messages.py
+++ b/plugins/mimecast/unit_test/test_track_messages.py
@@ -1,11 +1,13 @@
 import os
 import sys
+from jsonschema import validate
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
 
 sys.path.append(os.path.abspath("../"))
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_mimecast.actions import TrackMessages
+from komand_mimecast.actions.track_messages.schema import TrackMessagesOutput, TrackMessagesInput
 from komand_mimecast.util.constants import (
     TRACKED_EMAILS_ADVANCED_CAUSE,
     TRACKED_EMAILS_REQUIRED_CAUSE,
@@ -22,10 +24,13 @@ class TestTrackMessages(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(TrackMessages())
 
-    def test_track_messages(self, mocked_request: MagicMock):
-        actual = self.action.run(Util.load_json("inputs/search_message_tracking.json.exp"))
+    def test_track_messages(self, _mocked_request: MagicMock):
+        input_data = Util.load_json("inputs/search_message_tracking.json.exp")
+        validate(input_data, TrackMessagesInput.schema)
+        actual = self.action.run(input_data)
         expect = Util.load_json("expected/search_message_tracking.json.exp")
         self.assertEqual(expect, actual)
+        validate(actual, TrackMessagesOutput.schema)
 
     @parameterized.expand(
         [

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -41,7 +41,7 @@ class Util:
             return json.loads(file.read())
 
     @staticmethod
-    def get_mocked_zip():
+    def get_mocked_zip(path_traversal=False):
         file_contents = [
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_1]},
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_2]},
@@ -49,7 +49,7 @@ class Util:
         zip_file = BytesIO()
         with ZipFile(zip_file, "w") as myzip:
             for i, content in enumerate(file_contents):
-                filename = f"{i}.json"
+                filename = get_filename(i, path_traversal)
                 myzip.writestr(filename, json.dumps(content))
 
         return zip_file.getvalue()
@@ -167,5 +167,11 @@ class Util:
                 resp = MockResponseZip(200, Util.get_mocked_zip(), headers, json_decode)
             elif "no_results" in data:
                 resp = MockResponseZip(200, b"", {"mc-siem-token": "token123"}, {"meta": {"status": 200}})
+            elif "path_traversal" in data:
+                resp = MockResponseZip(200, Util.get_mocked_zip(True), headers, {"meta": {"status": 200}})
             return resp
         return "Not implemented"
+
+
+def get_filename(i, path_traversal):
+    return f"filename-{i}-from-mimecast.json" if not path_traversal else f"../filename-{i}-from-mimecast.json"


### PR DESCRIPTION
Release of Mimecast 5.3.3

PRs pulled in this release:
- #2220 
- #2223 
- #2224 
- #2233

Overview:
- Bump SDK version to get task improved logging and exception handling. 
- Unit tests now validate input/output schemas. 
- Schema fixes for broken actions. 
- Validators lib bumped to remove vulnerability. 
- Sanitise filenames in request content to prevent path traversal. 