### PR TITLE
[SOAR-16345] [Mimecast] : sanitise filenames from zip content

### DIFF
--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.3 - Task `monitor_siem_logs` improved error logging | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
+* 5.3.3 - Task `monitor_siem_logs` improved error logging and sanitization of filenames | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field
 * 5.3.0 - Handled rate limiting error messaging | Update to latest plugin SDK 

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -170,12 +170,16 @@ class MimecastAPI:
             List[Dict]: A list of dictionaries, where each dictionary represents a log entry extracted from the ZIP file
         """
         try:
-            with ZipFile(BytesIO(request.content)) as my_zip:
+            content = self.sanitise_content(request.content)
+            with ZipFile(BytesIO(content)) as my_zip:
                 combined_json_list = [
                     log for file_name in my_zip.namelist() for log in json.loads(my_zip.read(file_name)).get("data")
                 ]
             return combined_json_list
-        except BadZipFile:
+        except BadZipFile as error:
+            # empty response from Mimecast can hit this, which we know is not an error, don't log it
+            if error.args[0] != "File is not a zip file":
+                self.logger.error(f"Hit BadZipFile, returning []. Error: {error}")
             return []
 
     def _prepare_header(self, uri: str) -> dict:
@@ -323,3 +327,12 @@ class MimecastAPI:
             return response
 
         self._handle_status_code_response(response, status_code)
+
+    @staticmethod
+    def sanitise_content(request_content: bytes) -> bytes:
+        # Sanitise file names to help guard against path traversal
+        sanitised_content = request_content.replace(b"%2e%2e%2f", b"../")
+        sanitised_content = sanitised_content.replace(b"../", b"")
+        sanitised_content = sanitised_content.replace(b"%2e%2e%5C", b"..\\")
+        sanitised_content = sanitised_content.replace(b"..\\", b"")
+        return sanitised_content

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -41,7 +41,7 @@ class Util:
             return json.loads(file.read())
 
     @staticmethod
-    def get_mocked_zip():
+    def get_mocked_zip(path_traversal=False):
         file_contents = [
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_1]},
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_2]},
@@ -49,7 +49,7 @@ class Util:
         zip_file = BytesIO()
         with ZipFile(zip_file, "w") as myzip:
             for i, content in enumerate(file_contents):
-                filename = f"{i}.json"
+                filename = get_filename(i, path_traversal)
                 myzip.writestr(filename, json.dumps(content))
 
         return zip_file.getvalue()
@@ -167,5 +167,11 @@ class Util:
                 resp = MockResponseZip(200, Util.get_mocked_zip(), headers, json_decode)
             elif "no_results" in data:
                 resp = MockResponseZip(200, b"", {"mc-siem-token": "token123"}, {"meta": {"status": 200}})
+            elif "path_traversal" in data:
+                resp = MockResponseZip(200, Util.get_mocked_zip(True), headers, {"meta": {"status": 200}})
             return resp
         return "Not implemented"
+
+
+def get_filename(i, path_traversal):
+    return f"filename-{i}-from-mimecast.json" if not path_traversal else f"../filename-{i}-from-mimecast.json"


### PR DESCRIPTION
## Proposed Changes
[SOAR-16345: Mimecast: rapid7/insightconnect-plugins(master) - Path Traversal](https://rapid7.atlassian.net/browse/SOAR-16345)

### Description

Describe the proposed changes:

  - sanitise the file names retrieved from response content before attempting to open these. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

- Tested by adding a unit test that will include the `../` in file names and can see by doing this it will then hit then BadZipFile
after the .replace has occurred. 
-- by using .replace it now passes the snyk test.
- Testing against mimecast with valid values:
-- returned filenames/zip files: `.replace()` has no action and parses content as expected
-- empty response: hit BadZipFile as no zip file is in the content, and we return `[]` as before but don't log an error. 

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
