### PR TITLE
[PLGN-639] Proofpoint TAP Release v4.1.2

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "d1493ef38c62f567771d7036bad1893f",
-	"manifest": "a3ee5e6adb00aad45679877f40597052",
+	"spec": "d3d68bbdba90655716ee26c5b8bdfcc7",
+	"manifest": "062e6b1b5040557d266b72600d901cfa",
 	"setup": "05601ce03de7ffb575c1624250bbfe27",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",
-			"hash": "1bc4f1d39eb7a8537a47383f5ec00255"
+			"hash": "cfc2b6790cbbd17d426f7e157fc17468"
 		},
 		{
 			"identifier": "get_all_threats/schema.py",
@@ -45,7 +45,7 @@
 		},
 		{
 			"identifier": "monitor_events/schema.py",
-			"hash": "41aa46532b340c5c93d1905a7b832347"
+			"hash": "a209946dd335677bf9a8ba403934d3c9"
 		}
 	]
 }

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.1"
+Version = "4.1.2"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.2 - Update to latest plugin SDK to get task and exception logging
 * 4.1.1 - Monitor Events Task: Update max lookback time, remove log cleaning, add debugging
 * 4.1.0 - Update to latest plugin SDK
 * 4.0.0 - Add Monitor Events task | Code refactor | Update plugin to be cloud enabled

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/actions/fetch_forensics/schema.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/actions/fetch_forensics/schema.py
@@ -74,6 +74,7 @@ class FetchForensicsOutput(insightconnect_plugin_runtime.Output):
     }
   },
   "required": [
+    "generated",
     "reports"
   ],
   "definitions": {

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -26,7 +26,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
             state=MonitorEventsState(),
         )
 
-    def run(self, params={}, state={}):  # pylint: disable=unused-argument
+    def run(self, params={}, state={}):  # noqa: MC0001
         self.connection.client.toggle_rate_limiting = False
         has_more_pages = False
         try:
@@ -110,7 +110,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
                 return new_unique_logs, state, has_more_pages, 200, None
 
             except ApiException as error:
-                self.logger.info(f"API Exception occurred: {error}")
+                self.logger.info(f"API Exception occurred: status_code: {error.status_code}, error: {error}")
                 state[self.PREVIOUS_LOGS_HASHES] = []
                 return [], state, False, error.status_code, error
         except Exception as error:

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,9 +4,9 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.1
+version: 4.1.2
 connection_version: 4
-supported_versions: ["Proofpoint TAP API v2", "Tested on 2023-06-22"]
+supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
   version: 5


### PR DESCRIPTION
Release of v4.1.2 which bumps the SDK version to pull task logging and exception handling. 

Original PR: 
- https://github.com/rapid7/insightconnect-plugins/pull/2229)

Testing:
- All actions passing on ICON 
<img width="1426" alt="Screenshot 2024-01-16 at 15 57 18" src="https://github.com/rapid7/insightconnect-plugins/assets/139136675/b70c4f89-0995-4990-ab47-78c2e02f9ad5">

- Dashboard on datadog showing swap over to new version and no alarming exceptions in platform logs. 
- unit test failing is expected on GH actions - unable to find a cache file, however pass locally. 

