### PR TITLE
[PLGN-696] [Mimecast] : handle JSONDecodeError / negative seek

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "4232d7bba45c9b6fe506a9ec94b305d6",
-	"manifest": "3a6f785a66ed07111301f9bf8e5ad1d6",
-	"setup": "4167aab8af34af2b7a0e8324d5621363",
+	"spec": "da3c3549ed5c1053a034950298d0acb3",
+	"manifest": "96ec24e1b47f24c2274a00db94801439",
+	"setup": "c5a4223eca84fe94d005a993136e7e61",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.3"
+Version = "5.3.4"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -103,12 +103,12 @@ Creates a blocked sender policy
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |description|string|None|True|A description for the policy which is kept with the email in the archive for future reference|None|A description|
-|from_part|string|envelope_from|True|Must be: envelope_from, header_from or both|['envelope_from', 'header_from', 'both']|envelope_from|
-|from_type|string|individual_email_address|True|Can be one of: everyone, internal_addresses, external_addresses, email_domain, profile_group or individual_email_address|['everyone', 'internal_addresses', 'external_addresses', 'email_domain', 'profile_group', 'individual_email_address']|internal_addresses|
+|from_part|string|envelope_from|True|Must be: envelope_from, header_from or both|["envelope_from", "header_from", "both"]|envelope_from|
+|from_type|string|individual_email_address|True|Can be one of: everyone, internal_addresses, external_addresses, email_domain, profile_group or individual_email_address|["everyone", "internal_addresses", "external_addresses", "email_domain", "profile_group", "individual_email_address"]|internal_addresses|
 |from_value|string|None|False|Required if `From Type` is one of email_domain, profile_group, individual_email_address. Expected values: If `From Type` is email_domain, a domain name without the @ symbol. If `From Type` is profile_group, the ID of the profile group. If `From Type` is individual_email_address, an email address|None|user@example.com|
-|option|string|block_sender|True|The block, option must be: no_action or block_sender|['block_sender', 'no_action']|block_sender|
+|option|string|block_sender|True|The block, option must be: no_action or block_sender|["block_sender", "no_action"]|block_sender|
 |source_ips|string|None|False|A comma separated list of IP addresses using CIDR notation (X.X.X.X/XX). When set the policy only applies for connections from matching addresses|None|198.51.100.0/24|
-|to_type|string|individual_email_address|True|Can be one of: everyone, internal_addresses, external_addresses, email_domain, profile_group or individual_email_address|['everyone', 'internal_addresses', 'external_addresses', 'email_domain', 'profile_group', 'individual_email_address']|everyone|
+|to_type|string|individual_email_address|True|Can be one of: everyone, internal_addresses, external_addresses, email_domain, profile_group or individual_email_address|["everyone", "internal_addresses", "external_addresses", "email_domain", "profile_group", "individual_email_address"]|everyone|
 |to_value|string|None|False|Required if `To Type` is one of email_domain, profile_group, individual_email_address. Expected values: If `To Type` is email_domain, a domain name without the @ symbol. If `To Type` is profile_group, the ID of the profile group. If `To Type` is individual_email_address, an email address|None|user@example.com|
   
 Example input:
@@ -176,12 +176,12 @@ Create a managed URL
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|block|True|Set to 'block' to blacklist the URL, 'permit' to whitelist it|['block', 'permit']|block|
+|action|string|block|True|Set to "block" to blacklist the URL, "permit" to whitelist it|["block", "permit"]|block|
 |comment|string|None|False|A comment about the why the URL is managed; for tracking purposes|None|Deemed malicious by VirusTotal|
 |disable_log_click|boolean|None|True|Disable logging of user clicks on the URL|None|False|
 |disable_rewrite|boolean|None|True|Disable rewriting of this URL in emails. Applies only if action = 'permit'|None|True|
 |disable_user_awareness|boolean|None|True|Disable User Awareness challenges for this URL. Applies only if action = 'permit'|None|False|
-|match_type|string|explicit|True|Set to 'explicit' to block or permit only instances of the full URL. Set to 'domain' to block or permit any URL with the same domain|['explicit', 'domain']|explicit|
+|match_type|string|explicit|True|Set to "explicit" to block or permit only instances of the full URL. Set to "domain" to block or permit any URL with the same domain|["explicit", "domain"]|explicit|
 |url|string|None|True|The URL to block or permit. Do not include a fragment|None|https://example.com|
   
 Example input:
@@ -369,7 +369,7 @@ Find groups that match a given query
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |query|string|None|False|A string to query for|None|mygroup|
-|source|string|cloud|True|A group source to filter on, either "cloud" or "ldap"|['cloud', 'ldap']|cloud|
+|source|string|cloud|True|A group source to filter on, either "cloud" or "ldap"|["cloud", "ldap"]|cloud|
   
 Example input:
 
@@ -484,15 +484,15 @@ This action is used to get information on a managed URL.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|none|False|Filter on whether or not the action is 'block' or 'permit'|['none', 'block', 'permit']|block|
-|disable_log_click|string|None|False|Filter on whether or not clicks are logged for this URL|['None', 'False', 'True']|True|
-|disable_rewrite|string|None|False|Filter on whether or not rewriting of this URL in emails is enabled|['None', 'False', 'True']|False|
-|disable_user_awareness|string|None|False|Filter on whether or not User Awareness challenges for this URL|['None', 'False', 'True']|False|
+|action|string|none|False|Filter on whether or not the action is "block" or "permit"|["none", "block", "permit"]|block|
+|disable_log_click|string|None|False|Filter on whether or not clicks are logged for this URL|["None", "False", "True"]|True|
+|disable_rewrite|string|None|False|Filter on whether or not rewriting of this URL in emails is enabled|["None", "False", "True"]|False|
+|disable_user_awareness|string|None|False|Filter on whether or not User Awareness challenges for this URL|["None", "False", "True"]|False|
 |domain|string|None|False|The managed domain|None|https://example.com|
 |domainOrUrl|string|None|False|A domain or URL to filter results|None|https://example.com|
 |exactMatch|boolean|False|False|If true, the domainOrUrl value to act as an exact match value. If false, any partial matches will be returned|None|False|
 |id|string|None|False|Filter on the Mimecast secure ID of the managed URL|None|wOi3MCwjYFYhZfkYlp2RMAhwOgsDZixCK43rDjLP0YPWrtBgqVtVbzzFK8SjGLNE4|
-|match_type|string|none|False|Filter on whether or not the match type is 'explicit' or 'domain'|['none', 'explicit', 'domain']|domain|
+|match_type|string|none|False|Filter on whether or not the match type is "explicit" or "domain"|["none", "explicit", "domain"]|domain|
 |scheme|string|None|False|Filter on whether or not the protocol is HTTP or HTTPS|None|http|
 
 Example input:
@@ -551,8 +551,8 @@ Get TTP URL logs
 |max_pages|integer|100|False|Max pages returned, default 100|None|10|
 |oldest_first|boolean|False|False|When true return results in descending order with oldest result first|None|False|
 |page_size|integer|10|False|The number of results to request|None|10|
-|route|string|all|True|Filters logs by route, must be one of inbound, outbound, internal, or all|['all', 'inbound', 'outbound', 'internal']|inbound|
-|scan_result|string|all|True|Filters logs by scan result, must be one of clean, malicious, or all|['clean', 'malicious', 'all']|malicious|
+|route|string|all|True|Filters logs by route, must be one of inbound, outbound, internal, or all|["all", "inbound", "outbound", "internal"]|inbound|
+|scan_result|string|all|True|Filters logs by scan result, must be one of clean, malicious, or all|["clean", "malicious", "all"]|malicious|
 |to|string|None|False|End date of logs to return in the following format 2015-11-16T14:49:18+0000. Default is time of request|None|2018-11-22T14:49:18+0000|
 |url_to_filter|string|None|False|Regular expression to filter on. e.g. `examp` will return only URLs with the letters examp in them|None|exam.*|
   
@@ -607,7 +607,7 @@ This action is used to permit or block a sender.
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|block|True|Either 'permit' (to bypass spam checks) or 'block' (to reject the email)|['block', 'permit']|block|
+|action|string|block|True|Either "permit" (to bypass spam checks) or "block" (to reject the email)|["block", "permit"]|block|
 |sender|string|None|True|The email address of the external sender|None|user@example.com|
 |to|string|None|True|The email address of the internal recipient|None|user@example.com|
 
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.
 * 5.3.3 - Task `monitor_siem_logs` improved error logging and sanitization of filenames | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.
 * 5.3.2 - Connection: added regions USB and USBCOM | Monitor SIEM Logs: added logs for request and results information, removed `token` input parameter, updated pagination handler
 * 5.3.1 - Monitor SIEM Logs: stop parsing datetime field

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -45,10 +45,11 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                         break
                 except ApiClientException as error:
                     self.logger.error(
-                        f"An API client exception has been raised. Status code: {error.status_code}. Error: {error}"
-                        f"returning state={state}, has_more_pages={has_more_pages}"
+                        f"An exception has been raised during retrieval of siem logs. Status code: {error.status_code} "
+                        f"Error: {error}, returning state={state}, has_more_pages={has_more_pages}"
                     )
                     return [], state, has_more_pages, error.status_code, error
+
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
                 output = self._filter_and_sort_recent_events(output)
                 if output:
@@ -62,7 +63,8 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
         except Exception as error:
             self.logger.error(
                 f"An exception has been raised. Error: {error}, returning state={state}, "
-                f"has_more_pages={has_more_pages}"
+                f"has_more_pages={has_more_pages}",
+                exc_info=True,
             )
             return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -27,7 +27,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             state=MonitorSiemLogsState(),
         )
 
-    def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument
+    def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument  # noqa: MC0001
         has_more_pages = False
         try:
             header_next_token = state.get(self.NEXT_TOKEN, "")
@@ -60,13 +60,15 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                 has_more_pages = IS_LAST_TOKEN_FIELD not in headers
 
             return output, state, has_more_pages, status_code, None
-        except Exception as error:
-            self.logger.error(
-                f"An exception has been raised. Error: {error}, returning state={state}, "
-                f"has_more_pages={has_more_pages}",
-                exc_info=True,
-            )
-            return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
+        except Exception as gen_error:
+            gen_info, exp = f"Error: {gen_error}, returning state={state}, has_more_pages={has_more_pages}", None
+            if "negative seek" in str(gen_error):
+                # this seems to be intermittent on what Mimecast returns, don't log with word `error`
+                self.logger.debug(f"Found negative seek. {gen_info}", exc_info=True)
+            else:
+                self.logger.error(f"An exception has been raised. {gen_info}", exc_info=True)
+                exp = PluginException(preset=PluginException.Preset.UNKNOWN, data=gen_error)
+            return [], state, has_more_pages, 500, exp
 
     def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
         """

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.3
+version: 5.3.4
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7
@@ -997,7 +997,7 @@ actions:
         required: true
       action:
         title: Action
-        description: Set to 'block' to blacklist the URL, 'permit' to whitelist it
+        description: Set to "block" to blacklist the URL, "permit" to whitelist it
         type: string
         example: block
         required: true
@@ -1007,8 +1007,8 @@ actions:
         - permit
       match_type:
         title: Match Type
-        description: Set to 'explicit' to block or permit only instances of the full
-          URL. Set to 'domain' to block or permit any URL with the same domain
+        description: Set to "explicit" to block or permit only instances of the full
+          URL. Set to "domain" to block or permit any URL with the same domain
         type: string
         example: explicit
         required: true
@@ -1087,7 +1087,7 @@ actions:
           - 'True'
       action:
         title: 'Filter: Action'
-        description: Filter on whether or not the action is 'block' or 'permit'
+        description: Filter on whether or not the action is "block" or "permit"
         type: string
         required: false
         example: block
@@ -1098,7 +1098,7 @@ actions:
           - permit
       match_type:
         title: 'Filter: Match Type'
-        description: Filter on whether or not the match type is 'explicit' or 'domain'
+        description: Filter on whether or not the match type is "explicit" or "domain"
         type: string
         example: domain
         required: false
@@ -1143,7 +1143,7 @@ actions:
     input:
       action:
         title: Action
-        description: Either 'permit' (to bypass spam checks) or 'block' (to reject
+        description: Either "permit" (to bypass spam checks) or "block" (to reject
           the email)
         type: string
         example: block

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.3",
+      version="5.3.4",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -70,6 +70,18 @@ class TestMonitorSiemLogs(TestCase):
         mock_logger.assert_called()
         self.assertIn("JSON", mock_logger.call_args[0][0])
 
+    @patch("logging.Logger.debug")
+    @patch("komand_mimecast.util.api.MimecastAPI.get_siem_logs", side_effect=Exception("negative seek"))
+    def test_monitor_siem_logs_raises_negative_seek(self, mock_siem_logs, mock_logger, _mock_data):
+        test_state = {"next_token": "negative_seek error"}  # this forces our mocked response to raise negative seek
+        response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=test_state)
+        self.assertEqual(status_code, 500)
+        self.assertEqual(has_more_pages, False)
+        self.assertEqual(response, [])  # no logs will be parsed as we raise error after catching negative seek
+        self.assertEqual(new_state, test_state)  # we shouldn't change the state if we encounter an error
+        mock_logger.assert_called()
+        self.assertIn("negative seek", mock_logger.call_args[0][0])
+
 
 class TestEventLogs(TestCase):
     def setUp(self) -> None:


### PR DESCRIPTION
## Proposed Changes
[[C2C Mimecast] Bad JSON decode error](https://rapid7.atlassian.net/browse/PLGN-696)

Snyk code analysis is failing on a different plugin for 'hardcoded' secrets in a unit test and can be ignored.

### Description
After marking Mimecast v5.3.3 as GA:
- noticed that a customer is in a bad retry loop, as the state contains a next_token value, and on trying to access `request.content` we're raising a JSON decode error. On the next try for this integration we make the same request returning the same content and so on..
- mimecast is occasionally returning bad data which is throwing `bad seek value - 3`
- Fix validator issues around quotes in plugin.spec and help.md

  - Added a catch for this type of error which builds up an error string containing the as much detail as possible to see which response is being given to us from Mimecast. 
  - On outer try/except added exec_info=True so we can debug if other edge cases get applied that we can backtrace exactly where it went wrong. 
  - Added specific condition to catch when negative seek error to not contain 'error' in the log.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:
- Tested the task happy paths with no `next_token` <- defaults to run last 24 hours with a next token returned
- Use this next_token and no logs are returned but no JSON decode error. 
- Built an image that raises JSON decode to force hitting this new error log, change for this were as follows: 
```
(venv) joneill:mimecast/ (PLGN-696✗) $ git diff | cat                                                                                                             [11:30:30]
diff --git a/plugins/mimecast/komand_mimecast/util/api.py b/plugins/mimecast/komand_mimecast/util/api.py
index 00c347eaa..57fe18702 100644
--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -99,12 +99,15 @@ class MimecastAPI:
             method="POST", url=f"{self.url}{uri}", headers=self._prepare_header(uri), data=str(payload)
         )
         self._check_rate_limiting(request)
-        if "attachment" in request.headers.get("Content-Disposition", "") or self._is_last_token(request):
-            combined_json_list = self._handle_zip_file(request)
-            return combined_json_list, request.headers, request.status_code
PLGN-696: add exception for bad json returned from mimecast.
+
+
+        # if "attachment" in request.headers.get("Content-Disposition", "") or self._is_last_token(request):
+        #     combined_json_list = self._handle_zip_file(request)
+        #     return combined_json_list, request.headers, request.status_code

         try:
             response = request.json()
+            raise json.JSONDecodeError("forced json", "error", 1)
             status_code = response.get(META_FIELD, {}).get(STATUS_FIELD)
             if response.get(FAIL_FIELD):
                 self._handle_siem_logs_error_response(response, status_code)
@@ -112,7 +115,7 @@ class MimecastAPI:
             error_info = f'response content="{request.content}", response headers="{request.headers}"'
             raise ApiClientException(
                 cause=json_error,
-                assistance=error_info,
+                data=error_info,
                 preset=PluginException.Preset.INVALID_JSON,
                 status_code=request.status_code,
             )
```
Screenshot showing output of an empty response with forced error, and beginning of full response with forced error being dumped in the exception logger.
![Screenshot 2024-01-23 at 11 33 54](https://github.com/rapid7/insightconnect-plugins/assets/139136675/d0efc928-2d4b-4ee9-b8ab-20c498210643)



### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
