### PR TITLE
[PLGN-648] Python 3 Script - Updated the SDK to latest version | Fix issue where input argument was too long

### DIFF
--- a/plugins/python_3_script/.CHECKSUM
+++ b/plugins/python_3_script/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "35a664c2015a27eb5a5026d746f7213c",
-	"manifest": "50ec47def361c8d3e6ecfd7503f1964d",
-	"setup": "f02f843d20f1de6d92372cdf5a8656e5",
+	"spec": "cf03ee8c17dab798de1c2d177619e794",
+	"manifest": "798db99502cb45d6a553dc13e2afc215",
+	"setup": "a1ce493a5f3b03dedd7fa40cee2edaaf",
 	"schemas": [
 		{
 			"identifier": "run/schema.py",

--- a/plugins/python_3_script/bin/icon_python_3_script
+++ b/plugins/python_3_script/bin/icon_python_3_script
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Python 3 Script"
 Vendor = "rapid7"
-Version = "4.0.7"
+Version = "4.0.8"
 Description = "Python is a programming language that lets you work quickly and integrate systems more effectively. This plugin allows you to run Python 3 code. It includes Python 3.8.1 and its standard library as well as the following 3rd party libraries"
 
 

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -61,9 +61,10 @@ Example input:
 
 ### Actions
 
-#### Run Function
 
-Run a Python 3 function
+#### Run Function
+  
+This action is used to run a Python 3 function
 
 ##### Input
 
@@ -87,7 +88,7 @@ Example input:
 
 ```
 {
-  "function": "def run(params={}):\n\tprint(params.get('some_input'))\n\tprint(username, password, secret_key)\n\treturn {'result1': 'example output 1', 'result2': 'example output 2'}",
+  "function": "def run(params={}):\\n    return {}",
   "input": {
     "some_input": "example input"
   }
@@ -118,7 +119,6 @@ Example output:
 ### Triggers
   
 *This plugin does not contain any triggers.*
-
 ### Tasks
   
 *This plugin does not contain any tasks.*
@@ -134,6 +134,7 @@ If installation fails, try increasing the `Timeout` connection input to `900` (1
 
 # Version History
 
+* 4.0.8 - Updated the SDK to latest version | Fix issue where input argument was too long
 * 4.0.7 - Updated the SDK | Updated Python version to `3.9.18` | Added handler to run function separately
 * 4.0.6 - Added empty `__init__.py` file to `unit_test` folder | Refreshed with new tooling
 * 4.0.5 - Updated the SDK version to include output masking | Updated all dependencies to the newest versions

--- a/plugins/python_3_script/icon_python_3_script/actions/run/action.py
+++ b/plugins/python_3_script/icon_python_3_script/actions/run/action.py
@@ -1,5 +1,6 @@
 import subprocess  # nosec B404
 import sys
+from pathlib import Path
 from typing import Any, Dict, Union
 from uuid import uuid4
 
@@ -7,7 +8,12 @@ import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 
-from icon_python_3_script.util.constants import DEFAULT_ENCODING, DEFAULT_PROCESS_TIMEOUT, INDENTATION_CHARACTER
+from icon_python_3_script.util.constants import (
+    DEFAULT_ENCODING,
+    DEFAULT_PROCESS_TIMEOUT,
+    INDENTATION_CHARACTER,
+    RUN_FUNCTION_TEMPLATE,
+)
 from icon_python_3_script.util.util import extract_output_from_stdout
 
 from .schema import Component, Input, RunInput, RunOutput
@@ -22,16 +28,16 @@ class Run(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         function_ = params.get(Input.FUNCTION, "")
-        function_ = self._add_credentials_to_function(
-            function_, self.connection.script_credentials, self._check_indentation_character(function_)
-        )
+        input_parameters = params.get(Input.INPUT, {})
+        # END INPUT BINDING - DO NOT REMOVE
 
         self.logger.info(f"Input: (below)\n\n{params.get(Input.INPUT)}\n")
         self.logger.info(f"Function: (below)\n\n{params.get(Input.FUNCTION)}\n")
 
         try:
-            output = self._execute_function_as_process(function_, params.get(Input.INPUT, {}))
+            output = self._execute_function_as_process(function_, input_parameters, self.connection.script_credentials)
         except Exception as error:
             raise PluginException(cause="Could not run supplied script", data=error) from None
         try:
@@ -63,8 +69,9 @@ class Run(insightconnect_plugin_runtime.Action):
         function_name = function_.split(" ")[1].split("(")[0]
         return locals()[function_name](params.get(Input.INPUT))
 
-    @staticmethod
-    def _execute_function_as_process(function_: str, parameters: Dict[str, Any]) -> Union[Dict[str, Any], None]:
+    def _execute_function_as_process(
+        self, function_: str, parameters: Dict[str, Any], credentials: Dict[str, Any]
+    ) -> Union[Dict[str, Any], None]:
         """
         Execute a function as a separate process and return its data.
 
@@ -74,28 +81,68 @@ class Run(insightconnect_plugin_runtime.Action):
         :param parameters: The input parameters to pass to the function.
         :type: Dict[str, Any]
 
+        :param credentials: The credentials to pass to the function.
+        :type: Dict[str, Any]
+
         :return: The result of the function execution.
         :rtype: Union[Dict[str, Any], None]
         """
 
-        execution_id = f"Python3Script-ActionRun-{uuid4()}:"
-        function_name = function_.split(" ")[1].split("(")[0]
+        execution_id = f"Python3Script-ActionRun-{uuid4()}"
+        execution_file = self.create_execution_file(execution_id, function_, parameters)
+        execution_arguments = ["python", execution_file.name]
+
+        if credentials:
+            for key, value in credentials.items():
+                if value:
+                    execution_arguments.append(f"--{key}={value}")
+
         try:
             output = subprocess.check_output(  # nosec B603, B607
-                [
-                    "python",
-                    "-c",
-                    f'import sys\n\nsys.path.append("/var/cache/python_dependencies/lib/python3.9/site-packages")\n\n{function_}\nsys.stdout.write("{execution_id}" + str({function_name}({parameters})))',
-                ],
+                execution_arguments,
                 shell=False,
                 stderr=subprocess.PIPE,
                 timeout=DEFAULT_PROCESS_TIMEOUT,
             )
             return extract_output_from_stdout(output.decode(DEFAULT_ENCODING), execution_id)
         except subprocess.CalledProcessError as error:
-            raise PluginException(error.stderr.decode(DEFAULT_ENCODING)) from None
+            raise PluginException(error.stderr.decode(DEFAULT_ENCODING).replace(execution_id, "")) from None
         except subprocess.TimeoutExpired:
             raise PluginException(f"Function got timed out after {DEFAULT_PROCESS_TIMEOUT} seconds.") from None
+        finally:
+            if execution_file.is_file():
+                execution_file.unlink()
+
+    @staticmethod
+    def create_execution_file(execution_id: str, function_: str, parameters: Dict[str, Any]) -> Path:
+        """
+        Create an execution file with the given execution ID, function name, and parameters.
+
+        :param execution_id: A unique identifier for the execution.
+        :type: str
+
+        :param function_: The body of the function to be executed.
+        :type: str
+
+        :param parameters: A dictionary of parameters to be passed to the function.
+        :type: Dict[str, Any]
+
+        :return: The path to the created execution file.
+        :rtype: Path
+        """
+
+        filename = f"{execution_id}.py"
+        function_name = function_.split(" ")[1].split("(")[0]
+        with open(filename, "w", encoding=DEFAULT_ENCODING) as file_:
+            file_.write(
+                RUN_FUNCTION_TEMPLATE.format(
+                    execution_id=execution_id,
+                    function_=function_,
+                    function_name=function_name,
+                    parameters=parameters,
+                )
+            )
+        return Path(filename)
 
     @staticmethod
     def _add_credentials_to_function(

--- a/plugins/python_3_script/icon_python_3_script/util/constants.py
+++ b/plugins/python_3_script/icon_python_3_script/util/constants.py
@@ -1,3 +1,22 @@
 INDENTATION_CHARACTER = " " * 4
 DEFAULT_ENCODING = "utf-8"
 DEFAULT_PROCESS_TIMEOUT = 5 * 60
+
+RUN_FUNCTION_TEMPLATE = """import sys
+from argparse import ArgumentParser
+
+sys.path.append("/var/cache/python_dependencies/lib/python3.9/site-packages")
+
+parser = ArgumentParser()
+parser.add_argument("--username")
+parser.add_argument("--password")
+parser.add_argument("--secret_key")
+
+arguments = parser.parse_args()
+username = arguments.username
+password = arguments.password
+secret_key = arguments.secret_key
+
+{function_}
+sys.stdout.write("{execution_id}" + str({function_name}({parameters})))
+"""

--- a/plugins/python_3_script/plugin.spec.yaml
+++ b/plugins/python_3_script/plugin.spec.yaml
@@ -7,7 +7,8 @@ vendor: rapid7
 support: rapid7
 status: []
 description: Python is a programming language that lets you work quickly and integrate systems more effectively. This plugin allows you to run Python 3 code. It includes Python 3.8.1 and its standard library as well as the following 3rd party libraries
-version: 4.0.7
+version: 4.0.8
+connection_version: 4
 supported_versions: ["Python 3.9.18"]
 sdk:
   type: full
@@ -68,8 +69,8 @@ actions:
       function:
         description: Function definition. Must be named `run`. Accepts the `input` object as params. Returns the dict as output. In this action you can use `username`, `password`, `secret_key` variables if defined in connection
         type: python
-        default: def run(params={}):\n    return {}
         required: true
+        default: def run(params={}):\n    return {}
         example: def run(params={}):\n\tprint(params.get('some_input'))\n\tprint(username, password)\n\treturn {}
       input:
         description: Input object to be passed as `params={}` to the `run` function

--- a/plugins/python_3_script/setup.py
+++ b/plugins/python_3_script/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="python_3_script-rapid7-plugin",
-      version="4.0.7",
+      version="4.0.8",
       description="Python is a programming language that lets you work quickly and integrate systems more effectively. This plugin allows you to run Python 3 code. It includes Python 3.8.1 and its standard library as well as the following 3rd party libraries",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Updated the SDK to latest version
  - Fix issue where input argument was too long

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [X] Screenshot of job output with the plugin changes
- [X] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [X] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [X] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [X] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [X] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [X] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [X] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [X] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [X] Work fully completed
- [X] Functional
  - [X] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [X] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [X] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [X] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [X] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section