### PR TITLE
[PLGN-701] [PLGN-693] Proofpoint Tap: allow backfill date to be specified by env var / fix sorting on missing md5

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d3d68bbdba90655716ee26c5b8bdfcc7",
-	"manifest": "062e6b1b5040557d266b72600d901cfa",
-	"setup": "05601ce03de7ffb575c1624250bbfe27",
+	"spec": "09129232ac4f98202dcbf875eab4431a",
+	"manifest": "87289b606db549934e9e2848e6c5b293",
+	"setup": "23e418bf3cc9276a36870a61a0af5be4",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.1
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -16,5 +16,10 @@ RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody
+
+# PLGN-701: POC how we can inject an env var into the container to specify a new date
+# the intention will be in next version to remove this hard coded injection and then if a backfill is needed
+# again we simply inject the value at the deployment level (TBD on how we would do this and persist if pod restarts etc)
+ENV SPECIFIC_DATE='{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
 
 ENTRYPOINT ["/usr/local/bin/komand_proofpoint_tap"]

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.2"
+Version = "4.1.3"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -239,7 +239,7 @@ This action is used to fetch events for clicks to malicious URLs permitted in th
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 |url|string|None|False|The URL for which the results will be returned. Returns all results if left empty|None|https://example.com|
@@ -299,8 +299,8 @@ This action is used to fetch events for messages delivered in the specified time
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |subject|string|None|False|The subject of the email for which the results will be returned (performs a full-match lookup). Returns all results if left empty|None|A phishy email|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
-|threatType|string|all|True|The threat type which will be returned in the data|['url', 'attachment', 'messageText', 'all']|url|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
+|threatType|string|all|True|The threat type which will be returned in the data|["url", "attachment", "messageText", "all"]|url|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 
@@ -414,8 +414,8 @@ This action is used to fetch events for messages blocked in the specified time p
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |subject|string|None|False|The subject of the email for which the results will be returned (performs a full-match lookup). Returns all results if left empty|None|A phishy email|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
-|threatType|string|all|True|The threat type which will be returned in the data|['url', 'attachment', 'messageText', 'all']|url|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
+|threatType|string|all|True|The threat type which will be returned in the data|["url", "attachment", "messageText", "all"]|url|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 
@@ -533,8 +533,8 @@ This action is used to fetch events for all clicks and messages relating to know
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
-|threatType|string|all|True|The threat type which will be returned in the data|['url', 'attachment', 'messageText', 'all']|url|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
+|threatType|string|all|True|The threat type which will be returned in the data|["url", "attachment", "messageText", "all"]|url|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 
@@ -643,7 +643,7 @@ This action is used to fetch events for clicks to malicious URLs blocked in the 
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 |url|string|None|False|The URL for which the results will be returned. Returns all results if left empty|None|https://example.com|
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.3 - Allow task `monitor_events` to poll from a set date in env var.
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging
 * 4.1.1 - Monitor Events Task: Update max lookback time, remove log cleaning, add debugging
 * 4.1.0 - Update to latest plugin SDK

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,7 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where no MD5 value in returned from Proofpoint was breaking the sorting of the list
+* 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging
 * 4.1.1 - Monitor Events Task: Update max lookback time, remove log cleaning, add debugging
 * 4.1.0 - Update to latest plugin SDK

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,7 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 4.1.3 - Allow task `monitor_events` to poll from a set date in env var.
+* 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where no MD5 value in returned from Proofpoint was breaking the sorting of the list
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging
 * 4.1.1 - Monitor Events Task: Update max lookback time, remove log cleaning, add debugging
 * 4.1.0 - Update to latest plugin SDK

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -147,7 +147,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
 
         # preventing random sorting of the list to ensure that the same hash is generated with each request
         if log.get("messageParts"):
-            log["messageParts"] = sorted(log.get("messageParts", []), key=lambda part: part.get("md5", ""))
+            log["messageParts"] = sorted(log.get("messageParts", []), key=lambda part: part.get("md5", None) or "")
         return dict(sorted(log.items()))
 
     @staticmethod

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.2
+version: 4.1.3
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
-  version: 5
+  version: 5.3.1
   user: nobody
 vendor: rapid7
 support: community

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.1",
+      version="4.1.3",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Tickets:
- [[C2C Proofpoint] Update polling logic to get missing data from outage](https://rapid7.atlassian.net/browse/PLGN-701)
- [[C2C Proofpoint] Handle comparison of nonetype of str error](https://rapid7.atlassian.net/browse/PLGN-693)

### Description

Describe the proposed changes:

  - Allow env var to override the date that we perform the first integration run. 
  - Resolve a bug that if proofpoint returns `{'md5': ""}` we use the value `""` and not `None`
    - when retrieving the value from the response because they supply md5 as "", this gets saved as None.
    - added an additional try/catch around this logic so that if we hit this we will drop a single log event in this time frame rather than the entire time frame. This is also needed because due to the `if not SPECIFIC_DATE:` we will not be able to jump forward if we hit a bad time period. Adding a comment to the code to explain further. 
  - Validator fixes around quotations for examples. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code <- agreed to write on the next release when removing env var from Dockerfile

Existing unit tests passing in IDE, unit test that is failing previously had issues on GH actions. 

#### In-Product Tests

Testing changes locally in terminal:
```
# Using env var from the dockerfile:
Plugin task beginning execution...
Connect: Connecting...
rapid7/Proofpoint TAP:4.1.3. Step name: monitor_events
Last collection date retrieved: None
First run... Using env var value of {"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-01-27T00:00:00+00:00/2024-01-27T01:00:00+00:00'}
Retrieved 81 total parsed events in time interval
Original number of events: 81. Number of events after de-duplication: 81
Retrieved 81 events
Plugin task finished execution...

# Second iteration moving time slot forward
Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.3. Step name: monitor_events
Last collection date retrieved: 2024-01-27T01:00:00+00:00
Subsequent run
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-01-27T01:00:00+00:00/2024-01-27T02:00:00+00:00'}
Retrieved 114 total parsed events in time interval
Original number of events: 114. Number of events after de-duplication: 114
Retrieved 114 events
Plugin task finished execution...

# Third iteration moving time slot forward.
Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.3. Step name: monitor_events
Last collection date retrieved: 2024-01-27T02:00:00+00:00
Subsequent run
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-01-27T02:00:00+00:00/2024-01-27T03:00:00+00:00'}
Retrieved 25 total parsed events in time interval
Original number of events: 25. Number of events after de-duplication: 25
Retrieved 25 events
Plugin task finished execution...

# Four iteration moving time slot forward.
Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.3. Step name: monitor_events
Last collection date retrieved: 2024-01-27T03:00:00+00:00
Subsequent run
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-01-27T03:00:00+00:00/2024-01-27T04:00:00+00:00'}
Retrieved 8 total parsed events in time interval
Original number of events: 8. Number of events after de-duplication: 8
Retrieved 8 events
Plugin task finished execution...

# Forcing state forward to a new time period. 
Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.3. Step name: monitor_events
Last collection date retrieved: 2024-01-29T12:34:56+00:00
Subsequent run
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-01-29T12:34:56+00:00/2024-01-29T13:34:56+00:00'}
Retrieved 1493 total parsed events in time interval
Set next page index to 1 and has more pages to True for the next run
Original number of events: 1000. Number of events after de-duplication: 1000
Retrieved 1000 events
Plugin task finished execution...

# New time period still honoured to get second page of results. 
Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.3. Step name: monitor_events
Last collection date retrieved: 2024-01-29T13:34:56+00:00
Getting the next page (page index 1) of results...
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-01-29T12:34:56+00:00/2024-01-29T13:34:56+00:00'}
Retrieved 1493 total parsed events in time interval
Original number of events: 493. Number of events after de-duplication: 493
Retrieved 493 events
Plugin task finished execution...
```

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
