### PR TITLE
Proofpoint TAP Release 4.1.3

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d3d68bbdba90655716ee26c5b8bdfcc7",
-	"manifest": "062e6b1b5040557d266b72600d901cfa",
-	"setup": "05601ce03de7ffb575c1624250bbfe27",
+	"spec": "09129232ac4f98202dcbf875eab4431a",
+	"manifest": "87289b606db549934e9e2848e6c5b293",
+	"setup": "23e418bf3cc9276a36870a61a0af5be4",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.1
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -16,5 +16,10 @@ RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody
+
+# PLGN-701: POC how we can inject an env var into the container to specify a new date
+# the intention will be in next version to remove this hard coded injection and then if a backfill is needed
+# again we simply inject the value at the deployment level (TBD on how we would do this and persist if pod restarts etc)
+ENV SPECIFIC_DATE='{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
 
 ENTRYPOINT ["/usr/local/bin/komand_proofpoint_tap"]

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.2"
+Version = "4.1.3"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -239,7 +239,7 @@ This action is used to fetch events for clicks to malicious URLs permitted in th
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 |url|string|None|False|The URL for which the results will be returned. Returns all results if left empty|None|https://example.com|
@@ -299,8 +299,8 @@ This action is used to fetch events for messages delivered in the specified time
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |subject|string|None|False|The subject of the email for which the results will be returned (performs a full-match lookup). Returns all results if left empty|None|A phishy email|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
-|threatType|string|all|True|The threat type which will be returned in the data|['url', 'attachment', 'messageText', 'all']|url|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
+|threatType|string|all|True|The threat type which will be returned in the data|["url", "attachment", "messageText", "all"]|url|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 
@@ -414,8 +414,8 @@ This action is used to fetch events for messages blocked in the specified time p
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
 |subject|string|None|False|The subject of the email for which the results will be returned (performs a full-match lookup). Returns all results if left empty|None|A phishy email|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
-|threatType|string|all|True|The threat type which will be returned in the data|['url', 'attachment', 'messageText', 'all']|url|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
+|threatType|string|all|True|The threat type which will be returned in the data|["url", "attachment", "messageText", "all"]|url|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 
@@ -533,8 +533,8 @@ This action is used to fetch events for all clicks and messages relating to know
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
-|threatType|string|all|True|The threat type which will be returned in the data|['url', 'attachment', 'messageText', 'all']|url|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
+|threatType|string|all|True|The threat type which will be returned in the data|["url", "attachment", "messageText", "all"]|url|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 
@@ -643,7 +643,7 @@ This action is used to fetch events for clicks to malicious URLs blocked in the 
 
 |Name|Type|Default|Required|Description|Enum|Example|
 |----|----|-------|--------|-----------|----|-------|
-|threatStatus|string|all|True|The threat statuses which will be returned in the data|['active', 'cleared', 'falsePositive', 'all']|active|
+|threatStatus|string|all|True|The threat statuses which will be returned in the data|["active", "cleared", "falsePositive", "all"]|active|
 |timeEnd|date|None|False|The end of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T22:00:00Z. If left empty, it will be calculated from the 'time_start' parameter. If the 'time_start' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T22:00:00+00:00|
 |timeStart|date|None|False|The start of the data retrieval period as ISO8601-formatted date e.g 2021-04-20T21:00:00Z. If left empty, it will be calculated from the 'time_end' parameter. If the 'time_end' parameter is empty, data from one hour before the current API server time will be returned. The minimum time range is thirty seconds. The maximum time range is one hour|None|2021-04-20T21:00:00+00:00|
 |url|string|None|False|The URL for which the results will be returned. Returns all results if left empty|None|https://example.com|
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging
 * 4.1.1 - Monitor Events Task: Update max lookback time, remove log cleaning, add debugging
 * 4.1.0 - Update to latest plugin SDK

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -1,5 +1,7 @@
 from datetime import datetime, timedelta, timezone
 from hashlib import sha1
+from json import loads
+from os import getenv
 
 import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -8,6 +10,9 @@ from komand_proofpoint_tap.util.api import Endpoint
 from komand_proofpoint_tap.util.exceptions import ApiException
 from komand_proofpoint_tap.util.util import SiemUtils
 from .schema import MonitorEventsInput, MonitorEventsOutput, MonitorEventsState, Component
+
+MAX_ALLOWED_LOOKBACK_HOURS = 3
+SPECIFIC_DATE = getenv("SPECIFIC_DATE")
 
 
 class MonitorEvents(insightconnect_plugin_runtime.Task):
@@ -34,23 +39,31 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
             self.logger.info(f"Last collection date retrieved: {last_collection_date}")
             next_page_index = state.get(self.NEXT_PAGE_INDEX)
             now = self.get_current_time() - timedelta(minutes=1)
-            max_allowed_lookback = now - timedelta(hours=3)
-            # Don't allow collection to go back further than 3 hours max
-            if last_collection_date and datetime.fromisoformat(last_collection_date) < max_allowed_lookback:
-                last_collection_date = max_allowed_lookback.isoformat()
-                if next_page_index:
-                    next_page_index = None
-                    state.pop(self.NEXT_PAGE_INDEX)
-                self.logger.info(f"Last collection date reset to max lookback allowed: {last_collection_date}")
+
+            # [PLGN-701] ignore any look back limitations if we're forcing a backfill date
+            if not SPECIFIC_DATE:
+                max_allowed_lookback = now - timedelta(hours=MAX_ALLOWED_LOOKBACK_HOURS)
+                # Don't allow collection to go back further than MAX_ALLOWED_LOOKBACK_HOURS (3) hours max
+                if last_collection_date and datetime.fromisoformat(last_collection_date) < max_allowed_lookback:
+                    last_collection_date = max_allowed_lookback.isoformat()
+                    if next_page_index:
+                        next_page_index = None
+                        state.pop(self.NEXT_PAGE_INDEX)
+                    self.logger.info(f"Last collection date reset to max lookback allowed: {last_collection_date}")
 
             previous_logs_hashes = state.get(self.PREVIOUS_LOGS_HASHES, [])
             query_params = {"format": "JSON"}
 
             if not state or not last_collection_date:
-                self.logger.info("First run")
-                last_hour = now - timedelta(hours=1)
-                state[self.LAST_COLLECTION_DATE] = now.isoformat()
-                parameters = SiemUtils.prepare_time_range(last_hour.isoformat(), now.isoformat(), query_params)
+                task_start = "First run... "
+                first_time = now - timedelta(hours=1)
+                if SPECIFIC_DATE:
+                    first_time = datetime(**loads(SPECIFIC_DATE), tzinfo=timezone.utc)  # PLGN-701: hard set to 27th Jan
+                    task_start += f"Using env var value of {SPECIFIC_DATE}"
+                self.logger.info(task_start)
+                last_time = first_time + timedelta(hours=1)
+                state[self.LAST_COLLECTION_DATE] = last_time.isoformat()
+                parameters = SiemUtils.prepare_time_range(first_time.isoformat(), last_time.isoformat(), query_params)
             else:
                 if next_page_index:
                     state.pop(self.NEXT_PAGE_INDEX)
@@ -114,7 +127,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
                 state[self.PREVIOUS_LOGS_HASHES] = []
                 return [], state, False, error.status_code, error
         except Exception as error:
-            self.logger.info(f"Exception occurred in monitor events task: {error}")
+            self.logger.info(f"Exception occurred in monitor events task: {error}", exc_info=True)
             state[self.PREVIOUS_LOGS_HASHES] = []
             return [], state, has_more_pages, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
@@ -122,20 +135,27 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
     def get_current_time():
         return datetime.now(timezone.utc)
 
-    def parse_logs(self, unparsed_logs: list) -> list:
+    def parse_logs(self, unparsed_logs: dict) -> list:
         parsed_logs = []
         for event_type in ["clicksBlocked", "clicksPermitted", "messagesBlocked", "messagesDelivered"]:
             parsed_logs.extend(self.prepare_log(log, event_type) for log in unparsed_logs.get(event_type, []))
         return parsed_logs
 
-    @staticmethod
-    def prepare_log(log: dict, value: str) -> dict:
+    def prepare_log(self, log: dict, value: str) -> dict:
         log["eventType"] = value
 
         # preventing random sorting of the list to ensure that the same hash is generated with each request
-        if log.get("messageParts"):
-            log["messageParts"] = sorted(log.get("messageParts", []), key=lambda part: part.get("md5", ""))
-        return dict(sorted(log.items()))
+        try:
+            if log.get("messageParts"):
+                log["messageParts"] = sorted(log.get("messageParts", []), key=lambda part: part.get("md5", None) or "")
+            return dict(sorted(log.items()))
+        except Exception as error:
+            self.logger.error(
+                "Hit an unexpected exception when preparing log. Dropping this single log to "
+                f"continue parsing timeframe. Error: {error}",
+                exc_info=True,
+            )
+            return {}
 
     @staticmethod
     def sha1(log: dict) -> str:

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.2
+version: 4.1.3
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
-  version: 5
+  version: 5.3.1
   user: nobody
 vendor: rapid7
 support: community

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.1",
+      version="4.1.3",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Release of plugin v4.1.3 to allow the extended look back on Proofpoint TAP API due to an outage. 

Original PR:
- #2277 