### PR TITLE
PLGN-696: adjust filter back to 24 hours and pin SDK version

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "3aba821f223d10f90d2faec6594ecd25",
-	"manifest": "b9adca158bbf1445c087e8018eef3bcc",
-	"setup": "6c71977139c3fd3545fd40c353b5cb60",
+	"spec": "1df084b24abaf1c2b8197be70e304856",
+	"manifest": "6bee538f80e002b8f296491af9136a9c",
+	"setup": "b1323509d65b011d3a3db3ed202d2715",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.2
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.5"
+Version = "5.3.6"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.
 * 5.3.3 - Task `monitor_siem_logs` improved error logging and sanitization of filenames | SDK bump | fix schema for `find_groups` & `get_audit_events` | bump validators version.

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -12,7 +12,7 @@ from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
-CUTOFF = 108
+CUTOFF = 24
 
 
 class MonitorSiemLogs(insightconnect_plugin_runtime.Task):

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -182,7 +182,6 @@ class MimecastAPI:
             with ZipFile(BytesIO(request.content)) as my_zip:
                 combined_json_list = []
                 for file_name in my_zip.namelist():
-                    self.logger.info(f"About to read file name {file_name}")
                     try:
                         contents = my_zip.read(file_name)
                         for log in json.loads(contents).get("data"):

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.5
+version: 5.3.6
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7
@@ -13,7 +13,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.3.0
+  version: 5.3.2
   user: nobody
 status: []
 resources:

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.5",
+      version="5.3.6",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Previously we used to filter by a timeframe of 24 hours. this was bumped in the following PRs:
    - #2275 I bumped the cut off period to 108 hours to allow a backfill of data after coming close to the date we needed. 
    - #2272 Original PR that I bumped to 96 hours. 
    - We now want to put this back to the originally timeframe of 24 hours to get everyone on production inline on one version. 
  - I also added a lot of logging to log each file name, which is excessive and ca now be removed. This is possibly causing of memory issue as well when the pods on production. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] ~Unit tests written for any new or updated code~

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

Tested task locally with this version vs the one on production with a larger filter period. Inlcuding screenshot below showing how 5.3.6 filters out a lot more for the same calls:

![Screenshot 2024-02-01 at 12 03 10](https://github.com/rapid7/insightconnect-plugins/assets/139136675/6e9c0370-0843-4406-a968-0db9d8fac9ac)

