### PR TITLE
[PLGN-700] - Mimecast - Adding in file sanitation from zip files

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1df084b24abaf1c2b8197be70e304856",
-	"manifest": "6bee538f80e002b8f296491af9136a9c",
-	"setup": "b1323509d65b011d3a3db3ed202d2715",
+	"spec": "a98bb0dc71021fa75760c5c73bc153cf",
+	"manifest": "6deb75e59d3c42d42c06fd792a88ab73",
+	"setup": "5286b065ae2c0266ddcd641289276bad",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.6"
+Version = "5.3.7"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.7 - Task `monitor_siem_logs` adding in sanitaion for names of files to be read in.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.7 - Task `monitor_siem_logs` adding in sanitaion for names of files to be read in.
+* 5.3.7 - Task `monitor_siem_logs` adding in sanitisation for names of files to be read in.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -8,6 +8,7 @@ import uuid
 from io import BytesIO
 from typing import Union, List, Dict, Any
 from zipfile import ZipFile, BadZipFile
+from werkzeug.utils import secure_filename
 
 import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -183,6 +184,7 @@ class MimecastAPI:
                 combined_json_list = []
                 for file_name in my_zip.namelist():
                     try:
+                        file_name = secure_filename(file_name)
                         contents = my_zip.read(file_name)
                         for log in json.loads(contents).get("data"):
                             combined_json_list += [log]

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -184,7 +184,10 @@ class MimecastAPI:
                 combined_json_list = []
                 for file_name in my_zip.namelist():
                     try:
+                        # To avoid potential path traversal vulnerabilities, only valid files should be allowed.
+                        # Due to the nature of the IO buffer, the filename cannot be checked until it is read in.
                         file_name = secure_filename(file_name)
+
                         contents = my_zip.read(file_name)
                         for log in json.loads(contents).get("data"):
                             combined_json_list += [log]

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.6
+version: 5.3.7
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -5,3 +5,4 @@ validators==0.21.0
 parameterized==0.8.1
 python-dateutil==2.6.1
 jsonschema==3.2.0
+werkzeug==3.0.1

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.6",
+      version="5.3.7",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -50,7 +50,6 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(new_state, state_params)  # we shouldn't change the state if we encounter an error
         self.assertEqual(type(error), ApiClientException)
 
-    @skip("Have pulled the sanitise method as possible negative seek cause - TODO in 5.3.6")
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_stops_path_traversal(self, mock_logger, _mock_data):
         test_state = {"next_token": "path_traversal"}  # this forces our mock util to append `../` into filenames
@@ -60,7 +59,7 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(response, [])  # no logs will be parsed as we raise error after catching BadZipFile
         self.assertEqual(new_state, test_state)  # we shouldn't change the state if we encounter an error
         mock_logger.assert_called()
-        self.assertIn("Hit BadZipFile, returning []. Error", mock_logger.call_args[0][0])
+        self.assertIn("There is no item named \'filename-1-from-mimecast.json\' in the archive", mock_logger.call_args[0][0])
 
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_raises_json_error(self, mock_logger, _mock_data):

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -59,7 +59,9 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(response, [])  # no logs will be parsed as we raise error after catching BadZipFile
         self.assertEqual(new_state, test_state)  # we shouldn't change the state if we encounter an error
         mock_logger.assert_called()
-        self.assertIn("There is no item named \'filename-1-from-mimecast.json\' in the archive", mock_logger.call_args[0][0])
+        self.assertIn(
+            "There is no item named 'filename-1-from-mimecast.json' in the archive", mock_logger.call_args[0][0]
+        )
 
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_raises_json_error(self, mock_logger, _mock_data):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

 After changes were made in https://rapid7.atlassian.net/browse/SOAR-16345 to try and sanitise the file path names `data='negative seek value -3'` errors were being raised. This was caused as the way the way the zip file is being read in, is from a buffer an not from a file path  as a result the replace that was called on `../` and .`.\\` could cause the file to get corrupted as it read in as they were not part of the file path, but just general data 
  
 This change will try to sanitise the filenames before the individual files are loaded to ensure only the correct files get red in, however for this approach the snyk vuln still appears in the list 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

updated the old unit test to ensure that a file that has `../` will not be correctly read in  

```
❯ python3 -m unittest *
.2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Group member already exists.', assistance='Please check input and try again.', data='{'meta': {'status': 200}, 'data': [], 'fail': [{'key': {'id': 'eNoVzrsOgjAUANB_uaskgoFgSRwsGoMBVFB8xEXoRdBilVJ8xX9X9zOcN0jMVI0lAwfyfVclYXSb2-LeI16yK142Laf6NkyTlsTuya86VjD21iaNhk-xOR47nowJ9y-r5bg_8wvMp6bbzMXknChZ3qnBt5zO0icWapH2mBe0j1sbLiR9yAFowNnhCk5-4BI1yJRsRIV1Jhj-Lm4cjoyhTSzzB1usZSku4Bga5IIzrP9fS9eJ-fkCsJk_yA', 'emailAddress': 'bad@rapid7.com'}, 'errors': [{'code': 'err_folder_group_member_already_exists', 'message': 'Group member already exists', 'retryable': False}]}]}'
..2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='The managed URL already exists; to update it, delete and recreate.', assistance='Please check input and try again.', data='{'meta': {'status': 200}, 'data': [], 'fail': [{'key': {'url': 'https://www.morele344.net/', 'matchType': 'explicit', 'action': 'permit', 'overrideUrl': False, 'disableUserAwareness': False, 'disableRewrite': False, 'disableLogClick': False}, 'errors': [{'code': 'err_managed_url_exists_code', 'message': 'The managed URL already exists; to update it, delete and recreate', 'retryable': False}]}]}'
...2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Invalid or unreachable endpoint provided.', assistance='Verify the URLs or endpoints in your configuration are correct.', data='{'meta': {'status': 404}, 'data': [], 'fail': []}', preset='not_found'
..2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Error email address not found.', assistance='Please check input and try again.', data='{'meta': {'status': 200}, 'data': [], 'fail': [{'key': {'id': 'eNoVzrsOgjAUANB_uaskgoFgSRwsGoMBVFB8xEXoRdBilVJ8xX9X9zOcN0jMVI0lAwfyfVclYXSb2-LeI16yK142Laf6NkyTlsTuya86VjD21iaNhk-xOR47nowJ9y-r5bg_8wvMp6bbzMXknChZ3qnBt5zO0icWapH2mBe0j1sbLiR9yAFowNnhCk5-4BI1yJRsRIV1Jhj-Lm4cjoyhTSzzB1usZSku4Bga5IIzrP9fS9eJ-fkCsJk_yA', 'emailAddress': 'test4@rapid7.com'}, 'errors': [{'code': 'err_folder_email_address_not_found', 'message': 'Error email address not found', 'retryable': False}]}]}'
..2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Managed URL not found.', assistance='Please check input and try again.', data='{'meta': {'status': 200}, 'data': [], 'fail': [{'errors': [{'code': 'err_managed_url_not_found', 'message': 'Managed URL not found', 'retryable': False}]}]}'
................s2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Received an unexpected response from the server.', assistance='(non-JSON or no response was received).', data='response content="this is bad json returned", response headers="{'mc-siem-token': 'token123', 'Content-Disposition': ''}"', preset='invalid_json'
....2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Email address is not valid.', assistance='Please check input and try again.', data='{'meta': {'status': 200}, 'data': [], 'fail': [{'key': {'sender': 'bad_email', 'to': 'test2@rapid7.com', 'action': 'block'}, 'errors': [{'field': 'sender', 'code': 'err_validation_invalid_email_address', 'message': 'Email address is not valid', 'retryable': False}]}]}'
...2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='The account configured in your connection is unauthorized to access this service.', assistance='Verify the permissions for your account and try again.', data='{'meta': {'status': 403, 'pagination': {'pageSize': 0}}, 'data': [{'source': 'cloud', 'query': 'test_query', 'folders': []}], 'fail': []}', preset='unauthorized'
.2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Invalid or unreachable endpoint provided.', assistance='Verify the URLs or endpoints in your configuration are correct.', data='{'meta': {'status': 404, 'pagination': {'pageSize': 0}}, 'data': [{'source': 'cloud', 'query': 'test_query', 'folders': []}], 'fail': []}', preset='not_found'
.2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Server error occurred', assistance='Verify your plugin connection inputs are correct and not malformed and try again. If the issue persists, please contact support.', data='{'meta': {'status': 500, 'pagination': {'pageSize': 0}}, 'data': [{'source': 'cloud', 'query': 'test_query', 'folders': []}], 'fail': []}', preset='server_error'
..2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='Either one of `Send From`, `Send To`, `Subject`, `Sender IP` fields, or `Message ID` must not be empty.', assistance='Please fill the necessary fields with data, and try again.'
.2024-02-01 16:27:01 [error    ] Plugin exception instantiated. cause='One of fields `Send From`, `Send To`, `Subject`, `Sender IP` must not be empty.', assistance='Please fill the necessary fields with data, and try again.'
.
----------------------------------------------------------------------
Ran 40 tests in 0.064s
```

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

testing the new code using postman we are still able to get back correct data
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/af28ebb2-207e-4817-8cae-e64dff1ff0be)


If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
