### PR TITLE
Proofpoint TAP Release 4.1.4

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "09129232ac4f98202dcbf875eab4431a",
-	"manifest": "87289b606db549934e9e2848e6c5b293",
-	"setup": "23e418bf3cc9276a36870a61a0af5be4",
+	"spec": "b8737473cda4c9744ba85c4bfefa9451",
+	"manifest": "0f92f58aa70ea4b86ebba1828b26e098",
+	"setup": "5f03513017650052a2e41897671977e1",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -20,6 +20,7 @@ USER nobody
 # PLGN-701: POC how we can inject an env var into the container to specify a new date
 # the intention will be in next version to remove this hard coded injection and then if a backfill is needed
 # again we simply inject the value at the deployment level (TBD on how we would do this and persist if pod restarts etc)
-ENV SPECIFIC_DATE='{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
+# PLGN-716: keeping env var but commented out as an example if this is ever needed again.
+#ENV SPECIFIC_DATE='{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
 
 ENTRYPOINT ["/usr/local/bin/komand_proofpoint_tap"]

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.3"
+Version = "4.1.4"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.4 - Remove hard coded env var from Dockerfile.
 * 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging
 * 4.1.1 - Monitor Events Task: Update max lookback time, remove log cleaning, add debugging

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -11,7 +11,7 @@ from komand_proofpoint_tap.util.exceptions import ApiException
 from komand_proofpoint_tap.util.util import SiemUtils
 from .schema import MonitorEventsInput, MonitorEventsOutput, MonitorEventsState, Component
 
-MAX_ALLOWED_LOOKBACK_HOURS = 3
+MAX_ALLOWED_LOOKBACK_HOURS = 24
 SPECIFIC_DATE = getenv("SPECIFIC_DATE")
 
 
@@ -43,7 +43,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
             # [PLGN-701] ignore any look back limitations if we're forcing a backfill date
             if not SPECIFIC_DATE:
                 max_allowed_lookback = now - timedelta(hours=MAX_ALLOWED_LOOKBACK_HOURS)
-                # Don't allow collection to go back further than MAX_ALLOWED_LOOKBACK_HOURS (3) hours max
+                # Don't allow collection to go back further than MAX_ALLOWED_LOOKBACK_HOURS (24) hours max
                 if last_collection_date and datetime.fromisoformat(last_collection_date) < max_allowed_lookback:
                     last_collection_date = max_allowed_lookback.isoformat()
                     if next_page_index:
@@ -56,7 +56,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
 
             if not state or not last_collection_date:
                 task_start = "First run... "
-                first_time = now - timedelta(hours=1)
+                first_time = now - timedelta(hours=MAX_ALLOWED_LOOKBACK_HOURS)
                 if SPECIFIC_DATE:
                     first_time = datetime(**loads(SPECIFIC_DATE), tzinfo=timezone.utc)  # PLGN-701: hard set to 27th Jan
                     task_start += f"Using env var value of {SPECIFIC_DATE}"

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.3
+version: 4.1.4
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.3",
+      version="4.1.4",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",

--- a/plugins/proofpoint_tap/unit_test/expected/monitor_events_bad_request.json.exp
+++ b/plugins/proofpoint_tap/unit_test/expected/monitor_events_bad_request.json.exp
@@ -1,7 +1,7 @@
 {
   "events": [],
   "state": {
-    "last_collection_date": "2023-04-04T05:59:00+00:00",
+    "last_collection_date": "2023-04-03T07:59:00+00:00",
     "previous_logs_hashes": []
   },
   "hasMorePages": false,

--- a/plugins/proofpoint_tap/unit_test/expected/monitor_events_first_run.json.exp
+++ b/plugins/proofpoint_tap/unit_test/expected/monitor_events_first_run.json.exp
@@ -58,7 +58,7 @@
     }
   ],
   "state": {
-    "last_collection_date": "2023-04-04T07:59:00+00:00",
+    "last_collection_date": "2023-04-03T08:59:00+00:00",
     "next_page_index": 1,
     "previous_logs_hashes": [
       "1604441c3c213eb3d2efc9557cae93a5796fa5a8",

--- a/plugins/proofpoint_tap/unit_test/expected/monitor_events_server_error.json.exp
+++ b/plugins/proofpoint_tap/unit_test/expected/monitor_events_server_error.json.exp
@@ -1,9 +1,9 @@
 {
   "events": [],
   "state": {
-    "last_collection_date": "2023-04-04T05:59:00+00:00",
+    "last_collection_date": "2023-04-04T05:00:00+00:00",
     "previous_logs_hashes": []
   },
-  "hasMorePages": false,
+  "hasMorePages": true,
   "status_code": 500
 }

--- a/plugins/proofpoint_tap/unit_test/inputs/monitor_events_bad_request.json.inp
+++ b/plugins/proofpoint_tap/unit_test/inputs/monitor_events_bad_request.json.inp
@@ -1,5 +1,5 @@
 {
-  "last_collection_date": "2023-01-01T01:59:00+00:00",
+  "last_collection_date": "2023-04-03T07:59:00+00:00",
   "next_page_index": 2,
   "previous_logs_hashes": [
     "df05d563ebc4c2044954cd88b4debf63d5845b78",

--- a/plugins/proofpoint_tap/unit_test/inputs/monitor_events_server_error.json.inp
+++ b/plugins/proofpoint_tap/unit_test/inputs/monitor_events_server_error.json.inp
@@ -1,5 +1,5 @@
 {
-  "last_collection_date": "2023-02-02T02:59:00+00:00",
+  "last_collection_date": "2023-04-04T05:00:00+00:00",
   "next_page_index": 2,
   "previous_logs_hashes": [
     "df05d563ebc4c2044954cd88b4debf63d5845b78",

--- a/plugins/proofpoint_tap/unit_test/test_monitor_events.py
+++ b/plugins/proofpoint_tap/unit_test/test_monitor_events.py
@@ -11,12 +11,15 @@ from datetime import datetime, timezone
 
 sys.path.append(os.path.abspath("../"))
 
+ENV_VALUE = '{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
+TEST_PAGE_SIZE = 2
+
 
 @patch(
     "komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.get_current_time",
     return_value=datetime.strptime("2023-04-04T08:00:00", "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc),
 )
-@patch("komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.SPLIT_SIZE", new=2)
+@patch("komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.SPLIT_SIZE", new=TEST_PAGE_SIZE)
 @patch("requests.request", side_effect=Util.mocked_requests_get)
 class TestMonitorEvents(TestCase):
     @classmethod
@@ -62,7 +65,40 @@ class TestMonitorEvents(TestCase):
             ],
         ]
     )
-    def test_monitor_events(self, mock_request, mock_get_time, test_name, current_state, expected):
+    def test_monitor_events(self, _mock_request, _mock_get_time, _test_name, current_state, expected):
         actual, actual_state, has_more_pages, status_code, error = self.action.run(state=current_state)
         self.assertEqual(actual, expected.get("events"))
         self.assertEqual(actual_state, expected.get("state"))
+
+    @patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=ENV_VALUE)
+    @patch("logging.Logger.info")
+    def test_monitor_events_with_env_variable_empty_state(self, mock_logger, _mock_request, _mock_time):
+        # When we inject the env variable into the pod we should change the time we retrieve events from.
+        response, state, has_more_pages, status_code, _error = self.action.run(state={})
+
+        # we should have logged using env var
+        self.assertIn("Using env var value", mock_logger.call_args_list[1][0][0])
+
+        # state last time should be injected env var + 1 hour
+        self.assertEqual("2024-01-27T01:00:00+00:00", state["last_collection_date"])
+
+        # Split the logs being returned by the SPLIT_SIZE variable
+        self.assertEqual(TEST_PAGE_SIZE, len(response))
+
+        # We should expect next_page = True because we cut the results and NEXT_PAGE to be set
+        self.assertTrue(has_more_pages)
+        self.assertEqual(1, state["next_page_index"])
+
+    @patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=ENV_VALUE)
+    @patch("logging.Logger.info")
+    def test_monitor_events_with_env_variable_existing_state(self, mock_logger, _mock_request, _mock_time):
+        # Although we inject the env var because we have a state saved we can ignore and continue our usual logic
+        # use this date to avoid cut off logic from mocked current time.
+        existing_state = {"last_collection_date": "2023-04-04T01:00:00+00:00"}
+        response, state, has_more_pages, status_code, _error = self.action.run(state=existing_state)
+
+        # state last time should be last_collected_date + 1 hour
+        self.assertEqual("2023-04-04T02:00:00+00:00", state["last_collection_date"])
+
+        # Split the logs being returned by the SPLIT_SIZE variable
+        self.assertEqual(TEST_PAGE_SIZE, len(response))

--- a/plugins/proofpoint_tap/unit_test/test_parse_tap_alert.py
+++ b/plugins/proofpoint_tap/unit_test/test_parse_tap_alert.py
@@ -1,6 +1,7 @@
 import os
 import sys
 from unittest import TestCase
+from unittest.mock import patch
 
 from parameterized import parameterized
 
@@ -29,6 +30,19 @@ class TestParseTapAlert(TestCase):
             ],
         ]
     )
-    def test_parse_tap_alert(self, test_name, input_params, expected):
+    @patch("urlextract.urlextract_core.URLExtract.__new__")
+    def test_parse_tap_alert(self, _test_name, input_params, expected, mock_url_extract):
+        # GH actions fails on finding a cachefile for URLExtract and has no impact on this unit test mock it.
+        mock_url_extract.return_value = MockURLExtract()
+
         actual = self.action.run(input_params)
         self.assertDictEqual(actual, expected)
+
+
+class MockURLExtract:
+    def __init__(self):
+        pass
+
+    @staticmethod
+    def find_urls(_input):
+        return []

--- a/plugins/proofpoint_tap/unit_test/test_util.py
+++ b/plugins/proofpoint_tap/unit_test/test_util.py
@@ -152,12 +152,14 @@ class Util:
                 return MockResponse("blocked_clicks_without_time_start_end", 200)
 
         if "siem/all" in url:
-            if interval == "2023-04-04T04:59:00+00:00/2023-04-04T05:59:00+00:00":
-                return MockResponse("", 400)
-            if interval == "2023-02-02T01:59:00+00:00/2023-02-02T02:59:00+00:00":
+            if interval == "2023-04-03T06:59:00+00:00/2023-04-03T07:59:00+00:00":
+                return MockResponse("", 400)  # input state is 07:59 but we lookback an hour because of page state
+            if interval == "2023-04-04T04:00:00+00:00/2023-04-04T05:00:00+00:00":
                 return MockResponse("", 500)
+            if interval == "2023-04-03T07:59:00+00:00/2023-04-03T08:59:00+00:00":
+                return MockResponse("monitor_events", 200)  # input state is empty so we lookback 24 hours from 'now'
             if interval == "2023-04-04T06:59:00+00:00/2023-04-04T07:59:00+00:00":
-                return MockResponse("monitor_events", 200)
+                return MockResponse("monitor_events", 200)  # use input state supplied
             if interval == "2023-06-20T13:59:00+00:00/2023-06-20T14:59:00+00:00":
                 return MockResponse("monitor_events", 200)
 
@@ -167,6 +169,8 @@ class Util:
                 return MockResponse("all_threats_without_time_start", 200)
             if interval == "2021-08-20T13:00:00/2021-08-20T14:00:00":
                 return MockResponse("all_threats_without_time_end", 200)
+            if interval == "2024-01-27T00:00:00+00:00/2024-01-27T01:00:00+00:00":
+                return MockResponse("monitor_events", 200)
             if threat_status == "cleared" and threat_type == "url":
                 return MockResponse("all_threats_cleared_status", 200)
             if threat_status == "active":


### PR DESCRIPTION
Release of Proofpoint TAP v4.1.4

Original PR:
- #2295

Changes:
- Increase look back/cutoff times to 24 hours.
- Remove env var but keep logic to allow injection of env var to the plugin if a backfill is needed. 