### PR TITLE
[PLGN-697] - Microsoft Teams - Using urllib parse to ensure any symbols in the teams name are correctly encoded

### DIFF
--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -1210,7 +1210,7 @@ If there is more than one team with the same name in your organization, the olde
 
 # Version History
 
-* 6.0.1 - Using exact match on channel names rather than search, from user input channel names when getting the channel id
+* 6.0.1 - Using exact match on channel names rather than search, from user input channel names when getting the channel id | using urllib to encode any team names in API calls to avoid symbols not being parsed correctly
 * 6.0.0 - New actions: `create_teams_chat` | `list_messages_in_chat` | update type of `Event Detail` to type object 
 * 5.1.0 - New actions: Get Reply List | Improve typing on message
 * 5.0.0 - New actions: Get Message in Chat, Get Message in Channel | Update to latest SDK version | Change required fields in message schema

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/teams_utils.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/teams_utils.py
@@ -2,6 +2,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 import requests
 import re
 from logging import Logger
+import urllib.parse
 import insightconnect_plugin_runtime.connection
 from insightconnect_plugin_runtime.helper import clean
 
@@ -34,7 +35,8 @@ def get_teams_from_microsoft(  # noqa: C901
 
     # See if we are looking for a team name exactly or not
     if explicit:
-        teams_url = f"https://graph.microsoft.com/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '{team_name}'"
+        parsed_team_name = urllib.parse.quote(team_name, safe="")
+        teams_url = f"https://graph.microsoft.com/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq '{parsed_team_name}'"
     else:
         teams_url = "https://graph.microsoft.com/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')"
     headers = connection.get_headers()

--- a/plugins/microsoft_teams/unit_test/util.py
+++ b/plugins/microsoft_teams/unit_test/util.py
@@ -66,7 +66,7 @@ class Util:
 
         if (
             args[0]
-            == "https://graph.microsoft.com/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq 'Example Team'"
+            == "https://graph.microsoft.com/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq 'Example%20Team'"
         ):
             return MockResponse("get_teams", 200)
         if args[0] == "https://graph.microsoft.com/beta/1/teams/12345/channels":


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

 when using the test team name of "I&T I&O" it was noticted that the`&` was casuing issusing the url when try to make a request to ms team's api 

After encding the team team before making the call this can now allow the request to be processed correctly 

https://rapid7.atlassian.net/browse/PLGN-697

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section


testing the new logic, we can see that the url is now correctly encoded 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/48512de2-e66b-42e2-bfce-f572e7599cb5)


when testing the post html message action using the team name of "I&T I&O"  we can now see it can post to the correct channel
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/5963e0c7-15a3-4ce7-a8eb-827f0ce90dc3)

