### PR TITLE
[PLGN-712][PLGN-723] - Carbon Black Cloud- when getting agent details, allowing for case insensitive search and escaping any special chars in agent names

### DIFF
--- a/plugins/carbon_black_cloud/.CHECKSUM
+++ b/plugins/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "7a5657896c1f07e826c5c384f218ebeb",
-	"manifest": "d2e7fc2babe82cd2cc3a65d6b30c25a7",
-	"setup": "cc8128ff5f6d2041b968dbf96d81cd6d",
+	"spec": "c57b928f44386841f6bdefb46d942944",
+	"manifest": "02123fd6fd4af62463c6cab2fce3027e",
+	"setup": "7ca5be5347d5a4cb63e78c4fc376b12d",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/plugins/carbon_black_cloud/Dockerfile
+++ b/plugins/carbon_black_cloud/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "VMware Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "2.0.0"
+Version = "2.0.1"
 Description = "Quarantine endpoints and get device details with the VMware Carbon Black Cloud plugin"
 
 

--- a/plugins/carbon_black_cloud/help.md
+++ b/plugins/carbon_black_cloud/help.md
@@ -50,7 +50,7 @@ Example input:
 
 #### Get Agent Details
   
-This action is used to get agent details.
+This action is used to get agent details
 
 ##### Input
 
@@ -168,7 +168,7 @@ Example output:
 
 #### Quarantine
   
-This action is used to quarantine an agent.
+This action is used to quarantine an agent
 
 ##### Input
 
@@ -298,6 +298,7 @@ Example output:
 
 # Version History
 
+* 2.0.1 - Allows user entered hostnames to be case insensitive for `get_agent_details` and `quarantine` actions | Fix bug where error is raised if endpoint was not found in `get_agent` method | To add escaping of special characters in hostnames when performing hostname searches to Carbon Black
 * 2.0.0 - Updated the SDK version | Cloud enabled
 * 1.0.2 - Updated branding
 * 1.0.1 - Fix issue where retry on error call could crash plugin

--- a/plugins/carbon_black_cloud/plugin.spec.yaml
+++ b/plugins/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
 description: Quarantine endpoints and get device details with the VMware Carbon Black Cloud plugin
-version: 2.0.0
+version: 2.0.1
 vendor: rapid7
 support: rapid7
 cloud_ready: true
@@ -23,7 +23,7 @@ tags:
 - vmware
 hub_tags:
   use_cases: [threat_detection_and_response]
-  keywords: [carbon black, vmware, cloud, antivirus, cloud_enabled]
+  keywords: [carbon_black, vmware, cloud, antivirus, cloud_enabled]
   features: []
 sdk:
   type: full
@@ -454,7 +454,7 @@ connection:
 actions:
   get_agent_details:
     title: Get Agent Details
-    description: Get Agent Details
+    description: Get agent details
     input:
       agent:
         title: Agent

--- a/plugins/carbon_black_cloud/setup.py
+++ b/plugins/carbon_black_cloud/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="carbon_black_cloud-rapid7-plugin",
-      version="2.0.0",
+      version="2.0.1",
       description="Quarantine endpoints and get device details with the VMware Carbon Black Cloud plugin",
       author="rapid7",
       author_email="",

--- a/plugins/carbon_black_cloud/unit_test/responses/get_agent_details.json.resp
+++ b/plugins/carbon_black_cloud/unit_test/responses/get_agent_details.json.resp
@@ -65,7 +65,7 @@
       "login_user_name": "CARBONBLACK\\testuser",
       "mac_address": "fa163e92d344",
       "middle_name": null,
-      "name": "carbonblack",
+      "name": "carbonblack\\test",
       "nsx_distributed_firewall_policy": null,
       "nsx_enabled": null,
       "organization_id": 1105,

--- a/plugins/carbon_black_cloud/unit_test/test_agent_type.py
+++ b/plugins/carbon_black_cloud/unit_test/test_agent_type.py
@@ -13,11 +13,13 @@ class TestAgentType(TestCase):
         input_ip = "192.168.1.1"
         input_ip_v6 = "2001:0db8:85a3:0000:0000:8a2e:0370:7334"
         input_hostname = "foo-bar_pc1"
+        input_hostname_2 = "foo\\bar\\pc1"
         input_mac_address = "00:0a:95:9d:68:16"
         input_device_id = "3365550"
 
         self.assertEqual(agent_typer.get_agent_type(input_ip), agent_typer.IP_ADDRESS)
         self.assertEqual(agent_typer.get_agent_type(input_ip_v6), agent_typer.IP_ADDRESS)
         self.assertEqual(agent_typer.get_agent_type(input_hostname), agent_typer.HOSTNAME)
+        self.assertEqual(agent_typer.get_agent_type(input_hostname_2), agent_typer.HOSTNAME)
         self.assertEqual(agent_typer.get_agent_type(input_mac_address), agent_typer.MAC_ADDRESS)
         self.assertEqual(agent_typer.get_agent_type(input_device_id), agent_typer.DEVICE_ID)

--- a/plugins/carbon_black_cloud/unit_test/test_get_agent_details.py
+++ b/plugins/carbon_black_cloud/unit_test/test_get_agent_details.py
@@ -25,16 +25,20 @@ from util import (
 )
 
 STUB_AGENT_ID = "192.168.0.1"
+STUB_AGENT_ID_HOSTNAME = "carbonblack\\test"
+STUB_AGENT_ID_HOSTNAME_CAPS = "CARBONBLACK\\TEST"
 
 
 class TestGetAgentDetails(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(GetAgentDetails())
-        self.payload = {Input.AGENT: STUB_AGENT_ID}
 
+    @parameterized.expand(
+        [STUB_AGENT_ID, STUB_AGENT_ID_HOSTNAME, STUB_AGENT_ID_HOSTNAME_CAPS],
+    )
     @patch("requests.post", side_effect=mock_request_200)
-    def test_get_agent_details(self, mocked_post: MagicMock) -> None:
-        response = self.action.run(self.payload)
+    def test_get_agent_details(self, input: str, mocked_post: MagicMock) -> None:
+        response = self.action.run({Input.AGENT: input})
         expected = {
             Output.AGENT: {
                 "activation_code_expiry_time": "2022-07-11T06:53:06.190Z",
@@ -66,7 +70,7 @@ class TestGetAgentDetails(TestCase):
                 "last_shutdown_time": "2022-07-04T06:58:55.867Z",
                 "login_user_name": "CARBONBLACK\\testuser",
                 "mac_address": "fa163e92d344",
-                "name": "carbonblack",
+                "name": "carbonblack\\test",
                 "organization_id": 1105,
                 "organization_name": "cb-internal-alliances.com",
                 "os": "WINDOWS",
@@ -112,7 +116,7 @@ class TestGetAgentDetails(TestCase):
     def test_get_agent_details_exception(self, mock_request: MagicMock, exception: str) -> None:
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:
-            self.action.run(self.payload)
+            self.action.run({Input.AGENT: STUB_AGENT_ID})
         self.assertEqual(
             context.exception.cause,
             exception,


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

 https://rapid7.atlassian.net/browse/PLGN-712
- To return {} rather than None in the case the search returns results, but none match the hostname provided
- To esacpe any special chars that are in the agent names to avoid broken searches 
- To add new unit tests to cover these cases

https://rapid7.atlassian.net/browse/PLGN-723
-  To allow for case insensitive hostname search
-  To add in new unit test case to ensure that the search works

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests
All unit tests are passing locally with new tests added for new functionality
```
----------------------------------------------------------------------
Ran 18 tests in 20.044s

OK

```

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

example to show new escape of chars now correctly searches 
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/3ec67cde-c3ec-4a21-863f-7ddd6044386b)

example to show that hostname can now be case insensitive  
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/a08195a5-2bd4-4769-8a25-1e9a8ffe3f1c)

example for that when the search finds something, but the hostname is not an exact match, no error is now returned 
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/39facb4b-5b49-4f58-9584-011baecff6f7)


If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
