### PR TITLE
[PLGN-724] - Google Drive - Updating the code to comply with all of our code checks 

### DIFF
--- a/plugins/google_drive/.CHECKSUM
+++ b/plugins/google_drive/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1a182d70551623a9944e44834f29376a",
-	"manifest": "a52bd177266fb385277073d437829c65",
-	"setup": "643f9f889fd5d01998e7acfd1c6a63ef",
+	"spec": "90c98f863381f60dcc83ac9b114cae7c",
+	"manifest": "82042289459d5841695d63a431c9a593",
+	"setup": "c9014489e526312c91034ad23db83356",
 	"schemas": [
 		{
 			"identifier": "copy_file/schema.py",

--- a/plugins/google_drive/bin/komand_google_drive
+++ b/plugins/google_drive/bin/komand_google_drive
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Google Drive"
 Vendor = "rapid7"
-Version = "2.3.0"
+Version = "3.0.0"
 Description = "Upload and retrieve files from Google Drive"
 
 

--- a/plugins/google_drive/help.md
+++ b/plugins/google_drive/help.md
@@ -411,10 +411,9 @@ Example output:
 * When using file overwrite, the MIME Type should be set to the correct type to avoid data formatting issues.
 
 # Version History
-  
-* 2.3.0 - Implement shared drive support | Add Copy file action | Code refactor  
-* 2.2.0 - Add Create Folder, Create File in Folder and Move File actions | Add missing input and output examples | Code 
-refactor  
+
+* 3.0.0 - Implement shared drive support | Add Copy file action | Code refactor  
+* 2.2.0 - Add Create Folder, Create File in Folder and Move File actions | Add missing input and output examples | Code refactor  
 * 2.1.3 - Correct spelling in help.md  
 * 2.1.2 - New spec and help.md format for the Extension Library  
 * 2.1.1 - Fix typo in plugin spec  

--- a/plugins/google_drive/komand_google_drive/actions/copy_file/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/copy_file/action.py
@@ -15,11 +15,13 @@ class CopyFile(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         file_id = params.get(Input.FILE_ID)
         folder_id = params.get(Input.FOLDER_ID)
-        new_file_name=params.get(Input.NEW_FILE_NAME)
+        new_file_name = params.get(Input.NEW_FILE_NAME)
         try:
             metadata_body = clean({"name": new_file_name, "parents": [folder_id]})
             return {
-                Output.RESULT: self.connection.service.files().copy(fileId=file_id, body=metadata_body, fields='id, parents', supportsAllDrives=True).execute()
+                Output.RESULT: self.connection.service.files()
+                .copy(fileId=file_id, body=metadata_body, fields="id, parents", supportsAllDrives=True)
+                .execute()
             }
         except HttpError as error:
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=str(error))

--- a/plugins/google_drive/komand_google_drive/actions/copy_file/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/copy_file/action.py
@@ -4,6 +4,8 @@ from .schema import CopyFileInput, CopyFileOutput, Input, Output, Component
 # Custom imports below
 from insightconnect_plugin_runtime.exceptions import PluginException
 from googleapiclient.errors import HttpError
+from insightconnect_plugin_runtime.helper import clean
+
 
 
 class CopyFile(insightconnect_plugin_runtime.Action):

--- a/plugins/google_drive/komand_google_drive/actions/copy_file/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/copy_file/action.py
@@ -7,7 +7,6 @@ from googleapiclient.errors import HttpError
 from insightconnect_plugin_runtime.helper import clean
 
 
-
 class CopyFile(insightconnect_plugin_runtime.Action):
     def __init__(self):
         super(self.__class__, self).__init__(

--- a/plugins/google_drive/komand_google_drive/actions/create_file_in_folder/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/create_file_in_folder/action.py
@@ -34,7 +34,11 @@ class CreateFileInFolder(insightconnect_plugin_runtime.Action):
         media = MediaIoBaseUpload(file_bytes, mime_type, resumable=True)
 
         try:
-            result = self.connection.service.files().create(body=file_metadata, media_body=media, fields="id", supportsAllDrives=True).execute()
+            result = (
+                self.connection.service.files()
+                .create(body=file_metadata, media_body=media, fields="id", supportsAllDrives=True)
+                .execute()
+            )
             return {Output.FILE_ID: result.get("id")}
         except HttpError as error:
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=str(error))

--- a/plugins/google_drive/komand_google_drive/actions/create_folder/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/create_folder/action.py
@@ -22,7 +22,11 @@ class CreateFolder(insightconnect_plugin_runtime.Action):
             folder_metadata["parents"] = [parent_folder_id]
 
         try:
-            result = self.connection.service.files().create(body=folder_metadata, fields="id", supportsAllDrives=True).execute()
+            result = (
+                self.connection.service.files()
+                .create(body=folder_metadata, fields="id", supportsAllDrives=True)
+                .execute()
+            )
             return {Output.FOLDER_ID: result.get("id")}
         except HttpError as error:
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=str(error))

--- a/plugins/google_drive/komand_google_drive/actions/find_file_by_name/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/find_file_by_name/action.py
@@ -23,7 +23,17 @@ class FindFileByName(insightconnect_plugin_runtime.Action):
         else:
             query = f"name {filename_operator} '{filename}'"
 
-        response = self.connection.service.files().list(q=query, spaces="drive", fields="files(id, name)", supportsAllDrives=True, includeItemsFromAllDrives=True).execute()
+        response = (
+            self.connection.service.files()
+            .list(
+                q=query,
+                spaces="drive",
+                fields="files(id, name)",
+                supportsAllDrives=True,
+                includeItemsFromAllDrives=True,
+            )
+            .execute()
+        )
         file_info = []
         for file in response.get("files", []):
             file_info.append({"file_name": file.get("name"), "file_id": file.get("id")})

--- a/plugins/google_drive/komand_google_drive/actions/move_file/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/move_file/action.py
@@ -16,12 +16,20 @@ class MoveFile(insightconnect_plugin_runtime.Action):
         file_id = params.get(Input.FILE_ID)
         folder_id = params.get(Input.FOLDER_ID)
         try:
-            file_parents = self.connection.service.files().get(fileId=file_id, fields="parents", supportsAllDrives=True).execute()
+            file_parents = (
+                self.connection.service.files().get(fileId=file_id, fields="parents", supportsAllDrives=True).execute()
+            )
             file_parents = ",".join(file_parents.get("parents", []))
 
             return {
                 Output.RESULT: self.connection.service.files()
-                .update(fileId=file_id, addParents=folder_id, removeParents=file_parents, fields="id, parents", supportsAllDrives=True)
+                .update(
+                    fileId=file_id,
+                    addParents=folder_id,
+                    removeParents=file_parents,
+                    fields="id, parents",
+                    supportsAllDrives=True,
+                )
                 .execute()
             }
         except HttpError as error:

--- a/plugins/google_drive/komand_google_drive/actions/overwrite_file/action.py
+++ b/plugins/google_drive/komand_google_drive/actions/overwrite_file/action.py
@@ -52,7 +52,7 @@ class OverwriteFile(insightconnect_plugin_runtime.Action):
                     fileId=file_id,
                     media_mime_type=mime_type,
                     media_body=media,
-                    supportsAllDrives=True
+                    supportsAllDrives=True,
                 )
                 .execute()
             )

--- a/plugins/google_drive/plugin.spec.yaml
+++ b/plugins/google_drive/plugin.spec.yaml
@@ -4,8 +4,8 @@ products: [insightconnect]
 name: google_drive
 title: Google Drive
 description: Upload and retrieve files from Google Drive
-version: 2.3.0
-connection_version: 2
+version: 3.0.0
+connection_version: 3
 supported_versions: ["Google Drive API v3 2021-09-27"]
 vendor: rapid7
 support: community
@@ -21,7 +21,7 @@ requirements:
 - A JWT With Google Drive Permissions
 - The Google Drive API must be enabled
 version_history:
-- 2.3.0 - Implement shared drive support | Add Copy file action | Code refactor
+- 3.0.0 - Implement shared drive support | Add Copy file action | Code refactor
 - 2.2.0 - Add Create Folder, Create File in Folder and Move File actions | Add missing input and output examples | Code refactor
 - 2.1.3 - Correct spelling in help.md
 - 2.1.2 - New spec and help.md format for the Extension Library

--- a/plugins/google_drive/setup.py
+++ b/plugins/google_drive/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="google_drive-rapid7-plugin",
-      version="2.3.0",
+      version="3.0.0",
       description="Upload and retrieve files from Google Drive",
       author="rapid7",
       author_email="",

--- a/plugins/google_drive/unit_test/test_copy_file.py
+++ b/plugins/google_drive/unit_test/test_copy_file.py
@@ -1,14 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.copy_file import CopyFile
 from komand_google_drive.actions.copy_file.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from tests.util import Util
+from util import Util
 from parameterized import parameterized
-
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestCopyFile(TestCase):

--- a/plugins/google_drive/unit_test/test_create_file_in_folder.py
+++ b/plugins/google_drive/unit_test/test_create_file_in_folder.py
@@ -1,13 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.create_file_in_folder import CreateFileInFolder
 from komand_google_drive.actions.create_file_in_folder.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestCreateFileInFolder(TestCase):

--- a/plugins/google_drive/unit_test/test_create_folder.py
+++ b/plugins/google_drive/unit_test/test_create_folder.py
@@ -1,13 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.create_folder import CreateFolder
 from komand_google_drive.actions.create_folder.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestCreateFolder(TestCase):

--- a/plugins/google_drive/unit_test/test_find_file_by_name.py
+++ b/plugins/google_drive/unit_test/test_find_file_by_name.py
@@ -1,12 +1,12 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.find_file_by_name import FindFileByName
 from komand_google_drive.actions.find_file_by_name.schema import Input, Output
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestFindFileByName(TestCase):

--- a/plugins/google_drive/unit_test/test_get_file_contents.py
+++ b/plugins/google_drive/unit_test/test_get_file_contents.py
@@ -1,14 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.get_file_contents import GetFileContents
 from komand_google_drive.actions.get_file_contents.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestGetFileContents(TestCase):

--- a/plugins/google_drive/unit_test/test_move_file.py
+++ b/plugins/google_drive/unit_test/test_move_file.py
@@ -1,14 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.move_file import MoveFile
 from komand_google_drive.actions.move_file.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestMoveFile(TestCase):

--- a/plugins/google_drive/unit_test/test_overwrite_file.py
+++ b/plugins/google_drive/unit_test/test_overwrite_file.py
@@ -1,13 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.overwrite_file import OverwriteFile
 from komand_google_drive.actions.overwrite_file.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestOverwriteFile(TestCase):

--- a/plugins/google_drive/unit_test/test_upload_file.py
+++ b/plugins/google_drive/unit_test/test_upload_file.py
@@ -1,13 +1,13 @@
 import sys
 import os
+
+sys.path.append(os.path.abspath("../"))
 from unittest import TestCase
 from komand_google_drive.actions.upload_file import UploadFile
 from komand_google_drive.actions.upload_file.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
-from unit_test.util import Util
+from util import Util
 from parameterized import parameterized
-
-sys.path.append(os.path.abspath("../"))
 
 
 class TestUploadFile(TestCase):

--- a/plugins/google_drive/unit_test/util.py
+++ b/plugins/google_drive/unit_test/util.py
@@ -23,24 +23,36 @@ class MockClient:
     def files(self):
         return self
 
-    def create(self, body, fields, media_body=None, supportsTeamDrives=None):
+    def create(self, body, fields, media_body=None, supportsTeamDrives=None, supportsAllDrives=None):
         self.body = body
+        return self
+
+    def copy(self, fileId, fields, body=None, supportsAllDrives=None):
+        self.get_file_id = fileId
         return self
 
     def export(self, fileId, mimeType):
         self.export_file_id = fileId
         return self
 
-    def get(self, fileId, fields):
+    def get(self, fileId, fields, supportsAllDrives=None):
         self.get_file_id = fileId
         return self
 
-    def list(self, q, spaces, fields):
+    def list(self, q, spaces, fields, supportsAllDrives=None, includeItemsFromAllDrives=None):
         self.query = q
         return self
 
     def update(
-        self, fileId, body=None, media_mime_type=None, media_body=None, fields=None, addParents=None, removeParents=None
+        self,
+        fileId,
+        body=None,
+        media_mime_type=None,
+        media_body=None,
+        fields=None,
+        addParents=None,
+        removeParents=None,
+        supportsAllDrives=None,
     ):
         self.update_file_id = fileId
         return self
@@ -87,7 +99,7 @@ class MockClient:
             return {"id": "upload_file3"}
         elif self.get_file_id == "1pAT5CqVKi6XtyaD4betZvDQqOt8ZcuUR":
             self.get_file_id = None
-            return {"parents": ["1HJz7NbjASN8szc_MS1-BoDn_q4opJFmn"]}
+            return {"id": "1pAT5CqVKi6XtyaD4betZvDQqOt8ZcuUR", "parents": ["0BwwA4oUTeiV1TGRPeTVjaWRDY1E"]}
         elif self.get_file_id == "File Not Found":
             self.get_file_id = None
             raise HttpError(


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

after vendor submitted code in https://github.com/rapid7/insightconnect-plugins/pull/2292  Updating the code to comply with all of our code checks 
  
  - running black formater  
  - bumping from 2.2.0 to 3.0.0 rather than to 2.3.0 (Cause: Type folder_id removed from move_file_result without a major version increment. Please change the plugin version to 3.0.0)
  - add in import for `from  insightconnect_plugin_runtime.helper import clean` that was missed
  - Fix import paths in the unit tests
  - Update the unit tests util class to now correctly take the new parameters added in the new plugin updates 
  
  
  
https://rapid7.atlassian.net/browse/PLGN-724

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section


no snyk vulns added
```
❯ snyk test


Testing /Users/rbowden/insight_repos/insightconnect-plugins/plugins/google_drive...

Organization:      soar-insightconnect-new
Package manager:   pip
Target file:       requirements.txt
Project name:      google_drive
Open source:       no
Project path:      /Users/rbowden/insight_repos/insightconnect-plugins/plugins/google_drive
Licenses:          enabled

✔ Tested 21 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.
```