### PR TITLE
Rapid7 InsightIDR release 9.0.0

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "481aa78539c6bf6e47de13be4fb5c8fc",
-	"manifest": "591a35179734014ecd294ef24bafa104",
-	"setup": "2c78335b72bf8906a8e3fbdab070e2cb",
+	"spec": "ee64db37925b8f76655e04f1c38f8026",
+	"manifest": "3185ce535fa2f4037e1d371b499579b7",
+	"setup": "fa47fbcfbdf5ff3b7e77a4bf76dc3852",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "00bc1cfd11f5e82bbd42a41f7bb73aa6"
+			"hash": "47461eb19fd3c3e3cb284b9c7b6eae89"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",

--- a/plugins/rapid7_insightidr/Dockerfile
+++ b/plugins/rapid7_insightidr/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "8.2.0"
+Version = "9.0.0"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -112,13 +112,15 @@ Example output:
 #### Advanced Query on Log
   
 This action is used to realtime query an InsightIDR log. This will query individual logs for results. Note only 500 
-results will be returned from a single call, if all results are required for this query please use smaller timeranges
+results will be returned from a single call, if all results are required for this query please use smaller timeranges. 
+If both a log name and log ID are provided, the log ID will used over the log name
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|log|string|None|True|Log to search|None|Firewall Activity|
+|log|string|None|False|Log name to search|None|Firewall Activity|
+|log_id|string|None|False|Log id to search|None|123456-abcd-1234-abcd-123456abc|
 |query|string|None|True|LEQL Query|None|where(user=adagentadmin, loose)|
 |relative_time|string|Last 5 Minutes|True|A relative time in the past to look for alerts|["Last 5 Minutes", "Last 10 Minutes", "Last 20 Minutes", "Last 30 Minutes", "Last 45 Minutes", "Last 1 Hour", "Last 2 Hours", "Last 3 Hours", "Last 6 Hours", "Last 12 Hours", "Use Time From Value"]|Last 5 Minutes|
 |time_from|string|None|False|Beginning date and time for the query. This will be ignored unless Relative Time input is set to 'Use Time From Value'. The format is flexible and will work with simple dates (e.g. 01-01-2020) to full ISO time (e.g. 01-01-2020T00:00:00)|None|01-01-2020T00:00:00|
@@ -130,6 +132,7 @@ Example input:
 ```
 {
   "log": "Firewall Activity",
+  "log_id": "123456-abcd-1234-abcd-123456abc",
   "query": "where(user=adagentadmin, loose)",
   "relative_time": "Last 5 Minutes",
   "time_from": "01-01-2020T00:00:00",
@@ -3021,6 +3024,7 @@ Example output:
 
 # Version History
 
+* 9.0.0 - Actions: `Advanced Query On Log` - Now allows for either log id or log name to be used
 * 8.2.0 - Actions: `Advanced Query On Log Set` and `Advanced Query On Log` - optimized data fetching mechanisms 
 * 8.1.1 - Extended error logging for all the actions
 * 8.1.0 - New actions added: `Search Accounts` and `Get Account Information`

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -21,6 +21,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         query = params.get(Input.QUERY)
         log_name = params.get(Input.LOG)
+        log_id = params.get(Input.LOG_ID)
         timeout = params.get(Input.TIMEOUT)
 
         time_from_string = params.get(Input.TIME_FROM)
@@ -39,7 +40,17 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                 data=f"\nTime From: {time_from}\nTime To:{time_to}",
             )
 
-        log_id = self.get_log_id(log_name)
+        if log_id is None and log_name is None:
+            raise PluginException(
+                cause="No values were provided for log id or log name",
+                assistance="Please enter a valid value for either log id or log name",
+            )
+
+        if log_id and log_name:
+            self.logger.info("Values were provided for both log ID and log name, the value for log id will be used")
+
+        if not log_id:
+            log_id = self.get_log_id(log_name)
 
         # The IDR API will SOMETIMES return results immediately.
         # It will return results if it gets them. If not, we'll get a call back URL to work on

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -4,11 +4,12 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges"
+    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges. If both a log name and log ID are provided, the log ID will used over the log name"
 
 
 class Input:
     LOG = "log"
+    LOG_ID = "log_id"
     QUERY = "query"
     RELATIVE_TIME = "relative_time"
     TIME_FROM = "time_from"
@@ -30,9 +31,15 @@ class AdvancedQueryOnLogInput(insightconnect_plugin_runtime.Input):
   "properties": {
     "log": {
       "type": "string",
-      "title": "Log",
-      "description": "Log to search",
+      "title": "Log Name",
+      "description": "Log name to search",
       "order": 6
+    },
+    "log_id": {
+      "type": "string",
+      "title": "Log ID",
+      "description": "Log id to search",
+      "order": 7
     },
     "query": {
       "type": "string",
@@ -81,7 +88,6 @@ class AdvancedQueryOnLogInput(insightconnect_plugin_runtime.Input):
     }
   },
   "required": [
-    "log",
     "query",
     "relative_time",
     "timeout"

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,9 +4,9 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 8.2.0
+version: 9.0.0
 connection_version: 5
-supported_versions: ["Latest release successfully tested on 2022-07-20."]
+supported_versions: ["Latest release successfully tested on 2024-02-15."]
 vendor: rapid7
 cloud_ready: true
 resources:
@@ -1737,7 +1737,7 @@ actions:
         example: {"log": {"id": "0b9a242d-d2fb-4e42-8656-eb5ff64d652f","name": "Windows Defender","tokens": ["bc38a911-65f1-4755-cca3-a330a6336b3a"],"structures": ["1238a911-65f1-4755-cca3-a330a6336b3a"],"user_data": {"platform_managed": "true"},"source_type": "token","token_seed": null,"retention_period": "default","links": [{"rel": "Related","href": "https://example.com"}],"rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:log:bc38a911-65f1-4755-cca3-a330a6336b3a","logsets_info": [{"id": "bc38a911-65f1-4755-cca3-a330a6336b3a","name": "Unparsed Data","rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:logset:bc38a911-65f1-4755-cca3-a330a6336b3a","links": [{"rel": "Self","href": "https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85"}]}]}}
   advanced_query_on_log:
     title: Advanced Query on Log
-    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges
+    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges. If both a log name and log ID are provided, the log ID will used over the log name
     input:
       query:
         title: Query
@@ -1789,12 +1789,19 @@ actions:
         required: true
         order: 5
       log:
-        title: Log
-        description: Log to search
+        title: Log Name
+        description: Log name to search
         type: string
         example: Firewall Activity
-        required: true
+        required: false
         order: 6
+      log_id:
+        title: Log ID
+        description: Log id to search
+        type: string
+        example: 123456-abcd-1234-abcd-123456abc
+        required: false
+        order: 7
     output:
       results_events:
         title: Query Results (Events)

--- a/plugins/rapid7_insightidr/requirements.txt
+++ b/plugins/rapid7_insightidr/requirements.txt
@@ -3,5 +3,5 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 python-dateutil==2.8.1
 validators==0.21.0
-aiohttp==3.9.0
+aiohttp==3.9.2
 parameterized==0.8.1

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="8.2.0",
+      version="9.0.0",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -290,6 +290,7 @@ class Util:
         elif (
             args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/log_id"
             or args[0] == f"{Util.STUB_URL_API}/log_search/query/logsets/log_id"
+            or args[0] == f"{Util.STUB_URL_API}/log_search/query/logs/123456-abcd-1234-abcd-123456abc"
         ):
             return MockResponse("log_id", 200)
         elif (


### PR DESCRIPTION
Release pr for the following 

https://github.com/rapid7/insightconnect-plugins/pull/2313
  - to allow for the use of either a log name or log id to be passed in from the ned user 
  - to bump the version of Aiohhtp used (https://github.com/rapid7/insightconnect-plugins/pull/2279)


https://rapid7.atlassian.net/browse/PLGN-717


Testing on stging 

testing using just log id 
```
{
  "log": "",
  "log_id": "ac5d962a-bb9f-43df-b0d1-6ac96762f837",
  "query": "where(CROND)",
  "relative_time": "Use Time From Value",
  "time_from": "2024-01-29T23:00:00+00:00",
  "time_to": "2024-01-30T00:00:00+00:00",
  "timeout": 60
}
```
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/f3b09f87-3f03-4c1d-98a1-3af2458280e0)


testing using just log name
```
{
  "log": "Raw Data",
  "log_id": "",
  "query": "where(CROND)",
  "relative_time": "Use Time From Value",
  "time_from": "2024-01-29T23:00:00+00:00",
  "time_to": "2024-01-30T00:00:00+00:00",
  "timeout": 60
}
```
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/b73889ed-d7fa-4d86-aa26-9bfc20b9ec80)


testing using both 
```
{
  "log": "Raw Data",
  "log_id": "ac5d962a-bb9f-43df-b0d1-6ac96762f837",
  "query": "where(CROND)",
  "relative_time": "Use Time From Value",
  "time_from": "2024-01-29T23:00:00+00:00",
  "time_to": "2024-01-30T00:00:00+00:00",
  "timeout": 60
}
```
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/3ab07ecc-6d81-4ef9-9496-e15d464efbc1)



