### PR TITLE
[PLGN-734] - Zoom -Adding better handling to  if the users account does not have all of the required permsions

### DIFF
--- a/plugins/zoom/.CHECKSUM
+++ b/plugins/zoom/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "3626965e9846e16503976b0bfec6b2e5",
-	"manifest": "57e062026586210e8e08b584e37a33da",
-	"setup": "14d4f6edd9c69832b802f17c45278fe3",
+	"spec": "1525cf2a92936a6d9f531170d4f2fcec",
+	"manifest": "ca56acbed5c1a38693add93df82d8020",
+	"setup": "261233b4988195fdaa86fc75fa70b435",
 	"schemas": [
 		{
 			"identifier": "create_user/schema.py",
@@ -21,11 +21,11 @@
 		},
 		{
 			"identifier": "monitor_sign_in_out_activity/schema.py",
-			"hash": "8ce6d8306fa9109f65b2ddd2f9be972c"
+			"hash": "42bcff2a8e913f8f1218a4bd971060e2"
 		},
 		{
 			"identifier": "user_activity_event/schema.py",
-			"hash": "bed180af223a93e0ff9ef386b50a6542"
+			"hash": "b203ac1d025417e2afa28c7baec515df"
 		}
 	]
 }

--- a/plugins/zoom/Dockerfile
+++ b/plugins/zoom/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/zoom/bin/icon_zoom
+++ b/plugins/zoom/bin/icon_zoom
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Zoom"
 Vendor = "rapid7"
-Version = "4.1.5"
+Version = "4.1.6"
 Description = "Trigger workflows on user activity while also managing your users with the Zoom plugin"
 
 

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -56,17 +56,17 @@ Example input:
 
 #### Create User
   
-This action is used to create user associated to account  
+This action is used to create user associated to account
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|create|True|Specify how to create the new user|['create', 'autoCreate', 'custCreate', 'ssoCreate']|create|
+|action|string|create|True|Specify how to create the new user|["create", "autoCreate", "custCreate", "ssoCreate"]|create|
 |email|string|None|True|Email address of user|None|user@example.com|
 |first_name|string|None|False|First name of user|None|John|
 |last_name|string|None|True|Last name of user|None|Smith|
-|type|string|None|True|User type|['Basic', 'Licensed']|Basic|
+|type|string|None|True|User type|["Basic", "Licensed"]|Basic|
   
 Example input:
 
@@ -104,13 +104,13 @@ Example output:
 
 #### Delete User
   
-This action is used to delete or disassociate user from account  
+This action is used to delete or disassociate user from account
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|None|True|Specify how to delete the user. To delete pending user, use disassociate|['delete', 'disassociate']|delete|
+|action|string|None|True|Specify how to delete the user. To delete pending user, use disassociate|["delete", "disassociate"]|delete|
 |id|string|None|True|The user identifier or email address|None|user@example.com|
 |transfer_email|string|None|False|Email to transfer meetings, webinars, or recordings|None|user@example.com|
 |transfer_meetings|boolean|False|False|Whether to transfer meetings to defined transfer email|None|False|
@@ -186,13 +186,13 @@ Example output:
 
 #### User Activity Event
   
-This trigger is used to poll for user activity events  
+This trigger is used to poll for user activity events
 
 ##### Input
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|activity_type|string|None|True|Type of user activity to match event|['Sign in', 'Sign out', 'All']|All|
+|activity_type|string|None|True|Type of user activity to match event|["Sign in", "Sign out", "All"]|All|
   
 Example input:
 
@@ -227,7 +227,7 @@ Example output:
 
 #### Monitor Sign in and out Activity
   
-This task is used to monitor sign in and out activity  
+This task is used to monitor sign in and out activity
 
 ##### Input
   
@@ -242,16 +242,26 @@ This task is used to monitor sign in and out activity
 Example output:
 
 ```
-[
-  {
-    "client_type": "Browser",
-    "email": "user@example.com",
-    "ip_address": "198.51.100.100",
-    "time": "2020-06-05T16:51:28Z",
-    "type": "Sign in",
-    "version": "5.12.2"
-  }
-]
+{
+  "activity_logs": [
+    {
+      "client_type": "Browser",
+      "email": "user@example.com",
+      "ip_address": "198.51.100.100",
+      "time": "2020-06-05T16:51:28Z",
+      "type": "Sign in",
+      "version": "5.12.2"
+    },
+    {
+      "client_type": "Browser",
+      "email": "user@example.com",
+      "ip_address": "198.51.100.100",
+      "time": "2020-06-05T17:51:28Z",
+      "type": "Sign out",
+      "version": "5.12.2"
+    }
+  ]
+}
 ```
 
 ### Custom Types
@@ -276,10 +286,10 @@ Example output:
 |Department|string|None|False|Department of user|example department|
 |Email|string|None|False|Email address of user|user@example.com|
 |First Name|string|None|False|First name of user|John|
-|Web Group IDs|[]string|None|False|IDs of the web groups user belongs to|['t-_-d56CSWG-7BF15LLrOw', 't-_-d56CSWG-7BF15LLrow']|
+|Web Group IDs|[]string|None|False|IDs of the web groups user belongs to|["t-_-d56CSWG-7BF15LLrOw", "t-_-d56CSWG-7BF15LLrow"]|
 |Host Key|string|None|False|User's host key|123321|
 |ID|string|None|True|User identifier|T9ti3NBxR42swGKrqABGig|
-|IM Group IDs|[]string|None|False|IM IDs of the groups user belongs to|['t-_-d56CSWG-7BF15LLrOw', 't-_-d56CSWG-7BF15LLrow']|
+|IM Group IDs|[]string|None|False|IM IDs of the groups user belongs to|["t-_-d56CSWG-7BF15LLrOw", "t-_-d56CSWG-7BF15LLrow"]|
 |JID|string|None|False|JID of user|user@example.com|
 |Language|string|None|False|Language of user|en-US|
 |Last Login Time|string|None|False|Last login datetime of user|2023-06-21 13:41:14+00:00|
@@ -302,6 +312,7 @@ Example output:
 
 # Version History
 
+* 4.1.6 - Adding better handling to `monitor_sign_in_out_activity` if the users account does not have all of the required permsions 
 * 4.1.5 - Monitor Sign in and out Activity: Added exception logging and bumped latest plugin SDK
 * 4.1.4 - Update to the latest plugin SDK
 * 4.1.3 - Monitor Sign in and out Activity: set cutoff time of 24 hours

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -312,7 +312,7 @@ Example output:
 
 # Version History
 
-* 4.1.6 - Adding better handling to `monitor_sign_in_out_activity` if the users account does not have all of the required permsions 
+* 4.1.6 - Adding better handling to `monitor_sign_in_out_activity` task, if the users account does not have all of the required permissions 
 * 4.1.5 - Monitor Sign in and out Activity: Added exception logging and bumped latest plugin SDK
 * 4.1.4 - Update to the latest plugin SDK
 * 4.1.3 - Monitor Sign in and out Activity: set cutoff time of 24 hours

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/schema.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/schema.py
@@ -47,11 +47,7 @@ class MonitorSignInOutActivityOutput(insightconnect_plugin_runtime.Output):
     "$ref": "#/definitions/user_activity"
   },
   "required": [
-    "activity_logs",
-    "email",
-    "ip_address",
-    "time",
-    "type"
+    "activity_logs"
   ],
   "definitions": {
     "user_activity": {

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -51,6 +51,10 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         "Health check failed. An error occurred during event collection: insufficient permissions for this action. "
         "Please ensure you add all required scopes for the Rapid7 app in Zoom."
     )
+    PERMISSIONS_ERROR_MESSAGE_USER = (
+        "Health check failed. An error occurred during event collection: insufficient permissions for this action. "
+        "Please ensure you add all required user permissions for the Rapid7 app in Zoom."
+    )
 
     def __init__(self):
         super(self.__class__, self).__init__(
@@ -285,6 +289,22 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                     error=PluginException(
                         cause=PluginException.causes[PluginException.Preset.UNAUTHORIZED],
                         assistance=self.PERMISSIONS_ERROR_MESSAGE,
+                        data=exception.data,
+                    ),
+                )
+            elif "No permission." in exception.data:
+                self.logger.error(self.PERMISSIONS_ERROR_MESSAGE_USER)
+                return TaskOutput(
+                    output=[],
+                    state={
+                        self.LAST_REQUEST_TIMESTAMP: now,
+                        self.LATEST_EVENT_TIMESTAMP: None,
+                    },
+                    has_more_pages=False,
+                    status_code=403,
+                    error=PluginException(
+                        cause=PluginException.causes[PluginException.Preset.UNAUTHORIZED],
+                        assistance=self.PERMISSIONS_ERROR_MESSAGE_USER,
                         data=exception.data,
                     ),
                 )

--- a/plugins/zoom/icon_zoom/triggers/user_activity_event/schema.py
+++ b/plugins/zoom/icon_zoom/triggers/user_activity_event/schema.py
@@ -57,12 +57,6 @@ class UserActivityEventOutput(insightconnect_plugin_runtime.Output):
       "order": 1
     }
   },
-  "required": [
-    "email",
-    "ip_address",
-    "time",
-    "type"
-  ],
   "definitions": {
     "user_activity": {
       "type": "object",
@@ -107,14 +101,14 @@ class UserActivityEventOutput(insightconnect_plugin_runtime.Output):
           "title": "Version",
           "description": "The version of the client of the user's device",
           "order": 6
-        },
-        "required": [
-          "email",
-          "ip_address",
-          "time",
-          "type"
-        ]
-      }
+        }
+      },
+      "required": [
+        "email",
+        "ip_address",
+        "time",
+        "type"
+      ]
     }
   }
 }

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: zoom
 title: Zoom
 description: Trigger workflows on user activity while also managing your users with the Zoom plugin
-version: 4.1.5
+version: 4.1.6
 connection_version: 4
 vendor: rapid7
 support: rapid7

--- a/plugins/zoom/setup.py
+++ b/plugins/zoom/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="zoom-rapid7-plugin",
-      version="4.1.5",
+      version="4.1.6",
       description="Trigger workflows on user activity while also managing your users with the Zoom plugin",
       author="rapid7",
       author_email="",

--- a/plugins/zoom/unit_test/test_create_user.py
+++ b/plugins/zoom/unit_test/test_create_user.py
@@ -8,8 +8,10 @@ from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
 from icon_zoom.actions.create_user import CreateUser
+from icon_zoom.actions.create_user.schema import CreateUserInput, CreateUserOutput
 from insightconnect_plugin_runtime.exceptions import PluginException
 from parameterized import parameterized
+from jsonschema import validate
 
 from mock import STUB_CREATE_USER, Util, mock_request_201, mock_request_400, mock_request_404, mocked_request
 
@@ -24,6 +26,7 @@ class TestCreateUser(TestCase):
     @mock.patch("icon_zoom.util.api.ZoomAPI.authenticate")
     @mock.patch("requests.request", side_effect=mock_request_201)
     def test_create_user_success(self, mock_post: MagicMock, mock_auth: MagicMock) -> None:
+        validate(self.params, CreateUserInput.schema)
         mock_auth.return_value = 200
         response = self.action.run(self.params)
         expected_response = {
@@ -35,6 +38,7 @@ class TestCreateUser(TestCase):
         }
 
         self.assertEqual(response, expected_response)
+        validate(response, CreateUserOutput.schema)
 
     @parameterized.expand(
         [
@@ -44,6 +48,7 @@ class TestCreateUser(TestCase):
     )
     @mock.patch("icon_zoom.util.api.ZoomAPI._refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request: Callable, exception: str, mock_refresh: MagicMock) -> None:
+        validate(self.params, CreateUserInput.schema)
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:
             self.action.run(self.params)

--- a/plugins/zoom/unit_test/test_delete_user.py
+++ b/plugins/zoom/unit_test/test_delete_user.py
@@ -9,8 +9,9 @@ from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
 from icon_zoom.actions.delete_user import DeleteUser
-from icon_zoom.actions.delete_user.schema import Input
+from icon_zoom.actions.delete_user.schema import Input, DeleteUserInput, DeleteUserOutput
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 from mock import Util, mock_request_204, mock_request_400, mock_request_404, mocked_request
 
@@ -18,9 +19,9 @@ STUB_DELETE_USER_QUERY_PARAMS = {
     Input.ID: "12345",
     Input.ACTION: "delete",
     Input.TRANSFER_EMAIL: "user@example.com",
-    Input.TRANSFER_WEBINARS: "",
-    Input.TRANSFER_RECORDINGS: "",
-    Input.TRANSFER_MEETINGS: "",
+    Input.TRANSFER_WEBINARS: False,
+    Input.TRANSFER_RECORDINGS: False,
+    Input.TRANSFER_MEETINGS: False,
 }
 
 
@@ -33,10 +34,11 @@ class TestDeleteUser(TestCase):
     @mock.patch("requests.request", side_effect=mock_request_204)
     def delete_user_success(self, mock_delete: MagicMock) -> None:
         # mocked_request(mock_request_204)
+        validate(self.params, DeleteUserInput.schema)
         response = self.action.run(self.params)
         expected_response = None
-
         self.assertEqual(response, expected_response)
+        validate(response, DeleteUserOutput.schema)
 
     @parameterized.expand(
         [
@@ -46,8 +48,8 @@ class TestDeleteUser(TestCase):
     )
     @mock.patch("icon_zoom.util.api.ZoomAPI._refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request: MagicMock, exception: str, mock_refresh: MagicMock) -> None:
+        validate(self.params, DeleteUserInput.schema)
         mocked_request(mock_request)
-
         with self.assertRaises(PluginException) as context:
             self.action.run(self.params)
         self.assertEqual(context.exception.cause, exception)

--- a/plugins/zoom/unit_test/test_get_user.py
+++ b/plugins/zoom/unit_test/test_get_user.py
@@ -9,8 +9,9 @@ from unittest import TestCase, mock
 from unittest.mock import MagicMock
 
 from icon_zoom.actions.get_user import GetUser
-from icon_zoom.actions.get_user.schema import Input
+from icon_zoom.actions.get_user.schema import Input, GetUserInput, GetUserOutput
 from insightconnect_plugin_runtime.exceptions import PluginException
+from jsonschema import validate
 
 from mock import STUB_USER_ID, Util, mock_request_201, mock_request_400, mock_request_404, mocked_request
 
@@ -25,6 +26,7 @@ class TestGetUser(TestCase):
     @mock.patch("icon_zoom.util.api.ZoomAPI.authenticate")
     @mock.patch("requests.request", side_effect=mock_request_201)
     def test_get_user_success(self, mock_get, mock_authenticate):
+        validate(self.params, GetUserInput.schema)
         mock_authenticate.return_value = 200
         response = self.action.run(self.params)
         expected_response = {
@@ -74,6 +76,7 @@ class TestGetUser(TestCase):
             }
         }
         self.assertEqual(response, expected_response)
+        validate(response, GetUserOutput.schema)
 
     @parameterized.expand(
         [
@@ -83,6 +86,7 @@ class TestGetUser(TestCase):
     )
     @mock.patch("icon_zoom.util.api.ZoomAPI._refresh_oauth_token", return_value=None)
     def test_not_ok(self, mock_request: MagicMock, exception: str, mock_refresh: MagicMock) -> None:
+        validate(self.params, GetUserInput.schema)
         mocked_request(mock_request)
         with self.assertRaises(PluginException) as context:
             self.action.run(self.params)

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -10,9 +10,14 @@ from unittest.mock import MagicMock, patch
 
 from icon_zoom.connection.connection import Connection
 from icon_zoom.tasks.monitor_sign_in_out_activity.task import MonitorSignInOutActivity
+from icon_zoom.tasks.monitor_sign_in_out_activity.schema import (
+    MonitorSignInOutActivityOutput,
+    MonitorSignInOutActivityState,
+)
 from icon_zoom.util.event import Event
 from insightconnect_plugin_runtime.exceptions import PluginException
 from parameterized import parameterized
+from jsonschema import validate
 
 from mock import STUB_CONNECTION, STUB_OAUTH_TOKEN, Util
 
@@ -122,6 +127,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
             None,
         )
         expected_state = STUB_EXPECTED_PREVIOUS_STATE
+
         output, state, has_more_pages, status_code, error = self.task.run({})
 
         self.assertListEqual(output, expected_output)
@@ -129,6 +135,9 @@ class TestGetUserActivityEvents(unittest.TestCase):
         self.assertFalse(has_more_pages, expected_has_more_pages)
         self.assertEqual(status_code, expected_status_code)
         self.assertEqual(error, expected_error)
+
+        validate(output, MonitorSignInOutActivityOutput.schema)
+        validate(state, MonitorSignInOutActivityState.schema)
 
     @patch(GET_DATETIME_LAST_24_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
     @patch(GET_DATETIME_NOW_PATH, side_effect=[STUB_DATETIME_NOW + datetime.timedelta(minutes=DEFAULT_TIMEDELTA)])
@@ -148,6 +157,9 @@ class TestGetUserActivityEvents(unittest.TestCase):
         self.assertFalse(output, expected_has_more_pages)
         self.assertEqual(status_code, expected_status_code)
         self.assertEqual(error, expected_error)
+
+        validate(output, MonitorSignInOutActivityOutput.schema)
+        validate(state, MonitorSignInOutActivityState.schema)
 
     @patch(GET_DATETIME_LAST_24_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
     @patch(GET_DATETIME_NOW_PATH, side_effect=[STUB_DATETIME_NOW])
@@ -208,6 +220,9 @@ class TestGetUserActivityEvents(unittest.TestCase):
         self.assertEqual(status_code, first_expected_status_code)
         self.assertEqual(error, first_expected_error)
 
+        validate(output, MonitorSignInOutActivityOutput.schema)
+        validate(state, MonitorSignInOutActivityState.schema)
+
         # Second run
         mock_datetime_last_24.side_effect = [STUB_DATETIME_LAST_24_HOURS]
         mock_datetime_now.side_effect = [STUB_DATETIME_NOW + datetime.timedelta(minutes=DEFAULT_TIMEDELTA)]
@@ -246,6 +261,9 @@ class TestGetUserActivityEvents(unittest.TestCase):
         self.assertEqual(status_code, second_expected_status_code)
         self.assertEqual(error, second_expected_error)
 
+        validate(output, MonitorSignInOutActivityOutput.schema)
+        validate(state, MonitorSignInOutActivityState.schema)
+
     @patch(GET_DATETIME_NOW_PATH, return_value=datetime.datetime(2000, 1, 1))
     @patch(GET_USER_ACTIVITY_EVENTS_PATH, return_value=([{"test": "value"}], ""))
     def test_api_output_changed_error_catch(self, mock_call: MagicMock, mock_datetime: MagicMock) -> None:
@@ -270,6 +288,9 @@ class TestGetUserActivityEvents(unittest.TestCase):
         self.assertEqual(status_code, expected_status_code)
         self.assertEqual(error.cause, expected_error.cause)
         self.assertEqual(error.assistance, expected_error.assistance)
+
+        validate(output, MonitorSignInOutActivityOutput.schema)
+        validate(state, MonitorSignInOutActivityState.schema)
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Adding better handling to `monitor_sign_in_out_activity` if the users account does not have all of the required permsions
  - updated the unit  tests to add json schema validation 
  - ran refresh to fix a broken schema 
 
https://rapid7.atlassian.net/browse/PLGN-734

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

testing locally when the app has correct permissions, but the user account does not have the correct permissions 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/acbc310b-1b4a-4755-a12a-adb71da1cd54)


If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
