### PR TITLE
[PLGN-728] [Mimecast] - implement new SDK for custom_config backfilling.

### DIFF
--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.2
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | implement SDK 5.4 to include new task custom_config | bump setuptools.
+* 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.7 - Task `monitor_siem_logs` adding in sanitisation for names of files to be read in.
+* 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | implement SDK 5.4 to include new task custom_config | bump setuptools.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -112,9 +112,8 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
     def _get_filter_time(self, custom_config: Dict[str, int]) -> int:
         """
-        We want to apply the custom_config params if provided to the task. The logic is that if
-        a lookback value exists, this should take precedence to allow a larger filter time and only
-        once this no longer exists do we want to use the default value.
+        Apply custom_config params (if provided) to the task. If a lookback value exists, it should take
+        precedence (this can allow a larger filter time), otherwise use the default value.
         :param custom_config: dictionary passed containing `default` or `lookback` values
         :return: filter time to be applied in `_filter_and_sort_recent_events`
         """

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -29,10 +29,13 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             state=MonitorSiemLogsState(),
         )
 
-    def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument # noqa: MC0001
+    def run(  # pylint: disable=unused-argument # noqa: MC0001
+        self, params={}, state={}, custom_config={}
+    ) -> (List[Dict], Dict, Dict):
         try:
             has_more_pages = False
             header_next_token = state.get(self.NEXT_TOKEN, "")
+            filter_time = self._get_filter_time(custom_config)
 
             if not header_next_token:
                 self.logger.info("First run...")
@@ -52,7 +55,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     )
                     return [], state, has_more_pages, error.status_code, error
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
-                output = self._filter_and_sort_recent_events(output)
+                output = self._filter_and_sort_recent_events(output, filter_time)
                 if output:
                     break
 
@@ -71,31 +74,52 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                 exp = PluginException(preset=PluginException.Preset.UNKNOWN, data=gen_error)
             return [], state, has_more_pages, 500, exp
 
-    def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]], cut_off: int) -> List[Dict[str, Any]]:
         """
         Filters and sorts a list of events to retrieve only the recent events.
 
         :param task_output: A list of dictionaries representing the task output to be filtered and sorted.
         :type: List[Dict[str, Any]]
 
+        :param cut_off: integer specifying how far back in time we filter events from
+        :type: integer
+
         :return: A new list of dictionaries representing the filtered and sorted recent events.
         :rtype: List[Dict[str, Any]]
         """
 
         self.logger.info(f"Number of raw logs returned from Mimecast: {len(task_output)}")
+        filter_time = get_time_hours_ago(hours_ago=cut_off)
         task_output = sorted(
             map(
                 lambda event: event.get_dict(),
                 filter(
-                    lambda event: event.compare_datetime(get_time_hours_ago(hours_ago=CUTOFF)),
+                    lambda event: event.compare_datetime(filter_time),
                     [EventLogs(data=event) for event in task_output],
                 ),
             ),
             key=itemgetter(EventLogs.FILTER_DATETIME),
         )
-
+        latest_time = filter_time
         for event in task_output:
+            event_date_time = event.get(EventLogs.FILTER_DATETIME)
+            latest_time = event_date_time if event_date_time > latest_time else latest_time
             event.pop(EventLogs.FILTER_DATETIME, None)
         self.logger.info(f"Number of returned logs after filtering performed: {len(task_output)}")
-
+        if task_output:
+            self.logger.info(f"Latest event time returned from Mimecast logs: {latest_time}")
         return task_output
+
+    def _get_filter_time(self, custom_config: Dict[str, int]) -> int:
+        """
+        We want to apply the custom_config params if provided to the task. The logic is that if
+        a lookback value exists, this should take precedence to allow a larger filter time and only
+        once this no longer exists do we want to use the default value.
+        :param custom_config: dictionary passed containing `default` or `lookback` values
+        :return: filter time to be applied in `_filter_and_sort_recent_events`
+        """
+
+        default, lookback = custom_config.get("default", CUTOFF), custom_config.get("lookback")
+        filter_value = lookback if lookback else default
+        self.logger.info(f"Task execution will be applying filter period of {filter_value} hours...")
+        return int(filter_value)

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -6,3 +6,4 @@ parameterized==0.8.1
 python-dateutil==2.6.1
 jsonschema==3.2.0
 werkzeug==3.0.1
+setuptools==65.5.1


### PR DESCRIPTION
## Proposed Changes
Ticket: [[C2C Mimecast] Implement new configurable backfill and initial params from SDK](https://rapid7.atlassian.net/browse/PLGN-728)
### Description

Describe the proposed changes:

  - Implement new SDK image which will pass custom_config allowing us to carry out backfills with no new plugin release. 
  - To help traceability of when we have caught up, we now log the last event time at the end of the run. 
  - Included in with @rbowden-r7 's changes for sanitising file names which have yet been released to production. 
  - Bump setuptools to non vulnerable version. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Tested locally with forcing fake custom_configs and works as expected:
 - passing lookback the plugin applies this filter.
 - passing default the plugin applies this value.
 - new logging informing us of the last event returned. 

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
