### PR TITLE
[PLGN-731] - Zoom -Adding in support for a custom start to be used based on the custom config

### DIFF
--- a/plugins/zoom/.CHECKSUM
+++ b/plugins/zoom/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "1525cf2a92936a6d9f531170d4f2fcec",
+	"spec": "57528e4333d31b204cffe6121c8cc0fa",
 	"manifest": "ca56acbed5c1a38693add93df82d8020",
 	"setup": "261233b4988195fdaa86fc75fa70b435",
 	"schemas": [

--- a/plugins/zoom/Dockerfile
+++ b/plugins/zoom/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -312,7 +312,7 @@ Example output:
 
 # Version History
 
-* 4.1.6 - Adding better handling to `monitor_sign_in_out_activity` task, if the users account does not have all of the required permissions 
+* 4.1.6 - Adding better handling to `monitor_sign_in_out_activity` task, if the users account does not have all of the required permissions | Include SDK 5.4 which adds new task custom_config parameter
 * 4.1.5 - Monitor Sign in and out Activity: Added exception logging and bumped latest plugin SDK
 * 4.1.4 - Update to the latest plugin SDK
 * 4.1.3 - Monitor Sign in and out Activity: set cutoff time of 24 hours

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -9,7 +9,7 @@ from .schema import (
 )
 
 # Custom imports below
-from datetime import datetime, timedelta, timezone
+from datetime import datetime, timedelta, timezone, date
 from typing import Optional, Union
 
 from icon_zoom.tasks.enums import RunState
@@ -83,11 +83,13 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
     def loop(self, state: Dict[str, Any], custom_config: Dict[str, Any]):  # noqa: C901
         now = self._format_datetime_for_zoom(dt=self._get_datetime_now())
 
-        if custom_config.get("lookback") is not None:
-            lookback = custom_config.get("lookback", {})
+        lookback = custom_config.get("lookback")
+        if lookback is not None:
             last_day = self._format_datetime_for_zoom(
+                # a default of up to 12 months is used to allow for this to always run if there is missing value in the custom config
+                # as if the request is larger than 30 days, the api will only return 30 days worth of data
                 datetime(
-                    lookback.get("year", 1970),
+                    lookback.get("year", date.today().year),
                     lookback.get("month", 1),
                     lookback.get("day", 1),
                     lookback.get("hour", 0),

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -83,15 +83,16 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
     def loop(self, state: Dict[str, Any], custom_config: Dict[str, Any]):  # noqa: C901
         now = self._format_datetime_for_zoom(dt=self._get_datetime_now())
 
-        if custom_config is not None:
+        if custom_config.get("lookback") is not None:
+            lookback = custom_config.get("lookback", {})
             last_day = self._format_datetime_for_zoom(
                 datetime(
-                    custom_config.get("year", 1970),
-                    custom_config.get("month", 1),
-                    custom_config.get("day", 1),
-                    custom_config.get("hour", 0),
-                    custom_config.get("minute", 0),
-                    custom_config.get("second", 0),
+                    lookback.get("year", 1970),
+                    lookback.get("month", 1),
+                    lookback.get("day", 1),
+                    lookback.get("hour", 0),
+                    lookback.get("minute", 0),
+                    lookback.get("second", 0),
                 )
             )
             self.logger.info(f"A custom start time of {last_day} will be used")

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -14,7 +14,7 @@ cloud_ready: true
 tags: [zoom, chat]
 sdk:
   type: full
-  version: 5
+  version: 5.4
   user: nobody
 hub_tags:
   use_cases: [alerting_and_notifications, application_management, threat_detection_and_response, user_management]


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - bumped the version of the sdk used 
  - added in logic, that if there is a custom config, that it can be used to create a custom start time
  
https://rapid7.atlassian.net/browse/PLGN-731

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section



testing locally with a mocked custom config

1st run, there is no state and a custom config is used to make the start time

```
Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
Current runstate is: starting
Getting events for timeframe 2024-02-20T16:35:11Z to 2024-01-01T00:00:00Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 1 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-20T11:30:29Z
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'latest_event_timestamp': '2024-02-20T11:30:29Z', 'previous_run_state': 'starting', 'last_request_timestamp': '2024-02-20T16:35:11Z'}
Plugin task finished execution...
```


2nd run with a state from the previous run, the code will now run as usual 

```
Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
Current runstate is: continuing
Getting events for timeframe 2024-02-20T16:35:11Z to 2024-02-20T16:35:50Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 1 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-20T11:30:29Z
Event set requires de-duping
After de-duping, total event count is 0
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'latest_event_timestamp': '2024-02-20T11:30:29Z', 'previous_run_state': 'continuing', 'last_request_timestamp': '2024-02-20T16:35:50Z'}
```
Plugin task finished execution...