### PR TITLE
PLGN-731-Allowing for a custom cutoff time to be passed in from the custom config

### DIFF
--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -55,6 +55,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         "Health check failed. An error occurred during event collection: insufficient permissions for this action. "
         "Please ensure you add all required user permissions for the Rapid7 app in Zoom."
     )
+    DEFAULT_CUTOFF_HOURS = 24
 
     def __init__(self):
         super(self.__class__, self).__init__(
@@ -83,9 +84,12 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
     def loop(self, state: Dict[str, Any], custom_config: Dict[str, Any]):  # noqa: C901
         now = self._format_datetime_for_zoom(dt=self._get_datetime_now())
 
+        cutoff = custom_config.get("cutoff", {})
+        cutoff_date = cutoff.get("date")
         lookback = custom_config.get("lookback")
+
         if lookback is not None:
-            last_day = self._format_datetime_for_zoom(
+            start_time = self._format_datetime_for_zoom(
                 # a default of up to 12 months is used to allow for this to always run if there is missing value in the custom config
                 # as if the request is larger than 30 days, the api will only return 30 days worth of data
                 datetime(
@@ -97,18 +101,34 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                     lookback.get("second", 0),
                 )
             )
-            self.logger.info(f"A custom start time of {last_day} will be used")
+            self.logger.info(f"A custom start time of {start_time} will be used")
         else:
-            last_day = self._format_datetime_for_zoom(dt=self._get_datetime_last_24_hours())
+            if cutoff_date is not None:
+                start_time = self._format_datetime_for_zoom(
+                    # a default of up to 12 months is used to allow for this to always run if there is missing value in the custom config
+                    # as if the request is larger than 30 days, the api will only return 30 days worth of data
+                    datetime(
+                        cutoff_date.get("year", date.today().year),
+                        cutoff_date.get("month", 1),
+                        cutoff_date.get("day", 1),
+                        cutoff_date.get("hour", 0),
+                        cutoff_date.get("minute", 0),
+                        cutoff_date.get("second", 0),
+                    )
+                )
+            else:
+                start_time = self._format_datetime_for_zoom(
+                    dt=self._get_datetime_last_x_hours(cutoff.get("hours", self.DEFAULT_CUTOFF))
+                )
 
         start_date_params = {
-            RunState.starting: now,
+            RunState.starting: start_time,
             RunState.paginating: state.get(self.PARAM_START_DATE),
-            RunState.continuing: self._get_last_valid_timestamp(last_day, state),
+            RunState.continuing: self._get_last_valid_timestamp(start_time, state, cutoff),
         }
 
         end_date_params = {
-            RunState.starting: last_day,
+            RunState.starting: now,
             RunState.paginating: state.get(self.PARAM_END_DATE),
             # last request timestamp if coming from end of pagination, otherwise default to now
             RunState.continuing: state.get(self.PARAM_END_DATE, now),
@@ -200,16 +220,18 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         self.logger.info(f"Updated state, state is now: {state}")
         return TaskOutput(output=new_events, state=state, has_more_pages=has_more_pages, status_code=200, error=None)
 
-    def _get_last_valid_timestamp(self, last_day: str, state: Dict[str, Union[str, None]]) -> Optional[str]:
+    def _get_last_valid_timestamp(
+        self, start_time: str, state: Dict[str, Union[str, None]], cutoff: int
+    ) -> Optional[str]:
         """
-        Get the last valid timestamp based on the provided last_day and state.
+        Get the last valid timestamp based on the provided start_time and state.
 
         This method checks if the last request timestamp in the 'state' dictionary is earlier
-        than 'last_day' and returns 'last_day' if true, or returns the last request timestamp
+        than 'start_time' and returns 'start_time' if true, or returns the last request timestamp
         from the 'state' dictionary if it is later.
 
         Args:
-            last_day (int): The last day to compare against.
+            start_time (int): The last day to compare against.
             state (dict): The state dictionary containing the last request timestamp.
 
         Returns:
@@ -219,12 +241,12 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         last_request_timestamp = state.get(self.LAST_REQUEST_TIMESTAMP)
         if not last_request_timestamp:
             return
-        if last_request_timestamp < last_day:
+        if last_request_timestamp < start_time:
             self.logger.info(
-                f"Saved state {last_request_timestamp} exceeds the cut off 24 hours. "
-                f"Reverting to use time: {last_day}"
+                f"Saved state {last_request_timestamp} exceeds the cut off {cutoff} hours. "
+                f"Reverting to use time: {start_time}"
             )
-            return last_day
+            return start_time
         else:
             return last_request_timestamp
 
@@ -338,8 +360,8 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
     def _get_datetime_now() -> datetime:
         return datetime.now(timezone.utc)
 
-    def _get_datetime_last_24_hours(self) -> datetime:
-        return self._get_datetime_now() - timedelta(hours=24)
+    def _get_datetime_last_x_hours(self, hours: int) -> datetime:
+        return self._get_datetime_now() - timedelta(hours=hours)
 
     def _format_datetime_for_zoom(self, dt: datetime) -> str:
         return dt.strftime(self.ZOOM_TIME_FORMAT)

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -124,7 +124,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         start_date_params = {
             RunState.starting: start_time,
             RunState.paginating: state.get(self.PARAM_START_DATE),
-            RunState.continuing: self._get_last_valid_timestamp(start_time, state, cutoff),
+            RunState.continuing: self._get_last_valid_timestamp(start_time, state),
         }
 
         end_date_params = {
@@ -220,9 +220,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         self.logger.info(f"Updated state, state is now: {state}")
         return TaskOutput(output=new_events, state=state, has_more_pages=has_more_pages, status_code=200, error=None)
 
-    def _get_last_valid_timestamp(
-        self, start_time: str, state: Dict[str, Union[str, None]], cutoff: int
-    ) -> Optional[str]:
+    def _get_last_valid_timestamp(self, start_time: str, state: Dict[str, Union[str, None]]) -> Optional[str]:
         """
         Get the last valid timestamp based on the provided start_time and state.
 
@@ -231,7 +229,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         from the 'state' dictionary if it is later.
 
         Args:
-            start_time (int): The last day to compare against.
+            start_time (str): The last day to compare against.
             state (dict): The state dictionary containing the last request timestamp.
 
         Returns:
@@ -243,8 +241,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
             return
         if last_request_timestamp < start_time:
             self.logger.info(
-                f"Saved state {last_request_timestamp} exceeds the cut off {cutoff} hours. "
-                f"Reverting to use time: {start_time}"
+                f"Saved state {last_request_timestamp} exceeds the cut off." f"Reverting to use time: {start_time}"
             )
             return start_time
         else:

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -118,7 +118,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                 )
             else:
                 start_time = self._format_datetime_for_zoom(
-                    dt=self._get_datetime_last_x_hours(cutoff.get("hours", self.DEFAULT_CUTOFF))
+                    dt=self._get_datetime_last_x_hours(cutoff.get("hours", self.DEFAULT_CUTOFF_HOURS))
                 )
 
         start_date_params = {

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -241,7 +241,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
             return
         if last_request_timestamp < start_time:
             self.logger.info(
-                f"Saved state {last_request_timestamp} exceeds the cut off." f"Reverting to use time: {start_time}"
+                f"Saved state {last_request_timestamp} exceeds the cut off. Reverting to use time: {start_time}"
             )
             return start_time
         else:

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -313,7 +313,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
             [
                 {
                     "lookback": CUSTOM_LOOKBACK,
-                    "cuttoff": CUSTOM_CUTOFF_DATE,
+                    "cutoff": CUSTOM_CUTOFF_DATE,
                 },
                 {
                     "start_date": "2023-01-23T22:00:00Z",
@@ -326,7 +326,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
             [
                 {
                     "lookback": CUSTOM_LOOKBACK,
-                    "cuttoff": CUSTOM_CUTOFF_HOURS,
+                    "cutoff": CUSTOM_CUTOFF_HOURS,
                 },
                 {
                     "start_date": "2023-01-23T22:00:00Z",
@@ -348,7 +348,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
             ],
             [
                 {
-                    "cuttoff": CUSTOM_CUTOFF_HOURS,
+                    "cutoff": CUSTOM_CUTOFF_HOURS,
                 },
                 {
                     "start_date": "2023-01-23T22:00:00Z",

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -24,8 +24,8 @@ from mock import STUB_CONNECTION, STUB_OAUTH_TOKEN, Util
 REFRESH_OAUTH_TOKEN_PATH = "icon_zoom.util.api.ZoomAPI._refresh_oauth_token"
 GET_USER_ACTIVITY_EVENTS_PATH = "icon_zoom.util.api.ZoomAPI.get_user_activity_events_task"
 GET_DATETIME_NOW_PATH = "icon_zoom.tasks.monitor_sign_in_out_activity.task.MonitorSignInOutActivity._get_datetime_now"
-GET_DATETIME_LAST_24_HOURS_PATH = (
-    "icon_zoom.tasks.monitor_sign_in_out_activity.task.MonitorSignInOutActivity._get_datetime_last_24_hours"
+GET_DATETIME_LAST_X_HOURS_PATH = (
+    "icon_zoom.tasks.monitor_sign_in_out_activity.task.MonitorSignInOutActivity._get_datetime_last_x_hours"
 )
 
 STUB_SAMPLES = [
@@ -114,7 +114,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
     def setUp(self, mock_refresh_call: MagicMock) -> None:
         self.task = Util.default_connector(MonitorSignInOutActivity())
 
-    @patch(GET_DATETIME_LAST_24_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
+    @patch(GET_DATETIME_LAST_X_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
     @patch(GET_DATETIME_NOW_PATH, side_effect=[STUB_DATETIME_NOW])
     @patch(GET_USER_ACTIVITY_EVENTS_PATH, return_value=(STUB_EXPECTED_PREVIOUS_OUTPUT, ""))
     def test_first_run(
@@ -139,7 +139,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
         validate(output, MonitorSignInOutActivityOutput.schema)
         validate(state, MonitorSignInOutActivityState.schema)
 
-    @patch(GET_DATETIME_LAST_24_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
+    @patch(GET_DATETIME_LAST_X_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
     @patch(GET_DATETIME_NOW_PATH, side_effect=[STUB_DATETIME_NOW + datetime.timedelta(minutes=DEFAULT_TIMEDELTA)])
     @patch(GET_USER_ACTIVITY_EVENTS_PATH, return_value=(STUB_EXPECTED_PREVIOUS_OUTPUT, ""))
     def test_subsequent_run(
@@ -161,7 +161,7 @@ class TestGetUserActivityEvents(unittest.TestCase):
         validate(output, MonitorSignInOutActivityOutput.schema)
         validate(state, MonitorSignInOutActivityState.schema)
 
-    @patch(GET_DATETIME_LAST_24_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
+    @patch(GET_DATETIME_LAST_X_HOURS_PATH, side_effect=[STUB_DATETIME_LAST_24_HOURS])
     @patch(GET_DATETIME_NOW_PATH, side_effect=[STUB_DATETIME_NOW])
     @patch(GET_USER_ACTIVITY_EVENTS_PATH)
     def test_first_and_subsequent_runs(


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - swapping the start and end times round if there is no state as the were the wrong way round 
  - adding in logic so when doing a backfill and the while run doesn't complete we will not enforce the 24 cut off an miss data 

https://rapid7.atlassian.net/browse/PLGN-731

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section


testing 2 runs, with no state in the first run and no custom config, it will correctly use 24 hrs for the first run then `last_request_timestamp` for the second run from the state 
```
Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
Current runstate is: starting
Getting events for timeframe 2024-02-22T16:02:10Z to 2024-02-21T16:02:10Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 1 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-22T13:53:03Z
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'latest_event_timestamp': '2024-02-22T13:53:03Z', 'previous_run_state': 'starting', 'last_request_timestamp': '2024-02-22T16:02:10Z'}
Plugin task finished execution...

Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
Current runstate is: continuing
Getting events for timeframe 2024-02-22T16:02:10Z to 2024-02-22T16:02:19Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 1 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-22T13:53:03Z
Event set requires de-duping
After de-duping, total event count is 0
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'last_request_timestamp': '2024-02-22T16:02:19Z', 'latest_event_timestamp': '2024-02-22T13:53:03Z', 'previous_run_state': 'continuing'}
Plugin task finished execution...
```

testing using 
```
            custom_config = {
                "lookback":{
                    "year": 2024,
                    "month": 2,
                    "day": 1,
                    "hour": 0,
                    "minute": 0,
                    "second": 0
                },
                "cuttoff": 500
            }
```

1st run it will use the correct  backfill time
2nd time it will use `latest_event_timestamp` as `024-02-16T11:50:47Z` to check that if the value of cutoff is being used correctly

```
Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
A custom start time of 2024-02-01T00:00:00Z will be used
Current runstate is: starting
Getting events for timeframe 2024-02-01T00:00:00Z to 2024-02-22T16:26:22Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 20 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-22T13:53:03Z
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'latest_event_timestamp': '2024-02-22T13:53:03Z', 'previous_run_state': 'starting', 'last_request_timestamp': '2024-02-22T16:26:22Z'}
Plugin task finished execution...

Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
Current runstate is: continuing
Getting events for timeframe 2024-02-16T11:50:47Z to 2024-02-22T16:27:49Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 15 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-22T13:53:03Z
Event set requires de-duping
After de-duping, total event count is 13
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'last_request_timestamp': '2024-02-22T16:27:49Z', 'latest_event_timestamp': '2024-02-22T13:53:03Z', 'previous_run_state': 'continuing'}
Plugin task finished execution...
```



Also swapping round the use of last day and now for the starting run of zoom, as the look to be the wrong way round 

before
```
Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
A custom start time of 2024-02-01T00:00:00Z will be used
Current runstate is: starting
Getting events for timeframe 2024-02-22T16:31:12Z to 2024-02-01T00:00:00Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 1 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-22T13:53:03Z
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'latest_event_timestamp': '2024-02-22T13:53:03Z', 'previous_run_state': 'starting', 'last_request_timestamp': '2024-02-22T16:31:12Z'}
Plugin task finished execution...
```
only result returned is not all of them  
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/4fd00e81-f7b6-4fa9-ac91-d49c30061cd7)


after
```
Plugin task beginning execution...
rapid7/Zoom:4.1.6. Step name: monitor_sign_in_out_activity
A custom start time of 2024-02-01T00:00:00Z will be used
Current runstate is: starting
Getting events for timeframe 2024-02-01T00:00:00Z to 2024-02-22T16:26:22Z. Currently paginating: false
Calling GET https://api.zoom.us/v2/report/activities
Got response status code: 200
Got 20 raw events from Zoom (pre-deduping)!
Latest event from raw event set is 2024-02-22T13:53:03Z
No pagination token returned by Zoom API - all pages have been consumed
Updated state, state is now: {'latest_event_timestamp': '2024-02-22T13:53:03Z', 'previous_run_state': 'starting', 'last_request_timestamp': '2024-02-22T16:26:22Z'}
Plugin task finished execution...
```

results are all within the timerange 
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/31bb2855-b55d-4727-bbdd-2e0cb369dc81)



