### PR TITLE
Mimecast 5.3.7 Release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1df084b24abaf1c2b8197be70e304856",
-	"manifest": "6bee538f80e002b8f296491af9136a9c",
-	"setup": "b1323509d65b011d3a3db3ed202d2715",
+	"spec": "a98bb0dc71021fa75760c5c73bc153cf",
+	"manifest": "6deb75e59d3c42d42c06fd792a88ab73",
+	"setup": "5286b065ae2c0266ddcd641289276bad",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.2
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.6"
+Version = "5.3.7"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.7 - Task `monitor_siem_logs` adding in sanitisation for names of files to be read in.
+* 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.7 - Task `monitor_siem_logs` adding in sanitisation for names of files to be read in.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.
 * 5.3.4 - Task `monitor_siem_logs` exception handling for JSONDecodeError.

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -29,10 +29,13 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             state=MonitorSiemLogsState(),
         )
 
-    def run(self, params={}, state={}) -> (List[Dict], Dict):  # pylint: disable=unused-argument # noqa: MC0001
+    def run(  # pylint: disable=unused-argument # noqa: MC0001
+        self, params={}, state={}, custom_config={}
+    ) -> (List[Dict], Dict, Dict):
         try:
             has_more_pages = False
             header_next_token = state.get(self.NEXT_TOKEN, "")
+            filter_time = self._get_filter_time(custom_config)
 
             if not header_next_token:
                 self.logger.info("First run...")
@@ -52,7 +55,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     )
                     return [], state, has_more_pages, error.status_code, error
                 header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
-                output = self._filter_and_sort_recent_events(output)
+                output = self._filter_and_sort_recent_events(output, filter_time)
                 if output:
                     break
 
@@ -71,31 +74,51 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                 exp = PluginException(preset=PluginException.Preset.UNKNOWN, data=gen_error)
             return [], state, has_more_pages, 500, exp
 
-    def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    def _filter_and_sort_recent_events(self, task_output: List[Dict[str, Any]], cut_off: int) -> List[Dict[str, Any]]:
         """
         Filters and sorts a list of events to retrieve only the recent events.
 
         :param task_output: A list of dictionaries representing the task output to be filtered and sorted.
         :type: List[Dict[str, Any]]
 
+        :param cut_off: integer specifying how far back in time we filter events from
+        :type: integer
+
         :return: A new list of dictionaries representing the filtered and sorted recent events.
         :rtype: List[Dict[str, Any]]
         """
 
         self.logger.info(f"Number of raw logs returned from Mimecast: {len(task_output)}")
+        filter_time = get_time_hours_ago(hours_ago=cut_off)
         task_output = sorted(
             map(
                 lambda event: event.get_dict(),
                 filter(
-                    lambda event: event.compare_datetime(get_time_hours_ago(hours_ago=CUTOFF)),
+                    lambda event: event.compare_datetime(filter_time),
                     [EventLogs(data=event) for event in task_output],
                 ),
             ),
             key=itemgetter(EventLogs.FILTER_DATETIME),
         )
-
+        latest_time = filter_time
         for event in task_output:
+            event_date_time = event.get(EventLogs.FILTER_DATETIME)
+            latest_time = event_date_time if event_date_time > latest_time else latest_time
             event.pop(EventLogs.FILTER_DATETIME, None)
         self.logger.info(f"Number of returned logs after filtering performed: {len(task_output)}")
-
+        if task_output:
+            self.logger.info(f"Latest event time returned from Mimecast logs: {latest_time}")
         return task_output
+
+    def _get_filter_time(self, custom_config: Dict[str, int]) -> int:
+        """
+        Apply custom_config params (if provided) to the task. If a lookback value exists, it should take
+        precedence (this can allow a larger filter time), otherwise use the default value.
+        :param custom_config: dictionary passed containing `default` or `lookback` values
+        :return: filter time to be applied in `_filter_and_sort_recent_events`
+        """
+
+        default, lookback = custom_config.get("default", CUTOFF), custom_config.get("lookback")
+        filter_value = lookback if lookback else default
+        self.logger.info(f"Task execution will be applying filter period of {filter_value} hours...")
+        return int(filter_value)

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -8,6 +8,7 @@ import uuid
 from io import BytesIO
 from typing import Union, List, Dict, Any
 from zipfile import ZipFile, BadZipFile
+from werkzeug.utils import secure_filename
 
 import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -183,6 +184,10 @@ class MimecastAPI:
                 combined_json_list = []
                 for file_name in my_zip.namelist():
                     try:
+                        # To avoid potential path traversal vulnerabilities, only valid files should be allowed.
+                        # Due to the nature of the IO buffer, the filename cannot be checked until it is read in.
+                        file_name = secure_filename(file_name)
+
                         contents = my_zip.read(file_name)
                         for log in json.loads(contents).get("data"):
                             combined_json_list += [log]

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.6
+version: 5.3.7
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -6,3 +6,4 @@ parameterized==0.8.1
 python-dateutil==2.6.1
 jsonschema==3.2.0
 werkzeug==3.0.1
+setuptools==65.5.1

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -5,3 +5,4 @@ validators==0.21.0
 parameterized==0.8.1
 python-dateutil==2.6.1
 jsonschema==3.2.0
+werkzeug==3.0.1

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.6",
+      version="5.3.7",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -50,7 +50,6 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(new_state, state_params)  # we shouldn't change the state if we encounter an error
         self.assertEqual(type(error), ApiClientException)
 
-    @skip("Have pulled the sanitise method as possible negative seek cause - TODO in 5.3.6")
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_stops_path_traversal(self, mock_logger, _mock_data):
         test_state = {"next_token": "path_traversal"}  # this forces our mock util to append `../` into filenames
@@ -60,7 +59,9 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(response, [])  # no logs will be parsed as we raise error after catching BadZipFile
         self.assertEqual(new_state, test_state)  # we shouldn't change the state if we encounter an error
         mock_logger.assert_called()
-        self.assertIn("Hit BadZipFile, returning []. Error", mock_logger.call_args[0][0])
+        self.assertIn(
+            "There is no item named 'filename-1-from-mimecast.json' in the archive", mock_logger.call_args[0][0]
+        )
 
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_raises_json_error(self, mock_logger, _mock_data):


### PR DESCRIPTION
Release of Mimecast 5.3.7

- Improved file name sanitation to remove path traversal
- Package bumps to remove vulnerabiltiies
- Latest SDK to allow backfilling and ease of updating our filter time. 

Original PRs:
- #2290
- #2325 

Logs of a backfill run:
```
Plugin task beginning execution...
Found config options; adding this to the request parameters...
Custom config being sent to plugin: {'default': 108, 'lookback': 108}
rapid7/Mimecast:5.3.7. Step name: monitor_siem_logs
Task execution will be applying filter period of 108 hours...
First run...
Number of raw logs returned from Mimecast: 66
Number of returned logs after filtering performed: 38
Latest event time returned from Mimecast logs: 2024-02-22 02:49:56
Plugin task finished execution...
```

Logs of a normal run using next_header and no items returned:
```
Plugin task beginning execution...
Found config options; adding this to the request parameters...
Found an existing plugin state, not passing lookback value...
Custom config being sent to plugin: {'default': 108}
rapid7/Mimecast:5.3.7. Step name: monitor_siem_logs
Task execution will be applying filter period of 108 hours...
Subsequent run using header_next_token...
Plugin task finished execution...
Plugin task beginning execution...
```
