### PR TITLE
[PLGN-730] okta backfill datetime

### DIFF
--- a/plugins/okta/Dockerfile
+++ b/plugins/okta/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/okta/komand_okta/tasks/monitor_logs/schema.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/schema.py
@@ -44,7 +44,7 @@ class MonitorLogsOutput(insightconnect_plugin_runtime.Output):
   "title": "Logs",
   "description": "All system logs within the specified time range",
   "items": {
-    "type": "object"
+    "$ref": {}
   },
   "required": [
     "logs"

--- a/plugins/okta/komand_okta/tasks/monitor_logs/schema.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/schema.py
@@ -44,7 +44,7 @@ class MonitorLogsOutput(insightconnect_plugin_runtime.Output):
   "title": "Logs",
   "description": "All system logs within the specified time range",
   "items": {
-    "$ref": {}
+    "type": "object"
   },
   "required": [
     "logs"

--- a/plugins/okta/komand_okta/tasks/monitor_logs/task.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/task.py
@@ -34,7 +34,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             now = self.get_current_time() - timedelta(minutes=1)  # allow for latency of this being triggered
             now_iso = self.get_iso(now)
             # Whether to convert filter_time in hours to datetime
-            if self.check_if_datetime(self, filter_time):
+            if self.check_if_datetime(filter_time):
                 filter_hours = filter_time
             else:
                 # If false, we assume filter_time is an integer or string representing hours and get datetime
@@ -84,14 +84,14 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         return datetime.now(timezone.utc)
 
     @staticmethod
-    def check_if_datetime(self, date_time: Any):
+    def check_if_datetime(date_time: Any):
         """
         Check if passed value is a date_time, returning True or False
         :param date_time: date_time value, or int/string representing hours
         :return: boolean result based on date_time value type check
         """
         try:
-            datetime.fromisoformat(str(date_time).rstrip('Z'))
+            datetime.fromisoformat(str(date_time).rstrip("Z"))
             return True
         except ValueError:
             return False
@@ -208,7 +208,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             filter_cutoff = custom_config.get("filter_cutoff", {}).get("hours", CUTOFF)
         filter_lookback = custom_config.get("lookback")
         filter_value = filter_lookback if filter_lookback else filter_cutoff
-        if self.check_if_datetime(self, filter_value):
+        if self.check_if_datetime(filter_value):
             self.logger.info(f"Task execution will be applying a lookback to {filter_value}...")
         else:
             self.logger.info(f"Task execution will be applying filter period of {filter_value} hours...")

--- a/plugins/okta/unit_test/test_monitor_logs.py
+++ b/plugins/okta/unit_test/test_monitor_logs.py
@@ -29,31 +29,31 @@ class TestMonitorLogs(TestCase):
                 "without_state",
                 Util.read_file_to_dict("inputs/monitor_logs_without_state.json.inp"),
                 Util.read_file_to_dict("expected/get_logs.json.exp"),
-                {"cutoff": {"hours": 24}, "lookback": None}
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "with_state",
                 Util.read_file_to_dict("inputs/monitor_logs_with_state.json.inp"),
                 Util.read_file_to_dict("expected/get_logs.json.exp"),
-                {"cutoff": {"hours": 24}, "lookback": None}
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "next_page",
                 Util.read_file_to_dict("inputs/monitor_logs_next_page.json.inp"),
                 Util.read_file_to_dict("expected/get_logs_next_page.json.exp"),
-                {"cutoff": {"hours": 24}, "lookback": None}
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "next_page_no_results",
                 Util.read_file_to_dict("inputs/monitor_logs_next_page.json.inp"),
                 Util.read_file_to_dict("expected/get_logs_next_empty.json.exp"),
-                {"cutoff": {"hours": 24}, "lookback": None}
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "without_state_no_results",
                 Util.read_file_to_dict("inputs/monitor_logs_without_state.json.inp"),
                 Util.read_file_to_dict("expected/get_logs_empty_resp.json.exp"),
-                {"default": 108, "lookback": 108}
+                {"default": 108, "lookback": 108},
             ],
         ]
     )

--- a/plugins/okta/unit_test/test_monitor_logs.py
+++ b/plugins/okta/unit_test/test_monitor_logs.py
@@ -141,7 +141,7 @@ class TestMonitorLogs(TestCase):
         # Test the scenario that a customer has paused the collector for an extended amount of time to test when they
         # resume the task we should cut off, at a max 24 hours ago for since parameter.
         expected = Util.read_file_to_dict("expected/get_logs.json.exp")  # logs from last 24 hours
-        custom_config = {"default": 108, "lookback": 108}
+        custom_config = {"default": 108, "lookback": "2023-04-23T20:33:46.123Z"}
         paused_time = "2022-04-27T07:49:21.777Z"
         current_state = {"last_collection_timestamp": paused_time}  # Task has been paused for 1 year+
         actual, state, _has_more_pages, _status_code, _error = self.action.run(
@@ -154,7 +154,7 @@ class TestMonitorLogs(TestCase):
 
         # Check we called with the current parameters by looking at the info log
         logger = call(
-            f"Saved state {paused_time} exceeds the cut off (108 hours). "
+            f"Saved state {paused_time} is before the cut off date (2023-04-23T20:33:46.123Z). "
             f"Reverting to use time: 2023-04-23T20:33:46.123Z"
         )
         self.assertIn(logger, mocked_info_log.call_args_list)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Update to use datetime type as well as hours (int, str) in backfill logic

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
