### PR TITLE
PLGN-727: implement SDK 5.4 for custom_config task parameter.

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b8737473cda4c9744ba85c4bfefa9451",
-	"manifest": "0f92f58aa70ea4b86ebba1828b26e098",
-	"setup": "5f03513017650052a2e41897671977e1",
+	"spec": "45d2ba6621c249395aa65e7004f73d02",
+	"manifest": "a3bbea2eb02f40d24101601983add397",
+	"setup": "4a3aa78bc047aea80b8bdbf36521f481",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.4"
+Version = "4.1.5"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.5 - Include SDK 5.4 which adds new task custom_config parameter.
 * 4.1.4 - Remove hard coded env var from Dockerfile.
 * 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.4
+version: 4.1.5
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
-  version: 5.3.1
+  version: 5.4
   user: nobody
 vendor: rapid7
 support: community

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.4",
+      version="4.1.5",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",

--- a/plugins/proofpoint_tap/unit_test/test_monitor_events.py
+++ b/plugins/proofpoint_tap/unit_test/test_monitor_events.py
@@ -7,11 +7,13 @@ from komand_proofpoint_tap.tasks import MonitorEvents
 from test_util import Util
 from unittest import TestCase
 from parameterized import parameterized
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+from json import loads
 
 sys.path.append(os.path.abspath("../"))
 
 ENV_VALUE = '{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
+ENV_VALUE_2 = '{"year": 2024, "month": 2, "day": 20, "hour": 12, "minute": 0, "second": 0}'
 TEST_PAGE_SIZE = 2
 
 
@@ -66,7 +68,9 @@ class TestMonitorEvents(TestCase):
         ]
     )
     def test_monitor_events(self, _mock_request, _mock_get_time, _test_name, current_state, expected):
-        actual, actual_state, has_more_pages, status_code, error = self.action.run(state=current_state)
+        actual, actual_state, has_more_pages, status_code, error = self.action.run(
+            state=current_state, custom_config={}
+        )
         self.assertEqual(actual, expected.get("events"))
         self.assertEqual(actual_state, expected.get("state"))
 
@@ -74,10 +78,10 @@ class TestMonitorEvents(TestCase):
     @patch("logging.Logger.info")
     def test_monitor_events_with_env_variable_empty_state(self, mock_logger, _mock_request, _mock_time):
         # When we inject the env variable into the pod we should change the time we retrieve events from.
-        response, state, has_more_pages, status_code, _error = self.action.run(state={})
+        response, state, has_more_pages, status_code, _error = self.action.run(state={}, custom_config={})
 
         # we should have logged using env var
-        self.assertIn("Using env var value", mock_logger.call_args_list[1][0][0])
+        self.assertIn("Using custom value of", mock_logger.call_args_list[2][0][0])
 
         # state last time should be injected env var + 1 hour
         self.assertEqual("2024-01-27T01:00:00+00:00", state["last_collection_date"])
@@ -90,15 +94,57 @@ class TestMonitorEvents(TestCase):
         self.assertEqual(1, state["next_page_index"])
 
     @patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=ENV_VALUE)
-    @patch("logging.Logger.info")
-    def test_monitor_events_with_env_variable_existing_state(self, mock_logger, _mock_request, _mock_time):
+    def test_monitor_events_with_env_variable_existing_state(self, _mock_request, _mock_time):
         # Although we inject the env var because we have a state saved we can ignore and continue our usual logic
         # use this date to avoid cut off logic from mocked current time.
         existing_state = {"last_collection_date": "2023-04-04T01:00:00+00:00"}
-        response, state, has_more_pages, status_code, _error = self.action.run(state=existing_state)
+        response, state, has_more_pages, status_code, _error = self.action.run(state=existing_state, custom_config={})
 
         # state last time should be last_collected_date + 1 hour
         self.assertEqual("2023-04-04T02:00:00+00:00", state["last_collection_date"])
 
         # Split the logs being returned by the SPLIT_SIZE variable
         self.assertEqual(TEST_PAGE_SIZE, len(response))
+
+    @patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=ENV_VALUE_2)
+    @patch("logging.Logger.info")
+    def test_monitor_events_uses_custom_config_data(self, mock_logger, _mock_request, _mock_time):
+        # Even though we have an environment variable specified we use the custom_config passed from CPS
+        full_lookback_value = loads(ENV_VALUE)
+        cps_config = {"lookback": full_lookback_value}  # pass this as a dict as our API will supply as it like this
+        response, state, has_more_pages, status_code, _error = self.action.run({}, {}, cps_config)
+
+        # In this example we have an env var specified but this is ignored to use the value in the custom_config
+        self.assertIn(f"Using custom value of {full_lookback_value}", mock_logger.call_args_list[2][0][0])
+
+        # state last time should be custom config value + 1 hour
+        self.assertEqual("2024-01-27T01:00:00+00:00", state["last_collection_date"])
+        self.assertEqual(1, state["next_page_index"])
+
+        # second time we call we will then pass no lookback from SDK level and now use the cutoff date value
+        with patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=""):  # clear env var
+            cps_config = {"cutoff": {"date": full_lookback_value}}
+            _resp, state_2, _more_pages, _status_code, _error = self.action.run({}, state.copy(), cps_config)
+
+            # Due to pagination the last collection date will not change in our state
+            self.assertEqual(state["last_collection_date"], state_2["last_collection_date"])
+            self.assertEqual(2, state_2["next_page_index"])  # however we should be on the second page
+
+            # Third time we call - we increase page size to return more_pages=False from the task
+            with patch("komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.SPLIT_SIZE", new=40000):
+                _resp, state_3, more_pages, _status_code, _error = self.action.run({}, state_2.copy(), cps_config)
+                self.assertEqual(state_2["last_collection_date"], state_3["last_collection_date"])
+                self.assertEqual(False, more_pages)  # finished pagination now due to split size including all logs
+
+            # Fourth time task is called - custom_config is 'normal' and we do normal time calculations / cut off.
+            new_now = datetime.strptime("2024-03-25T08:00:00", "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+            with patch(
+                "komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.get_current_time", return_value=new_now
+            ):
+                mock_logger.reset_mock()
+                config = {"cutoff": {"hours": 24}}  # config reverted to normal behaviour
+                _resp, _state_4, _more_pages, _status_code, _error = self.action.run({}, state_3.copy(), config)
+                # get lookback time as task.py does with using now - (lookback + 1 minute latency delay)
+                lookback = new_now - timedelta(hours=config["cutoff"]["hours"], minutes=1)
+                lookback_msg = f"Last collection date reset to max lookback allowed: {lookback.isoformat()}"
+                self.assertEquals(lookback_msg, mock_logger.call_args_list[2][0][0])


### PR DESCRIPTION
## Proposed Changes
Ticket: [[C2C Proofpoint] Implement new configurable backfill and initial params from SDK](https://rapid7.atlassian.net/browse/PLGN-727)
### Description

Describe the proposed changes:
  - Update to the latest SDK so that we now accept the custom_config parameter.
  - I built on the existing logic that was accepting an environment variable to accept this new config parameter. 
    - I did not remove the environment variable but added unit tests to cover if this was supplied (for any reason) that the new custom_config parameter takes precedence. 
  - customer config can specify either options `lookback` or `cutoff`:
   - lookback will follow the env var logic and will epxect the year/month/day etc to specified and will do this lookback value if no state is passed.
   - `cutoff` can have either `date` to follow the same as above or be generic and accept `hours` in which case the task code will calculate this date to apply as the cut off.
     - having a date here allows us to be very precise as to the cut off being applied during a backfill where hours can be used on a day to day basis.   

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Tested locally that pagination works when in backfill and normal mode.
- Tested using org ID with specific look back values vs `*` and works as expected. 
- Unit tests updated to cover a backfill mode running until it catches up and pulling out custom_config to revert to normal logic of cut offs.


#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
