### PR TITLE
Okta 4.2.4 Release

### DIFF
--- a/plugins/okta/.CHECKSUM
+++ b/plugins/okta/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a41bba4ddbe2d2f0624afb797804c042",
-	"manifest": "3b21e09f89cbafd960e877f73954804e",
-	"setup": "0cbd3707da4cff30d5498e25e1f1bfe1",
+	"spec": "7f448e71c1388f5fdfc3f150db7ee752",
+	"manifest": "1e6b57d7c35bd2bd1783ce63e0734c28",
+	"setup": "ab9a4e3b9fee79ee97d4676579c2b3f8",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",
@@ -13,7 +13,7 @@
 		},
 		{
 			"identifier": "create_user/schema.py",
-			"hash": "a8383fea486432300fef75c7d887ed94"
+			"hash": "cb61fe8aa9a9ff2fa9f984a750385499"
 		},
 		{
 			"identifier": "deactivate_user/schema.py",
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "list_groups/schema.py",
-			"hash": "77d9beabc56bdae5c7b0eef31f99d354"
+			"hash": "24f3edbf51ad1f93966be1715bb537f9"
 		},
 		{
 			"identifier": "remove_user_from_group/schema.py",
@@ -73,7 +73,7 @@
 		},
 		{
 			"identifier": "monitor_logs/schema.py",
-			"hash": "c7846002b9cb1c3069e098b40868f0d2"
+			"hash": "6716ca24c5d2004903afd259a49fe66e"
 		},
 		{
 			"identifier": "users_added_removed_from_group/schema.py",

--- a/plugins/okta/bin/komand_okta
+++ b/plugins/okta/bin/komand_okta
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Okta"
 Vendor = "rapid7"
-Version = "4.2.3"
+Version = "4.2.4"
 Description = "Secure identity management and single sign-on to any application"
 
 

--- a/plugins/okta/help.md
+++ b/plugins/okta/help.md
@@ -1612,6 +1612,7 @@ by Okta themselves, or constructed by the plugin based on the information it has
 
 # Version History
 
+* 4.2.4 - Monitor Logs task: Update to latest SDK which adds new task custom_config parameter | Update validators to 0.22.0
 * 4.2.3 - Monitor Logs task: Added exception logging and use latest plugin SDK. Also Fixed schemas that contain passwords.
 * 4.2.2 - Monitor Logs task: log deduplication only applied when querying Okta using since and until parameters.
 * 4.2.1 - Monitor Logs task: filter previously returned log events | only update time checkpoint when an event is returned | update timestamp format | set cutoff time of 24 hours.

--- a/plugins/okta/komand_okta/actions/create_user/schema.py
+++ b/plugins/okta/komand_okta/actions/create_user/schema.py
@@ -69,7 +69,10 @@ class CreateUserInput(insightconnect_plugin_runtime.Input):
     }
   },
   "required": [
-    "nextLogin"
+    "activate",
+    "nextLogin",
+    "profile",
+    "provider"
   ],
   "definitions": {
     "credentials": {

--- a/plugins/okta/komand_okta/actions/list_groups/schema.py
+++ b/plugins/okta/komand_okta/actions/list_groups/schema.py
@@ -59,6 +59,9 @@ class ListGroupsOutput(insightconnect_plugin_runtime.Output):
       "order": 1
     }
   },
+  "required": [
+    "success"
+  ],
   "definitions": {
     "group": {
       "type": "object",

--- a/plugins/okta/komand_okta/actions/update_blacklist_zones/action.py
+++ b/plugins/okta/komand_okta/actions/update_blacklist_zones/action.py
@@ -19,8 +19,7 @@ class UpdateBlacklistZones(insightconnect_plugin_runtime.Action):
     def run(self, params={}):  # noqa: C901
         name = params.get(Input.NAME)
         value = params.get(Input.ADDRESS)
-
-        if validators.ipv4_cidr(value) or validators.ipv6_cidr(value):
+        if validators.ipv4(value, cidr=True, strict=True) or validators.ipv6(value, cidr=True, strict=True):
             value_type = "CIDR"
         else:
             value_type = "RANGE"

--- a/plugins/okta/komand_okta/tasks/monitor_logs/task.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/task.py
@@ -5,7 +5,10 @@ from .schema import MonitorLogsInput, MonitorLogsOutput, MonitorLogsState, Compo
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_okta.util.exceptions import ApiException
 from datetime import datetime, timedelta, timezone
+from typing import Dict
 import re
+
+CUTOFF = 24
 
 
 class MonitorLogs(insightconnect_plugin_runtime.Task):
@@ -22,26 +25,28 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             state=MonitorLogsState(),
         )
 
-    def run(self, params={}, state={}):  # pylint: disable=unused-argument
+    def run(self, params={}, state={}, custom_config={}):  # pylint: disable=unused-argument
         self.connection.api_client.toggle_rate_limiting = False
         has_more_pages = False
         parameters = {}
         try:
+            filter_time = self._get_filter_time(custom_config)
             now = self.get_current_time() - timedelta(minutes=1)  # allow for latency of this being triggered
             now_iso = self.get_iso(now)
-            last_24_hours = self.get_iso(now - timedelta(hours=24))  # cut off point - never query beyond 24 hours
+            filter_hours = self.get_iso(now - timedelta(hours=filter_time))  # cut off point - never query beyond
+            # cutoff hours
             next_page_link = state.get(self.NEXT_PAGE_LINK)
             if not state:
                 self.logger.info("First run")
-                parameters = {"since": last_24_hours, "until": now_iso, "limit": 1000}
-                state[self.LAST_COLLECTION_TIMESTAMP] = last_24_hours  # we only change this once we get new events
+                parameters = {"since": filter_hours, "until": now_iso, "limit": 1000}
+                state[self.LAST_COLLECTION_TIMESTAMP] = filter_hours  # we only change this once we get new events
             else:
                 if next_page_link:
                     state.pop(self.NEXT_PAGE_LINK)
                     self.logger.info("Getting the next page of results...")
                 else:
                     parameters = {
-                        "since": self.get_since(state, last_24_hours),
+                        "since": self.get_since(state, filter_hours, filter_time),
                         "until": now_iso,
                         "limit": 1000,
                     }
@@ -84,19 +89,22 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         """
         return time.isoformat("T", "milliseconds").replace("+00:00", "Z")
 
-    def get_since(self, state: dict, cut_off: str) -> str:
+    def get_since(self, state: dict, cut_off: str, filter_hours: int) -> str:
         """
         If the customer has paused this task for an extended amount of time we don't want start polling events that
-        exceed 24 hours ago. Check if the saved state is beyond this and revert to use the last 24 hours time.
+        exceed the cutoff hours. Check if the saved state is beyond this and revert to use the last cutoff hours time.
+        Default 24 hours.
         :param state: saved state to check and update the time being used.
-        :param cut_off: string time of now - 24 hours.
+        :param cut_off: string time of now - default 24 hours.
+        :param filter_hours: filter time in hours
         :return: updated time string to use in the parameters.
         """
         saved_time = state.get(self.LAST_COLLECTION_TIMESTAMP)
 
         if saved_time < cut_off:
             self.logger.info(
-                f"Saved state {saved_time} exceeds the cut off (24 hours)." f" Reverting to use time: {cut_off}"
+                f"Saved state {saved_time} exceeds the cut off ({filter_hours} hours)."
+                f" Reverting to use time: {cut_off}"
             )
             state[self.LAST_COLLECTION_TIMESTAMP] = cut_off
 
@@ -170,3 +178,16 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             new_ts = state_time
 
         return new_ts
+
+    def _get_filter_time(self, custom_config: Dict[str, int]) -> int:
+        """
+        Apply custom_config params (if provided) to the task. If a lookback value exists, it should take
+        precedence (this can allow a larger filter time), otherwise use the default value.
+        :param custom_config: dictionary passed containing `default` or `lookback` values
+        :return: filter time to be applied in request to Okta
+        """
+
+        default, lookback = custom_config.get("default", CUTOFF), custom_config.get("lookback")
+        filter_value = lookback if lookback else default
+        self.logger.info(f"Task execution will be applying filter period of {filter_value} hours...")
+        return int(filter_value)

--- a/plugins/okta/plugin.spec.yaml
+++ b/plugins/okta/plugin.spec.yaml
@@ -13,7 +13,7 @@ sdk:
   version: 5
   user: nobody
 description: Secure identity management and single sign-on to any application
-version: 4.2.3
+version: 4.2.4
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/okta

--- a/plugins/okta/requirements.txt
+++ b/plugins/okta/requirements.txt
@@ -1,6 +1,6 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-validators==0.20.0
+validators==0.22.0
 parameterized==0.8.1
 timeout-decorator==0.5.0

--- a/plugins/okta/setup.py
+++ b/plugins/okta/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="okta-rapid7-plugin",
-      version="4.2.3",
+      version="4.2.4",
       description="Secure identity management and single sign-on to any application",
       author="rapid7",
       author_email="",

--- a/plugins/okta/unit_test/expected/get_logs_empty_resp.json.exp
+++ b/plugins/okta/unit_test/expected/get_logs_empty_resp.json.exp
@@ -1,7 +1,7 @@
 {
     "logs": [],
     "state": {
-        "last_collection_timestamp": "2023-04-27T08:33:46.123Z"
+        "last_collection_timestamp": "2023-04-23T20:33:46.123Z"
     },
   "has_more_pages": false,
   "status_code": 200

--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b8737473cda4c9744ba85c4bfefa9451",
-	"manifest": "0f92f58aa70ea4b86ebba1828b26e098",
-	"setup": "5f03513017650052a2e41897671977e1",
+	"spec": "45d2ba6621c249395aa65e7004f73d02",
+	"manifest": "a3bbea2eb02f40d24101601983add397",
+	"setup": "4a3aa78bc047aea80b8bdbf36521f481",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.3.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.4"
+Version = "4.1.5"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.5 - Include SDK 5.4 which adds new task custom_config parameter.
 * 4.1.4 - Remove hard coded env var from Dockerfile.
 * 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task
 * 4.1.2 - Update to latest plugin SDK to get task and exception logging

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.4
+version: 4.1.5
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
-  version: 5.3.1
+  version: 5.4
   user: nobody
 vendor: rapid7
 support: community

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.4",
+      version="4.1.5",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",

--- a/plugins/proofpoint_tap/unit_test/test_monitor_events.py
+++ b/plugins/proofpoint_tap/unit_test/test_monitor_events.py
@@ -7,11 +7,13 @@ from komand_proofpoint_tap.tasks import MonitorEvents
 from test_util import Util
 from unittest import TestCase
 from parameterized import parameterized
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+from json import loads
 
 sys.path.append(os.path.abspath("../"))
 
 ENV_VALUE = '{"year": 2024, "month": 1, "day": 27, "hour": 0, "minute": 0, "second": 0}'
+ENV_VALUE_2 = '{"year": 2024, "month": 2, "day": 20, "hour": 12, "minute": 0, "second": 0}'
 TEST_PAGE_SIZE = 2
 
 
@@ -66,7 +68,9 @@ class TestMonitorEvents(TestCase):
         ]
     )
     def test_monitor_events(self, _mock_request, _mock_get_time, _test_name, current_state, expected):
-        actual, actual_state, has_more_pages, status_code, error = self.action.run(state=current_state)
+        actual, actual_state, has_more_pages, status_code, error = self.action.run(
+            state=current_state, custom_config={}
+        )
         self.assertEqual(actual, expected.get("events"))
         self.assertEqual(actual_state, expected.get("state"))
 
@@ -74,10 +78,10 @@ class TestMonitorEvents(TestCase):
     @patch("logging.Logger.info")
     def test_monitor_events_with_env_variable_empty_state(self, mock_logger, _mock_request, _mock_time):
         # When we inject the env variable into the pod we should change the time we retrieve events from.
-        response, state, has_more_pages, status_code, _error = self.action.run(state={})
+        response, state, has_more_pages, status_code, _error = self.action.run(state={}, custom_config={})
 
         # we should have logged using env var
-        self.assertIn("Using env var value", mock_logger.call_args_list[1][0][0])
+        self.assertIn("Using custom value of", mock_logger.call_args_list[2][0][0])
 
         # state last time should be injected env var + 1 hour
         self.assertEqual("2024-01-27T01:00:00+00:00", state["last_collection_date"])
@@ -90,15 +94,57 @@ class TestMonitorEvents(TestCase):
         self.assertEqual(1, state["next_page_index"])
 
     @patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=ENV_VALUE)
-    @patch("logging.Logger.info")
-    def test_monitor_events_with_env_variable_existing_state(self, mock_logger, _mock_request, _mock_time):
+    def test_monitor_events_with_env_variable_existing_state(self, _mock_request, _mock_time):
         # Although we inject the env var because we have a state saved we can ignore and continue our usual logic
         # use this date to avoid cut off logic from mocked current time.
         existing_state = {"last_collection_date": "2023-04-04T01:00:00+00:00"}
-        response, state, has_more_pages, status_code, _error = self.action.run(state=existing_state)
+        response, state, has_more_pages, status_code, _error = self.action.run(state=existing_state, custom_config={})
 
         # state last time should be last_collected_date + 1 hour
         self.assertEqual("2023-04-04T02:00:00+00:00", state["last_collection_date"])
 
         # Split the logs being returned by the SPLIT_SIZE variable
         self.assertEqual(TEST_PAGE_SIZE, len(response))
+
+    @patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=ENV_VALUE_2)
+    @patch("logging.Logger.info")
+    def test_monitor_events_uses_custom_config_data(self, mock_logger, _mock_request, _mock_time):
+        # Even though we have an environment variable specified we use the custom_config passed from CPS
+        full_lookback_value = loads(ENV_VALUE)
+        cps_config = {"lookback": full_lookback_value}  # pass this as a dict as our API will supply as it like this
+        response, state, has_more_pages, status_code, _error = self.action.run({}, {}, cps_config)
+
+        # In this example we have an env var specified but this is ignored to use the value in the custom_config
+        self.assertIn(f"Using custom value of {full_lookback_value}", mock_logger.call_args_list[2][0][0])
+
+        # state last time should be custom config value + 1 hour
+        self.assertEqual("2024-01-27T01:00:00+00:00", state["last_collection_date"])
+        self.assertEqual(1, state["next_page_index"])
+
+        # second time we call we will then pass no lookback from SDK level and now use the cutoff date value
+        with patch("komand_proofpoint_tap.tasks.monitor_events.task.SPECIFIC_DATE", new=""):  # clear env var
+            cps_config = {"cutoff": {"date": full_lookback_value}}
+            _resp, state_2, _more_pages, _status_code, _error = self.action.run({}, state.copy(), cps_config)
+
+            # Due to pagination the last collection date will not change in our state
+            self.assertEqual(state["last_collection_date"], state_2["last_collection_date"])
+            self.assertEqual(2, state_2["next_page_index"])  # however we should be on the second page
+
+            # Third time we call - we increase page size to return more_pages=False from the task
+            with patch("komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.SPLIT_SIZE", new=40000):
+                _resp, state_3, more_pages, _status_code, _error = self.action.run({}, state_2.copy(), cps_config)
+                self.assertEqual(state_2["last_collection_date"], state_3["last_collection_date"])
+                self.assertEqual(False, more_pages)  # finished pagination now due to split size including all logs
+
+            # Fourth time task is called - custom_config is 'normal' and we do normal time calculations / cut off.
+            new_now = datetime.strptime("2024-03-25T08:00:00", "%Y-%m-%dT%H:%M:%S").replace(tzinfo=timezone.utc)
+            with patch(
+                "komand_proofpoint_tap.tasks.monitor_events.task.MonitorEvents.get_current_time", return_value=new_now
+            ):
+                mock_logger.reset_mock()
+                config = {"cutoff": {"hours": 24}}  # config reverted to normal behaviour
+                _resp, _state_4, _more_pages, _status_code, _error = self.action.run({}, state_3.copy(), config)
+                # get lookback time as task.py does with using now - (lookback + 1 minute latency delay)
+                lookback = new_now - timedelta(hours=config["cutoff"]["hours"], minutes=1)
+                lookback_msg = f"Last collection date reset to max lookback allowed: {lookback.isoformat()}"
+                self.assertEquals(lookback_msg, mock_logger.call_args_list[2][0][0])


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Update validators
  - Update task monitor_logs for C2C backfill

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
