### PR TITLE
Okta  4.2.4 Release - 2

### DIFF
--- a/plugins/okta/Dockerfile
+++ b/plugins/okta/Dockerfile
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/okta/komand_okta/tasks/monitor_logs/task.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/task.py
@@ -5,7 +5,7 @@ from .schema import MonitorLogsInput, MonitorLogsOutput, MonitorLogsState, Compo
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_okta.util.exceptions import ApiException
 from datetime import datetime, timedelta, timezone
-from typing import Dict
+from typing import Dict, Any
 import re
 
 CUTOFF = 24
@@ -30,11 +30,15 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         has_more_pages = False
         parameters = {}
         try:
-            filter_time = self._get_filter_time(custom_config)
+            filter_time, is_filter_datetime = self._get_filter_time(custom_config)
             now = self.get_current_time() - timedelta(minutes=1)  # allow for latency of this being triggered
             now_iso = self.get_iso(now)
-            filter_hours = self.get_iso(now - timedelta(hours=filter_time))  # cut off point - never query beyond
-            # cutoff hours
+            # Whether to convert filter_time in hours to datetime
+            if is_filter_datetime:
+                filter_hours = filter_time
+            else:
+                # If false, we assume filter_time is an integer or string representing hours and get datetime
+                filter_hours = self.get_iso(now - timedelta(hours=int(filter_time)))  # cutoff point, never query beyond
             next_page_link = state.get(self.NEXT_PAGE_LINK)
             if not state:
                 self.logger.info("First run")
@@ -46,7 +50,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                     self.logger.info("Getting the next page of results...")
                 else:
                     parameters = {
-                        "since": self.get_since(state, filter_hours, filter_time),
+                        "since": self.get_since(state, filter_hours, filter_time, is_filter_datetime),
                         "until": now_iso,
                         "limit": 1000,
                     }
@@ -80,6 +84,19 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         return datetime.now(timezone.utc)
 
     @staticmethod
+    def check_if_datetime(date_time: Any):
+        """
+        Check if passed value is a date_time, returning True or False
+        :param date_time: date_time value, or int/string representing hours
+        :return: boolean result based on date_time value type check
+        """
+        try:
+            datetime.fromisoformat(str(date_time).rstrip("Z"))
+            return True
+        except ValueError:
+            return False
+
+    @staticmethod
     def get_iso(time: datetime) -> str:
         """
         Match the timestamp format used in old collector code and the format that Okta uses for 'published' to allow
@@ -89,23 +106,30 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         """
         return time.isoformat("T", "milliseconds").replace("+00:00", "Z")
 
-    def get_since(self, state: dict, cut_off: str, filter_hours: int) -> str:
+    def get_since(self, state: dict, cut_off: str, filter_hours: int, is_date_time: bool) -> str:
         """
         If the customer has paused this task for an extended amount of time we don't want start polling events that
         exceed the cutoff hours. Check if the saved state is beyond this and revert to use the last cutoff hours time.
-        Default 24 hours.
+        Default CUTOFF value.
         :param state: saved state to check and update the time being used.
-        :param cut_off: string time of now - default 24 hours.
-        :param filter_hours: filter time in hours
+        :param cut_off: string time of now - default CUTOFF value.
+        :param filter_hours: filter time in hours or timestamp
+        :param is_date_time: is filter time datetime or hours
         :return: updated time string to use in the parameters.
         """
         saved_time = state.get(self.LAST_COLLECTION_TIMESTAMP)
 
         if saved_time < cut_off:
-            self.logger.info(
-                f"Saved state {saved_time} exceeds the cut off ({filter_hours} hours)."
-                f" Reverting to use time: {cut_off}"
-            )
+            if is_date_time:
+                self.logger.info(
+                    f"Saved state {saved_time} is before the cut off date ({filter_hours})."
+                    f" Reverting to use time: {cut_off}"
+                )
+            else:
+                self.logger.info(
+                    f"Saved state {saved_time} exceeds the cut off ({filter_hours} hours)."
+                    f" Reverting to use time: {cut_off}"
+                )
             state[self.LAST_COLLECTION_TIMESTAMP] = cut_off
 
         return state[self.LAST_COLLECTION_TIMESTAMP]
@@ -179,15 +203,22 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
 
         return new_ts
 
-    def _get_filter_time(self, custom_config: Dict[str, int]) -> int:
+    def _get_filter_time(self, custom_config: Dict) -> int:
         """
         Apply custom_config params (if provided) to the task. If a lookback value exists, it should take
-        precedence (this can allow a larger filter time), otherwise use the default value.
-        :param custom_config: dictionary passed containing `default` or `lookback` values
-        :return: filter time to be applied in request to Okta
+        precedence (this can allow a larger filter time), otherwise use the cutoff value.
+        :param custom_config: dictionary passed containing `cutoff` or `lookback` values
+        :return: filter_value to be applied in request to Okta
+        :return: is_filter_datetime boolean value if filter_value is of type datetime
         """
-
-        default, lookback = custom_config.get("default", CUTOFF), custom_config.get("lookback")
-        filter_value = lookback if lookback else default
-        self.logger.info(f"Task execution will be applying filter period of {filter_value} hours...")
-        return int(filter_value)
+        filter_cutoff = custom_config.get("cutoff", {}).get("date")
+        if filter_cutoff is None:
+            filter_cutoff = custom_config.get("cutoff", {}).get("hours", CUTOFF)
+        filter_lookback = custom_config.get("lookback")
+        filter_value = filter_lookback if filter_lookback else filter_cutoff
+        is_filter_datetime = self.check_if_datetime(filter_value)
+        if is_filter_datetime:
+            self.logger.info(f"Task execution will be applying a lookback to {filter_value}...")
+        else:
+            self.logger.info(f"Task execution will be applying filter period of {filter_value} hours...")
+        return filter_value, is_filter_datetime

--- a/plugins/okta/unit_test/test_monitor_logs.py
+++ b/plugins/okta/unit_test/test_monitor_logs.py
@@ -21,7 +21,7 @@ class TestMonitorLogs(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(MonitorLogs())
-        cls.custom_config = {"default": 24, "lookback": 108}
+        cls.custom_config = {"cutoff": {"date": "2023-04-23T20:33:46.123Z"}, "lookback": "2023-04-23T20:33:46.123Z"}
 
     @parameterized.expand(
         [
@@ -29,30 +29,35 @@ class TestMonitorLogs(TestCase):
                 "without_state",
                 Util.read_file_to_dict("inputs/monitor_logs_without_state.json.inp"),
                 Util.read_file_to_dict("expected/get_logs.json.exp"),
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "with_state",
                 Util.read_file_to_dict("inputs/monitor_logs_with_state.json.inp"),
                 Util.read_file_to_dict("expected/get_logs.json.exp"),
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "next_page",
                 Util.read_file_to_dict("inputs/monitor_logs_next_page.json.inp"),
                 Util.read_file_to_dict("expected/get_logs_next_page.json.exp"),
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "next_page_no_results",
                 Util.read_file_to_dict("inputs/monitor_logs_next_page.json.inp"),
                 Util.read_file_to_dict("expected/get_logs_next_empty.json.exp"),
+                {"cutoff": {"hours": 24}, "lookback": None},
             ],
             [
                 "without_state_no_results",
                 Util.read_file_to_dict("inputs/monitor_logs_without_state.json.inp"),
                 Util.read_file_to_dict("expected/get_logs_empty_resp.json.exp"),
+                {"default": 108, "lookback": 108},
             ],
         ]
     )
-    def test_monitor_logs(self, mocked_warn, mock_request, _mock_get_time, test_name, current_state, expected):
+    def test_monitor_logs(self, mocked_warn, mock_request, _mock_get_time, test_name, current_state, expected, config):
         # Tests and their workflow descriptions:
         # 1. without_state - first run, query from 24 hours ago until now and results returned.
         # 2. with_state - queries using the saved 'last_collection_timestamp' to pull new logs.
@@ -64,7 +69,7 @@ class TestMonitorLogs(TestCase):
             mock_request.side_effect = Util.mock_empty_response
 
         actual, actual_state, has_more_pages, status_code, error = self.action.run(
-            state=current_state, custom_config=self.custom_config
+            state=current_state, custom_config=config
         )
         self.assertEqual(actual, expected.get("logs"))
         self.assertEqual(actual_state, expected.get("state"))
@@ -136,11 +141,11 @@ class TestMonitorLogs(TestCase):
         # Test the scenario that a customer has paused the collector for an extended amount of time to test when they
         # resume the task we should cut off, at a max 24 hours ago for since parameter.
         expected = Util.read_file_to_dict("expected/get_logs.json.exp")  # logs from last 24 hours
-
+        custom_config = {"default": 108, "lookback": "2023-04-23T20:33:46.123Z"}
         paused_time = "2022-04-27T07:49:21.777Z"
         current_state = {"last_collection_timestamp": paused_time}  # Task has been paused for 1 year+
         actual, state, _has_more_pages, _status_code, _error = self.action.run(
-            state=current_state, custom_config=self.custom_config
+            state=current_state, custom_config=custom_config
         )
 
         # Basic check that we match the same as a first test/run which returns logs from the last 24 hours
@@ -149,7 +154,7 @@ class TestMonitorLogs(TestCase):
 
         # Check we called with the current parameters by looking at the info log
         logger = call(
-            f"Saved state {paused_time} exceeds the cut off (108 hours). "
+            f"Saved state {paused_time} is before the cut off date (2023-04-23T20:33:46.123Z). "
             f"Reverting to use time: 2023-04-23T20:33:46.123Z"
         )
         self.assertIn(logger, mocked_info_log.call_args_list)


### PR DESCRIPTION
* Update cutoff logic for datetime type

* Black and Refresh

* Fix schema type error

* Update task to use komand properties cutoff value, improve logging, refactor date type check

## Proposed Changes

### Description

Describe the proposed changes:

  -

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
