### PR TITLE
[PLGN-729] [Salesforce] : implement custom_config for backfilling. 

### DIFF
--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "e010295b7c99018123f10a97753d9803",
+	"spec": "7d7c06725bca504c3507e8711cfb386d",
 	"manifest": "c6fa3574c7df0e1f49625a9fd7469413",
 	"setup": "596f3e004bb99dca0aa9404f24ffbb24",
 	"schemas": [
@@ -41,7 +41,7 @@
 		},
 		{
 			"identifier": "monitor_users/schema.py",
-			"hash": "5f655ee0326da8b7586009e58f28e162"
+			"hash": "87d5000d4862847cd58fec2364b9458a"
 		}
 	]
 }

--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "39961b8237f24bf66810ef73d84a0b13",
-	"manifest": "1bf1a6ea3128f9c4c152ba785f0ba17a",
-	"setup": "adf7f461ad84d7bf7f5c3e81fc9c5b13",
+	"spec": "e010295b7c99018123f10a97753d9803",
+	"manifest": "c6fa3574c7df0e1f49625a9fd7469413",
+	"setup": "596f3e004bb99dca0aa9404f24ffbb24",
 	"schemas": [
 		{
 			"identifier": "advanced_search/schema.py",

--- a/plugins/salesforce/Dockerfile
+++ b/plugins/salesforce/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-plugin:5
+FROM rapid7/insightconnect-python-3-plugin:5.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/salesforce/Dockerfile
+++ b/plugins/salesforce/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-plugin:5.4
+FROM rapid7/insightconnect-python-3-plugin:5.4.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/salesforce/bin/komand_salesforce
+++ b/plugins/salesforce/bin/komand_salesforce
@@ -6,20 +6,22 @@ from sys import argv
 
 Name = "Salesforce"
 Vendor = "rapid7"
-Version = "2.1.5"
+Version = "2.1.6"
 Description = "The Salesforce plugin allows you to search, update, and manage salesforce records"
 
 
 def main():
-    if 'http' in argv:
+    if "http" in argv:
         if os.environ.get("GUNICORN_CONFIG_FILE"):
             with open(os.environ.get("GUNICORN_CONFIG_FILE")) as gf:
                 gunicorn_cfg = json.load(gf)
                 if gunicorn_cfg.get("worker_class", "sync") == "gevent":
                     from gevent import monkey
+
                     monkey.patch_all()
-        elif 'gevent' in argv:
+        elif "gevent" in argv:
             from gevent import monkey
+
             monkey.patch_all()
 
     import insightconnect_plugin_runtime
@@ -28,30 +30,25 @@ def main():
     class ICONSalesforce(insightconnect_plugin_runtime.Plugin):
         def __init__(self):
             super(self.__class__, self).__init__(
-                name=Name,
-                vendor=Vendor,
-                version=Version,
-                description=Description,
-                connection=connection.Connection()
+                name=Name, vendor=Vendor, version=Version, description=Description, connection=connection.Connection()
             )
             self.add_action(actions.SimpleSearch())
-        
+
             self.add_action(actions.AdvancedSearch())
-        
+
             self.add_action(actions.CreateRecord())
-        
+
             self.add_action(actions.UpdateRecord())
-        
+
             self.add_action(actions.GetRecord())
-        
+
             self.add_action(actions.DeleteRecord())
-        
+
             self.add_action(actions.GetFields())
-        
+
             self.add_action(actions.GetBlobData())
-        
+
             self.add_task(tasks.MonitorUsers())
-        
 
     """Run plugin"""
     cli = insightconnect_plugin_runtime.CLI(ICONSalesforce())

--- a/plugins/salesforce/help.md
+++ b/plugins/salesforce/help.md
@@ -534,7 +534,7 @@ Example output:
 
 # Version History
 
-* 2.1.6 - Task Monitor Users: Implement SDK 5.4 for custom_config.
+* 2.1.6 - Task Monitor Users: Implement SDK 5.4.4 for custom_config parameter.
 * 2.1.5 - Task Monitor Users: Improved logging
 * 2.1.4 - Connection: Remove unnecessary logging 
 * 2.1.3 - Task Monitor Users: improve deduplication logic on user login history

--- a/plugins/salesforce/help.md
+++ b/plugins/salesforce/help.md
@@ -534,6 +534,7 @@ Example output:
 
 # Version History
 
+* 2.1.6 - Task Monitor Users: Implement SDK 5.4 for custom_config.
 * 2.1.5 - Task Monitor Users: Improved logging
 * 2.1.4 - Connection: Remove unnecessary logging 
 * 2.1.3 - Task Monitor Users: improve deduplication logic on user login history

--- a/plugins/salesforce/komand_salesforce/tasks/monitor_users/task.py
+++ b/plugins/salesforce/komand_salesforce/tasks/monitor_users/task.py
@@ -115,7 +115,9 @@ class MonitorUsers(insightconnect_plugin_runtime.Task):
                     now, self.convert_to_datetime(next_user_login_collection_timestamp)
                 ):
                     get_user_login_history = True
-                    state[self.NEXT_USER_LOGIN_COLLECTION_TIMESTAMP] = str(now + timedelta(hours=1))  # poll again in 1 hr
+                    state[self.NEXT_USER_LOGIN_COLLECTION_TIMESTAMP] = str(
+                        now + timedelta(hours=1)
+                    )  # poll again in 1 hr
                     user_login_start_timestamp = self._get_recent_timestamp(
                         state, cut_off_time, self.LAST_USER_LOGIN_COLLECTION_TIMESTAMP
                     )
@@ -125,9 +127,10 @@ class MonitorUsers(insightconnect_plugin_runtime.Task):
                 records = []
 
                 if not users_next_page_id and not user_login_next_page_id or updated_users_next_page_id:
-                    self.logger.info(
-                        f"Get updated users - start: {user_update_start_timestamp} end: {user_update_last_collection}"
-                    )
+                    msg = f"Get updated users - start: {user_update_start_timestamp} end: {user_update_last_collection}"
+                    if updated_users_next_page_id:  # log if we're not actually using times and using next page ID
+                        msg += f", next page ID: {updated_users_next_page_id}"
+                    self.logger.info(msg)
                     response = self.connection.api.query(
                         self.UPDATED_USERS_QUERY.format(
                             start_timestamp=user_update_start_timestamp.isoformat(),
@@ -157,9 +160,12 @@ class MonitorUsers(insightconnect_plugin_runtime.Task):
                     records.extend(self.add_data_type_field(users, "User"))
 
                 if get_user_login_history:
-                    self.logger.info(
+                    msg = (
                         f"Get user login history - start: {user_login_start_timestamp} end: {user_login_end_timestamp}"
                     )
+                    if user_login_next_page_id:  # log if we're not actually using times and using next page ID
+                        msg += f", next page ID: {user_login_next_page_id}"
+                    self.logger.info(msg)
                     response = self.connection.api.query(
                         self.USER_LOGIN_QUERY.format(
                             start_timestamp=user_login_start_timestamp.isoformat(),

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -13,7 +13,7 @@ status: []
 supported_versions: ["Salesforce API v58 2023-06-30"]
 sdk:
   type: full
-  version: 5.4
+  version: 5.4.4
   user: nobody
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/salesforce

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: salesforce
 title: Salesforce
 description: The Salesforce plugin allows you to search, update, and manage salesforce records
-version: 2.1.5
+version: 2.1.6
 connection_version: 2
 vendor: rapid7
 support: community
@@ -13,7 +13,7 @@ status: []
 supported_versions: ["Salesforce API v58 2023-06-30"]
 sdk:
   type: full
-  version: 5
+  version: 5.4
   user: nobody
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/salesforce

--- a/plugins/salesforce/setup.py
+++ b/plugins/salesforce/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="salesforce-rapid7-plugin",
-      version="2.1.5",
+      version="2.1.6",
       description="The Salesforce plugin allows you to search, update, and manage salesforce records",
       author="rapid7",
       author_email="",

--- a/plugins/salesforce/unit_test/util.py
+++ b/plugins/salesforce/unit_test/util.py
@@ -107,6 +107,8 @@ class Util:
                     return MockResponse(200, "get_updated_users.json.resp")
                 if params == {"start": "2023-07-20T16:10:15.340+00:00", "end": "2023-07-20T16:21:15.340+00:00"}:
                     return MockResponse(200, "get_updated_users_empty.json.resp")
+                if params == {"start": "2023-06-05T03:45:00+00:00", "end": "2023-07-20T16:21:15.340+00:00"}:
+                    return MockResponse(200, "get_updated_users.json.resp")
                 if params == {"start": "invalid", "end": "2023-07-20T16:21:15.340+00:00"}:
                     return MockResponse(400)
             if url == "https://example.com/services/data/v58.0/sobjects/Document/invalid/body":
@@ -146,6 +148,10 @@ class Util:
                 }:
                     return MockResponse(200, "get_specific_user.json.resp")
                 if params == {
+                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-06-05T03:45:00+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
+                }:
+                    return MockResponse(200, "get_specific_user.json.resp")
+                if params == {
                     "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-07-20T16:10:15.340262+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
                 }:
                     return MockResponse(200, "get_specific_user_empty.json.resp")
@@ -169,6 +175,10 @@ class Util:
                     "q": "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-07-20T14:21:15.340262+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
                 }:
                     return MockResponse(200, "get_login_history_empty.json.resp")
+                if params == {
+                    "q": "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-06-05T03:45:00+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
+                }:
+                    return MockResponse(200, "get_login_history.json.resp")
                 if params == {"q": "SELECT FIELDS(STANDARD) FROM Folder"}:
                     return MockResponse(200, "advanced_search_all.json.resp")
                 if params == {"q": "SELECT FIELDS(STANDARD) FROM Account WHERE Name='Example Account'"}:


### PR DESCRIPTION
## Proposed Changes
[Implement new configurable backfill and initial params from SDK](https://rapid7.atlassian.net/browse/PLGN-729)

### Description
Describe the proposed changes:

  - Allow task to accept custom config that will enable a configurable backfill and cut off date to be applied. 
  - This involved small refactoring of variable assignments to simplify how the code reads and flows
  - Added extra comments as I found this difficult to understand why certain conditions and timedeltas were being calculated.
  - Similar to other plugins:
    - the cut off values can be supplied in either hours or a date. 
    - the lookback can be supplied as a date. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Testing locally performing a normal execution with no lookback values.
- Testing locally with lage lookback involving pagination: 
```
Plugin task beginning execution...
Connect: Connecting...
rapid7/Salesforce:2.1.6. Step name: monitor_users
Cut off time being applied: 2023-06-05 00:00:00+00:00, along with custom lookback of 2023-06-05 03:45:00+00:00
First run
Get updated users - start: 2023-06-05 03:45:00+00:00 end: 2024-02-29 15:17:17.128307+00:00
Request to path: query
SalesforceAPI: Getting API token...
SalesforceAPI: API token received
6 updated users added to output
Get all internal users
Request to path: query
6 internal users added to output
Get user login history - start: 2023-06-05 03:45:00+00:00 end: 2024-02-29 15:17:17.128307+00:00
Request to path: query
Removed 1997 duplicate from a total of 2000 duplicate records.
3 users login history added to output
Plugin task finished execution...

# Second run ignoring lookback and applying pagination:

Plugin task beginning execution...
rapid7/Salesforce:2.1.6. Step name: monitor_users
Cut off time being applied: 2023-06-05 00:00:00+00:00
Getting next page of results...
Get user login history - start: 2023-06-05 03:45:00+00:00 end: 2024-02-29 15:17:45.956721+00:00, next page ID: /0r8xx2hkrPsaYT7AQM-2000
Request to path: query/0r8xx2hkrPsaYT7AQM-2000
Removed 1996 duplicate from a total of 2000 duplicate records.
4 users login history added to output
Plugin task finished execution...
```

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
