### PR TITLE
PLGN-764: bump SDK version in Proofpoint TAP

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "45d2ba6621c249395aa65e7004f73d02",
-	"manifest": "a3bbea2eb02f40d24101601983add397",
-	"setup": "4a3aa78bc047aea80b8bdbf36521f481",
+	"spec": "1e98792017727a48c8c72518ab362380",
+	"manifest": "272da866bfc36c061b268d0d5ff378f4",
+	"setup": "b5fff5e03666958e0e71911c8218709d",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.5"
+Version = "4.1.6"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,7 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
-* 4.1.6 - Include SDK 5.4.4 which prevents any potential memory leaks.
+* 4.1.6 - Include SDK 5.4.4 which prevents any potential memory leaks | first task lookup should only be 1 hour unless override supplied.
 * 4.1.5 - Include SDK 5.4 which adds new task custom_config parameter.
 * 4.1.4 - Remove hard coded env var from Dockerfile.
 * 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.6 - Include SDK 5.4.4 which prevents any potential memory leaks.
 * 4.1.5 - Include SDK 5.4 which adds new task custom_config parameter.
 * 4.1.4 - Remove hard coded env var from Dockerfile.
 * 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -59,7 +59,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
 
             if not state or not last_collection_date:
                 task_start = "First run... "
-                first_time = max_allowed_lookback
+                first_time = now - timedelta(hours=1)
                 if backfill_date:
                     first_time = datetime(**backfill_date, tzinfo=timezone.utc)  # PLGN-727: allow backfill
                     task_start += f"Using custom value of {backfill_date}"

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.5
+version: 4.1.6
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
-  version: 5.4
+  version: 5.4.4
   user: nobody
 vendor: rapid7
 support: community

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.5",
+      version="4.1.6",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",

--- a/plugins/proofpoint_tap/unit_test/expected/monitor_events_first_run.json.exp
+++ b/plugins/proofpoint_tap/unit_test/expected/monitor_events_first_run.json.exp
@@ -58,7 +58,7 @@
     }
   ],
   "state": {
-    "last_collection_date": "2023-04-03T08:59:00+00:00",
+    "last_collection_date": "2023-04-04T07:59:00+00:00",
     "next_page_index": 1,
     "previous_logs_hashes": [
       "1604441c3c213eb3d2efc9557cae93a5796fa5a8",


### PR DESCRIPTION
## Proposed Changes
[PLGN-764](https://rapid7.atlassian.net/browse/PLGN-764)
### Description

Describe the proposed changes:

  - Bump to the latest SDK version. 
  - I noticed during testing that during a first run for a user we were looking back 24 hours and this didn't seem right... I checked and I changed this logic during one of my previous releases when I shouldn't have. I've changed this back to only lookback 1 hour for first run.
    - Still showing now - 1 hour: [#2281](https://github.com/rapid7/insightconnect-plugins/pull/2281/files#diff-96569c90f581170f3a472609d19e792b6bedd2d4cbc62de9408cd6c100500f91R59)
    -  Where I changed this logic - [#2297](https://github.com/rapid7/insightconnect-plugins/pull/2297/files#diff-96569c90f581170f3a472609d19e792b6bedd2d4cbc62de9408cd6c100500f91R59)
 
## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
Tested locally, multiple runs to get over pagination and return to normal polling:
```
Plugin task beginning execution...
Connect: Connecting...
rapid7/Proofpoint TAP:4.1.6. Step name: monitor_events
Last collection date retrieved: None
Plugin task execution will apply the following restrictions. Max lookback=2024-02-29 16:50:26.236675+00:00, specific date=None
First run...
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-03-01T15:50:26.236675+00:00/2024-03-01T16:50:26.236675+00:00'}
Retrieved 2037 total parsed events in time interval
Set next page index to 1 and has more pages to True for the next run
Original number of events: 1000. Number of events after de-duplication: 1000
Retrieved 1000 events
Plugin task finished execution...


Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.6. Step name: monitor_events
Last collection date retrieved: 2024-03-01T16:50:26.236675+00:00
Plugin task execution will apply the following restrictions. Max lookback=2024-02-29 16:51:15.595226+00:00, specific date=None
Getting the next page (page index 1) of results...
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-03-01T15:50:26.236675+00:00/2024-03-01T16:50:26.236675+00:00'}
Retrieved 2037 total parsed events in time interval
Set next page index to 2 and has more pages to True for the next run
Original number of events: 1000. Number of events after de-duplication: 999
Retrieved 999 events
Plugin task finished execution...

Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.6. Step name: monitor_events
Last collection date retrieved: 2024-03-01T16:50:26.236675+00:00
Plugin task execution will apply the following restrictions. Max lookback=2024-02-29 16:52:14.955312+00:00, specific date=None
Getting the next page (page index 2) of results...
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-03-01T15:50:26.236675+00:00/2024-03-01T16:50:26.236675+00:00'}
Retrieved 2037 total parsed events in time interval
Original number of events: 37. Number of events after de-duplication: 37
Retrieved 37 events
Plugin task finished execution...


Plugin task beginning execution...
rapid7/Proofpoint TAP:4.1.6. Step name: monitor_events
Last collection date retrieved: 2024-03-01T16:50:26.236675+00:00
Plugin task execution will apply the following restrictions. Max lookback=2024-02-29 16:52:58.004086+00:00, specific date=None
Subsequent run
End time for lookup reset from 2024-03-01T17:50:26.236675+00:00 to 2024-03-01T16:52:58.004086+00:00 to avoid going out of range
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-03-01T16:50:26.236675+00:00/2024-03-01T16:52:58.004086+00:00'}
Retrieved 48 total parsed events in time interval
Original number of events: 48. Number of events after de-duplication: 48
Retrieved 48 events
Plugin task finished execution...
```


#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code - updated now look up time is correct.

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section


[PLGN-764]: https://rapid7.atlassian.net/browse/PLGN-764?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ