### PR TITLE
Mimecast v5.3.8 Release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a98bb0dc71021fa75760c5c73bc153cf",
-	"manifest": "6deb75e59d3c42d42c06fd792a88ab73",
-	"setup": "5286b065ae2c0266ddcd641289276bad",
+	"spec": "fb7361ebf56ebaf52def6f5234251bc5",
+	"manifest": "092b0e57820bdad2fd0b0244e0e84163",
+	"setup": "92f33b42e4b58d16f2cf86706360c5a9",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.7"
+Version = "5.3.8"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,6 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned.
 * 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1017,7 +1017,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned.
+* 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned | Improve error handling.
 * 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.
 * 5.3.6 - Task `monitor_siem_logs` revert filter logic to 24 hours.
 * 5.3.5 - Task `monitor_siem_logs` further error logging and bump filter logic to 108 hours.

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -62,6 +62,8 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
             if header_next_token:
                 state[self.NEXT_TOKEN] = header_next_token
+                # Mimecast API only returns isLastToken in the headers if no more pages, so if it is not present then
+                # we know that there are no more pages to be consumed.
                 has_more_pages = IS_LAST_TOKEN_FIELD not in headers
 
             return output, state, has_more_pages, status_code, None

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -47,6 +47,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                 try:
                     output, headers, status_code = self.connection.client.get_siem_logs(header_next_token)
                     if not output:
+                        self.logger.info("No new logs returned from Mimecast")
                         break
                 except ApiClientException as error:
                     self.logger.error(

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.7
+version: 5.3.8
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7
@@ -13,7 +13,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.3.2
+  version: 5.4.4
   user: nobody
 status: []
 resources:

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.7",
+      version="5.3.8",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -24,7 +24,7 @@ class TestMonitorSiemLogs(TestCase):
         token = SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")
         tests = [
             {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
-            {"next_token": "force_json_error", "resp": content, "has_more_pages": True, "token": token},
+            {"next_token": "force_json_error", "resp": [], "has_more_pages": True, "token": "force_json_error"},
             {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
         ]
         for test in tests:
@@ -38,7 +38,6 @@ class TestMonitorSiemLogs(TestCase):
                 self.assertEqual(status_code, 200)
                 validate(response, MonitorSiemLogsOutput.schema)
 
-    @skip("Have not pulled logic to raise 401 successfully - TODO in 5.3.6")
     def test_monitor_siem_logs_raises_401(self, _mock_data):
         # TODO: update 401 logic to successfully check is_last_token that was introduced in 5.3.3
         state_params = {"next_token": "force_401"}


### PR DESCRIPTION
Release of Mimecast v5.3.8. 

Changes:
- Bump SDK to v5.4.4
- Add additional logger to indicate when no logs returned in a run. 
- Handle incorrect app ID correctly and raise this to the user.

Original PRs:
- #2370 
- #2386