### PR TITLE
Release Proofpoint TAP v4.1.6

### DIFF
--- a/plugins/proofpoint_tap/.CHECKSUM
+++ b/plugins/proofpoint_tap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "45d2ba6621c249395aa65e7004f73d02",
-	"manifest": "a3bbea2eb02f40d24101601983add397",
-	"setup": "4a3aa78bc047aea80b8bdbf36521f481",
+	"spec": "1e98792017727a48c8c72518ab362380",
+	"manifest": "272da866bfc36c061b268d0d5ff378f4",
+	"setup": "b5fff5e03666958e0e71911c8218709d",
 	"schemas": [
 		{
 			"identifier": "fetch_forensics/schema.py",

--- a/plugins/proofpoint_tap/Dockerfile
+++ b/plugins/proofpoint_tap/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/proofpoint_tap/bin/komand_proofpoint_tap
+++ b/plugins/proofpoint_tap/bin/komand_proofpoint_tap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Proofpoint TAP"
 Vendor = "rapid7"
-Version = "4.1.5"
+Version = "4.1.6"
 Description = "Parse Proofpoint Targeted Attack Protection (TAP) alerts"
 
 

--- a/plugins/proofpoint_tap/help.md
+++ b/plugins/proofpoint_tap/help.md
@@ -1171,6 +1171,7 @@ This plugin does not contain any troubleshooting information.
 
 # Version History
 
+* 4.1.6 - Include SDK 5.4.4 which prevents any potential memory leaks | first task lookup should only be 1 hour unless override supplied.
 * 4.1.5 - Include SDK 5.4 which adds new task custom_config parameter.
 * 4.1.4 - Remove hard coded env var from Dockerfile.
 * 4.1.3 - Allow task `monitor_events` to poll from a set date in env var. | Fix issue where an MD5 value of None from Proofpoint was breaking the sorting of the list in the `monitor_events` task

--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -59,7 +59,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
 
             if not state or not last_collection_date:
                 task_start = "First run... "
-                first_time = max_allowed_lookback
+                first_time = now - timedelta(hours=1)
                 if backfill_date:
                     first_time = datetime(**backfill_date, tzinfo=timezone.utc)  # PLGN-727: allow backfill
                     task_start += f"Using custom value of {backfill_date}"

--- a/plugins/proofpoint_tap/plugin.spec.yaml
+++ b/plugins/proofpoint_tap/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: proofpoint_tap
 title: Proofpoint TAP
 description: Parse Proofpoint Targeted Attack Protection (TAP) alerts
-version: 4.1.5
+version: 4.1.6
 connection_version: 4
 supported_versions: ["Proofpoint TAP API v2", "Tested on 2024-01-12"]
 sdk:
   type: slim
-  version: 5.4
+  version: 5.4.4
   user: nobody
 vendor: rapid7
 support: community

--- a/plugins/proofpoint_tap/setup.py
+++ b/plugins/proofpoint_tap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="proofpoint_tap-rapid7-plugin",
-      version="4.1.5",
+      version="4.1.6",
       description="Parse Proofpoint Targeted Attack Protection (TAP) alerts",
       author="rapid7",
       author_email="",

--- a/plugins/proofpoint_tap/unit_test/expected/monitor_events_first_run.json.exp
+++ b/plugins/proofpoint_tap/unit_test/expected/monitor_events_first_run.json.exp
@@ -58,7 +58,7 @@
     }
   ],
   "state": {
-    "last_collection_date": "2023-04-03T08:59:00+00:00",
+    "last_collection_date": "2023-04-04T07:59:00+00:00",
     "next_page_index": 1,
     "previous_logs_hashes": [
       "1604441c3c213eb3d2efc9557cae93a5796fa5a8",


### PR DESCRIPTION
Release of Proofpoint TAP v4.1.6.

Changes:
- Make use of the latest SDK.
- Revert back that the first poll for an org will look back 1 hour. 

Original PR: 
- #2373 

