### PR TITLE
Salesforce 2.1.7 Release

### DIFF
--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "8b22ad3912cdfd3ec8bde3c61b4f5865",
+	"spec": "5a0cd40347a80e1390b3cc85699dff36",
 	"manifest": "a71579f8403fb1b95d482098d9e9336c",
 	"setup": "0bd99dc4790e18065eb879fc431b0022",
 	"schemas": [
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "6e727108c83cd0f731f6bcdde5ac49ac"
+			"hash": "b1fddc72ed2a25a340203d5eac124be0"
 		},
 		{
 			"identifier": "monitor_users/schema.py",

--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "7d7c06725bca504c3507e8711cfb386d",
-	"manifest": "c6fa3574c7df0e1f49625a9fd7469413",
-	"setup": "596f3e004bb99dca0aa9404f24ffbb24",
+	"spec": "8b22ad3912cdfd3ec8bde3c61b4f5865",
+	"manifest": "a71579f8403fb1b95d482098d9e9336c",
+	"setup": "0bd99dc4790e18065eb879fc431b0022",
 	"schemas": [
 		{
 			"identifier": "advanced_search/schema.py",
@@ -37,7 +37,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "1656ec1e43c8581104c369faa18c177e"
+			"hash": "6e727108c83cd0f731f6bcdde5ac49ac"
 		},
 		{
 			"identifier": "monitor_users/schema.py",

--- a/plugins/salesforce/Dockerfile
+++ b/plugins/salesforce/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-plugin:5.4.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.4
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/salesforce/bin/komand_salesforce
+++ b/plugins/salesforce/bin/komand_salesforce
@@ -6,22 +6,20 @@ from sys import argv
 
 Name = "Salesforce"
 Vendor = "rapid7"
-Version = "2.1.6"
+Version = "2.1.7"
 Description = "The Salesforce plugin allows you to search, update, and manage salesforce records"
 
 
 def main():
-    if "http" in argv:
+    if 'http' in argv:
         if os.environ.get("GUNICORN_CONFIG_FILE"):
             with open(os.environ.get("GUNICORN_CONFIG_FILE")) as gf:
                 gunicorn_cfg = json.load(gf)
                 if gunicorn_cfg.get("worker_class", "sync") == "gevent":
                     from gevent import monkey
-
                     monkey.patch_all()
-        elif "gevent" in argv:
+        elif 'gevent' in argv:
             from gevent import monkey
-
             monkey.patch_all()
 
     import insightconnect_plugin_runtime
@@ -30,25 +28,30 @@ def main():
     class ICONSalesforce(insightconnect_plugin_runtime.Plugin):
         def __init__(self):
             super(self.__class__, self).__init__(
-                name=Name, vendor=Vendor, version=Version, description=Description, connection=connection.Connection()
+                name=Name,
+                vendor=Vendor,
+                version=Version,
+                description=Description,
+                connection=connection.Connection()
             )
             self.add_action(actions.SimpleSearch())
-
+        
             self.add_action(actions.AdvancedSearch())
-
+        
             self.add_action(actions.CreateRecord())
-
+        
             self.add_action(actions.UpdateRecord())
-
+        
             self.add_action(actions.GetRecord())
-
+        
             self.add_action(actions.DeleteRecord())
-
+        
             self.add_action(actions.GetFields())
-
+        
             self.add_action(actions.GetBlobData())
-
+        
             self.add_task(tasks.MonitorUsers())
+        
 
     """Run plugin"""
     cli = insightconnect_plugin_runtime.CLI(ICONSalesforce())

--- a/plugins/salesforce/help.md
+++ b/plugins/salesforce/help.md
@@ -34,6 +34,7 @@ The connection configuration accepts the following parameters:
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |clientId|string|None|True|Consumer Key of the connected app|None|1234567890aBcdEFRoeRxDE1234567890abCDef6Etz7VLwwLQZn19jyW3U_1234567890AbcdEF4VkuMS4ze|
 |clientSecret|credential_secret_key|None|True|Consumer Secret of the connected app|None|1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF|
+|instanceUrl|string|https://login.salesforce.com|False|Salesforce URL that is used to retrieve OAuth token|None|https://login.salesforce.com|
 |salesforceAccountUsernameAndPassword|credential_username_password|None|True|Name and password of the Salesforce user|None|{"username": "user@example.com", "password": "password"}|
 |securityToken|credential_secret_key|None|True|Security token of the Salesforce user|None|Ier6YY78KxJwKtHy7HeK0oPc|
   
@@ -43,6 +44,7 @@ Example input:
 {
   "clientId": "1234567890aBcdEFRoeRxDE1234567890abCDef6Etz7VLwwLQZn19jyW3U_1234567890AbcdEF4VkuMS4ze",
   "clientSecret": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
+  "instanceUrl": "https://login.salesforce.com",
   "salesforceAccountUsernameAndPassword": {
     "password": "password",
     "username": "user@example.com"
@@ -58,7 +60,7 @@ Example input:
 
 #### Advanced Search
   
-This action is used to execute a SOQL (Salesforce Object Query Language) query.
+This action is used to execute a SOQL (Salesforce Object Query Language) query
 
 ##### Input
 
@@ -97,7 +99,7 @@ Example output:
 
 #### Create Record
   
-This action is used to create a new SObject record.
+This action is used to create a new SObject record
 
 ##### Input
 
@@ -167,7 +169,7 @@ Example output:
 
 #### Get Blob Data
   
-This action is used to retrieve blob data for a given record.
+This action is used to retrieve blob data for a given record
 
 ##### Input
 
@@ -203,7 +205,7 @@ Example output:
 
 #### Get Fields
   
-This action is used to retrieve field values from the record of the given object.
+This action is used to retrieve field values from the record of the given object
 
 ##### Input
 
@@ -247,7 +249,7 @@ Example output:
 
 #### Get Record
   
-This action is used to retrieve a record.
+This action is used to retrieve a record
 
 ##### Input
 
@@ -300,7 +302,7 @@ Example output:
 
 #### Simple Search
   
-This action is used to execute a simple search for a text.
+This action is used to execute a simple search for a text
 
 ##### Input
 
@@ -363,7 +365,7 @@ Example output:
 
 #### Update Record
   
-This action is used to update a record.
+This action is used to update a record
 
 ##### Input
 
@@ -406,7 +408,7 @@ Example output:
 
 #### Monitor Users
   
-This task is used to get information about users, their login history and which users have been updated.
+This task is used to get information about users, their login history and which users have been updated
 
 ##### Input
   
@@ -534,6 +536,7 @@ Example output:
 
 # Version History
 
+* 2.1.7 - Task Monitor Users: Update connection to accept instance URL and force new token request per execution.
 * 2.1.6 - Task Monitor Users: Implement SDK 5.4.4 for custom_config parameter.
 * 2.1.5 - Task Monitor Users: Improved logging
 * 2.1.4 - Connection: Remove unnecessary logging 

--- a/plugins/salesforce/komand_salesforce/connection/connection.py
+++ b/plugins/salesforce/komand_salesforce/connection/connection.py
@@ -16,7 +16,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
         client_id = params.get(Input.CLIENTID)
         client_secret = params.get(Input.CLIENTSECRET, {}).get("secretKey")
-        oauth_url = params.get(Input.INSTANCEURL)
+        oauth_url = params.get(Input.LOGINURL)
         username = params.get(Input.SALESFORCEACCOUNTUSERNAMEANDPASSWORD, {}).get("username")
         password = params.get(Input.SALESFORCEACCOUNTUSERNAMEANDPASSWORD, {}).get("password")
         security_token = params.get(Input.SECURITYTOKEN).get("secretKey")

--- a/plugins/salesforce/komand_salesforce/connection/connection.py
+++ b/plugins/salesforce/komand_salesforce/connection/connection.py
@@ -16,11 +16,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
         client_id = params.get(Input.CLIENTID)
         client_secret = params.get(Input.CLIENTSECRET, {}).get("secretKey")
+        oauth_url = params.get(Input.INSTANCEURL)
         username = params.get(Input.SALESFORCEACCOUNTUSERNAMEANDPASSWORD, {}).get("username")
         password = params.get(Input.SALESFORCEACCOUNTUSERNAMEANDPASSWORD, {}).get("password")
         security_token = params.get(Input.SECURITYTOKEN).get("secretKey")
 
-        self.api = SalesforceAPI(client_id, client_secret, username, password, security_token, self.logger)
+        self.api = SalesforceAPI(client_id, client_secret, oauth_url, username, password, security_token, self.logger)
 
     def test(self):
         try:

--- a/plugins/salesforce/komand_salesforce/connection/schema.py
+++ b/plugins/salesforce/komand_salesforce/connection/schema.py
@@ -6,7 +6,7 @@ import json
 class Input:
     CLIENTID = "clientId"
     CLIENTSECRET = "clientSecret"
-    INSTANCEURL = "instanceUrl"
+    LOGINURL = "loginURL"
     SALESFORCEACCOUNTUSERNAMEANDPASSWORD = "salesforceAccountUsernameAndPassword"
     SECURITYTOKEN = "securityToken"
 
@@ -29,10 +29,10 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "description": "Consumer Secret of the connected app",
       "order": 3
     },
-    "instanceUrl": {
+    "loginURL": {
       "type": "string",
-      "title": "Salesforce URL",
-      "description": "Salesforce URL that is used to retrieve OAuth token",
+      "title": "Login URL",
+      "description": "Salesforce login URL",
       "default": "https://login.salesforce.com",
       "order": 1
     },

--- a/plugins/salesforce/komand_salesforce/connection/schema.py
+++ b/plugins/salesforce/komand_salesforce/connection/schema.py
@@ -6,6 +6,7 @@ import json
 class Input:
     CLIENTID = "clientId"
     CLIENTSECRET = "clientSecret"
+    INSTANCEURL = "instanceUrl"
     SALESFORCEACCOUNTUSERNAMEANDPASSWORD = "salesforceAccountUsernameAndPassword"
     SECURITYTOKEN = "securityToken"
 
@@ -20,25 +21,32 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "type": "string",
       "title": "Client ID",
       "description": "Consumer Key of the connected app",
-      "order": 1
+      "order": 2
     },
     "clientSecret": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Client Secret",
       "description": "Consumer Secret of the connected app",
-      "order": 2
+      "order": 3
+    },
+    "instanceUrl": {
+      "type": "string",
+      "title": "Salesforce URL",
+      "description": "Salesforce URL that is used to retrieve OAuth token",
+      "default": "https://login.salesforce.com",
+      "order": 1
     },
     "salesforceAccountUsernameAndPassword": {
       "$ref": "#/definitions/credential_username_password",
       "title": "Salesforce Account Username and Password",
       "description": "Name and password of the Salesforce user",
-      "order": 3
+      "order": 4
     },
     "securityToken": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Security Token",
       "description": "Security token of the Salesforce user",
-      "order": 4
+      "order": 5
     }
   },
   "required": [

--- a/plugins/salesforce/komand_salesforce/tasks/monitor_users/task.py
+++ b/plugins/salesforce/komand_salesforce/tasks/monitor_users/task.py
@@ -185,13 +185,15 @@ class MonitorUsers(insightconnect_plugin_runtime.Task):
 
                     self.logger.info(f"{len(users_login)} users login history added to output")
                     records.extend(self.add_data_type_field(users_login, "User Login"))
-
+                self.connection.api.unset_token()
                 return records, state, has_more_pages, 200, None
             except ApiException as error:
                 self.logger.info(f"An API Exception has been raised. Status code: {error.status_code}. Error: {error}")
+                self.connection.api.unset_token()
                 return [], state, False, error.status_code, error
         except Exception as error:
             self.logger.info(f"An Exception has been raised. Error: {error}")
+            self.connection.api.unset_token()
             return [], state, False, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
     def _is_valid_state(self, state: dict) -> Tuple[bool, str]:

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -145,9 +145,9 @@ types:
       required: false
       example: Chrome 114
 connection:
-  instanceUrl:
-    title: Salesforce URL
-    description: Salesforce URL that is used to retrieve OAuth token
+  loginURL:
+    title: Login URL
+    description: Salesforce login URL
     type: string
     required: false
     example: https://login.salesforce.com

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: salesforce
 title: Salesforce
 description: The Salesforce plugin allows you to search, update, and manage salesforce records
-version: 2.1.6
+version: 2.1.7
 connection_version: 2
 vendor: rapid7
 support: community
@@ -145,6 +145,13 @@ types:
       required: false
       example: Chrome 114
 connection:
+  instanceUrl:
+    title: Salesforce URL
+    description: Salesforce URL that is used to retrieve OAuth token
+    type: string
+    required: false
+    example: https://login.salesforce.com
+    default: https://login.salesforce.com
   clientId:
     title: Client ID
     description: Consumer Key of the connected app

--- a/plugins/salesforce/setup.py
+++ b/plugins/salesforce/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="salesforce-rapid7-plugin",
-      version="2.1.6",
+      version="2.1.7",
       description="The Salesforce plugin allows you to search, update, and manage salesforce records",
       author="rapid7",
       author_email="",

--- a/plugins/salesforce/unit_test/inputs/connection_invalid_client_id.json.inp
+++ b/plugins/salesforce/unit_test/inputs/connection_invalid_client_id.json.inp
@@ -1,0 +1,13 @@
+{
+  "clientId": "invalid-id-for-connection",
+  "clientSecret": {
+    "secretKey": "example-secret-key"
+  },
+  "salesforceAccountUsernameAndPassword": {
+    "username": "example-username",
+    "password": "example-password"
+  },
+  "securityToken": {
+    "secretKey": "example-secret-key"
+  }
+}

--- a/plugins/salesforce/unit_test/inputs/connection_server_error.json.inp
+++ b/plugins/salesforce/unit_test/inputs/connection_server_error.json.inp
@@ -1,0 +1,13 @@
+{
+  "clientId": "valid-id-bad-endpoint",
+  "clientSecret": {
+    "secretKey": "example-secret-key"
+  },
+  "salesforceAccountUsernameAndPassword": {
+    "username": "example-username",
+    "password": "example-password"
+  },
+  "securityToken": {
+    "secretKey": "example-secret-key"
+  }
+}

--- a/plugins/salesforce/unit_test/responses/invalid_client_id.json.resp
+++ b/plugins/salesforce/unit_test/responses/invalid_client_id.json.resp
@@ -1,0 +1,4 @@
+{
+    "error": "invalid_client_id",
+    "error_description": "client identifier invalid"
+}

--- a/plugins/salesforce/unit_test/responses/invalid_grant.json.resp
+++ b/plugins/salesforce/unit_test/responses/invalid_grant.json.resp
@@ -1,0 +1,4 @@
+{
+    "error": "invalid_grant",
+    "error_description": "authentication failure"
+}

--- a/plugins/salesforce/unit_test/test_connection.py
+++ b/plugins/salesforce/unit_test/test_connection.py
@@ -36,6 +36,7 @@ class TestConnection(TestCase):
             self.action.connection.api._username,
             self.action.connection.api._password,
             self.action.connection.api._security_token,
+            self.action.connection.api._oauth_url,
         )
         self.assertEqual(token, expected)
 
@@ -46,7 +47,13 @@ class TestConnection(TestCase):
                 Util.read_file_to_dict("inputs/connection_invalid.json.inp"),
                 PluginException.causes[PluginException.Preset.INVALID_CREDENTIALS],
                 PluginException.assistances[PluginException.Preset.INVALID_CREDENTIALS],
-            ]
+            ],
+            [
+                "salesforce_server_error",
+                Util.read_file_to_dict("inputs/connection_server_error.json.inp"),
+                PluginException.causes[PluginException.Preset.UNKNOWN],
+                PluginException.assistances[PluginException.Preset.UNKNOWN],
+            ],
         ]
     )
     def test_connection_raise_exception(
@@ -60,6 +67,7 @@ class TestConnection(TestCase):
                 self.action.connection.api._username,
                 self.action.connection.api._password,
                 self.action.connection.api._security_token,
+                self.action.connection.api._oauth_url,
             )
 
         self.assertEqual(error.exception.cause, cause)

--- a/plugins/salesforce/unit_test/test_connection.py
+++ b/plugins/salesforce/unit_test/test_connection.py
@@ -54,6 +54,12 @@ class TestConnection(TestCase):
                 PluginException.causes[PluginException.Preset.UNKNOWN],
                 PluginException.assistances[PluginException.Preset.UNKNOWN],
             ],
+            [
+                "invalid_client_id",
+                Util.read_file_to_dict("inputs/connection_invalid_client_id.json.inp"),
+                "Salesforce error: 'client identifier invalid'",
+                PluginException.assistances[PluginException.Preset.UNKNOWN],
+            ],
         ]
     )
     def test_connection_raise_exception(

--- a/plugins/salesforce/unit_test/test_monitor_users.py
+++ b/plugins/salesforce/unit_test/test_monitor_users.py
@@ -24,6 +24,7 @@ from util import Util
 )
 @patch("requests.request", side_effect=Util.mock_request)
 @patch("logging.Logger.info")
+@patch("komand_salesforce.util.api.SalesforceAPI.unset_token")
 class TestMonitorUsers(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
@@ -65,6 +66,7 @@ class TestMonitorUsers(TestCase):
     )
     def test_monitor_users(
         self,
+        mocked_unset: MagicMock,
         mocked_logger: MagicMock,
         _mock_request: MagicMock,
         _mock_get_time: MagicMock,
@@ -79,11 +81,16 @@ class TestMonitorUsers(TestCase):
         self.assertEqual(has_more_pages, expected.get("has_more_pages"))
         self.assertEqual(status_code, expected.get("status_code"))
 
+        if test_name != "bad_request":
+            mocked_unset.assert_called()  # corrupt state so a token is never retrieved from Salesforce
+
         if test_name == "without_state":
             self.assertTrue(mocked_logger.called)
             self.assertIn("lookback time of 24 hours", mocked_logger.call_args_list[0][0][0])
 
-    def test_monitor_events_uses_custom_config_for_backfill(self, mocked_logger, _mock_request, _mock_get_time):
+    def test_monitor_events_uses_custom_config_for_backfill(
+        self, mock_unset, mocked_logger, _mock_request, _mock_get_time
+    ):
         config = {
             "lookback": {"year": 2023, "month": 6, "day": 5, "hour": 3, "minute": 45, "second": 0},
             "cutoff": {"date": {"year": 2023, "month": 6, "day": 5}},
@@ -103,9 +110,11 @@ class TestMonitorUsers(TestCase):
         self.assertDictEqual(actual_state, expected_state)
 
         self.assertIn("custom lookback", mocked_logger.call_args_list[0][0][0])
+        mock_unset.assert_called()
 
         # on the second iteration we then carry on as normal that we query from last poll end time to now
         mocked_logger.reset_mock()
+        mock_unset.reset_mock()
         _logs, updated_state, _more_pages, status_code, error = self.action.run({}, expected_state, config)
         self.assertNotIn("custom lookback", mocked_logger.call_args_list[0][0][0])  # lookback no longer used
 
@@ -118,7 +127,11 @@ class TestMonitorUsers(TestCase):
         for state_key in ["next_user_login_collection_timestamp", "next_user_collection_timestamp"]:
             self.assertEqual(updated_state[state_key], expected_state[state_key])
 
-    def test_monitor_events_uses_custom_config_for_cutoff_override(self, mocked_logger, _mock_request, _mock_get_time):
+        mock_unset.assert_called()
+
+    def test_monitor_events_uses_custom_config_for_cutoff_override(
+        self, mock_unset, mocked_logger, _mock_request, _mock_get_time
+    ):
         config = {"cutoff": {"hours": 2}}
         customers_paused_state = {
             "last_user_login_collection_timestamp": "2023-06-21 16:21:15.340262+00:00",  # last time customer ran this
@@ -140,3 +153,5 @@ class TestMonitorUsers(TestCase):
         }
 
         self.assertDictEqual(expected_state, new_state)
+
+        mock_unset.assert_called()

--- a/plugins/salesforce/unit_test/util.py
+++ b/plugins/salesforce/unit_test/util.py
@@ -52,7 +52,9 @@ class Util:
                     if filename == "bytes":
                         self.content = b"test"
                     else:
-                        self.text = Util.read_file_to_string(f"responses/{filename}")
+                        file_content = Util.read_file_to_string(f"responses/{filename}")
+                        self.text = file_content
+                        self.content = f"{file_content}".encode()
 
             def json(self):
                 return json.loads(self.text)
@@ -64,7 +66,9 @@ class Util:
 
         if url == "https://login.salesforce.com/services/oauth2/token":
             if data.get("client_id") == "invalid-client-id":
-                return MockResponse(401)
+                return MockResponse(400, "invalid_grant.json.resp")  # returns 400 when failing to get a token.
+            if data.get("client_id") == "valid-id-bad-endpoint":
+                return MockResponse(503)
             return MockResponse(200, "get_token.json.resp")
         if url == "https://example.com/services/data/":
             return MockResponse(200, "get_version.json.resp")

--- a/plugins/salesforce/unit_test/util.py
+++ b/plugins/salesforce/unit_test/util.py
@@ -69,6 +69,8 @@ class Util:
                 return MockResponse(400, "invalid_grant.json.resp")  # returns 400 when failing to get a token.
             if data.get("client_id") == "valid-id-bad-endpoint":
                 return MockResponse(503)
+            if data.get("client_id") == "invalid-id-for-connection":
+                return MockResponse(400, "invalid_client_id.json.resp")
             return MockResponse(200, "get_token.json.resp")
         if url == "https://example.com/services/data/":
             return MockResponse(200, "get_version.json.resp")


### PR DESCRIPTION
Release of Salesforce 2.1.7

Changes in this version:
- Allow customer to specify their own Salesforce URL; implemented to let the user hit sandbox instances. 
- Force a reset on the token held within the connection object at the end of each task execution; this will bubble to the customer as soon as their password and security token has expired. 
- Update the retry logic so that on getting invalid_grant (typically expired password), we don't retry 10 times to avoid an account lockout. 
- New helper method `get_error` to try and surface as much information to the customer when an error is returned from Salesforce. 

Original PRs:
- #2396 
- #2402 

Jiras:
- [PLGN-771 Salesforce connection update](https://rapid7.atlassian.net/browse/PLGN-771)
- [PLGN-775 Salesforce token expiration](https://rapid7.atlassian.net/browse/PLGN-775)