### PR TITLE
Update reschdule task output

### DIFF
--- a/plugins/cuckoo/.CHECKSUM
+++ b/plugins/cuckoo/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "f44307814c9d61cc737585d0e530f102",
+	"spec": "e07c1d588d569f467ddb27760e5533be",
 	"manifest": "df4d2bb633ba7b13ec89178a62dc0abc",
 	"setup": "c45e2c823af289694f329d51a9fe1546",
 	"schemas": [
@@ -57,7 +57,7 @@
 		},
 		{
 			"identifier": "reschedule_task/schema.py",
-			"hash": "6377a718768100b96b2f1fef0c6774b0"
+			"hash": "4801e9a8a576bec41f6c0097bed04da2"
 		},
 		{
 			"identifier": "submit_files/schema.py",

--- a/plugins/cuckoo/help.md
+++ b/plugins/cuckoo/help.md
@@ -497,15 +497,15 @@ Example input:
 
 |Name|Type|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- |
-|success|boolean|False|Reschedule success flag|True|
+|status|string|False|Reschedule status value|OK|
 |task_id|integer|False|Task ID|12345678910|
   
 Example output:
 
 ```
 {
-  "success": true,
-  "task_id": 12345678910
+  "status": true,
+  "task_id": "OK"
 }
 ```
 
@@ -891,7 +891,7 @@ Example output:
 
 # Version History
 
-* 2.0.0 - Update to insightconnect-plugin-runtime | Update `Reschedule Task` output to include `success` | Update title of `Delete Task` output from `Error message` to `Error Message` | Add `options` to `Machine` type
+* 2.0.0 - Update to insightconnect-plugin-runtime | Update `Reschedule Task` output to include `status` | Update title of `Delete Task` output from `Error message` to `Error Message` | Add `options` to `Machine` type
 * 1.0.3 - Updated Requests version to 2.20.0
 * 1.0.2 - New spec and help.md format for the Extension Library
 * 1.0.1 - Bug fix for Submit Files where Submit ID was required

--- a/plugins/cuckoo/komand_cuckoo/actions/reschedule_task/action.py
+++ b/plugins/cuckoo/komand_cuckoo/actions/reschedule_task/action.py
@@ -19,4 +19,4 @@ class RescheduleTask(insightconnect_plugin_runtime.Action):
         else:
             endpoint = f"tasks/reschedule/{task_id}"
         response = self.connection.api.send(endpoint)
-        return {Output.TASK_ID: response.get("task_id"), Output.SUCCESS: response.get("success")}
+        return {Output.TASK_ID: response.get("task_id"), Output.STATUS: response.get("status", "")}

--- a/plugins/cuckoo/komand_cuckoo/actions/reschedule_task/schema.py
+++ b/plugins/cuckoo/komand_cuckoo/actions/reschedule_task/schema.py
@@ -13,7 +13,7 @@ class Input:
 
 
 class Output:
-    SUCCESS = "success"
+    STATUS = "status"
     TASK_ID = "task_id"
 
 
@@ -52,10 +52,10 @@ class RescheduleTaskOutput(insightconnect_plugin_runtime.Output):
   "type": "object",
   "title": "Variables",
   "properties": {
-    "success": {
-      "type": "boolean",
-      "title": "Success",
-      "description": "Reschedule success flag",
+    "status": {
+      "type": "string",
+      "title": "Status",
+      "description": "Reschedule status value",
       "order": 2
     },
     "task_id": {

--- a/plugins/cuckoo/plugin.spec.yaml
+++ b/plugins/cuckoo/plugin.spec.yaml
@@ -382,12 +382,12 @@ actions:
         description: Task ID
         required: false
         example: 12345678910
-      success:
-        title: Success
-        type: boolean
-        description: Reschedule success flag
+      status:
+        title: Status
+        type: string
+        description: Reschedule status value
         required: false
-        example: True
+        example: OK
   delete_task:
     title: Delete Task
     description: Removes the given task from the database and deletes the results

--- a/plugins/cuckoo/unit_test/expected/reschedule_task_success.json.exp
+++ b/plugins/cuckoo/unit_test/expected/reschedule_task_success.json.exp
@@ -1,4 +1,4 @@
 {
     "task_id": 1,
-    "success": true
+    "status": "OK"
 }

--- a/plugins/cuckoo/unit_test/responses/reschedule_task_success.json.resp
+++ b/plugins/cuckoo/unit_test/responses/reschedule_task_success.json.resp
@@ -1,4 +1,4 @@
 {
     "task_id": 1,
-    "success": true
+    "status": "OK"
 }


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Reschedule Task - Output: Success -> Status

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
