### PR TITLE
PLGN-793: add extra logging to track has_more_pages

### DIFF
--- a/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
+++ b/plugins/proofpoint_tap/komand_proofpoint_tap/tasks/monitor_events/task.py
@@ -118,7 +118,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
                 state[self.PREVIOUS_LOGS_HASHES] = (
                     [*previous_logs_hashes, *new_logs_hashes] if current_page_index > 0 else new_logs_hashes
                 )
-                self.logger.info(f"Retrieved {len(new_unique_logs)} events")
+                self.logger.info(f"Retrieved {len(new_unique_logs)} events. Returning has_more_pages={has_more_pages}")
                 return new_unique_logs, state, has_more_pages, 200, None
 
             except ApiException as error:
@@ -151,6 +151,7 @@ class MonitorEvents(insightconnect_plugin_runtime.Task):
         else:
             end_str, now_str = query_params.get("interval").split("/")[1], now.isoformat().replace("z", "")
             if now_str != end_str:  # we want to force more pages if the end query time is not 'now'
+                self.logger.info("Setting has more pages to True as interval params is not querying until now")
                 has_more_pages = True
 
         return state, has_more_pages


### PR DESCRIPTION
## Proposed Changes
Additional logging to track has_more_pages value. 

### Description

Describe the proposed changes:
  - Noticed during testing on staging that our integration seems to be getting called constantly and may not be correctly setting/returning `has_more_pages`. Adding additional logging to track when we're deciding this on the API response vs our query params, and the final return value. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
Tested locally and logs match as expected:

- Set to true as not querying until now:
```
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-04-01T10:10:47.783025+00:00/2024-04-01T11:10:47.783025+00:00'}
Retrieved 546 total parsed events in time interval
Setting has more pages to True as interval params is not querying until now
Original number of events: 546. Number of events after de-duplication: 546 
Retrieved 546 events. Returning has_more_pages=True
Plugin task finished execution...
```
- Set to false as we're queried until now:
```
Plugin task execution received the following date values. Max lookback=2024-04-01 10:12:46.713272+00:00, specific date=None
Subsequent run
End time for lookup reset from 2024-04-02T11:10:47.783025+00:00 to 2024-04-02T10:12:46.713272+00:00 to avoid going out of range
Parameters used to query endpoint: {'format': 'JSON', 'interval': '2024-04-02T10:10:47.783025+00:00/2024-04-02T10:12:46.713272+00:00'}
Retrieved 30 total parsed events in time interval
Original number of events: 30. Number of events after de-duplication: 30 
Retrieved 30 events. Returning has_more_pages=False
```

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] ~Unit tests written for any new or updated code~ <- adding new loggers, unit tests still passing and currently do check we return this value correctly within the state.

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
