### PR TITLE
Mimecast no new logs unit test

### DIFF
--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -25,7 +25,8 @@ class TestMonitorSiemLogs(TestCase):
         tests = [
             {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
             {"next_token": "force_json_error", "resp": [], "has_more_pages": True, "token": "force_json_error"},
-            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "token123"},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
+            {"next_token": "force_single_json_error", "resp": [], "has_more_pages": True, "token": "new_token"},
         ]
         for test in tests:
             with self.subTest(f"Success test with token: {test.get('next_token')}"):

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -25,8 +25,8 @@ class TestMonitorSiemLogs(TestCase):
         tests = [
             {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
             {"next_token": "force_json_error", "resp": [], "has_more_pages": True, "token": "force_json_error"},
-            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "new_token"},
-            {"next_token": "force_single_json_error", "resp": [], "has_more_pages": True, "token": "new_token"},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": token},
+            {"next_token": "force_single_json_error", "resp": [], "has_more_pages": True, "token": token},
         ]
         for test in tests:
             with self.subTest(f"Success test with token: {test.get('next_token')}"):

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -25,7 +25,7 @@ class TestMonitorSiemLogs(TestCase):
         tests = [
             {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
             {"next_token": "force_json_error", "resp": [], "has_more_pages": True, "token": "force_json_error"},
-            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "token123"},
         ]
         for test in tests:
             with self.subTest(f"Success test with token: {test.get('next_token')}"):

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -25,7 +25,7 @@ class TestMonitorSiemLogs(TestCase):
         tests = [
             {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
             {"next_token": "force_json_error", "resp": [], "has_more_pages": True, "token": "force_json_error"},
-            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "new_token"},
             {"next_token": "force_single_json_error", "resp": [], "has_more_pages": True, "token": "new_token"},
         ]
         for test in tests:

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -174,7 +174,9 @@ class Util:
             elif "force_single_json_error" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
                 headers = headers.copy()
-                resp = MockResponseZip(200, Util.get_mocked_zip_json_decode_error(), headers, json.dumps({"meta": {"status": 200}}))
+                resp = MockResponseZip(
+                    200, Util.get_mocked_zip_json_decode_error(), headers, json.dumps({"meta": {"status": 200}})
+                )
             elif "no_results" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
                 no_results = b'{"meta":{"isLastToken":true,"status":200},"data":[],"fail":[]}'

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -173,12 +173,12 @@ class Util:
                 resp = MockResponseZip(200, b'{ "type" : "MTA", "data" : ', headers, '{"meta": {"status": 200}}')
             elif "force_single_json_error" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
-                headers = {"mc-siem-token": "new_token", "Content-Disposition": "attachment"}
+                headers = headers.copy()
                 resp = MockResponseZip(200, Util.get_mocked_zip_json_decode_error(), headers, json.dumps({"meta": {"status": 200}}))
             elif "no_results" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
                 no_results = b'{"meta":{"isLastToken":true,"status":200},"data":[],"fail":[]}'
-                no_results_headers = {"mc-siem-token": "new_token", "Content-Disposition": "attachment"}
+                no_results_headers = headers.copy()
                 no_results_headers["isLastToken"] = "true"
                 resp = MockResponseZip(200, no_results, no_results_headers, '{"meta": {"status": 200}}')
             elif "path_traversal" in data:

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -178,7 +178,7 @@ class Util:
             elif "no_results" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
                 no_results = b'{"meta":{"isLastToken":true,"status":200},"data":[],"fail":[]}'
-                no_results_headers = {"mc-siem-token": "token123", "Content-Disposition": "attachment"}
+                no_results_headers = {"mc-siem-token": "new_token", "Content-Disposition": "attachment"}
                 no_results_headers["isLastToken"] = "true"
                 resp = MockResponseZip(200, no_results, no_results_headers, '{"meta": {"status": 200}}')
             elif "path_traversal" in data:

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -167,7 +167,7 @@ class Util:
             elif "no_results" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
                 no_results = b'{"meta":{"isLastToken":true,"status":200},"data":[],"fail":[]}'
-                no_results_headers = headers.copy()
+                no_results_headers = {"mc-siem-token": "token123", "Content-Disposition": "attachment"}
                 no_results_headers["isLastToken"] = "true"
                 resp = MockResponseZip(200, no_results, no_results_headers, '{"meta": {"status": 200}}')
             elif "path_traversal" in data:


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Add unit test single failing json response in monitor siem logs

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
