### PR TITLE
PLGN-824-increase the default cuttoff time to 7 days

### DIFF
--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -992,7 +992,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7
+* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | Task `monitor_siem_logs` increase the default cuttoff time to 7 days | bump SDK to 5.4.7
 * 5.3.9 - Task `monitor_siem_logs`: Add in better error messages if the wrong region is provided
 * 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned | Improve error handling.
 * 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -12,7 +12,7 @@ from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
-CUTOFF = (24 * 7)
+CUTOFF = 24 * 7
 
 
 class MonitorSiemLogs(insightconnect_plugin_runtime.Task):

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -12,7 +12,7 @@ from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
-CUTOFF = 24
+CUTOFF = (24 * 7)
 
 
 class MonitorSiemLogs(insightconnect_plugin_runtime.Task):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - to increase the default cuttoff time from 24hrs to 7 days 


testing locally we can see that the new cuttoff time is honoured on the first run 
```
rapid7/Mimecast:5.3.10. Step name: monitor_siem_logs
Task execution will be applying filter period of 168 hours...
First run...
Number of raw logs returned from Mimecast: 15
Number of returned logs after filtering performed: 14
Latest event time returned from Mimecast logs: 2024-04-15 03:54:48
The token will be set to 'eNo9js1Og0AYAN_lu0pil4WykHgA2iWKxtJWsIkXsn7o1v0xLKu2je9u9eB9ZjIncCj8iPIZMpjrMVrt-MWtrobVXbJu17l67aQOa3a9r7kT4itXlntLkbPSN8fDptfHPOz2Bo1YqGXR0JvdolFvlfVVW8fWkHsuny6ZtX77WXTlY9_WxC9NEl1BAHYYHE6QzQJwErWyL78bMYvTKGUBiBH7CbdSI2QkIZQkaRjO6Yz-49PhHf_0DxydtObMBdALYb05Z6F82BQkzQmD7x-Zmkmu' in the state.
Plugin task finished execution...
```

