### PR TITLE
Mimecast 5.3.10 release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e009e19b1f42da6e844c6dd43e108327",
-	"manifest": "ca96fba53d76c1dff39941519ace1ec1",
-	"setup": "e0d7b6da70f710e2eab78741ab2ee843",
+	"spec": "0b30110d63c0d25f69563de81da319f8",
+	"manifest": "72dce0569d68a65ed750cdeff3e4e521",
+	"setup": "5c3e8232e50c9015cd34a832ca9a90b0",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.7
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.9"
+Version = "5.3.10"
 Description = "Services for email security, archiving and continuity. Protect, manage and archive without compromise"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -992,6 +992,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
+* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7
 * 5.3.9 - Task `monitor_siem_logs`: Add in better error messages if the wrong region is provided
 * 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned | Improve error handling.
 * 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -992,7 +992,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7
+* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | Task `monitor_siem_logs` increase the default cuttoff time to 7 days | bump SDK to 5.4.7
 * 5.3.9 - Task `monitor_siem_logs`: Add in better error messages if the wrong region is provided
 * 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned | Improve error handling.
 * 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -992,7 +992,7 @@ Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api
 
 # Version History
 
-* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | Task `monitor_siem_logs` increase the default cuttoff time to 7 days | bump SDK to 5.4.7
+* 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7
 * 5.3.9 - Task `monitor_siem_logs`: Add in better error messages if the wrong region is provided
 * 5.3.8 - Task `monitor_siem_logs` Update to use SDK 5.4.4 | Add additional logger for traceability when no logs returned | Improve error handling.
 * 5.3.7 - Task `monitor_siem_logs` adding in sanitization for names of files to be read in | Include SDK 5.4 which adds new task custom_config parameter | Bump setuptools.

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -12,7 +12,7 @@ from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
-CUTOFF = 24 * 7
+CUTOFF = 24
 
 
 class MonitorSiemLogs(insightconnect_plugin_runtime.Task):

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -12,7 +12,7 @@ from ...util.constants import IS_LAST_TOKEN_FIELD
 from ...util.event import EventLogs
 from ...util.exceptions import ApiClientException
 
-CUTOFF = 24
+CUTOFF = 24 * 7
 
 
 class MonitorSiemLogs(insightconnect_plugin_runtime.Task):

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -46,6 +46,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             while time() < limit_time:
                 try:
                     output, headers, status_code = self.connection.client.get_siem_logs(header_next_token)
+                    header_next_token = headers.get(self.HEADER_NEXT_TOKEN, header_next_token)
                     if not output:
                         self.logger.info("No new logs returned from Mimecast")
                         break
@@ -55,12 +56,12 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                         f"Error: {error}, returning state={state}, has_more_pages={has_more_pages}"
                     )
                     return [], state, has_more_pages, error.status_code, error
-                header_next_token = headers.get(self.HEADER_NEXT_TOKEN)
                 output = self._filter_and_sort_recent_events(output, filter_time)
                 if output:
                     break
 
             if header_next_token:
+                self.logger.info(f"The token will be set to '{header_next_token}' in the state.")
                 state[self.NEXT_TOKEN] = header_next_token
                 # Mimecast API only returns isLastToken in the headers if no more pages, so if it is not present then
                 # we know that there are no more pages to be consumed.
@@ -108,7 +109,11 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             event_date_time = event.get(EventLogs.FILTER_DATETIME)
             latest_time = event_date_time if event_date_time > latest_time else latest_time
             event.pop(EventLogs.FILTER_DATETIME, None)
-        self.logger.info(f"Number of returned logs after filtering performed: {len(task_output)}")
+
+        if len(task_output) > 0:
+            self.logger.info(f"Number of returned logs after filtering performed: {len(task_output)}")
+        else:
+            self.logger.info("None of the raw logs returned from Mimecast where with in filter timerange")
         if task_output:
             self.logger.info(f"Latest event time returned from Mimecast logs: {latest_time}")
         return task_output

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: Services for email security, archiving and continuity. Protect, manage
   and archive without compromise
-version: 5.3.9
+version: 5.3.10
 connection_version: 5
 supported_versions: ["Mimecast API 2022-11-07"]
 vendor: rapid7
@@ -13,7 +13,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.4.4
+  version: 5.4.7
   user: nobody
 status: []
 resources:

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.9",
+      version="5.3.10",
       description="Services for email security, archiving and continuity. Protect, manage and archive without compromise",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -31,10 +31,9 @@ class TestMonitorSiemLogs(TestCase):
             with self.subTest(f"Success test with token: {test.get('next_token')}"):
                 test_state = {"next_token": test.get("next_token")}
                 response, new_state, has_more_pages, status_code, _ = self.task.run(params={}, state=test_state)
-
                 self.assertEqual(has_more_pages, test.get("has_more_pages"))
                 self.assertEqual(response, test.get("resp"))
-                self.assertEqual(new_state, {"next_token": test.get("token")})
+                self.assertEqual(new_state, {"next_token": token})
                 self.assertEqual(status_code, 200)
                 validate(response, MonitorSiemLogsOutput.schema)
 

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -25,7 +25,8 @@ class TestMonitorSiemLogs(TestCase):
         tests = [
             {"next_token": "happy_token", "resp": content, "has_more_pages": True, "token": token},
             {"next_token": "force_json_error", "resp": [], "has_more_pages": True, "token": "force_json_error"},
-            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": "no_results"},
+            {"next_token": "no_results", "resp": [], "has_more_pages": False, "token": token},
+            {"next_token": "force_single_json_error", "resp": [], "has_more_pages": True, "token": token},
         ]
         for test in tests:
             with self.subTest(f"Success test with token: {test.get('next_token')}"):

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -41,6 +41,14 @@ class Util:
             return json.loads(file.read())
 
     @staticmethod
+    def get_mocked_zip_json_decode_error(path_traversal=False):
+        zip_file = BytesIO()
+        with ZipFile(zip_file, "w") as myzip:
+            filename = get_filename("0", path_traversal)
+            myzip.writestr(filename, """{type": "MTA", "data": '}""")
+        return zip_file.getvalue()
+
+    @staticmethod
     def get_mocked_zip(path_traversal=False):
         file_contents = [
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_1]},
@@ -51,7 +59,6 @@ class Util:
             for i, content in enumerate(file_contents):
                 filename = get_filename(i, path_traversal)
                 myzip.writestr(filename, json.dumps(content))
-
         return zip_file.getvalue()
 
     @staticmethod
@@ -164,6 +171,12 @@ class Util:
                 resp = MockResponseZip(401, b"", {}, json.dumps(json_value))
             elif "force_json" in data:
                 resp = MockResponseZip(200, b'{ "type" : "MTA", "data" : ', headers, '{"meta": {"status": 200}}')
+            elif "force_single_json_error" in data:
+                # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
+                headers = headers.copy()
+                resp = MockResponseZip(
+                    200, Util.get_mocked_zip_json_decode_error(), headers, json.dumps({"meta": {"status": 200}})
+                )
             elif "no_results" in data:
                 # isLastToken returns `true` when testing against live API and no results returned from Mimecast.
                 no_results = b'{"meta":{"isLastToken":true,"status":200},"data":[],"fail":[]}'


### PR DESCRIPTION
## Proposed Changes

### Description

- https://github.com/rapid7/insightconnect-plugins/pull/2477
  - To always set the value of header_next_token as even when there is no chance the Mimecast should always return the value for itself if the item fetch is the last in the list
  - bump the sdk to the latest
  
- https://github.com/rapid7/insightconnect-plugins/pull/2478  
  - Add unit test single failing json response in monitor siem logs

- https://github.com/rapid7/insightconnect-plugins/pull/2480
  - to increase the default cuttoff time from 24hrs to 7 days

- https://github.com/rapid7/insightconnect-plugins/pull/2481
  - revert of 2480