### PR TITLE
[PLGN-261] Threat Command - 5.2.0

### DIFF
--- a/plugins/rapid7_intsights/.CHECKSUM
+++ b/plugins/rapid7_intsights/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "117df16f2ee9263a796e317ccbc43d56",
+	"spec": "63bb9e1c5603228258adaf80b9d60092",
 	"manifest": "c3bb4f3dedae0e4981e665aaca08cd3a",
 	"setup": "4eaf77e407dde5e40eea2fc57d79cab8",
 	"schemas": [
@@ -49,7 +49,7 @@
 		},
 		{
 			"identifier": "get_indicator_by_value/schema.py",
-			"hash": "2c3ea399d01e282905205c339d5cb0e0"
+			"hash": "2a8bded330a783ad9157a549b7ee7c0f"
 		},
 		{
 			"identifier": "get_iocs_by_filter/schema.py",

--- a/plugins/rapid7_intsights/.CHECKSUM
+++ b/plugins/rapid7_intsights/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "73a15b62a686f300fce22fe1cf417fec",
-	"manifest": "bfd87bb435b6b4d577f1915b1e1f09e5",
-	"setup": "558e11d56f2b313ba0235c755d92af90",
+	"spec": "117df16f2ee9263a796e317ccbc43d56",
+	"manifest": "c3bb4f3dedae0e4981e665aaca08cd3a",
+	"setup": "4eaf77e407dde5e40eea2fc57d79cab8",
 	"schemas": [
 		{
 			"identifier": "add_cve/schema.py",
@@ -49,7 +49,7 @@
 		},
 		{
 			"identifier": "get_indicator_by_value/schema.py",
-			"hash": "d6db7e7eeb18e54e0874c32102177bcf"
+			"hash": "2c3ea399d01e282905205c339d5cb0e0"
 		},
 		{
 			"identifier": "get_iocs_by_filter/schema.py",

--- a/plugins/rapid7_intsights/.CHECKSUM
+++ b/plugins/rapid7_intsights/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "db2fe76897541507fd96ca5ced1d8c09",
-	"manifest": "18252502c2c369668d3674e766479edd",
-	"setup": "e61acd8c138758ae83c485a9cf2a451f",
+	"spec": "73a15b62a686f300fce22fe1cf417fec",
+	"manifest": "bfd87bb435b6b4d577f1915b1e1f09e5",
+	"setup": "558e11d56f2b313ba0235c755d92af90",
 	"schemas": [
 		{
 			"identifier": "add_cve/schema.py",

--- a/plugins/rapid7_intsights/Dockerfile
+++ b/plugins/rapid7_intsights/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.7
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.8
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/rapid7_intsights/Dockerfile
+++ b/plugins/rapid7_intsights/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:latest
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.7
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/rapid7_intsights/bin/icon_rapid7_intsights
+++ b/plugins/rapid7_intsights/bin/icon_rapid7_intsights
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Threat Command"
 Vendor = "rapid7"
-Version = "5.1.2"
+Version = "5.2.0"
 Description = "Threat Command by Rapid7 is disrupting external threat intelligence with a combination of human and automated collection, intelligent analysis, and strategic threat hunting that turns the clear, deep, and dark webs into an intelligence resource that any company can deploy"
 
 

--- a/plugins/rapid7_intsights/bin/icon_rapid7_intsights
+++ b/plugins/rapid7_intsights/bin/icon_rapid7_intsights
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Threat Command"
 Vendor = "rapid7"
-Version = "5.1.1"
+Version = "5.1.2"
 Description = "Threat Command by Rapid7 is disrupting external threat intelligence with a combination of human and automated collection, intelligent analysis, and strategic threat hunting that turns the clear, deep, and dark webs into an intelligence resource that any company can deploy"
 
 

--- a/plugins/rapid7_intsights/help.md
+++ b/plugins/rapid7_intsights/help.md
@@ -32,14 +32,14 @@
 # Documentation
 
 ## Setup
-  
+
 The connection configuration accepts the following parameters:  
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |account_id|string|None|True|Account ID for Threat Command|None|9de5069c5afe602b2ea0a04b|
 |api_key|credential_secret_key|None|True|API key for Threat Command|None|cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab|
-  
+
 Example input:
 
 ```
@@ -55,7 +55,7 @@ Example input:
 
 
 #### Add CVEs
-  
+
 This action is used to add CVEs to account
 
 ##### Input
@@ -96,7 +96,7 @@ Example output:
 ```
 
 #### Add Manual Alert
-  
+
 This action is used to create a manual alert with the provided parameters
 
 ##### Input
@@ -153,7 +153,7 @@ Example output:
 ```
 
 #### Close Alert
-  
+
 This action is used to close the alert with the given ID
 
 ##### Input
@@ -193,7 +193,7 @@ Example output:
 ```
 
 #### Delete CVEs
-  
+
 This action is used to delete CVEs from account
 
 ##### Input
@@ -229,7 +229,7 @@ Example output:
 ```
 
 #### Enrich Indicator
-  
+
 This action is used to submit an indicator to Threat Command for investigation and return the results
 
 ##### Input
@@ -458,7 +458,7 @@ Example output:
 ```
 
 #### Get Alerts
-  
+
 This action is used to search alerts based on criteria
 
 ##### Input
@@ -532,7 +532,7 @@ Example output:
 ```
 
 #### Get Complete Alert by ID
-  
+
 This action is used to get an alert's complete details for a given alert ID
 
 ##### Input
@@ -602,7 +602,7 @@ Example output:
 ```
 
 #### Get CVE by ID
-  
+
 This action is used to get a list of CVE's with a list of IDs from an account
 
 ##### Input
@@ -678,7 +678,7 @@ Example output:
 ```
 
 #### Get CVE List
-  
+
 This action is used to get a partial list of all CVEs from an account
 
 ##### Input
@@ -779,7 +779,7 @@ Example output:
 ```
 
 #### Get CVEs for Cyber Term
-  
+
 This action is used to get the Common Vulnerabilities and Exposures that are related to a cyber term
 
 ##### Input
@@ -811,7 +811,7 @@ Example output:
 ```
 
 #### Get Cyber Terms by Filter
-  
+
 This action is used to get cyber terms for given filters
 
 ##### Input
@@ -878,7 +878,7 @@ Example output:
 ```
 
 #### Get Indicator by Value
-  
+
 This action is used to search indicators in Threat Command TIP
 
 ##### Input
@@ -962,7 +962,7 @@ Example output:
 ```
 
 #### Get IOCs by Filter
-  
+
 This action is used to get Indicators of Compromise by Filter
 
 ##### Input
@@ -1067,7 +1067,7 @@ Example output:
 ```
 
 #### Get IOCs for Cyber Term
-  
+
 This action is used to gets cyber term IOCs by cyber term ID
 
 ##### Input
@@ -1109,7 +1109,7 @@ Example output:
 ```
 
 #### Takedown Request
-  
+
 This action is used to request a takedown for a given alert in Threat Command
 
 ##### Input
@@ -1145,7 +1145,7 @@ Example output:
 
 
 #### New Alert
-  
+
 This trigger is used to triggers when a new alert that matches the given criteria is created in Threat Command
 
 ##### Input
@@ -1424,13 +1424,14 @@ Example output:
 
 
 ## Troubleshooting
-
-_This plugin does not contain any troubleshooting information._
+  
+*There is no troubleshooting for this plugin.*
 
 # Version History
 
+* 5.1.2 - Update exception presets in API and unit tests
 * 5.1.1 - Better handling of response from the threat connect API when using the `takedown_request` action | Bumped to use the newest version of the SDK | Updated old unit tests / added new unit tests
-* 5.1.0 - Add actions: `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
+* 5.1.0 - Add actions -> `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
 * 5.0.0 - Add action Get IOCs By Filter which returns a list of paginated IOC data based on input filters applied against IOC properties | Fix Bug relating to mismatched property names of output types geolocation, sources, and reported feeds for Get Indicator by Value action
 * 4.0.0 - Rename Plugin to Threat Command | Update descriptions to Threat Command | Update Get Indicator By Value to use API V3 | Remove Rescan Indicator and Get Indicator Scan Status | Update Get CVE List to request one page of results only
 * 3.2.0 - Fix is_closed bug in trigger | Add new input `source_date_from_enum` in trigger which allows user to specifiy Source Date From using ENUM rather than timestamp/string
@@ -1442,7 +1443,7 @@ _This plugin does not contain any troubleshooting information._
 
 # Links
 
-* [Threat Command](https://www.rapid7.com/products/threat-command)
+* [Threat Command](https://intsights.com/)
 
 ## References
 

--- a/plugins/rapid7_intsights/help.md
+++ b/plugins/rapid7_intsights/help.md
@@ -911,7 +911,7 @@ Example input:
 |severity|string|False|Severity|Low|
 |sources|[]source|False|Sources|[ { "confidenceLevel": 2, "name": "Cyber Threat Alliance" } ]|
 |status|string|False|Status|Active|
-|sub_type|string|False|SubType Value|MD5|
+|subtype|string|False|SubType Value|MD5|
 |system_tags|[]string|False|System tags|["MyTag_1"]|
 |tags|[]string|False|Tags|["MyTag_1"]|
 |type|string|False|Type|Hashes|
@@ -950,7 +950,7 @@ Example output:
     }
   ],
   "status": "Active",
-  "sub_type": "MD5",
+  "subtype": "MD5",
   "system_tags": [
     "MyTag_1"
   ],
@@ -1431,7 +1431,7 @@ Example output:
 
 # Version History
 
-* 5.2.0 - Update exception presets in API and unit tests | New `sub_type` output to `get_indicator_by_value` action
+* 5.2.0 - Update exception presets in API and unit tests | New `subtype` output to `get_indicator_by_value` action
 * 5.1.1 - Better handling of response from the threat connect API when using the `takedown_request` action | Bumped to use the newest version of the SDK | Updated old unit tests / added new unit tests
 * 5.1.0 - Add actions -> `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
 * 5.0.0 - Add action Get IOCs By Filter which returns a list of paginated IOC data based on input filters applied against IOC properties | Fix Bug relating to mismatched property names of output types geolocation, sources, and reported feeds for Get Indicator by Value action

--- a/plugins/rapid7_intsights/help.md
+++ b/plugins/rapid7_intsights/help.md
@@ -35,10 +35,10 @@
 
 The connection configuration accepts the following parameters:  
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|account_id|string|None|True|Account ID for Threat Command|None|9de5069c5afe602b2ea0a04b|
-|api_key|credential_secret_key|None|True|API key for Threat Command|None|cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|account_id|string|None|True|Account ID for Threat Command|None|9de5069c5afe602b2ea0a04b|None|None|
+|api_key|credential_secret_key|None|True|API key for Threat Command|None|cc805d5fab1fd71a4ab352a9c533e65fb2d5b885518f4e565e68847223b8e6b85cb48f3afad842726d99239c9e36505c64b0dc9a061d9e507d833277ada336ab|None|None|
 
 Example input:
 
@@ -60,9 +60,9 @@ This action is used to add CVEs to account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|cve_id|[]string|None|False|List of CVE IDs|None|["CVE-2020-0711"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|cve_id|[]string|None|False|List of CVE IDs|None|["CVE-2020-0711"]|None|None|
   
 Example input:
 
@@ -101,19 +101,19 @@ This action is used to create a manual alert with the provided parameters
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|description|string|None|True|Alert description|None|Suspicious addresses|
-|found_date|string|None|False|Alert found date|None|2020-01-01|
-|images|[]image|None|False|Alert images|None|[{"Type": "jpeg","Data": "UmFwaWQ3IEluc2lnaHRDb25uZWN0Cg=="}]|
-|severity|string|None|True|Alert severity|["High", "Medium", "Low"]|Medium|
-|source_date|string|None|False|Alert source date|None|2020-02-01|
-|source_network_type|string|None|True|Source network type|["ClearWeb", "DarkWeb"]|DarkWeb|
-|source_type|string|None|True|Source type|["Application Store", "Cyber Security Blog", "Hacking News", "Cyber Crime Forum", "Hacktivism Forum", "Social Media", "Facebook", "Twitter", "LinkedIn", "Google Plus", "VK", "Vimeo", "YouTube", "IRC Channel", "IOC Block List", "Credit Card Black Market", "Paste Site", "Data Leakage Website", "Leaked Database", "File Sharing Website", "Gray Hat Website", "Black Market", "WHOIS servers", "Company Website", "Wikileaks", "Pinterest", "Tumblr", "Instagram", "Telegram", "Webmail", "Malware Analysis", "Firehol", "VRA"]|Webmail|
-|source_url|string|None|True|Source URL|None|https://example.com|
-|sub_type|string|None|True|Alert sub type, needs to correlate with the selected "Type"|None|SuspiciousEmailAddress|
-|title|string|None|True|Alert title|None|New Alert|
-|type|string|None|True|Alert type|["AttackIndication", "DataLeakage", "Phishing", "BrandSecurity", "ExploitableData", "vip"]|Phishing|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|description|string|None|True|Alert description|None|Suspicious addresses|None|None|
+|found_date|string|None|False|Alert found date|None|2020-01-01|None|None|
+|images|[]image|None|False|Alert images|None|[{"Type": "jpeg","Data": "UmFwaWQ3IEluc2lnaHRDb25uZWN0Cg=="}]|None|None|
+|severity|string|None|True|Alert severity|["High", "Medium", "Low"]|Medium|None|None|
+|source_date|string|None|False|Alert source date|None|2020-02-01|None|None|
+|source_network_type|string|None|True|Source network type|["ClearWeb", "DarkWeb"]|DarkWeb|None|None|
+|source_type|string|None|True|Source type|["Application Store", "Cyber Security Blog", "Hacking News", "Cyber Crime Forum", "Hacktivism Forum", "Social Media", "Facebook", "Twitter", "LinkedIn", "Google Plus", "VK", "Vimeo", "YouTube", "IRC Channel", "IOC Block List", "Credit Card Black Market", "Paste Site", "Data Leakage Website", "Leaked Database", "File Sharing Website", "Gray Hat Website", "Black Market", "WHOIS servers", "Company Website", "Wikileaks", "Pinterest", "Tumblr", "Instagram", "Telegram", "Webmail", "Malware Analysis", "Firehol", "VRA"]|Webmail|None|None|
+|source_url|string|None|True|Source URL|None|https://example.com|None|None|
+|sub_type|string|None|True|Alert sub type, needs to correlate with the selected "Type"|None|SuspiciousEmailAddress|None|None|
+|title|string|None|True|Alert title|None|New Alert|None|None|
+|type|string|None|True|Alert type|["AttackIndication", "DataLeakage", "Phishing", "BrandSecurity", "ExploitableData", "vip"]|Phishing|None|None|
   
 Example input:
 
@@ -158,13 +158,13 @@ This action is used to close the alert with the given ID
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|alertId|string|None|True|Alert's unique ID|None|9de5069c5afe602b2ea0a04b|
-|freeText|string|None|False|Alert's comments|None|Example comment|
-|isHidden|boolean|False|True|Alert's hidden status. Delete alert from the account instance - only when reason is False Positive|None|False|
-|rate|integer|None|False|Alert's rate|None|5|
-|reason|string|None|True|Alert's closed reason|["Problem solved", "Informational only", "Problem we are already aware of", "Company owned domain", "Legitimate application/profile", "Not related to my company", "False positive", "Other"]|False Positive|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|alertId|string|None|True|Alert's unique ID|None|9de5069c5afe602b2ea0a04b|None|None|
+|freeText|string|None|False|Alert's comments|None|Example comment|None|None|
+|isHidden|boolean|False|True|Alert's hidden status. Delete alert from the account instance - only when reason is False Positive|None|False|None|None|
+|rate|integer|None|False|Alert's rate|None|5|None|None|
+|reason|string|None|True|Alert's closed reason|["Problem solved", "Informational only", "Problem we are already aware of", "Company owned domain", "Legitimate application/profile", "Not related to my company", "False positive", "Other"]|False Positive|None|None|
   
 Example input:
 
@@ -198,9 +198,9 @@ This action is used to delete CVEs from account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|cve_id|[]string|None|False|List of CVE IDs|None|["CVE-2020-0711"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|cve_id|[]string|None|False|List of CVE IDs|None|["CVE-2020-0711"]|None|None|
   
 Example input:
 
@@ -234,9 +234,9 @@ This action is used to submit an indicator to Threat Command for investigation a
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|indicator_value|string|None|True|Value of the indicator. Examples: IP address, URL, domain name, hash|None|example.com|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|indicator_value|string|None|True|Value of the indicator. Examples: IP address, URL, domain name, hash|None|example.com|None|None|
   
 Example input:
 
@@ -463,22 +463,22 @@ This action is used to search alerts based on criteria
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|alert_type|[]string|None|False|List of alert types. Allowed values: AttackIndication, DataLeakage, Phishing, BrandSecurity, ExploitableData, vip|None|["Phishing"]|
-|assigned|string|None|False|Show assigned/unassigned alerts|["Assigned", "Unassigned", ""]|Assigned|
-|found_date_from|string|None|False|Start date (when alert found event) to fetch from in Unix Millisecond Timestamp|None|0|
-|found_date_to|string|None|False|End date (when alert found event) to fetch to in Unix Millisecond Timestamp|None|1633047102456|
-|has_indicators|boolean|None|False|Show alerts with IOCs results|None|False|
-|is_closed|string|None|False|Status of the alert, either closed or open|["Closed", "Open", ""]|Closed|
-|is_flagged|string|None|False|Show flagged/unflagged alerts|["Flagged", "Unflagged", ""]|Flagged|
-|matched_asset_value|[]string|None|False|List of matched asset values. Examples: IP address, domain name, company name|None|["example.com"]|
-|network_type|[]string|None|False|List of network type. Allowed values: ClearWeb, DarkWeb|None|["DarkWeb"]|
-|remediation_status|[]string|None|False|List of remediation statuses. Allowed values: InProgress, Pending, CancellationInProgress, Cancelled, CompletedSuccessfully, Failed|None|["InProgress", "Pending"]|
-|severity|[]string|None|False|List of alerts severity. Allowed values: High, Medium, Low|None|["Low"]|
-|source_date_from|string|None|False|Start date (when the event occurred) to fetch from in Unix Millisecond Timestamp|None|1633047083142|
-|source_date_to|string|None|False|End date (when the event occurred) to fetch to in Unix Millisecond Timestamp|None|1633047102456|
-|source_type|[]string|None|False|List of alerts source type. Allowed values: Application Store, Cyber Security Blog, Hacking News, Cyber Crime Forum, Hacktivism Forum, Social Media, Facebook, Twitter, LinkedIn, Google Plus, VK, Vimeo, YouTube, IRC Channel, IOC Block List, Credit Card Black Market, Paste Site, Data Leakage Website, Leaked Database, File Sharing Website, Gray Hat Website, Black Market, WHOIS servers, Company Website, Wikileaks, Pinterest, Tumblr, Instagram, Telegram, Webmail, Malware Analysis, Firehol, VRA, Other|None|["Application Store"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|alert_type|[]string|None|False|List of alert types. Allowed values: AttackIndication, DataLeakage, Phishing, BrandSecurity, ExploitableData, vip|None|["Phishing"]|None|None|
+|assigned|string|None|False|Show assigned/unassigned alerts|["Assigned", "Unassigned", ""]|Assigned|None|None|
+|found_date_from|string|None|False|Start date (when alert found event) to fetch from in Unix Millisecond Timestamp|None|0|None|None|
+|found_date_to|string|None|False|End date (when alert found event) to fetch to in Unix Millisecond Timestamp|None|1633047102456|None|None|
+|has_indicators|boolean|None|False|Show alerts with IOCs results|None|False|None|None|
+|is_closed|string|None|False|Status of the alert, either closed or open|["Closed", "Open", ""]|Closed|None|None|
+|is_flagged|string|None|False|Show flagged/unflagged alerts|["Flagged", "Unflagged", ""]|Flagged|None|None|
+|matched_asset_value|[]string|None|False|List of matched asset values. Examples: IP address, domain name, company name|None|["example.com"]|None|None|
+|network_type|[]string|None|False|List of network type. Allowed values: ClearWeb, DarkWeb|None|["DarkWeb"]|None|None|
+|remediation_status|[]string|None|False|List of remediation statuses. Allowed values: InProgress, Pending, CancellationInProgress, Cancelled, CompletedSuccessfully, Failed|None|["InProgress", "Pending"]|None|None|
+|severity|[]string|None|False|List of alerts severity. Allowed values: High, Medium, Low|None|["Low"]|None|None|
+|source_date_from|string|None|False|Start date (when the event occurred) to fetch from in Unix Millisecond Timestamp|None|1633047083142|None|None|
+|source_date_to|string|None|False|End date (when the event occurred) to fetch to in Unix Millisecond Timestamp|None|1633047102456|None|None|
+|source_type|[]string|None|False|List of alerts source type. Allowed values: Application Store, Cyber Security Blog, Hacking News, Cyber Crime Forum, Hacktivism Forum, Social Media, Facebook, Twitter, LinkedIn, Google Plus, VK, Vimeo, YouTube, IRC Channel, IOC Block List, Credit Card Black Market, Paste Site, Data Leakage Website, Leaked Database, File Sharing Website, Gray Hat Website, Black Market, WHOIS servers, Company Website, Wikileaks, Pinterest, Tumblr, Instagram, Telegram, Webmail, Malware Analysis, Firehol, VRA, Other|None|["Application Store"]|None|None|
   
 Example input:
 
@@ -537,9 +537,9 @@ This action is used to get an alert's complete details for a given alert ID
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|alert_id|string|None|True|Alert's unique ID|None|44d88612fea8a8f36de82e12|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|alert_id|string|None|True|Alert's unique ID|None|44d88612fea8a8f36de82e12|None|None|
   
 Example input:
 
@@ -607,9 +607,9 @@ This action is used to get a list of CVE's with a list of IDs from an account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|cve_id|[]string|None|False|Specific CVE IDs|None|["CVE-2020-0711"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|cve_id|[]string|None|False|Specific CVE IDs|None|["CVE-2020-0711"]|None|None|
   
 Example input:
 
@@ -683,9 +683,9 @@ This action is used to get a partial list of all CVEs from an account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|offset|string|None|False|Offset value for pagination, if empty the first page of results will be returned|None|2000-00-00T00:00:00.000Z::614b8972da44a60005036b01|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|offset|string|None|False|Offset value for pagination, if empty the first page of results will be returned|None|2000-00-00T00:00:00.000Z::614b8972da44a60005036b01|None|None|
   
 Example input:
 
@@ -784,9 +784,9 @@ This action is used to get the Common Vulnerabilities and Exposures that are rel
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|cyberTermId|string|None|True|Cyber term unique ID|None|311g8204kf82mr1234ab987o|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|cyberTermId|string|None|True|Cyber term unique ID|None|311g8204kf82mr1234ab987o|None|None|
   
 Example input:
 
@@ -816,19 +816,19 @@ This action is used to get cyber terms for given filters
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|lastUpdateFrom|date|None|False|Filter by last update date is greater than the given value (in ISO 8601 format)|None|2022-09-29 13:45:55.627000+00:00|
-|lastUpdateTo|date|None|False|Filter by last update date is less than the given value (in ISO 8601 format)|None|2022-09-30 13:45:55.627000+00:00|
-|limit|integer|None|False|Limit the results amount per chunk. Default value: 200|None|100|
-|offset|string|None|False|Request the next page of cyber terms|None|2022-09-29T13:45:55.627Z::9de5069c5afe602b2ea0a04b66beb2c0|
-|origin|[]string|None|False|Filter by one or more nationalities|None|["Korea, Republic of"]|
-|search|string|None|False|Filter by free text, which can be the cyber term name or ID|None|9de5069c5afe602b2ea0a04b|
-|severity|[]string|None|False|Filter by one or more cyber term severities. Allowed values: High, Medium, Low|None|["Medium", "High"]|
-|targetCountry|[]string|None|False|Filter by one or more targeted countries|None|["United Status"]|
-|targetSector|[]string|None|False|Filter by one or more targeted sectors|None|["Electronics"]|
-|ttp|[]string|None|False|Filter by one or more TTPs|None|["Code Execution"]|
-|type|[]string|None|False|Filter by one or more cyber term types. Allowed values: ThreatActor, Malware, Campaign|None|["ThreatActor"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|lastUpdateFrom|date|None|False|Filter by last update date is greater than the given value (in ISO 8601 format)|None|2022-09-29 13:45:55.627000+00:00|None|None|
+|lastUpdateTo|date|None|False|Filter by last update date is less than the given value (in ISO 8601 format)|None|2022-09-30 13:45:55.627000+00:00|None|None|
+|limit|integer|None|False|Limit the results amount per chunk. Default value: 200|None|100|None|None|
+|offset|string|None|False|Request the next page of cyber terms|None|2022-09-29T13:45:55.627Z::9de5069c5afe602b2ea0a04b66beb2c0|None|None|
+|origin|[]string|None|False|Filter by one or more nationalities|None|["Korea, Republic of"]|None|None|
+|search|string|None|False|Filter by free text, which can be the cyber term name or ID|None|9de5069c5afe602b2ea0a04b|None|None|
+|severity|[]string|None|False|Filter by one or more cyber term severities. Allowed values: High, Medium, Low|None|["Medium", "High"]|None|None|
+|targetCountry|[]string|None|False|Filter by one or more targeted countries|None|["United Status"]|None|None|
+|targetSector|[]string|None|False|Filter by one or more targeted sectors|None|["Electronics"]|None|None|
+|ttp|[]string|None|False|Filter by one or more TTPs|None|["Code Execution"]|None|None|
+|type|[]string|None|False|Filter by one or more cyber term types. Allowed values: ThreatActor, Malware, Campaign|None|["ThreatActor"]|None|None|
   
 Example input:
 
@@ -883,9 +883,9 @@ This action is used to search indicators in Threat Command TIP
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|indicator_value|string|None|True|Value of the indicator. Examples: IP address, URL, domain name, hash|None|6c62e74dd5d99fc2d610bd84114990a2|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|indicator_value|string|None|True|Value of the indicator. Examples: IP address, URL, domain name, hash|None|6c62e74dd5d99fc2d610bd84114990a2|None|None|
   
 Example input:
 
@@ -969,22 +969,22 @@ This action is used to get Indicators of Compromise by Filter
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|enterprise_tactics|[]string|None|False|Filter by MITRE ATT&CK Enterprise tactic. Allowed values 'Reconnaissance', 'Resource Development', 'Initial Access', 'Execution', 'Persistence', 'Privilege Escalation', 'Defense Evasion', 'Credential Access', 'Discovery', 'Lateral Movement', 'Collection', 'Command and Control', 'Exfiltration', 'Impact'|None|["Reconnaissance"]|
-|first_seen_from|date|None|False|Filter by first seen date (IOC first-seen date is greater than)|None|2000-12-31T00:00:00Z|
-|first_seen_to|date|None|False|Filter by first seen date (IOC first-seen date is less than)|None|2000-12-31T00:00:00Z|
-|kill_chain_phases|[]string|None|False|Filter by phase of Lockheed-Martin intrusion kill chain (Allowed values: Reconnaissance, Weaponization, Delivery, Exploitation, Installation, Command and Control, Actions on Objective)|None|["Command and Control"]|
-|last_seen_from|date|None|False|Filter by last seen date (IOC last-seen date is greater than)|None|2000-12-31T00:00:00Z|
-|last_seen_to|date|None|False|Filter by last seen date (IOC last-seen date is less than)|None|2000-12-31T00:00:00Z|
-|last_updated_from|date|None|True|Filter by last update date (IOC update date is greater than)|None|2000-12-31T00:00:00Z|
-|last_updated_to|date|None|False|Filter by last update date (IOC update date is less than)|None|2000-12-31T00:00:00Z|
-|limit|integer|1000|False|Limit the results amount per page (1-1000)|None|1000|
-|offset|string|None|False|Getting the next page of IOCs from offset|None|2020-01-01T20:01:27.344Z|
-|severity|[]string|None|False|Filter by IOC severity (Allowed values: High, Medium, Low)|None|["High"]|
-|source_ids|[]string|None|False|Filter by source IDs|None|["123450000012345000001233"]|
-|status|string|None|False|Filter by IOC status|["", "Active", "Retired"]|Active|
-|type|[]string|None|False|Filter by IOC type (Allowed values: IpAddresses, Urls, Domains, Hashes, Emails)|None|["IpAddresses"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|enterprise_tactics|[]string|None|False|Filter by MITRE ATT&CK Enterprise tactic. Allowed values 'Reconnaissance', 'Resource Development', 'Initial Access', 'Execution', 'Persistence', 'Privilege Escalation', 'Defense Evasion', 'Credential Access', 'Discovery', 'Lateral Movement', 'Collection', 'Command and Control', 'Exfiltration', 'Impact'|None|["Reconnaissance"]|None|None|
+|first_seen_from|date|None|False|Filter by first seen date (IOC first-seen date is greater than)|None|2000-12-31T00:00:00Z|None|None|
+|first_seen_to|date|None|False|Filter by first seen date (IOC first-seen date is less than)|None|2000-12-31T00:00:00Z|None|None|
+|kill_chain_phases|[]string|None|False|Filter by phase of Lockheed-Martin intrusion kill chain (Allowed values: Reconnaissance, Weaponization, Delivery, Exploitation, Installation, Command and Control, Actions on Objective)|None|["Command and Control"]|None|None|
+|last_seen_from|date|None|False|Filter by last seen date (IOC last-seen date is greater than)|None|2000-12-31T00:00:00Z|None|None|
+|last_seen_to|date|None|False|Filter by last seen date (IOC last-seen date is less than)|None|2000-12-31T00:00:00Z|None|None|
+|last_updated_from|date|None|True|Filter by last update date (IOC update date is greater than)|None|2000-12-31T00:00:00Z|None|None|
+|last_updated_to|date|None|False|Filter by last update date (IOC update date is less than)|None|2000-12-31T00:00:00Z|None|None|
+|limit|integer|1000|False|Limit the results amount per page (1-1000)|None|1000|None|None|
+|offset|string|None|False|Getting the next page of IOCs from offset|None|2020-01-01T20:01:27.344Z|None|None|
+|severity|[]string|None|False|Filter by IOC severity (Allowed values: High, Medium, Low)|None|["High"]|None|None|
+|source_ids|[]string|None|False|Filter by source IDs|None|["123450000012345000001233"]|None|None|
+|status|string|None|False|Filter by IOC status|["", "Active", "Retired"]|Active|None|None|
+|type|[]string|None|False|Filter by IOC type (Allowed values: IpAddresses, Urls, Domains, Hashes, Emails)|None|["IpAddresses"]|None|None|
   
 Example input:
 
@@ -1074,12 +1074,12 @@ This action is used to gets cyber term IOCs by cyber term ID
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|cyberTermId|string|None|True|Cyber term unique ID|None|593e74cfc022ac015814f8d9|
-|iocType|[]string|None|False|IOC types to include. Allowed values "IpAddresses", "Urls", "Domains", "Hashes", "Emails"|None|["IpAddresses"]|
-|limit|integer|None|False|Desired number of results. Default value 100. Size range 1-1000|None|100|
-|offset|string|None|False|Request the next page of IOCs|None|2020-08-13T12:17:08.755Z|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|cyberTermId|string|None|True|Cyber term unique ID|None|593e74cfc022ac015814f8d9|None|None|
+|iocType|[]string|None|False|IOC types to include. Allowed values "IpAddresses", "Urls", "Domains", "Hashes", "Emails"|None|["IpAddresses"]|None|None|
+|limit|integer|None|False|Desired number of results. Default value 100. Size range 1-1000|None|100|None|None|
+|offset|string|None|False|Request the next page of IOCs|None|2020-08-13T12:17:08.755Z|None|None|
   
 Example input:
 
@@ -1116,10 +1116,10 @@ This action is used to request a takedown for a given alert in Threat Command
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|alert_id|string|None|True|Alert's unique ID|None|44d88612fea8a8f36de82e12|
-|target|string|Domain|True|Target|["Website", "Domain"]|Domain|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|alert_id|string|None|True|Alert's unique ID|None|44d88612fea8a8f36de82e12|None|None|
+|target|string|Domain|True|Target|["Website", "Domain"]|Domain|None|None|
   
 Example input:
 
@@ -1152,24 +1152,24 @@ This trigger is used to triggers when a new alert that matches the given criteri
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|alert_type|[]string|None|False|List of alert types. Allowed values: AttackIndication, DataLeakage, Phishing, BrandSecurity, ExploitableData, vip|None|["Phishing"]|
-|assigned|string|None|False|Show assigned/unassigned alerts|["Assigned", "Unassigned", ""]|Assigned|
-|found_date_from|string|None|False|Start date (when alert found event) to fetch from in Unix Millisecond Timestamp|None|0|
-|found_date_to|string|None|False|End date (when alert found event) to fetch to in Unix Millisecond Timestamp|None|1633047102456|
-|frequency|integer|60|False|Poll frequency in seconds|None|60|
-|has_indicators|boolean|None|False|Shows alerts with IOC results|None|False|
-|is_closed|string|None|False|Status of the alert, either closed or open|["Closed", "Open", ""]|Closed|
-|is_flagged|string|None|False|Show flagged/unflagged alerts|["Flagged", "Unflagged", ""]|Flagged|
-|matched_asset_value|[]string|None|False|List of matched asset values. Examples: IP address, domain name, company name|None|["example.com"]|
-|network_type|[]string|None|False|List of network types. Allowed values: ClearWeb, DarkWeb|None|["DarkWeb"]|
-|remediation_status|[]string|None|False|List of remediation statuses. Allowed values: InProgress, Pending, CancellationInProgress, Cancelled, CompletedSuccessfully, Failed|None|["InProgress", "Pending"]|
-|severity|[]string|None|False|List of alerts severity. Allowed values: High, Medium, Low|None|["Low"]|
-|source_date_from|string|None|False|Start date (when the event occured) to fetch from in Unix Millisecond Timestamp|None|1633047083142|
-|source_date_from_enum|string|None|False|Start date to fetch from with options, such as choose Hour to pull alerts in the last hour|["Hour", "Day", "Week", ""]|Hour|
-|source_date_to|string|None|False|End date (when the event occured) to fetch to in Unix Millisecond Timestamp|None|1633047102456|
-|source_type|[]string|None|False|List of alert's source type. Allowed values: Application Store, Cyber Security Blog, Hacking News, Cyber Crime Forum, Hacktivism Forum, Social Media, Facebook, Twitter, LinkedIn, Google Plus, VK, Vimeo, YouTube, IRC Channel, IOC Block List, Credit Card Black Market, Paste Site, Data Leakage Website, Leaked Database, File Sharing Website, Gray Hat Website, Black Market, WHOIS servers, Company Website, Wikileaks, Pinterest, Tumblr, Instagram, Telegram, Webmail, Malware Analysis, Firehol, VRA, Other|None|["Application Store"]|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|alert_type|[]string|None|False|List of alert types. Allowed values: AttackIndication, DataLeakage, Phishing, BrandSecurity, ExploitableData, vip|None|["Phishing"]|None|None|
+|assigned|string|None|False|Show assigned/unassigned alerts|["Assigned", "Unassigned", ""]|Assigned|None|None|
+|found_date_from|string|None|False|Start date (when alert found event) to fetch from in Unix Millisecond Timestamp|None|0|None|None|
+|found_date_to|string|None|False|End date (when alert found event) to fetch to in Unix Millisecond Timestamp|None|1633047102456|None|None|
+|frequency|integer|60|False|Poll frequency in seconds|None|60|None|None|
+|has_indicators|boolean|None|False|Shows alerts with IOC results|None|False|None|None|
+|is_closed|string|None|False|Status of the alert, either closed or open|["Closed", "Open", ""]|Closed|None|None|
+|is_flagged|string|None|False|Show flagged/unflagged alerts|["Flagged", "Unflagged", ""]|Flagged|None|None|
+|matched_asset_value|[]string|None|False|List of matched asset values. Examples: IP address, domain name, company name|None|["example.com"]|None|None|
+|network_type|[]string|None|False|List of network types. Allowed values: ClearWeb, DarkWeb|None|["DarkWeb"]|None|None|
+|remediation_status|[]string|None|False|List of remediation statuses. Allowed values: InProgress, Pending, CancellationInProgress, Cancelled, CompletedSuccessfully, Failed|None|["InProgress", "Pending"]|None|None|
+|severity|[]string|None|False|List of alerts severity. Allowed values: High, Medium, Low|None|["Low"]|None|None|
+|source_date_from|string|None|False|Start date (when the event occured) to fetch from in Unix Millisecond Timestamp|None|1633047083142|None|None|
+|source_date_from_enum|string|None|False|Start date to fetch from with options, such as choose Hour to pull alerts in the last hour|["Hour", "Day", "Week", ""]|Hour|None|None|
+|source_date_to|string|None|False|End date (when the event occured) to fetch to in Unix Millisecond Timestamp|None|1633047102456|None|None|
+|source_type|[]string|None|False|List of alert's source type. Allowed values: Application Store, Cyber Security Blog, Hacking News, Cyber Crime Forum, Hacktivism Forum, Social Media, Facebook, Twitter, LinkedIn, Google Plus, VK, Vimeo, YouTube, IRC Channel, IOC Block List, Credit Card Black Market, Paste Site, Data Leakage Website, Leaked Database, File Sharing Website, Gray Hat Website, Black Market, WHOIS servers, Company Website, Wikileaks, Pinterest, Tumblr, Instagram, Telegram, Webmail, Malware Analysis, Firehol, VRA, Other|None|["Application Store"]|None|None|
   
 Example input:
 

--- a/plugins/rapid7_intsights/help.md
+++ b/plugins/rapid7_intsights/help.md
@@ -885,13 +885,13 @@ This action is used to search indicators in Threat Command TIP
 
 |Name|Type|Default|Required|Description|Enum|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|indicator_value|string|None|True|Value of the indicator. Examples: IP address, URL, domain name, hash|None|example.com|
+|indicator_value|string|None|True|Value of the indicator. Examples: IP address, URL, domain name, hash|None|6c62e74dd5d99fc2d610bd84114990a2|
   
 Example input:
 
 ```
 {
-  "indicator_value": "example.com"
+  "indicator_value": "6c62e74dd5d99fc2d610bd84114990a2"
 }
 ```
 
@@ -911,10 +911,11 @@ Example input:
 |severity|string|False|Severity|Low|
 |sources|[]source|False|Sources|[ { "confidenceLevel": 2, "name": "Cyber Threat Alliance" } ]|
 |status|string|False|Status|Active|
+|sub_type|string|False|SubType Value|MD5|
 |system_tags|[]string|False|System tags|["MyTag_1"]|
 |tags|[]string|False|Tags|["MyTag_1"]|
-|type|string|False|Type|Domains|
-|value|string|False|Indicator value|example.com|
+|type|string|False|Type|Hashes|
+|value|string|False|Indicator value|6c62e74dd5d99fc2d610bd84114990a2|
 |whitelist|boolean|False|Whitelist|True|
   
 Example output:
@@ -949,14 +950,15 @@ Example output:
     }
   ],
   "status": "Active",
+  "sub_type": "MD5",
   "system_tags": [
     "MyTag_1"
   ],
   "tags": [
     "MyTag_1"
   ],
-  "type": "Domains",
-  "value": "example.com",
+  "type": "Hashes",
+  "value": "6c62e74dd5d99fc2d610bd84114990a2",
   "whitelist": true
 }
 ```
@@ -1429,7 +1431,7 @@ Example output:
 
 # Version History
 
-* 5.1.2 - Update exception presets in API and unit tests
+* 5.2.0 - Update exception presets in API and unit tests | New `sub_type` output to `get_indicator_by_value` action
 * 5.1.1 - Better handling of response from the threat connect API when using the `takedown_request` action | Bumped to use the newest version of the SDK | Updated old unit tests / added new unit tests
 * 5.1.0 - Add actions -> `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
 * 5.0.0 - Add action Get IOCs By Filter which returns a list of paginated IOC data based on input filters applied against IOC properties | Fix Bug relating to mismatched property names of output types geolocation, sources, and reported feeds for Get Indicator by Value action

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/action.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/action.py
@@ -20,7 +20,7 @@ class GetIndicatorByValue(insightconnect_plugin_runtime.Action):
             {
                 Output.VALUE: response.get("value"),
                 Output.TYPE: response.get("type"),
-                Output.SUB_TYPE: response.get("subType"),
+                Output.SUBTYPE: response.get("subType"),
                 Output.SEVERITY: response.get("severity"),
                 Output.SCORE: response.get("score", 0),
                 Output.WHITELIST: response.get("whitelisted", False),

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/action.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/action.py
@@ -20,6 +20,7 @@ class GetIndicatorByValue(insightconnect_plugin_runtime.Action):
             {
                 Output.VALUE: response.get("value"),
                 Output.TYPE: response.get("type"),
+                Output.SUB_TYPE: response.get("subType"),
                 Output.SEVERITY: response.get("severity"),
                 Output.SCORE: response.get("score", 0),
                 Output.WHITELIST: response.get("whitelisted", False),

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/schema.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/schema.py
@@ -24,7 +24,7 @@ class Output:
     SEVERITY = "severity"
     SOURCES = "sources"
     STATUS = "status"
-    SUB_TYPE = "sub_type"
+    SUBTYPE = "subtype"
     SYSTEM_TAGS = "system_tags"
     TAGS = "tags"
     TYPE = "type"
@@ -149,9 +149,9 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "description": "Status",
       "order": 17
     },
-    "sub_type": {
+    "subtype": {
       "type": "string",
-      "title": "Sub_Type",
+      "title": "Subtype",
       "description": "SubType Value",
       "order": 3
     },

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/schema.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/actions/get_indicator_by_value/schema.py
@@ -24,6 +24,7 @@ class Output:
     SEVERITY = "severity"
     SOURCES = "sources"
     STATUS = "status"
+    SUB_TYPE = "sub_type"
     SYSTEM_TAGS = "system_tags"
     TAGS = "tags"
     TYPE = "type"
@@ -65,25 +66,25 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "type": "string",
       "title": "First Seen",
       "description": "First seen",
-      "order": 6
+      "order": 7
     },
     "geo_location": {
       "type": "string",
       "title": "Geographic Location",
       "description": "Geographic location",
-      "order": 9
+      "order": 10
     },
     "last_seen": {
       "type": "string",
       "title": "Last Seen",
       "description": "Last seen",
-      "order": 7
+      "order": 8
     },
     "last_update": {
       "type": "string",
       "title": "Last Update",
       "description": "Last update",
-      "order": 8
+      "order": 9
     },
     "related_campaigns": {
       "type": "array",
@@ -92,7 +93,7 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "type": "string"
       },
-      "order": 14
+      "order": 15
     },
     "related_malware": {
       "type": "array",
@@ -101,7 +102,7 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "type": "string"
       },
-      "order": 13
+      "order": 14
     },
     "related_threat_actors": {
       "type": "array",
@@ -110,7 +111,7 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "type": "string"
       },
-      "order": 15
+      "order": 16
     },
     "reported_feeds": {
       "type": "array",
@@ -119,19 +120,19 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "$ref": "#/definitions/reported_feed"
       },
-      "order": 17
+      "order": 18
     },
     "score": {
       "type": "number",
       "title": "Score",
       "description": "Score",
-      "order": 4
+      "order": 5
     },
     "severity": {
       "type": "string",
       "title": "Severity",
       "description": "Severity",
-      "order": 3
+      "order": 4
     },
     "sources": {
       "type": "array",
@@ -140,13 +141,19 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "$ref": "#/definitions/source"
       },
-      "order": 10
+      "order": 11
     },
     "status": {
       "type": "string",
       "title": "Status",
       "description": "Status",
-      "order": 16
+      "order": 17
+    },
+    "sub_type": {
+      "type": "string",
+      "title": "Sub_Type",
+      "description": "SubType Value",
+      "order": 3
     },
     "system_tags": {
       "type": "array",
@@ -155,7 +162,7 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "type": "string"
       },
-      "order": 12
+      "order": 13
     },
     "tags": {
       "type": "array",
@@ -164,7 +171,7 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "items": {
         "type": "string"
       },
-      "order": 11
+      "order": 12
     },
     "type": {
       "type": "string",
@@ -182,7 +189,7 @@ class GetIndicatorByValueOutput(insightconnect_plugin_runtime.Output):
       "type": "boolean",
       "title": "Whitelist",
       "description": "Whitelist",
-      "order": 5
+      "order": 6
     }
   },
   "definitions": {

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/triggers/new_alert/trigger.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/triggers/new_alert/trigger.py
@@ -18,7 +18,6 @@ class NewAlert(insightconnect_plugin_runtime.Trigger):
         )
 
     def run(self, params={}):
-
         SOURCE_FROM_ENUM = params.get(Input.SOURCE_DATE_FROM_ENUM, "")
         SOURCE_FROM_STRING = params.get(Input.SOURCE_DATE_FROM, "")
         source_date = ""

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/util/api.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/util/api.py
@@ -6,7 +6,6 @@ import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from requests.auth import HTTPBasicAuth
-from icon_rapid7_intsights.util.constants import Assistance, Cause
 
 
 @dataclass
@@ -300,7 +299,7 @@ class IntSightsAPI:
 
     @staticmethod
     def check_status_codes(response: requests.Response):
-        if response.status_code == 400:
+        if response.status_code in [400, 422]:
             if "StatusNotChanged" in response.text:
                 raise PluginException(
                     cause="The status for the alert was not changed by this request",
@@ -318,12 +317,6 @@ class IntSightsAPI:
             raise PluginException(preset=PluginException.Preset.API_KEY, data=response.text)
         if response.status_code == 404:
             raise PluginException(preset=PluginException.Preset.NOT_FOUND, data=response.text)
-        if response.status_code == 422:
-            raise PluginException(
-                cause=Cause.INVALID_DETAILS,
-                assistance=Assistance.VERIFY_INPUT,
-                data=response.text,
-            )
         if 400 <= response.status_code < 500:
             raise PluginException(
                 preset=PluginException.Preset.UNKNOWN,

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/util/constants.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/util/constants.py
@@ -1,12 +1,3 @@
-class Cause:
-    INVALID_DETAILS = "Invalid details provided."
-
-
-class Assistance:
-    VERIFY_INPUT = (
-        "Verify your input is correct and not malformed and try again. If the issue persists, please contact support."
-    )
-
 
 accepted_empty_fields = ["cyberTerms", "cyberTermCves", "iocs"]
 closing_ticket_reasons = {

--- a/plugins/rapid7_intsights/icon_rapid7_intsights/util/constants.py
+++ b/plugins/rapid7_intsights/icon_rapid7_intsights/util/constants.py
@@ -1,4 +1,3 @@
-
 accepted_empty_fields = ["cyberTerms", "cyberTermCves", "iocs"]
 closing_ticket_reasons = {
     "Problem solved": "ProblemSolved",

--- a/plugins/rapid7_intsights/plugin.spec.yaml
+++ b/plugins/rapid7_intsights/plugin.spec.yaml
@@ -11,7 +11,7 @@ vendor: rapid7
 support: rapid7
 status: []
 version_history:
-    - 5.2.0 - Update exception presets in API and unit tests | New `sub_type` output to `get_indicator_by_value` action
+    - 5.2.0 - Update exception presets in API and unit tests | New `subtype` output to `get_indicator_by_value` action
     - 5.1.1 - Better handling of response from the threat connect API when using the `takedown_request` action | Bumped to use the newest version of the SDK | Updated old unit tests / added new unit tests
     - 5.1.0 - Add actions -> `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
     - 5.0.0 - Add action Get IOCs By Filter which returns a list of paginated IOC data based on input filters applied against IOC properties | Fix Bug relating to mismatched property names of output types geolocation, sources, and reported feeds for Get Indicator by Value action
@@ -655,8 +655,8 @@ actions:
         type: string
         required: false
         example: Hashes
-      sub_type:
-        title: Sub_Type
+      subtype:
+        title: Subtype
         description: SubType Value
         type: string
         required: false

--- a/plugins/rapid7_intsights/plugin.spec.yaml
+++ b/plugins/rapid7_intsights/plugin.spec.yaml
@@ -4,14 +4,14 @@ products: [insightconnect]
 name: rapid7_intsights
 title: Threat Command
 description: Threat Command by Rapid7 is disrupting external threat intelligence with a combination of human and automated collection, intelligent analysis, and strategic threat hunting that turns the clear, deep, and dark webs into an intelligence resource that any company can deploy
-version: 5.1.2
+version: 5.2.0
 connection_version: 5
 supported_versions: ["2.4.0"]
 vendor: rapid7
 support: rapid7
 status: []
 version_history:
-    - 5.1.2 - Update exception presets in API and unit tests
+    - 5.2.0 - Update exception presets in API and unit tests | New `sub_type` output to `get_indicator_by_value` action
     - 5.1.1 - Better handling of response from the threat connect API when using the `takedown_request` action | Bumped to use the newest version of the SDK | Updated old unit tests / added new unit tests
     - 5.1.0 - Add actions -> `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
     - 5.0.0 - Add action Get IOCs By Filter which returns a list of paginated IOC data based on input filters applied against IOC properties | Fix Bug relating to mismatched property names of output types geolocation, sources, and reported feeds for Get Indicator by Value action
@@ -641,20 +641,26 @@ actions:
         description: "Value of the indicator. Examples: IP address, URL, domain name, hash"
         type: string
         required: true
-        example: example.com
+        example: 6c62e74dd5d99fc2d610bd84114990a2
     output:
       value:
         title: Indicator Value
         description: Indicator value
         type: string
         required: false
-        example: example.com
+        example: 6c62e74dd5d99fc2d610bd84114990a2
       type:
         title: Type
         description: Type
         type: string
         required: false
-        example: Domains
+        example: Hashes
+      sub_type:
+        title: Sub_Type
+        description: SubType Value
+        type: string
+        required: false
+        example: MD5
       severity:
         title: Severity
         description: Severity

--- a/plugins/rapid7_intsights/plugin.spec.yaml
+++ b/plugins/rapid7_intsights/plugin.spec.yaml
@@ -4,16 +4,32 @@ products: [insightconnect]
 name: rapid7_intsights
 title: Threat Command
 description: Threat Command by Rapid7 is disrupting external threat intelligence with a combination of human and automated collection, intelligent analysis, and strategic threat hunting that turns the clear, deep, and dark webs into an intelligence resource that any company can deploy
-version: 5.1.1
+version: 5.1.2
 connection_version: 5
 supported_versions: ["2.4.0"]
 vendor: rapid7
 support: rapid7
 status: []
+version_history:
+    - 5.1.2 - Update exception presets in API and unit tests
+    - 5.1.1 - Better handling of response from the threat connect API when using the `takedown_request` action | Bumped to use the newest version of the SDK | Updated old unit tests / added new unit tests
+    - 5.1.0 - Add actions -> `Get Cyber Terms by Filter`, `Get IOCs for Cyber Term`, `Get CVEs for Cyber Term`, `Close Alert`. Add new input for `Get IOCs By Filter` action
+    - 5.0.0 - Add action Get IOCs By Filter which returns a list of paginated IOC data based on input filters applied against IOC properties | Fix Bug relating to mismatched property names of output types geolocation, sources, and reported feeds for Get Indicator by Value action
+    - 4.0.0 - Rename Plugin to Threat Command | Update descriptions to Threat Command | Update Get Indicator By Value to use API V3 | Remove Rescan Indicator and Get Indicator Scan Status | Update Get CVE List to request one page of results only
+    - 3.2.0 - Fix is_closed bug in trigger | Add new input `source_date_from_enum` in trigger which allows user to specifiy Source Date From using ENUM rather than timestamp/string
+    - 3.1.0 - Add new actions Add CVEs, Delete CVEs and Get CVE List
+    - 3.0.1 - Fix issue where New Alert trigger sends empty list when there are no new alerts
+    - 3.0.0 - Add `assets` custom output type in Add Manual Alert action | Fix missing URL bug in DarkWeb Webmail alerts in Add Manual Alert action
+    - 2.0.0 - Add new trigger New Alert | Add new action Get CVE by ID
+    - 1.0.0 - Initial plugin
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/rapid7_intsights
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
   vendor_url: https://www.rapid7.com/products/threat-command
+key_features: ["Get Indicator by Value", "Enrich Indicator", "Get Alerts", "Get Complete Alert by ID", "Takedown Request", "Add Manual Alert", "Get CVE by ID", "Get CVE List", "Delete CVE", "Add CVE", "Get IOCs by Filter", "Get Cyber Terms by Filter", "Get IOCs for Cyber Term", "Get CVEs for Cyber Term", "Close Alert"]
+requirements: ["Requires an Account ID for Threat Command", "Requires API key for Threat Command"]
+references: ["[Threat Command](https://www.rapid7.com/products/threat-command)"]
+links: ["[Threat Command](https://intsights.com/)"]
 tags:
 - rapid7
 - darkweb

--- a/plugins/rapid7_intsights/setup.py
+++ b/plugins/rapid7_intsights/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_intsights-rapid7-plugin",
-      version="5.1.2",
+      version="5.2.0",
       description="Threat Command by Rapid7 is disrupting external threat intelligence with a combination of human and automated collection, intelligent analysis, and strategic threat hunting that turns the clear, deep, and dark webs into an intelligence resource that any company can deploy",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_intsights/setup.py
+++ b/plugins/rapid7_intsights/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_intsights-rapid7-plugin",
-      version="5.1.1",
+      version="5.1.2",
       description="Threat Command by Rapid7 is disrupting external threat intelligence with a combination of human and automated collection, intelligent analysis, and strategic threat hunting that turns the clear, deep, and dark webs into an intelligence resource that any company can deploy",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_intsights/unit_test/test_close_alert.py
+++ b/plugins/rapid7_intsights/unit_test/test_close_alert.py
@@ -54,14 +54,13 @@ class TestCloseAlert(TestCase):
             [
                 "invalid_id",
                 Util.read_file_to_dict("inputs/close_alert_bad.json.inp"),
-                "The server is unable to process the request.",
-                "Verify your plugin input is correct and not malformed and try again. If the issue persists, please contact support.",
+                PluginException(preset=PluginException.Preset.BAD_REQUEST),
             ]
         ]
     )
-    def test_close_alert_bad(self, mock_request, test_name, input_parameters, cause, assistance):
+    def test_close_alert_bad(self, mock_request, test_name, input_parameters, expected_error):
         validate(input_parameters, CloseAlertInput.schema)
         with self.assertRaises(PluginException) as error:
             self.action.run(input_parameters)
-        self.assertEqual(error.exception.cause, cause)
-        self.assertEqual(error.exception.assistance, assistance)
+        self.assertEqual(error.exception.cause, expected_error.cause)
+        self.assertEqual(error.exception.assistance, expected_error.assistance)

--- a/plugins/rapid7_intsights/unit_test/test_connection.py
+++ b/plugins/rapid7_intsights/unit_test/test_connection.py
@@ -8,7 +8,7 @@ from unittest.mock import patch
 from util import Util
 from icon_rapid7_intsights.actions.get_indicator_by_value.action import GetIndicatorByValue
 from icon_rapid7_intsights.connection.schema import Input, ConnectionSchema
-from insightconnect_plugin_runtime.exceptions import ConnectionTestException
+from insightconnect_plugin_runtime.exceptions import ConnectionTestException, PluginException
 from jsonschema import validate
 
 
@@ -39,5 +39,5 @@ class TestConnection(TestCase):
         with self.assertRaises(ConnectionTestException) as error:
             action.connection.test()
 
-        self.assertEqual("Invalid API key provided.", error.exception.cause)
-        self.assertEqual("Verify your API key configured in your connection is correct.", error.exception.assistance)
+        self.assertEqual(PluginException.causes.get("api_key"), error.exception.cause)
+        self.assertEqual(PluginException.assistances.get("api_key"), error.exception.assistance)

--- a/plugins/rapid7_intsights/unit_test/test_get_iocs_for_cyber_term.py
+++ b/plugins/rapid7_intsights/unit_test/test_get_iocs_for_cyber_term.py
@@ -13,7 +13,6 @@ from icon_rapid7_intsights.actions.get_iocs_for_cyber_term.schema import (
     GetIocsForCyberTermOutput,
 )
 from insightconnect_plugin_runtime.exceptions import PluginException
-from icon_rapid7_intsights.util.constants import Assistance, Cause
 from jsonschema import validate
 
 
@@ -53,22 +52,20 @@ class TestGetIocsForCyberTerm(TestCase):
             [
                 "invalid_param",
                 Util.read_file_to_dict("inputs/get_iocs_cyber_term_params_bad.json.inp"),
-                Cause.INVALID_DETAILS,
-                Assistance.VERIFY_INPUT,
+                PluginException(preset=PluginException.Preset.BAD_REQUEST),
             ],
             [
                 "cyber_term_not_found",
                 Util.read_file_to_dict("inputs/get_iocs_cyber_term_invalid_id.json.inp"),
-                "Invalid or unreachable endpoint provided.",
-                "Verify the URLs or endpoints in your configuration are correct.",
+                PluginException(preset=PluginException.Preset.NOT_FOUND),
             ],
         ]
     )
     def test_get_iocs_for_cyber_term_raise_exception(
-        self, mock_request, test_name, input_parameters, cause, assistance
+        self, mock_request, test_name, input_parameters, expected_error
     ):
         validate(input_parameters, GetIocsForCyberTermInput.schema)
         with self.assertRaises(PluginException) as error:
             self.action.run(input_parameters)
-        self.assertEqual(error.exception.cause, cause)
-        self.assertEqual(error.exception.assistance, assistance)
+        self.assertEqual(error.exception.cause, expected_error.cause)
+        self.assertEqual(error.exception.assistance, expected_error.assistance)

--- a/plugins/rapid7_intsights/unit_test/test_get_iocs_for_cyber_term.py
+++ b/plugins/rapid7_intsights/unit_test/test_get_iocs_for_cyber_term.py
@@ -61,9 +61,7 @@ class TestGetIocsForCyberTerm(TestCase):
             ],
         ]
     )
-    def test_get_iocs_for_cyber_term_raise_exception(
-        self, mock_request, test_name, input_parameters, expected_error
-    ):
+    def test_get_iocs_for_cyber_term_raise_exception(self, mock_request, test_name, input_parameters, expected_error):
         validate(input_parameters, GetIocsForCyberTermInput.schema)
         with self.assertRaises(PluginException) as error:
             self.action.run(input_parameters)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Exception presets may be hard coded into unit tests or code which may cause issues if the preset text in the SDK changes in any upgrade.
  - Updating unit tests to directly refer to the causes and assistance in the SDK instead of hard coding text.
  - Specify SDK version
  - Added new `subType` output field to action `get_indicator_by_value`

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

![image](https://github.com/rapid7/insightconnect-plugins/assets/135721892/ebb2a4c1-6a43-4d64-bd22-0a11505371e0)

New output field:
![image](https://github.com/rapid7/insightconnect-plugins/assets/135721892/f5206053-9b2b-4899-a168-c356d2d0ecac)

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
