### PR TITLE
[PLGN-823]- ServiceNow- Fix Incident Created Trigger

### DIFF
--- a/plugins/servicenow/.CHECKSUM
+++ b/plugins/servicenow/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "df27ad5510e10ae33482e15139c80a15",
-	"manifest": "82f844c95ef90916342ddc89143cff09",
-	"setup": "ef8a2606b780be57a6bd3af65a445aab",
+	"spec": "ac0aa71e3e04a2673c321327d707ec57",
+	"manifest": "86ac8e408183d15929439cbb8d00888d",
+	"setup": "0662bed8269ca9b4a233329c57d29ab5",
 	"schemas": [
 		{
 			"identifier": "create_change_request/schema.py",

--- a/plugins/servicenow/Dockerfile
+++ b/plugins/servicenow/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-slim-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.7
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/servicenow/bin/icon_servicenow
+++ b/plugins/servicenow/bin/icon_servicenow
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ServiceNow"
 Vendor = "rapid7"
-Version = "7.4.0"
+Version = "7.4.1"
 Description = "ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes"
 
 

--- a/plugins/servicenow/help.md
+++ b/plugins/servicenow/help.md
@@ -1681,6 +1681,7 @@ Example output:
 
 # Version History
 
+* 7.4.1 - `Incident Created`: Resolved issue related to trigger not working. Updated SDK
 * 7.4.0 - Add ability to use OAuth for API authentication (requires OAuth Client ID and OAuth Client Secret in connection)
 * 7.3.1 - `Incident Created`: Resolved issue related to object parsing
 * 7.3.0 - Add new actions Create Security Incident, Update Security Incident, Delete Security Incident, Get Security Incident and Search Security Incident

--- a/plugins/servicenow/plugin.spec.yaml
+++ b/plugins/servicenow/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: ["insightconnect"]
 name: servicenow
 title: ServiceNow
 description: ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes
-version: 7.4.0
+version: 7.4.1
 connection_version: 7
 supported_versions: ["2023-10-28 Tokyo"]
 vendor: rapid7

--- a/plugins/servicenow/setup.py
+++ b/plugins/servicenow/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="servicenow-rapid7-plugin",
-      version="7.4.0",
+      version="7.4.1",
       description="ServiceNow is a tool for managing incidents and configuration management. Using the ServiceNow plugin for Rapid7 InsightConnect, users can manage all aspects of incidents including creation, search, updates, as well as monitor them for changes",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Updated to the latest SDK 5.47
  - Trigger was not working properly to find new incidents. Found that there is now a limit where it pulls back 10,000 results so it was never finding the latest incident. I have changed this now so it pulls the most recent 10,000 results.
  - Also fixed an issue with the polling time as it kept missing new incidents.

### Testing

Ran the trigger locally and created new incidents on ServiceNow to watch them flow through.
