### PR TITLE
[SOAR-26854] Zoom task lookback time

### DIFF
--- a/plugins/zoom/.CHECKSUM
+++ b/plugins/zoom/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "3100ac9faac63a7f92a06dc5faa0429a",
-	"manifest": "172750decb129c839a945c56ae220216",
-	"setup": "824819673849bd350a0987eba5cb8fcc",
+	"spec": "fac16fdae1823f186572e3d2122e991c",
+	"manifest": "300c760269420bfb6b3fd45c8b0f54fc",
+	"setup": "558bbbce986040d346c8f9540bd0776a",
 	"schemas": [
 		{
 			"identifier": "create_user/schema.py",

--- a/plugins/zoom/Dockerfile
+++ b/plugins/zoom/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.8
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/zoom/bin/icon_zoom
+++ b/plugins/zoom/bin/icon_zoom
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Zoom"
 Vendor = "rapid7"
-Version = "4.1.8"
+Version = "4.1.9"
 Description = "[Zoom](https://zoom.us) is a cloud platform for video and audio conferencing, chat, and webinars. The Zoom plugin allows you to add and remove users as part of of workflow, while also providing the ability to trigger workflows on new user sign-in and sign-out activity events. This plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/introduction) and requires a Pro, Business, or Enterprise plan"
 
 

--- a/plugins/zoom/help.md
+++ b/plugins/zoom/help.md
@@ -1,8 +1,6 @@
 # Description
 
-[Zoom](https://zoom.us) is a cloud platform for video and audio conferencing, chat, and webinars. The Zoom plugin allows you to add and remove users as part of of workflow, while also providing the ability to trigger workflows on new user sign-in and sign-out activity events. 
-
-This plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/introduction) and requires a Pro, Business, or Enterprise plan
+[Zoom](https://zoom.us) is a cloud platform for video and audio conferencing, chat, and webinars. The Zoom plugin allows you to add and remove users as part of of workflow, while also providing the ability to trigger workflows on new user sign-in and sign-out activity events. This plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/introduction) and requires a Pro, Business, or Enterprise plan
 
 # Key Features
 
@@ -26,12 +24,12 @@ This plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/i
 
 The connection configuration accepts the following parameters:  
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|account_id|string|None|True|Zoom app account ID, required for OAuth authentication|None|dBs0x4Kf7HuIK0LLbzMduW|
-|authentication_retry_limit|integer|5|True|How many times to retry authentication to Zoom before failing, required for OAuth authentication|None|5|
-|client_id|string|None|True|Zoom app client ID, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|
-|client_secret|credential_secret_key|None|True|Zoom app client secret, required for OAuth authentication|None|{'secretKey': '9de5069c5afe602b2ea0a04b66beb2c0'}|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|account_id|string|None|True|Zoom app account ID, required for OAuth authentication|None|dBs0x4Kf7HuIK0LLbzMduW|None|None|
+|authentication_retry_limit|integer|5|True|How many times to retry authentication to Zoom before failing, required for OAuth authentication|None|5|None|None|
+|client_id|string|None|True|Zoom app client ID, required for OAuth authentication|None|9de5069c5afe602b2ea0a04b66beb2c0|None|None|
+|client_secret|credential_secret_key|None|True|Zoom app client secret, required for OAuth authentication|None|{'secretKey': '9de5069c5afe602b2ea0a04b66beb2c0'}|None|None|
 
 Example input:
 
@@ -57,13 +55,13 @@ This action is used to create user associated to account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|create|True|Specify how to create the new user|["create", "autoCreate", "custCreate", "ssoCreate"]|create|
-|email|string|None|True|Email address of user|None|user@example.com|
-|first_name|string|None|False|First name of user|None|John|
-|last_name|string|None|True|Last name of user|None|Smith|
-|type|string|None|True|User type|["Basic", "Licensed"]|Basic|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|action|string|create|True|Specify how to create the new user|["create", "autoCreate", "custCreate", "ssoCreate"]|create|None|None|
+|email|string|None|True|Email address of user|None|user@example.com|None|None|
+|first_name|string|None|False|First name of user|None|John|None|None|
+|last_name|string|None|True|Last name of user|None|Smith|None|None|
+|type|string|None|True|User type|["Basic", "Licensed"]|Basic|None|None|
   
 Example input:
 
@@ -105,14 +103,14 @@ This action is used to delete or disassociate user from account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|None|True|Specify how to delete the user. To delete pending user, use disassociate|["delete", "disassociate"]|delete|
-|id|string|None|True|The user identifier or email address|None|user@example.com|
-|transfer_email|string|None|False|Email to transfer meetings, webinars, or recordings|None|user@example.com|
-|transfer_meetings|boolean|False|False|Whether to transfer meetings to defined transfer email|None|False|
-|transfer_recordings|boolean|False|False|Whether to transfer recordings to defined transfer email|None|False|
-|transfer_webinars|boolean|False|False|Whether to transfer webinars to defined transfer email|None|False|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|action|string|None|True|Specify how to delete the user. To delete pending user, use disassociate|["delete", "disassociate"]|delete|None|None|
+|id|string|None|True|The user identifier or email address|None|user@example.com|None|None|
+|transfer_email|string|None|False|Email to transfer meetings, webinars, or recordings|None|user@example.com|None|None|
+|transfer_meetings|boolean|False|False|Whether to transfer meetings to defined transfer email|None|False|None|None|
+|transfer_recordings|boolean|False|False|Whether to transfer recordings to defined transfer email|None|False|None|None|
+|transfer_webinars|boolean|False|False|Whether to transfer webinars to defined transfer email|None|False|None|None|
   
 Example input:
 
@@ -147,9 +145,9 @@ This action is used to get user in Zoom account
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|user_id|string|None|True|The user identifier or email address|None|user@example.com|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|user_id|string|None|True|The user identifier or email address|None|user@example.com|None|None|
   
 Example input:
 
@@ -187,9 +185,9 @@ This trigger is used to poll for user activity events
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|activity_type|string|None|True|Type of user activity to match event|["Sign in", "Sign out", "All"]|All|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|activity_type|string|None|True|Type of user activity to match event|["Sign in", "Sign out", "All"]|All|None|None|
   
 Example input:
 
@@ -309,6 +307,7 @@ Example output:
 
 # Version History
 
+* 4.1.9 - Updated to include latest SDK functionality v5.4.8 | Task `monitor_sign_in_out_activity` updated to increase max lookback cutoff to 7 days
 * 4.1.8 - Updated to include latest SDK functionality v5.4.5 | Adding logic to `monitor_sign_in_out_activity` task to keep paginating until endtime catches up to now
 * 4.1.7 - Updated to include latest SDK functionality
 * 4.1.6 - Adding better handling to `monitor_sign_in_out_activity` task, if the users account does not have all of the required permissions | Include SDK 5.4 which adds new task custom_config parameter

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -130,12 +130,14 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                     # no previous timestamp - this is considered first time through, use an initial lookback cutiff
                     self.logger.info("Setting min start time: No manual cutoff applied and no last request timestamp")
                     start_time = self._format_datetime_for_zoom(
-                        dt=self._get_datetime_last_x_hours(self.DEFAULT_INITIAL_LOOKBACK))
+                        dt=self._get_datetime_last_x_hours(self.DEFAULT_INITIAL_LOOKBACK)
+                    )
                 else:
                     # Not the first run, ensure a max cutoff is applied if necessary
                     self.logger.info("Setting min start time: No manual cutoff applied, last request timestamp exists")
                     start_time = self._format_datetime_for_zoom(
-                        dt=self._get_datetime_last_x_hours(self.DEFAULT_CUTOFF_HOURS))
+                        dt=self._get_datetime_last_x_hours(self.DEFAULT_CUTOFF_HOURS)
+                    )
 
         start_date_params = {
             RunState.starting: start_time,

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -122,21 +122,23 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                 )
             elif cutoff_hours is not None:
                 self.logger.info(f"Setting min start time (cutoff: {cutoff_hours} hours manually applied)")
-                start_time = self._format_datetime_for_zoom(
-                    dt=self._get_datetime_last_x_hours(cutoff_hours)
-                )
+                start_time = self._format_datetime_for_zoom(dt=self._get_datetime_last_x_hours(cutoff_hours))
             else:
                 if not state.get(self.LAST_REQUEST_TIMESTAMP):
                     # no previous timestamp - this is considered first time through, use an initial lookback cutoff
-                    self.logger.info("Setting min start time: No manual cutoff applied and no last request timestamp. "
-                                     f"Use default initial lookback cutoff: {self.DEFAULT_INITIAL_LOOKBACK} hours")
+                    self.logger.info(
+                        "Setting min start time: No manual cutoff applied and no last request timestamp. "
+                        f"Use default initial lookback cutoff: {self.DEFAULT_INITIAL_LOOKBACK} hours"
+                    )
                     start_time = self._format_datetime_for_zoom(
                         dt=self._get_datetime_last_x_hours(self.DEFAULT_INITIAL_LOOKBACK)
                     )
                 else:
                     # Not the first run, ensure a max cutoff is applied if necessary
-                    self.logger.info("Setting min start time: No manual cutoff applied, last request timestamp exists. "
-                                     f"Use default lookback cutoff: {self.DEFAULT_CUTOFF_HOURS} hours")
+                    self.logger.info(
+                        "Setting min start time: No manual cutoff applied, last request timestamp exists. "
+                        f"Use default lookback cutoff: {self.DEFAULT_CUTOFF_HOURS} hours"
+                    )
                     start_time = self._format_datetime_for_zoom(
                         dt=self._get_datetime_last_x_hours(self.DEFAULT_CUTOFF_HOURS)
                     )

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -55,7 +55,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         "Health check failed. An error occurred during event collection: insufficient permissions for this action. "
         "Please ensure you add all required user permissions for the Rapid7 app in Zoom."
     )
-    DEFAULT_CUTOFF_HOURS = 24
+    DEFAULT_CUTOFF_HOURS = 168
 
     def __init__(self):
         super(self.__class__, self).__init__(

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -121,20 +121,22 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                     )
                 )
             elif cutoff_hours is not None:
-                self.logger.info("Setting min start time (cutoff hours manually applied)")
+                self.logger.info(f"Setting min start time (cutoff: {cutoff_hours} hours manually applied)")
                 start_time = self._format_datetime_for_zoom(
-                    dt=self._get_datetime_last_x_hours(cutoff.get("hours", self.DEFAULT_CUTOFF_HOURS))
+                    dt=self._get_datetime_last_x_hours(cutoff_hours)
                 )
             else:
                 if not state.get(self.LAST_REQUEST_TIMESTAMP):
-                    # no previous timestamp - this is considered first time through, use an initial lookback cutiff
-                    self.logger.info("Setting min start time: No manual cutoff applied and no last request timestamp")
+                    # no previous timestamp - this is considered first time through, use an initial lookback cutoff
+                    self.logger.info("Setting min start time: No manual cutoff applied and no last request timestamp. "
+                                     f"Use default initial lookback cutoff: {self.DEFAULT_INITIAL_LOOKBACK} hours")
                     start_time = self._format_datetime_for_zoom(
                         dt=self._get_datetime_last_x_hours(self.DEFAULT_INITIAL_LOOKBACK)
                     )
                 else:
                     # Not the first run, ensure a max cutoff is applied if necessary
-                    self.logger.info("Setting min start time: No manual cutoff applied, last request timestamp exists")
+                    self.logger.info("Setting min start time: No manual cutoff applied, last request timestamp exists. "
+                                     f"Use default lookback cutoff: {self.DEFAULT_CUTOFF_HOURS} hours")
                     start_time = self._format_datetime_for_zoom(
                         dt=self._get_datetime_last_x_hours(self.DEFAULT_CUTOFF_HOURS)
                     )

--- a/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
+++ b/plugins/zoom/icon_zoom/tasks/monitor_sign_in_out_activity/task.py
@@ -56,6 +56,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
         "Please ensure you add all required user permissions for the Rapid7 app in Zoom."
     )
     DEFAULT_CUTOFF_HOURS = 168
+    DEFAULT_INITIAL_LOOKBACK = 24
 
     def __init__(self):
         super(self.__class__, self).__init__(
@@ -86,9 +87,11 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
 
         cutoff = custom_config.get("cutoff", {})
         cutoff_date = cutoff.get("date")
+        cutoff_hours = cutoff.get("hours")
         lookback = custom_config.get("lookback")
 
         if lookback is not None:
+            self.logger.info("Setting min start time (lookback manually applied)")
             start_time = self._format_datetime_for_zoom(
                 # a default of up to 12 months is used to allow for this to always run if there is missing value in the custom config
                 # as if the request is larger than 30 days, the api will only return 30 days worth of data
@@ -104,6 +107,7 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
             self.logger.info(f"A custom start time of {start_time} will be used")
         else:
             if cutoff_date is not None:
+                self.logger.info("Setting min start time (cutoff date manually applied)")
                 start_time = self._format_datetime_for_zoom(
                     # a default of up to 12 months is used to allow for this to always run if there is missing value in the custom config
                     # as if the request is larger than 30 days, the api will only return 30 days worth of data
@@ -116,17 +120,29 @@ class MonitorSignInOutActivity(insightconnect_plugin_runtime.Task):
                         cutoff_date.get("second", 0),
                     )
                 )
-            else:
+            elif cutoff_hours is not None:
+                self.logger.info("Setting min start time (cutoff hours manually applied)")
                 start_time = self._format_datetime_for_zoom(
                     dt=self._get_datetime_last_x_hours(cutoff.get("hours", self.DEFAULT_CUTOFF_HOURS))
                 )
+            else:
+                if not state.get(self.LAST_REQUEST_TIMESTAMP):
+                    # no previous timestamp - this is considered first time through, use an initial lookback cutiff
+                    self.logger.info("Setting min start time: No manual cutoff applied and no last request timestamp")
+                    start_time = self._format_datetime_for_zoom(
+                        dt=self._get_datetime_last_x_hours(self.DEFAULT_INITIAL_LOOKBACK))
+                else:
+                    # Not the first run, ensure a max cutoff is applied if necessary
+                    self.logger.info("Setting min start time: No manual cutoff applied, last request timestamp exists")
+                    start_time = self._format_datetime_for_zoom(
+                        dt=self._get_datetime_last_x_hours(self.DEFAULT_CUTOFF_HOURS))
 
         start_date_params = {
             RunState.starting: start_time,
             RunState.paginating: state.get(self.PARAM_START_DATE),
             RunState.continuing: self._get_last_valid_timestamp(start_time, state),
         }
-
+        self.logger.info(f"Start_date_params: {start_date_params}")
         end_date_params = {
             RunState.starting: now,
             RunState.paginating: state.get(self.PARAM_END_DATE),

--- a/plugins/zoom/plugin.spec.yaml
+++ b/plugins/zoom/plugin.spec.yaml
@@ -3,7 +3,7 @@ extension: plugin
 products: [insightconnect]
 name: zoom
 title: Zoom
-description: "[Zoom](https://zoom.us) is a cloud platform for video and audio conferencing, chat, and webinars. The Zoom plugin allows you to add and remove users as part of of workflow, while also providing the ability to trigger workflows on new user sign-in and sign-out activity events. \n\nThis plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/introduction) and requires a Pro, Business, or Enterprise plan"
+description: "[Zoom](https://zoom.us) is a cloud platform for video and audio conferencing, chat, and webinars. The Zoom plugin allows you to add and remove users as part of of workflow, while also providing the ability to trigger workflows on new user sign-in and sign-out activity events. This plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/introduction) and requires a Pro, Business, or Enterprise plan"
 key_features: 
   - "Trigger workflows on user sign-in and sign-out activity events"
   - "Add and remove user accounts to automate provisioning/deprovisioning of users"
@@ -12,7 +12,7 @@ requirements:
   - "API credentials for OAuth 2.0:
       \n\t* Requires account ID as well as client ID and secret from a Server-to-Server OAuth app in the Zoom Marketplace.
       \n\t* Server-to-Server OAuth app has the `report:read:admin` scope enabled."
-version: 4.1.8
+version: 4.1.9
 connection_version: 4
 vendor: rapid7
 support: rapid7
@@ -22,7 +22,7 @@ cloud_ready: true
 tags: [zoom, chat]
 sdk:
   type: full
-  version: 5.4.5
+  version: 5.4.8
   user: nobody
 hub_tags:
   use_cases: [alerting_and_notifications, application_management, threat_detection_and_response, user_management]
@@ -35,6 +35,7 @@ resources:
 enable_cache: false
 
 version_history:
+  - "4.1.9 - Updated to include latest SDK functionality v5.4.8 | Task `monitor_sign_in_out_activity` updated to increase max lookback cutoff to 7 days"
   - "4.1.8 - Updated to include latest SDK functionality v5.4.5 | Adding logic to `monitor_sign_in_out_activity` task to keep paginating until endtime catches up to now"
   - "4.1.7 - Updated to include latest SDK functionality"
   - "4.1.6 - Adding better handling to `monitor_sign_in_out_activity` task, if the users account does not have all of the required permissions | Include SDK 5.4 which adds new task custom_config parameter"

--- a/plugins/zoom/setup.py
+++ b/plugins/zoom/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="zoom-rapid7-plugin",
-      version="4.1.8",
+      version="4.1.9",
       description="[Zoom](https://zoom.us) is a cloud platform for video and audio conferencing, chat, and webinars. The Zoom plugin allows you to add and remove users as part of of workflow, while also providing the ability to trigger workflows on new user sign-in and sign-out activity events. This plugin uses the [Zoom API](https://marketplace.zoom.us/docs/api-reference/introduction) and requires a Pro, Business, or Enterprise plan",
       author="rapid7",
       author_email="",

--- a/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
+++ b/plugins/zoom/unit_test/test_monitor_sign_in_out_activity.py
@@ -174,7 +174,6 @@ class TestGetUserActivityEvents(unittest.TestCase):
     def test_first_and_subsequent_runs(
         self, mock_call: MagicMock, mock_datetime_now: MagicMock, mock_datetime_last_24: MagicMock
     ) -> None:
-
         # First run
         first_event_set = [
             {
@@ -383,7 +382,6 @@ class TestGetUserActivityEvents(unittest.TestCase):
         mock_datetime_now: MagicMock,
         mock_datetime_last_x: MagicMock,
     ) -> None:
-
         mock_datetime_last_x.side_effect = [mock_last_x_hours]
 
         expected_output, expected_has_more_pages, expected_status_code, expected_error = (
@@ -418,7 +416,6 @@ class TestGetUserActivityEvents(unittest.TestCase):
     def test_backfill_continiuous_pagination(
         self, mock_call: MagicMock, mock_datetime_now: MagicMock, mock_datetime_last_24: MagicMock
     ) -> None:
-
         state = {
             "param_end_date": "2023-02-23T22:00:00Z",
             "param_start_date": "2023-02-22T21:44:44Z",


### PR DESCRIPTION
## Proposed Changes

### Description

Increase the max lookback cutoff time from 24 hours to 7 days for the task.
Update to latest SDK version. 

Testing
Tested locally against docker container by setting a time previous to the cutoff time. 

Prior to change:
```
Plugin task beginning execution...
rapid7/Zoom:4.1.8. Step name: monitor_sign_in_out_activity
Saved state 2023-05-02T15:47:47Z exceeds the cut off. Reverting to use time: 2024-05-01T15:50:44Z
Current runstate is: continuing
Getting events for timeframe 2024-05-01T15:50:44Z to 2024-05-02T15:50:44Z. Currently paginating: false
```

Following change:

No state:

```
Plugin task beginning execution...
rapid7/Zoom:4.1.9. Step name: monitor_sign_in_out_activity
Setting min start time: No manual cutoff applied and no last request timestamp. Use default initial lookback cutoff: 24 hours
Start_date_params: {<RunState.starting: 'starting'>: '2024-05-06T14:18:20Z', <RunState.paginating: 'paginating'>: None, <RunState.continuing: 'continuing'>: None}
Current runstate is: starting
Getting events for timeframe 2024-05-06T14:18:20Z to 2024-05-07T14:18:20Z. Currently paginating: false

```
State exists:

```
Plugin task beginning execution...
rapid7/Zoom:4.1.9. Step name: monitor_sign_in_out_activity
Setting min start time: No manual cutoff applied, last request timestamp exists. Use default lookback cutoff: 168 hours
Start_date_params: {<RunState.starting: 'starting'>: '2024-04-30T14:21:11Z', <RunState.paginating: 'paginating'>: None, <RunState.continuing: 'continuing'>: '2024-05-01T15:47:47Z'}
Current runstate is: continuing
```

Within last week:

```
Plugin task beginning execution...
rapid7/Zoom:4.1.9. Step name: monitor_sign_in_out_activity
Setting min start time: No manual cutoff applied, last request timestamp exists. Use default lookback cutoff: 168 hours
Start_date_params: {<RunState.starting: 'starting'>: '2024-04-30T14:21:11Z', <RunState.paginating: 'paginating'>: None, <RunState.continuing: 'continuing'>: '2024-05-01T15:47:47Z'}
Current runstate is: continuing
Getting events for timeframe 2024-05-01T15:47:47Z to 2024-05-07T14:21:11Z. Currently paginating: false

```

More than a week:
```
rapid7/Zoom:4.1.9. Step name: monitor_sign_in_out_activity
Setting min start time: No manual cutoff applied, last request timestamp exists. Use default lookback cutoff: 168 hours
Saved state 2024-03-01T15:47:47Z exceeds the cut off. Reverting to use time: 2024-04-30T15:24:12Z
Start_date_params: {<RunState.starting: 'starting'>: '2024-04-30T15:24:12Z', <RunState.paginating: 'paginating'>: None, <RunState.continuing: 'continuing'>: '2024-04-30T15:24:12Z'}
Current runstate is: continuing
Getting events for timeframe 2024-04-30T15:24:12Z to 2024-05-07T15:24:12Z. Currently paginating: false
```