### PR TITLE
[SOAR-16699][Carbon Black] Improved error handling to raise CB status code in task. 

### DIFF
--- a/plugins/carbon_black_cloud/.CHECKSUM
+++ b/plugins/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e1d828ca45a78e32ff3015dfbb487255",
-	"manifest": "e7177f918ba0c6af9e4214677c682167",
-	"setup": "02fcf4bc99206f8e1678cb422d3ad518",
+	"spec": "0e25f4b3b8b22ece74ff21a245f52958",
+	"manifest": "50c5d7d558375c4fafd161c622a7cd87",
+	"setup": "5629bc85ea5eb045e1093a084b1bcdbd",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "VMware Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "2.2.0"
+Version = "2.2.1"
 Description = "The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin"
 
 

--- a/plugins/carbon_black_cloud/help.md
+++ b/plugins/carbon_black_cloud/help.md
@@ -440,6 +440,7 @@ Example output:
 
 # Version History
 
+* 2.2.1 - `Monitor Alerts and Observations` surface status code from Carbon Black in task error.
 * 2.2.0 - Implement new task `Monitor Alerts and Observations` and bump to SDK 5.4.8
 * 2.0.1 - Allows user entered hostnames to be case insensitive for `get_agent_details` and `quarantine` actions | Fix bug where error is raised if endpoint was not found in `get_agent` method | To add escaping of special characters in hostnames when performing hostname searches to Carbon Black
 * 2.0.0 - Updated the SDK version | Cloud enabled

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/connection/connection.py
@@ -8,7 +8,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException, Connection
 import time
 from icon_carbon_black_cloud.util import agent_typer
 from icon_carbon_black_cloud.util.constants import DEFAULT_TIMEOUT, ERROR_HANDLING
-from icon_carbon_black_cloud.util.exceptions import RateLimitException
+from icon_carbon_black_cloud.util.exceptions import RateLimitException, HTTPErrorException
 
 from typing import Dict, Any
 import re
@@ -106,7 +106,9 @@ class Connection(insightconnect_plugin_runtime.Connection):
                     error_assistance = exception_values.get("assistance")
                     break
 
-        raise PluginException(cause=error_cause, assistance=error_assistance, data=error_data)
+        raise HTTPErrorException(
+            cause=error_cause, assistance=error_assistance, data=error_data, status_code=response.status_code
+        )
 
     def test(self):
         device_endpoint = "/device"

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/util/constants.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/util/constants.py
@@ -20,7 +20,7 @@ OBSERVATION_TYPES = [
 ERROR_HANDLING = {
     400: {"cause": "400 Bad Request", "assistance": "Verify that your request adheres to API documentation."},
     401: {
-        "cause": "Authentication Error",
+        "cause": "Authentication Error. Please verify connection details are correct.",
         "assistance": "Please verify that your Secret Key and API ID values in the plugin connection are correct.",
     },
     403: {
@@ -30,7 +30,7 @@ ERROR_HANDLING = {
         "API in use.",
     },
     404: {
-        "cause": "The object referenced in the request cannot be found.",
+        "cause": "The requested URL can not be found. Ensure your organization key and URL in your connection is correct.",
         "assistance": "Verify that your request contains objects that haven't been deleted. Verify that the "
         "organization key in the URL is correct.",
     },

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/util/exceptions.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/util/exceptions.py
@@ -3,3 +3,9 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 class RateLimitException(PluginException):
     """Raise when we hit get rate limited so the task can delay running again."""
+
+
+class HTTPErrorException(PluginException):
+    def __init__(self, cause=None, assistance=None, data=None, preset=None, status_code=None):
+        super().__init__(cause, assistance, data, preset)
+        self.status_code = status_code

--- a/plugins/carbon_black_cloud/plugin.spec.yaml
+++ b/plugins/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
 description: The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin
-version: 2.2.0
+version: 2.2.1
 vendor: rapid7
 support: rapid7
 cloud_ready: true
@@ -18,6 +18,7 @@ requirements:
   - API Credentials
   - Base URL
 version_history:
+  - "2.2.1 - `Monitor Alerts and Observations` surface status code from Carbon Black in task error."
   - "2.2.0 - Implement new task `Monitor Alerts and Observations` and bump to SDK 5.4.8"
   - "2.0.1 - Allows user entered hostnames to be case insensitive for `get_agent_details` and `quarantine` actions | Fix bug where error is raised if endpoint was not found in `get_agent` method | To add escaping of special characters in hostnames when performing hostname searches to Carbon Black"
   - "2.0.0 - Updated the SDK version | Cloud enabled"

--- a/plugins/carbon_black_cloud/setup.py
+++ b/plugins/carbon_black_cloud/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="carbon_black_cloud-rapid7-plugin",
-      version="2.2.0",
+      version="2.2.1",
       description="The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin",
       author="rapid7",
       author_email="",

--- a/plugins/carbon_black_cloud/unit_test/responses/task_test_data.py
+++ b/plugins/carbon_black_cloud/unit_test/responses/task_test_data.py
@@ -58,13 +58,11 @@ task_401_on_second_request = {
 }
 
 
-task_403_on_third_request = {
+task_404_on_third_request = {
     "last_alert_hashes": ["9bceab49bf5441923e8fe8345195d5ec4d270193"],
     "last_alert_time": "2024-04-25T15:50:38.389Z",
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
     "last_observation_time": "2024-04-25T15:39:38.389Z",
-    "last_observation_job": "1234-abcd-5678-sqs",
-    "last_observation_job_time": "2024-04-25T16:00:00.000000Z",
 }
 
 observation_job_exceeded = {
@@ -79,3 +77,9 @@ observation_job_not_finished_but_parsed = {
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
     "last_observation_time": "2024-04-25T15:39:38.389Z",
 }
+
+# the same values for observations and hashes from the input as we don't get any new values, but add the
+# new observation job details.
+task_404_on_second_request = task_first_run_output.copy()
+task_404_on_second_request["last_observation_job"] = "1234-abcd-5678-sqs"
+task_404_on_second_request["last_observation_job_time"] = "2024-04-25T16:00:00.000000Z"

--- a/plugins/carbon_black_cloud/unit_test/test_get_agent_details.py
+++ b/plugins/carbon_black_cloud/unit_test/test_get_agent_details.py
@@ -106,9 +106,12 @@ class TestGetAgentDetails(TestCase):
     @parameterized.expand(
         [
             (mock_request_400, "400 Bad Request"),
-            (mock_request_401, "Authentication Error"),
+            (mock_request_401, "Authentication Error. Please verify connection details are correct."),
             (mock_request_403, "The specified object cannot be accessed or changed."),
-            (mock_request_404, "The object referenced in the request cannot be found."),
+            (
+                mock_request_404,
+                "The requested URL can not be found. Ensure your organization key and URL in your connection is correct.",
+            ),
             (mock_request_409, "Either the name you chose already exists, or there is an unacceptable character used."),
             (mock_request_503, PluginException.causes[PluginException.Preset.UNKNOWN]),
         ],

--- a/plugins/carbon_black_cloud/unit_test/test_quarantine.py
+++ b/plugins/carbon_black_cloud/unit_test/test_quarantine.py
@@ -43,9 +43,12 @@ class TestQuarantine(TestCase):
     @parameterized.expand(
         [
             (mock_request_400, "400 Bad Request"),
-            (mock_request_401, "Authentication Error"),
+            (mock_request_401, "Authentication Error. Please verify connection details are correct."),
             (mock_request_403, "The specified object cannot be accessed or changed."),
-            (mock_request_404, "The object referenced in the request cannot be found."),
+            (
+                mock_request_404,
+                "The requested URL can not be found. Ensure your organization key and URL in your connection is correct.",
+            ),
             (mock_request_409, "Either the name you chose already exists, or there is an unacceptable character used."),
             (mock_request_503, PluginException.causes[PluginException.Preset.UNKNOWN]),
         ],


### PR DESCRIPTION
## Proposed Changes
Noticed when testing the task that we will raise 500 from the task call when invalid credentials are sent. 

### Description

Describe the proposed changes:

  - Implement new exception type to catch and raise this status from the task call. 
  - Implementing that we will delete the observation job details from the state if we get a 404 when trying to poll this results. 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Updated unit test to no longer expect a generic 500 error. 
- Tested manually and can see a 401 returned when invalid credentials are sent. (screenshot attached to JIRA)
- Tested manually with a made up observation ID returns 404. (screenshot attached to JIRA)

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [X] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
