### PR TITLE
[SOAR-16858]- Duo Admin- update max lookback to 7 days

### DIFF
--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1b1da27fce51b3dd62bb06445931a131",
-	"manifest": "c888effebe3990fcea7d50971a399358",
-	"setup": "6b8afaf1cf5e530029f0f11152b745d0",
+	"spec": "e6f5d47d912d00b20fe51a7ffa082a93",
+	"manifest": "e71860d2685a737f80bf50495cbae80c",
+	"setup": "4271ead3909ea6c4525f05977a8e5347",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",
@@ -49,7 +49,7 @@
 		},
 		{
 			"identifier": "monitor_logs/schema.py",
-			"hash": "5ce8b19344da9506c08512370681f783"
+			"hash": "4119a8c82613406e16d830d7b48e0c86"
 		}
 	]
 }

--- a/plugins/duo_admin/Dockerfile
+++ b/plugins/duo_admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.9
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/duo_admin/bin/komand_duo_admin
+++ b/plugins/duo_admin/bin/komand_duo_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Duo Admin API"
 Vendor = "rapid7"
-Version = "4.4.1"
+Version = "4.4.2"
 Description = "Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization"
 
 

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -1033,6 +1033,7 @@ A User ID can be obtained by passing a username to the Get User Status action.
 
 # Version History
 
+* 4.4.2 - Updated to include latest SDK v5.4.9 | Task `Monitor Logs` updated to increase max lookback cutoff to 7 days
 * 4.4.1 - `Monitor Logs` task updated to stop logging of trust monitor events response
 * 4.4.0 - `Monitor Logs` task updated to handle `custom_config` parameter for each log type separately | Apply lookback limit of 180 days due to Duo Admin API limitation
 * 4.3.2 - Monitor Logs task: Update to latest SDK | `Monitor Logs` task updated to handle `custom_config` parameter

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -10,10 +10,10 @@ status: []
 supported_versions: ["Duo Admin API 2023-05-19"]
 sdk:
   type: full
-  version: 5
+  version: 5.4.9
   user: nobody
 description: Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization
-version: 4.4.1
+version: 4.4.2
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/duo_admin

--- a/plugins/duo_admin/setup.py
+++ b/plugins/duo_admin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="duo_admin-rapid7-plugin",
-      version="4.4.1",
+      version="4.4.2",
       description="Duo is a trusted access solution for organizations. The Duo Admin plugin for Rapid7 InsightConnect allows users to manage and administrate their Duo organization",
       author="rapid7",
       author_email="",

--- a/plugins/duo_admin/unit_test/expected/monitor_logs_2.json.exp
+++ b/plugins/duo_admin/unit_test/expected/monitor_logs_2.json.exp
@@ -160,7 +160,6 @@
       }
 ],
   "state": {
-    "last_collection_timestamp": null,
     "previous_admin_log_hashes": [
       "cd9aa0fc02dd4a4538a3368025b2fab7480fbc7a",
       "79ac88bf9a2b241fc385a1501b614c39cdf7cd8c"
@@ -172,17 +171,17 @@
     "previous_trust_monitor_event_hashes": [
       "b7db98ed56420f228cf72b3b80a26c44e14e0dec"
     ],
-    "trust_monitor_last_log_timestamp": 1682843686000,
+    "trust_monitor_last_log_timestamp": 1682930026000,
     "trust_monitor_next_page_params": {
-      "mintime": "1682843686000",
+      "mintime": "1682930026000",
       "maxtime": "1682929966000",
       "limit": "200",
       "offset": "1591014"
      },
-     "admin_logs_last_log_timestamp": 1682843686,
+     "admin_logs_last_log_timestamp": 1682930026,
      "auth_logs_last_log_timestamp": 1684749133,
      "auth_logs_next_page_params": {
-       "mintime": "1682843686000",
+       "mintime": "1682930026000",
        "maxtime": "1682929966000",
        "limit": "1000",
        "sort": "ts:asc",

--- a/plugins/duo_admin/unit_test/expected/monitor_logs_3.json.exp
+++ b/plugins/duo_admin/unit_test/expected/monitor_logs_3.json.exp
@@ -111,7 +111,6 @@
       "next_offset": "1683730665255,9de5069c-5afe-602b-2ea0-a04b66beb2c0",
       "sort": "ts:asc"
     },
-    "last_collection_timestamp": null,
     "previous_admin_log_hashes": [
       "cd9aa0fc02dd4a4538a3368025b2fab7480fbc7a",
       "79ac88bf9a2b241fc385a1501b614c39cdf7cd8c"

--- a/plugins/duo_admin/unit_test/inputs/monitor_logs_next_page.json.inp
+++ b/plugins/duo_admin/unit_test/inputs/monitor_logs_next_page.json.inp
@@ -8,7 +8,6 @@
       "9de5069c-5afe-602b-2ea0-a04b66beb2c0"
     ]
   },
-  "last_collection_timestamp": 1682930026000,
   "previous_admin_log_hashes": [
     "9044a3c0964c859ae26aee09a0ad031b0546b0b4",
     "29f17fa591dc5b46c1dfac976364059d80208fdb"
@@ -24,5 +23,8 @@
     "maxtime": "1682930026000",
     "mintime": "1682843686000",
     "offset": "1591014"
-  }
+  },
+  "admin_logs_last_log_timestamp": 1682930026,
+  "auth_logs_last_log_timestamp": 1682930026,
+  "trust_monitor_last_log_timestamp": 1682930026000
 }

--- a/plugins/duo_admin/unit_test/inputs/monitor_logs_with_state.json.inp
+++ b/plugins/duo_admin/unit_test/inputs/monitor_logs_with_state.json.inp
@@ -1,8 +1,10 @@
 {
-  "last_collection_timestamp": 1682843686000,
   "previous_admin_log_hashes": [
     "9044a3c0964c859ae26aee09a0ad031b0546b0b4"
   ],
   "previous_auth_log_hashes": [],
-  "previous_trust_monitor_event_hashes": []
+  "previous_trust_monitor_event_hashes": [],
+  "admin_logs_last_log_timestamp": 1682930026,
+  "auth_logs_last_log_timestamp": 1682930026,
+  "trust_monitor_last_log_timestamp": 1682930026000
 }

--- a/plugins/duo_admin/unit_test/util.py
+++ b/plugins/duo_admin/unit_test/util.py
@@ -59,6 +59,8 @@ class Util:
                 return MockResponse(200, "get_auth_logs.json.resp")
             if params == {"mintime": "1684009458000", "maxtime": "1684209458000", "limit": "1000"}:
                 return MockResponse(200, "get_auth_logs.json.resp")
+            if params == {"mintime": "1682930026000", "maxtime": "1682929966000", "limit": "1000", "sort": "ts:asc"}:
+                return MockResponse(200, "get_auth_logs.json.resp")
             if params == {"mintime": "1683009458000", "maxtime": "1683209458000", "limit": "1000"}:
                 return MockResponse(200, "get_auth_logs_empty.json.resp")
             if params == {
@@ -91,10 +93,14 @@ class Util:
                 return MockResponse(200, "get_admin_logs.json.resp")
             if params == {"mintime": "1682930026"}:
                 return MockResponse(200, "get_admin_logs.json.resp")
+            if params == {"mintime": "112321582426"}:
+                return MockResponse(200, "get_admin_logs.json.resp")
         if url == "https://example.com/admin/v1/trust_monitor/events":
             if params == {"mintime": "1682843686000", "maxtime": "1682929966000", "limit": "200"}:
                 return MockResponse(200, "get_trust_monitor_events.json.resp")
             if params == {"mintime": "1682670886000", "maxtime": "1682929966000", "limit": "200"}:
+                return MockResponse(200, "get_trust_monitor_events.json.resp")
+            if params == {"mintime": "1682930026000", "maxtime": "1682929966000", "limit": "200"}:
                 return MockResponse(200, "get_trust_monitor_events.json.resp")
             if params == {"mintime": "1682843686000", "maxtime": "1682930026000", "limit": "200", "offset": "1591014"}:
                 return MockResponse(200, "get_trust_monitor_events_2.json.resp")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Update SDK to 5.4.9
  - Update MAX_CUTOFF_HOURS to 7 days for tasks
  
https://rapid7.atlassian.net/browse/SOAR-16858 

### Testing

First run (no state) then 24 look back is still used:
```
rapid7/Duo Admin API:4.4.2. Step name: monitor_logs
Previous timestamps retrieved. Auth None. Admin: None. Trust monitor None.
First run for Trust monitor events
Task execution for Trust monitor events will be applying a lookback to 2024-05-13 14:29:16.331290+00:00 UTC...
Retrieve data from 1715610556331 to 1715696836331. Get next page is set to False
Parameters for get trust monitor events set to {'mintime': '1715610556331', 'maxtime': '1715696836331', 'limit': '200'}
Request to path: /admin/v1/trust_monitor/events
Parameters to return from trust monitor events set to {'mintime': '1715610556331', 'maxtime': '1715696836331', 'limit': '200'}. Return 0 events
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 0
Highest timestamp set to 0 for Trust monitor events
0 trust monitor events retrieved
First run for Admin logs
Task execution for Admin logs will be applying a lookback to 2024-05-13 14:29:16.331290+00:00 UTC...
Retrieve data from 1715610556 to 1715696836. Get next page is set to False
Get admin logs: mintime:1715610556, maxtime:1715696836, next_page_params:None
Parameters for get admin logs set to {'mintime': '1715610556'}
Request to path: /admin/v1/logs/administrator
Parameters to return from get admin logs set to {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 0
Highest timestamp set to 0 for Admin logs
0 admin logs retrieved
First run for Auth logs
Task execution for Auth logs will be applying a lookback to 2024-05-13 14:29:16.331290+00:00 UTC...
Retrieve data from 1715610556331 to 1715696836331. Get next page is set to False
Get auth logs: mintime:1715610556331, maxtime:1715696836331, next_page_params:None
Parameters for get auth logs set to {'mintime': '1715610556331', 'maxtime': '1715696836331', 'limit': '1000', 'sort': 'ts:asc'}
Request to path: /admin/v2/logs/authentication
Get auth logs: parameters to return {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 0
Highest timestamp set to 0 for Auth logs
0 auth logs retrieved
Plugin task finished execution...
```

State that simulates the run has stopped/is within the last 7 days:- Date and time (GMT): Sunday, 12 May 2024 09:58:50
```
 "state": {
            "admin_logs_last_log_timestamp": 1715507930,
            "auth_logs_last_log_timestamp": 1715507930,
            "trust_monitor_last_log_timestamp": 1715507930
        },
```
Can see the plugin is using the last log timestamp because it is within 7 days:
```
rapid7/Duo Admin API:4.4.2. Step name: monitor_logs
Previous timestamps retrieved. Auth 1715507930. Admin: 1715507930. Trust monitor 1715507930.
Subsequent run for Trust monitor events
Task execution for Trust monitor events will be applying a lookback to 2024-05-12 09:58:50+00:00 UTC...
Retrieve data from 1715507930000 to 1715785072381. Get next page is set to False
Parameters for get trust monitor events set to {'mintime': '1715507930000', 'maxtime': '1715785072381', 'limit': '200'}
Request to path: /admin/v1/trust_monitor/events
Parameters to return from trust monitor events set to {'mintime': '1715507930000', 'maxtime': '1715785072381', 'limit': '200'}. Return 0 events
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 1715507930
Highest timestamp set to 1715507930 for Trust monitor events
0 trust monitor events retrieved
Subsequent run for Admin logs
Task execution for Admin logs will be applying a lookback to 2024-05-12 09:58:50+00:00 UTC...
Retrieve data from 1715507930 to 1715785072. Get next page is set to False
Get admin logs: mintime:1715507930, maxtime:1715785072, next_page_params:None
Parameters for get admin logs set to {'mintime': '1715507930'}
Request to path: /admin/v1/logs/administrator
Parameters to return from get admin logs set to {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 1715507930
Highest timestamp set to 1715507930 for Admin logs
0 admin logs retrieved
Subsequent run for Auth logs
Task execution for Auth logs will be applying a lookback to 2024-05-12 09:58:50+00:00 UTC...
Retrieve data from 1715507930000 to 1715785072381. Get next page is set to False
Get auth logs: mintime:1715507930000, maxtime:1715785072381, next_page_params:None
Parameters for get auth logs set to {'mintime': '1715507930000', 'maxtime': '1715785072381', 'limit': '1000', 'sort': 'ts:asc'}
Request to path: /admin/v2/logs/authentication
Get auth logs: parameters to return {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 1715507930
Highest timestamp set to 1715507930 for Auth logs
0 auth logs retrieved
Plugin task finished execution...
```

State that simulates the run has stopped/is over 7 days:- Date and time (GMT): Wednesday, 1 May 2024 09:58:50
```
 "state": {
            "admin_logs_last_log_timestamp": 1714557530,
            "auth_logs_last_log_timestamp": 1714557530,
            "trust_monitor_last_log_timestamp": 1714557530
        },
```
Can see the plugin is now using the cutoff time of 7 days:
```
rapid7/Duo Admin API:4.4.2. Step name: monitor_logs
Previous timestamps retrieved. Auth 1714557530. Admin: 1714557530. Trust monitor 1714557530.
Subsequent run for Trust monitor events
Task execution for Trust monitor events will be applying a lookback to 2024-05-08 15:04:46.812268+00:00 UTC...
Retrieve data from 1715180686812 to 1715785366812. Get next page is set to False
Parameters for get trust monitor events set to {'mintime': '1715180686812', 'maxtime': '1715785366812', 'limit': '200'}
Request to path: /admin/v1/trust_monitor/events
Parameters to return from trust monitor events set to {'mintime': '1715180686812', 'maxtime': '1715785366812', 'limit': '200'}. Return 0 events
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 1714557530
Highest timestamp set to 1714557530 for Trust monitor events
0 trust monitor events retrieved
Subsequent run for Admin logs
Task execution for Admin logs will be applying a lookback to 2024-05-08 15:04:46.812268+00:00 UTC...
Retrieve data from 1715180686 to 1715785366. Get next page is set to False
Get admin logs: mintime:1715180686, maxtime:1715785366, next_page_params:None
Parameters for get admin logs set to {'mintime': '1715180686'}
Request to path: /admin/v1/logs/administrator
Parameters to return from get admin logs set to {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 1714557530
Highest timestamp set to 1714557530 for Admin logs
0 admin logs retrieved
Subsequent run for Auth logs
Task execution for Auth logs will be applying a lookback to 2024-05-08 15:04:46.812268+00:00 UTC...
Retrieve data from 1715180686812 to 1715785366812. Get next page is set to False
Get auth logs: mintime:1715180686812, maxtime:1715785366812, next_page_params:None
Parameters for get auth logs set to {'mintime': '1715180686812', 'maxtime': '1715785366812', 'limit': '1000', 'sort': 'ts:asc'}
Request to path: /admin/v2/logs/authentication
Get auth logs: parameters to return {}. Return 0 logs
Original number of logs:0. Number of logs after de-duplication:0
Previous highest recorded timestamp is 1714557530
Highest timestamp set to 1714557530 for Auth logs
0 auth logs retrieved
Plugin task finished execution...
```