### PR TITLE
[ SOAR-16856] [SOAR-16983] Salesforce v2.1.8 Release

### DIFF
--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "5a0cd40347a80e1390b3cc85699dff36",
-	"manifest": "a71579f8403fb1b95d482098d9e9336c",
-	"setup": "0bd99dc4790e18065eb879fc431b0022",
+	"spec": "614111433baf12e2b4c9978da383c358",
+	"manifest": "f787955b19d27fee238342612ae21af2",
+	"setup": "b353dce779709f83134551c73df4bb84",
 	"schemas": [
 		{
 			"identifier": "advanced_search/schema.py",

--- a/plugins/salesforce/Dockerfile
+++ b/plugins/salesforce/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:5.4.9
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/salesforce/bin/komand_salesforce
+++ b/plugins/salesforce/bin/komand_salesforce
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Salesforce"
 Vendor = "rapid7"
-Version = "2.1.7"
+Version = "2.1.8"
 Description = "The Salesforce plugin allows you to search, update, and manage salesforce records"
 
 

--- a/plugins/salesforce/help.md
+++ b/plugins/salesforce/help.md
@@ -21,30 +21,30 @@ This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/
 * Consumer Key and Secret of the connected app
 
 # Supported Product Versions
-  
+
 * Salesforce API v58 2023-06-30
 
 # Documentation
 
 ## Setup
-  
+
 The connection configuration accepts the following parameters:  
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|clientId|string|None|True|Consumer Key of the connected app|None|1234567890aBcdEFRoeRxDE1234567890abCDef6Etz7VLwwLQZn19jyW3U_1234567890AbcdEF4VkuMS4ze|
-|clientSecret|credential_secret_key|None|True|Consumer Secret of the connected app|None|1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF|
-|instanceUrl|string|https://login.salesforce.com|False|Salesforce URL that is used to retrieve OAuth token|None|https://login.salesforce.com|
-|salesforceAccountUsernameAndPassword|credential_username_password|None|True|Name and password of the Salesforce user|None|{"username": "user@example.com", "password": "password"}|
-|securityToken|credential_secret_key|None|True|Security token of the Salesforce user|None|Ier6YY78KxJwKtHy7HeK0oPc|
-  
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|clientId|string|None|True|Consumer Key of the connected app|None|1234567890aBcdEFRoeRxDE1234567890abCDef6Etz7VLwwLQZn19jyW3U_1234567890AbcdEF4VkuMS4ze|None|None|
+|clientSecret|credential_secret_key|None|True|Consumer Secret of the connected app|None|1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF|None|None|
+|loginURL|string|https://login.salesforce.com|False|Salesforce login URL|None|https://login.salesforce.com|None|None|
+|salesforceAccountUsernameAndPassword|credential_username_password|None|True|Name and password of the Salesforce user|None|{"username": "user@example.com", "password": "password"}|None|None|
+|securityToken|credential_secret_key|None|True|Security token of the Salesforce user|None|Ier6YY78KxJwKtHy7HeK0oPc|None|None|
+
 Example input:
 
 ```
 {
   "clientId": "1234567890aBcdEFRoeRxDE1234567890abCDef6Etz7VLwwLQZn19jyW3U_1234567890AbcdEF4VkuMS4ze",
   "clientSecret": "1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF1234567890ABCDEF",
-  "instanceUrl": "https://login.salesforce.com",
+  "loginURL": "https://login.salesforce.com",
   "salesforceAccountUsernameAndPassword": {
     "password": "password",
     "username": "user@example.com"
@@ -59,14 +59,14 @@ Example input:
 
 
 #### Advanced Search
-  
+
 This action is used to execute a SOQL (Salesforce Object Query Language) query
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|query|string|None|True|SOQL query|None|SELECT FIELDS(STANDARD) FROM Account WHERE Name='Example Account'|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|query|string|None|True|SOQL query|None|SELECT FIELDS(STANDARD) FROM Account WHERE Name='Example Account'|None|None|
   
 Example input:
 
@@ -98,15 +98,15 @@ Example output:
 ```
 
 #### Create Record
-  
+
 This action is used to create a new SObject record
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|objectData|object|None|True|SObject information for the newly created record|None|{"name": "example-name"}|
-|objectName|string|None|True|The name of the object (e.g. 'Account')|None|Account|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|objectData|object|None|True|SObject information for the newly created record|None|{"name": "example-name"}|None|None|
+|objectName|string|None|True|The name of the object (e.g. 'Account')|None|Account|None|None|
   
 Example input:
 
@@ -134,15 +134,15 @@ Example output:
 ```
 
 #### Delete Record
-  
+
 This action is used to delete a record
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|objectName|string|Account|True|The name of the object (e.g. 'Account')|None|Account|
-|recordId|string|None|True|The ID of an existing record|None|000AA000000aa0aAAA|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|objectName|string|Account|True|The name of the object (e.g. 'Account')|None|Account|None|None|
+|recordId|string|None|True|The ID of an existing record|None|000AA000000aa0aAAA|None|None|
   
 Example input:
 
@@ -168,16 +168,16 @@ Example output:
 ```
 
 #### Get Blob Data
-  
+
 This action is used to retrieve blob data for a given record
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|fieldName|string|body|True|Blob field name|None|body|
-|objectName|string|Attachment|True|The name of the object (e.g. 'Attachment')|None|Attachment|
-|recordId|string|None|True|The ID of an existing record|None|001Hn00001uAJRtaB3|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|fieldName|string|body|True|Blob field name|None|body|None|None|
+|objectName|string|Attachment|True|The name of the object (e.g. 'Attachment')|None|Attachment|None|None|
+|recordId|string|None|True|The ID of an existing record|None|001Hn00001uAJRtaB3|None|None|
   
 Example input:
 
@@ -204,16 +204,16 @@ Example output:
 ```
 
 #### Get Fields
-  
+
 This action is used to retrieve field values from the record of the given object
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|fields|[]string|None|True|The fields which values should be retrieved|None|["Id", "Name", "Description"]|
-|objectName|string|Account|True|The name of the object (e.g. 'Account')|None|Account|
-|recordId|string|None|True|The ID of an existing record|None|001Hn00001uAJRtaB3|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|fields|[]string|None|True|The fields which values should be retrieved|None|["Id", "Name", "Description"]|None|None|
+|objectName|string|Account|True|The name of the object (e.g. 'Account')|None|Account|None|None|
+|recordId|string|None|True|The ID of an existing record|None|001Hn00001uAJRtaB3|None|None|
   
 Example input:
 
@@ -248,16 +248,16 @@ Example output:
 ```
 
 #### Get Record
-  
+
 This action is used to retrieve a record
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|externalIdFieldName|string|None|False|The name of the external ID field that should be matched with record_id. If empty, the 'Id' field of the record is used|None|ExampleExtID__c|
-|objectName|string|Account|True|The name of the object|None|Folder|
-|recordId|string|None|True|The ID of an existing record|None|999Hn99999uM8mnBBB|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|externalIdFieldName|string|None|False|The name of the external ID field that should be matched with record_id. If empty, the 'Id' field of the record is used|None|ExampleExtID__c|None|None|
+|objectName|string|Account|True|The name of the object|None|Folder|None|None|
+|recordId|string|None|True|The ID of an existing record|None|999Hn99999uM8mnBBB|None|None|
   
 Example input:
 
@@ -301,14 +301,14 @@ Example output:
 ```
 
 #### Simple Search
-  
+
 This action is used to execute a simple search for a text
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|text|string|None|True|Text to search for|None|test|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|text|string|None|True|Text to search for|None|test|None|None|
   
 Example input:
 
@@ -364,16 +364,16 @@ Example output:
 ```
 
 #### Update Record
-  
+
 This action is used to update a record
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|objectData|object|None|True|Updated SObject information|None|{"name": "example-name"}|
-|objectName|string|Account|True|The name of the object (e.g. 'Account')|None|Account|
-|recordId|string|None|True|The ID of an existing record|None|000AA000000aa0aAAA|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|objectData|object|None|True|Updated SObject information|None|{"name": "example-name"}|None|None|
+|objectName|string|Account|True|The name of the object (e.g. 'Account')|None|Account|None|None|
+|recordId|string|None|True|The ID of an existing record|None|000AA000000aa0aAAA|None|None|
   
 Example input:
 
@@ -407,7 +407,7 @@ Example output:
 
 
 #### Monitor Users
-  
+
 This task is used to get information about users, their login history and which users have been updated
 
 ##### Input
@@ -536,14 +536,15 @@ Example output:
 
 # Version History
 
+* 2.1.8 - Task Monitor Users: Allow lookback to be 7 days and initial run to be 24 hours & raise PluginException for API errors.
 * 2.1.7 - Task Monitor Users: Update connection to accept instance URL and force new token request per execution.
 * 2.1.6 - Task Monitor Users: Implement SDK 5.4.4 for custom_config parameter.
 * 2.1.5 - Task Monitor Users: Improved logging
-* 2.1.4 - Connection: Remove unnecessary logging 
+* 2.1.4 - Connection: Remove unnecessary logging
 * 2.1.3 - Task Monitor Users: improve deduplication logic on user login history
-* 2.1.2 - Task Monitor Users: normalisation for date in state, handle backwards compatibility 
+* 2.1.2 - Task Monitor Users: normalisation for date in state, handle backwards compatibility
 * 2.1.1 - Task Monitor Users: query improvement on updated users | Add extra logs on timestamp | Add cutoff time limit for 24 hours
-* 2.1.0 - Implemented token auto-refresh on expiration for continuous sessions | Task Monitor Users: add flag `remove_duplicates` for duplicated events | Task Monitor Users: removed formatting of task output and cleaning null 
+* 2.1.0 - Implemented token auto-refresh on expiration for continuous sessions | Task Monitor Users: add flag `remove_duplicates` for duplicated events | Task Monitor Users: removed formatting of task output and cleaning null
 * 2.0.2 - Task Monitor Users: query improvement | Handle exception related with grant type
 * 2.0.1 - Add extra logs register
 * 2.0.0 - Code refactor | Update plugin to be cloud enabled | Add new task Monitor Users
@@ -559,4 +560,3 @@ Example output:
 * [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)
 * [Connecting your app to the API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/quickstart.htm)
 * [SOQL](https://developer.salesforce.com/docs/atlas.en-us.216.0.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm)
-

--- a/plugins/salesforce/komand_salesforce/tasks/monitor_users/task.py
+++ b/plugins/salesforce/komand_salesforce/tasks/monitor_users/task.py
@@ -7,7 +7,8 @@ from datetime import datetime, timedelta, timezone
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_salesforce.util.exceptions import ApiException
 
-DEFAULT_CUTOFF_HOURS = 24
+DEFAULT_CUTOFF_HOURS = 24 * 7
+INITIAL_LOOKBACK = 24
 
 
 class MonitorUsers(insightconnect_plugin_runtime.Task):
@@ -259,8 +260,8 @@ class MonitorUsers(insightconnect_plugin_runtime.Task):
             start_time = datetime(**lookback_time, tzinfo=timezone.utc)
             additional_msg = f", along with custom lookback of {start_time}"
         else:
-            start_time = now - timedelta(hours=cut_off_hours)
-            additional_msg = f", along with lookback time of {cut_off_hours} hours ({start_time})"
+            start_time = now - timedelta(hours=INITIAL_LOOKBACK)
+            additional_msg = f", along with lookback time of {INITIAL_LOOKBACK} hours ({start_time})"
 
         if not state:  # we only care about lookback time if there's no state.
             log_msg += additional_msg

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: salesforce
 title: Salesforce
 description: The Salesforce plugin allows you to search, update, and manage salesforce records
-version: 2.1.7
+version: 2.1.8
 connection_version: 2
 vendor: rapid7
 support: community
@@ -13,12 +13,44 @@ status: []
 supported_versions: ["Salesforce API v58 2023-06-30"]
 sdk:
   type: full
-  version: 5.4.4
+  version: 5.4.9
   user: nobody
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/salesforce
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
   vendor_url: https://www.salesforce.com/
+key_features:
+  - Search records
+  - Get records
+  - Create records
+  - Update records
+  - Delete records
+  - Get record fields
+  - Get blob data for a given record
+requirements:
+  - Salesforce username, password and security token
+  - Consumer Key and Secret of the connected app
+links:
+  - "[Salesforce](https://salesforce.com)"
+references:
+  - "[Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)"
+  - "[Connecting your app to the API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/quickstart.htm)"
+  - "[SOQL](https://developer.salesforce.com/docs/atlas.en-us.216.0.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm)"
+version_history:
+  - "2.1.8 - Task Monitor Users: Allow lookback to be 7 days and initial run to be 24 hours & raise PluginException for API errors."
+  - "2.1.7 - Task Monitor Users: Update connection to accept instance URL and force new token request per execution."
+  - "2.1.6 - Task Monitor Users: Implement SDK 5.4.4 for custom_config parameter."
+  - "2.1.5 - Task Monitor Users: Improved logging"
+  - "2.1.4 - Connection: Remove unnecessary logging"
+  - "2.1.3 - Task Monitor Users: improve deduplication logic on user login history"
+  - "2.1.2 - Task Monitor Users: normalisation for date in state, handle backwards compatibility"
+  - "2.1.1 - Task Monitor Users: query improvement on updated users | Add extra logs on timestamp | Add cutoff time limit for 24 hours"
+  - "2.1.0 - Implemented token auto-refresh on expiration for continuous sessions | Task Monitor Users: add flag `remove_duplicates` for duplicated events | Task Monitor Users: removed formatting of task output and cleaning null"
+  - "2.0.2 - Task Monitor Users: query improvement | Handle exception related with grant type"
+  - "2.0.1 - Add extra logs register"
+  - "2.0.0 - Code refactor | Update plugin to be cloud enabled | Add new task Monitor Users"
+  - "1.0.1 - New spec and help.md format for the Extension Library"
+  - "1.0.0 - Initial plugin"
 tags:
 - marketing
 - sales

--- a/plugins/salesforce/setup.py
+++ b/plugins/salesforce/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="salesforce-rapid7-plugin",
-      version="2.1.7",
+      version="2.1.8",
       description="The Salesforce plugin allows you to search, update, and manage salesforce records",
       author="rapid7",
       author_email="",

--- a/plugins/salesforce/unit_test/test_connection.py
+++ b/plugins/salesforce/unit_test/test_connection.py
@@ -45,7 +45,7 @@ class TestConnection(TestCase):
             [
                 "invalid_credentials",
                 Util.read_file_to_dict("inputs/connection_invalid.json.inp"),
-                PluginException.causes[PluginException.Preset.INVALID_CREDENTIALS],
+                "Salesforce error: 'Invalid password or security token supplied.'",
                 PluginException.assistances[PluginException.Preset.INVALID_CREDENTIALS],
             ],
             [
@@ -57,8 +57,8 @@ class TestConnection(TestCase):
             [
                 "invalid_client_id",
                 Util.read_file_to_dict("inputs/connection_invalid_client_id.json.inp"),
-                "Salesforce error: 'client identifier invalid'",
-                PluginException.assistances[PluginException.Preset.UNKNOWN],
+                "Salesforce error: 'Invalid client ID supplied.'",
+                PluginException.assistances[PluginException.Preset.INVALID_CREDENTIALS],
             ],
         ]
     )

--- a/plugins/salesforce/unit_test/util.py
+++ b/plugins/salesforce/unit_test/util.py
@@ -107,16 +107,14 @@ class Util:
 
         if method == "GET":
             if url == "https://example.com/services/data/v58.0/sobjects/User/updated":
-                if params == {"start": "2023-07-19T16:21:15.340+00:00", "end": "2023-07-20T16:21:15.340+00:00"}:
-                    return MockResponse(200, "get_updated_users.json.resp")
-                if params == {"start": "2023-07-20T16:15:15.340+00:00", "end": "2023-07-20T16:21:15.340+00:00"}:
-                    return MockResponse(200, "get_updated_users.json.resp")
-                if params == {"start": "2023-07-20T16:10:15.340+00:00", "end": "2023-07-20T16:21:15.340+00:00"}:
+                # all of these query until now - just check the start parameter to determine the mocked resp
+                params_start = params.get("start")
+                if params_start == "2023-07-20T16:10:15.340+00:00":
                     return MockResponse(200, "get_updated_users_empty.json.resp")
-                if params == {"start": "2023-06-05T03:45:00+00:00", "end": "2023-07-20T16:21:15.340+00:00"}:
-                    return MockResponse(200, "get_updated_users.json.resp")
-                if params == {"start": "invalid", "end": "2023-07-20T16:21:15.340+00:00"}:
+                elif params_start == "invalid":
                     return MockResponse(400)
+                else:
+                    return MockResponse(200, "get_updated_users.json.resp")
             if url == "https://example.com/services/data/v58.0/sobjects/Document/invalid/body":
                 return MockResponse(404)
             if url == "https://example.com/services/data/v58.0/sobjects/Invalid/015Hn000002ge67890/body":
@@ -141,49 +139,31 @@ class Util:
                 if params == {"fields": "invalid"}:
                     return MockResponse(400)
             if url == "https://example.com/services/data/v58.0/query":
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE Id = '005Hn00000HVWwxIAH' AND UserType = 'Standard'"
-                }:
+                params_q = params.get("q")
+                params_db_table = params_q.split("FROM ")[1].split(" ")[0]
+                if params_db_table == "User":
+                    if (
+                        params_q
+                        == "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-07-20T16:10:15.340262+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
+                    ):
+                        return MockResponse(200, "get_specific_user_empty.json.resp")
+                    if (
+                        params_q
+                        == "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= invalid AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
+                    ):
+                        return MockResponse(400)
+                    if (
+                        params_q
+                        == "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard'"
+                    ):
+                        return MockResponse(200, "get_users.json.resp")
                     return MockResponse(200, "get_specific_user.json.resp")
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-07-19T16:21:15.340262+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_specific_user.json.resp")
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-07-20T16:15:15.340262+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_specific_user.json.resp")
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-06-05T03:45:00+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_specific_user.json.resp")
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= 2023-07-20T16:10:15.340262+00:00 AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_specific_user_empty.json.resp")
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard' AND LastModifiedDate >= invalid AND LastModifiedDate < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(400)
-                if params == {
-                    "q": "SELECT Id, FirstName, LastName, Email, Alias, IsActive FROM User WHERE UserType = 'Standard'"
-                }:
-                    return MockResponse(200, "get_users.json.resp")
-                if params == {
-                    "q": "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-07-19T16:21:15.340262+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_login_history.json.resp")
-                if params == {
-                    "q": "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-07-20T15:21:15.340262+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_login_history.json.resp")
-                if params == {
-                    "q": "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-07-20T14:21:15.340262+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
-                }:
-                    return MockResponse(200, "get_login_history_empty.json.resp")
-                if params == {
-                    "q": "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-06-05T03:45:00+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
-                }:
+                if params_db_table == "LoginHistory":
+                    if (
+                        params_q
+                        == "SELECT LoginTime, UserId, LoginType, LoginUrl, SourceIp, Status, Application, Browser FROM LoginHistory WHERE LoginTime >= 2023-07-20T14:21:15.340262+00:00 AND LoginTime < 2023-07-20T16:21:15.340262+00:00"
+                    ):
+                        return MockResponse(200, "get_login_history_empty.json.resp")
                     return MockResponse(200, "get_login_history.json.resp")
                 if params == {"q": "SELECT FIELDS(STANDARD) FROM Folder"}:
                     return MockResponse(200, "advanced_search_all.json.resp")


### PR DESCRIPTION
Release of Salesforce v2.1.8

Tickets:
- [[C2C Salesforce] Plugin returning 500/400 when customer uses invalid creds](https://rapid7.atlassian.net/browse/SOAR-16983)
- [[C2C] Salesforce: Update max lookback time](https://rapid7.atlassian.net/browse/SOAR-16856)

Changes:
- On an execution when a specific look back value is not supplied we should look back 24 hours.
- On subsequent runs we should apply the DEFAULT_CUTOFF_HOURS value against the held timestamp in the state.
- Improved error handling to raise a 401 when Salesforce returns 400 but with an error message related to their credentials being invalid.
- These error messages update the plugin cause to be more indicative other than 'Invalid Credentials' from our preset causes that would have got applied and not raise which part of the credentials value are incorrect.
- Small tidy up on unit tests as they were all returning the same mocked response.
- Updating plugin spec to keep values in [help.md](http://help.md/) during a refresh.

Original PR:
- #2553