### PR TITLE
[PLGN-378] SonicWall - Added retry login logic to handle multiple sessions

### DIFF
--- a/plugins/sonicwall/icon_sonicwall/util/api.py
+++ b/plugins/sonicwall/icon_sonicwall/util/api.py
@@ -1,4 +1,5 @@
 import json
+import time
 from collections import OrderedDict
 from logging import Logger
 from typing import Any, Dict, Tuple, Union
@@ -9,6 +10,7 @@ from icon_sonicwall.util.util import Message
 
 
 DEFAULT_REQUESTS_TIMEOUT = 30
+DEFAULT_MAX_LOGIN_RETRIES = 15
 
 
 class SonicWallAPI:
@@ -123,17 +125,62 @@ class SonicWallAPI:
         return self._make_request("POST", "direct/cli", data=payload, content_type="text/plain")
 
     def _make_request(
-        self, method: str, path: str, *args, commit_pending_changes: bool = False, **kwargs
+        self,
+        method: str,
+        path: str,
+        *args,
+        commit_pending_changes: bool = False,
+        max_tries: int = DEFAULT_MAX_LOGIN_RETRIES,
+        **kwargs,
     ) -> Dict[str, Any]:
-        try:
-            self.login()
-            response = self._call_api(method, path, *args, **kwargs)
-            if commit_pending_changes:
-                self._call_api("POST", "config/pending")
-                self.logger.info("Pending configuration committed.")
-            return response
-        finally:
-            self.logout()
+        """
+        Constructs and sends an HTTP request to the specified URL path using the given HTTP method. It contains retry
+        mechanism as when user logs in using SonicWall API it logs out other sessions for the same account. To allows
+        using a couple actions in parallel the retry mechanism has been added.
+
+        :param method: The HTTP method to use for the request (e.g., "GET", "POST").
+        :type: str
+
+        :param path: The URL path to which the request should be sent.
+        :type: str
+
+        :param args: Additional positional arguments passed to the requests.request.
+        :type: tuple
+
+        :param commit_pending_changes: Flag indicating whether to commit any pending changes or not. Defaults to ``False``.
+        :type: bool
+
+        :param max_tries: The maximum number of tries to attempt the request in case of failure. Defaults to `DEFAULT_MAX_LOGIN_RETRIES`.
+        :type: int
+
+        :param kwargs: Additional keyword arguments passed to the requests.request.
+        :type: dict
+
+        :return: A dictionary containing the response data from the server.
+        :rtype: Dict[str, Any]
+
+        :raises Exception: If the request fails after the maximum number of tries.
+        """
+
+        retry, attempts_counter, error_ = True, 0, None
+        while retry and attempts_counter < max_tries:
+            try:
+                retry = False
+                self.login()
+                response = self._call_api(method, path, *args, **kwargs)
+                if commit_pending_changes:
+                    self._call_api("POST", "config/pending")
+                    self.logger.info("Pending configuration committed.")
+                self.logout()
+                return response
+            except PluginException as error:
+                if error.preset != PluginException.Preset.USERNAME_PASSWORD and "E_LOST_CONN" not in error.data:
+                    raise
+                attempts_counter += 1
+                retry, error_ = True, error
+                self.logger.info(f"Retrying to login... ({attempts_counter}/{max_tries})")
+                time.sleep(1)
+        raise error_
 
     def _call_api(
         self,

--- a/plugins/sonicwall/unit_test/test_add_address_object_to_group.py
+++ b/plugins/sonicwall/unit_test/test_add_address_object_to_group.py
@@ -115,7 +115,10 @@ class TestAddAddressObjectToGroup(TestCase):
             ),
         ]
     )
-    def test_add_address_object_to_group_exception(self, mock_request: Callable, cause: str, assistance: str) -> None:
+    @patch("time.sleep")
+    def test_add_address_object_to_group_exception(
+        self, mock_request: Callable, cause: str, assistance: str, mock_time: MagicMock
+    ) -> None:
         mocked_request(mock_request, "request")
         with self.assertRaises(PluginException) as context:
             self.action.run(STUB_PAYLOAD)

--- a/plugins/sonicwall/unit_test/test_check_if_address_in_address_group.py
+++ b/plugins/sonicwall/unit_test/test_check_if_address_in_address_group.py
@@ -82,8 +82,9 @@ class TestCheckIfAddressInAddressGroup(TestCase):
             ),
         ]
     )
+    @patch("time.sleep")
     def test_check_if_address_in_address_group_exception(
-        self, mock_request: Callable, cause: str, assistance: str
+        self, mock_request: Callable, cause: str, assistance: str, mock_time: MagicMock
     ) -> None:
         mocked_request(mock_request, "request")
         with self.assertRaises(PluginException) as context:

--- a/plugins/sonicwall/unit_test/test_create_address_object.py
+++ b/plugins/sonicwall/unit_test/test_create_address_object.py
@@ -82,7 +82,10 @@ class TestCreateAddressObject(TestCase):
             ),
         ]
     )
-    def test_create_address_object_exception(self, mock_request: Callable, cause: str, assistance: str) -> None:
+    @patch("time.sleep")
+    def test_create_address_object_exception(
+        self, mock_request: Callable, cause: str, assistance: str, mock_time: MagicMock
+    ) -> None:
         mocked_request(mock_request, "request")
         with self.assertRaises(PluginException) as context:
             self.action.run(STUB_PAYLOAD)

--- a/plugins/sonicwall/unit_test/test_delete_address_object.py
+++ b/plugins/sonicwall/unit_test/test_delete_address_object.py
@@ -85,7 +85,10 @@ class TestDeleteAddressObject(TestCase):
             ),
         ]
     )
-    def test_delete_address_object_exception(self, mock_request: Callable, cause: str, assistance: str) -> None:
+    @patch("time.sleep")
+    def test_delete_address_object_exception(
+        self, mock_request: Callable, cause: str, assistance: str, mock_time: MagicMock
+    ) -> None:
         mocked_request(mock_request, "request")
         with self.assertRaises(PluginException) as context:
             self.action.run(STUB_PAYLOAD)

--- a/plugins/sonicwall/unit_test/test_remove_address_from_group.py
+++ b/plugins/sonicwall/unit_test/test_remove_address_from_group.py
@@ -90,7 +90,10 @@ class TestRemoveAddressFromGroup(TestCase):
             ),
         ]
     )
-    def test_remove_address_from_group_exception(self, mock_request: Callable, cause: str, assistance: str) -> None:
+    @patch("time.sleep")
+    def test_remove_address_from_group_exception(
+        self, mock_request: Callable, cause: str, assistance: str, mock_time: MagicMock
+    ) -> None:
         mocked_request(mock_request, "request")
         with self.assertRaises(PluginException) as context:
             self.action.run(STUB_PAYLOAD)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Added retry login logic to handle multiple sessions

The thing is that when working with SonicWall API only once `logged` user can be at time. When using the same creds in multiple workflows, running at the same time - the session can be dropped to one another. In order to fix so the retry login logic is implemented to `_make_request` method.

```
2024-05-29 13:22:50 [info     ] Retrying to login... (1/15)
2024-05-29 13:22:55 [error    ] Plugin exception instantiated. cause='Something unexpected occurred.', assistance='Check the....
2024-05-29 13:22:55 [info     ] Retrying to login... (2/15)
2024-05-29 13:23:00 [error    ] Plugin exception instantiated. cause='Something unexpected occurred.', assistance='Check the logs and if the issue persists please contact support.'...
2024-05-29 13:23:00 [info     ] Looking for address object as ipv6...
```

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
