### PR TITLE
SOAR-17038-If there is no datetime field in the mimecast response then don't check the timestamp

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "ab463786e6b678b8a7cd9e5dd93d2559",
-	"manifest": "5d11b9c09ddd31040ffa869f67a69686",
-	"setup": "7acc7f256bdb18f715edf7b02131fbee",
+	"spec": "2d101ebff407edd94c5757f53b5c11be",
+	"manifest": "1ab68873d2a221ff0ffb1a412f9747b4",
+	"setup": "5b681969411ccd987549d822b165cc8d",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.11"
+Version = "5.3.12"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,6 +1014,7 @@ Example output:
 
 # Version History
 
+* 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9
 * 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7
 * 5.3.9 - Task `monitor_siem_logs`: Add in better error messages if the wrong region is provided

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -109,7 +109,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                 lambda event: event.get_dict(),
                 filter(
                     lambda event: event.compare_datetime(filter_time),
-                    [EventLogs(data=event) for event in task_output],
+                    [EventLogs(data=event, logger=self.logger) for event in task_output],
                 ),
             ),
             key=itemgetter(EventLogs.FILTER_DATETIME),

--- a/plugins/mimecast/komand_mimecast/util/event.py
+++ b/plugins/mimecast/komand_mimecast/util/event.py
@@ -1,20 +1,27 @@
 from datetime import datetime
 from typing import Dict, Any
+from logging import Logger
 
 from dateutil.parser import parse
+from insightconnect_plugin_runtime.helper import get_time_now
 
 
 class EventLogs:
     DATETIME = "datetime"
     FILTER_DATETIME = "filter_datetime"
 
-    def __init__(self, data: Dict[str, Any]) -> None:
+    def __init__(self, data: Dict[str, Any], logger: Logger) -> None:
         self.data: Dict[str, Any] = data
+        self.logger = logger
         self._convert_datetime()
 
     def _convert_datetime(self) -> None:
         if date := self.data.get(self.DATETIME):
             self.data[self.FILTER_DATETIME] = parse(date, ignoretz=True)
+        else:
+            # if there is no datetime field that is returned from Mimecast we will use the current time as we want to try and ingest the log
+            self.logger.warning(f"There was no datetime key for the following event: {self.data}")
+            self.data[self.FILTER_DATETIME] = get_time_now()
 
     def get_dict(self) -> Dict[str, Any]:
         return self.__dict__["data"]

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.11
+version: 5.3.12
 connection_version: 5
 supported_versions: ["Mimecast API 2024-05-09"]
 vendor: rapid7
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"
 - "5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7"
 - "5.3.9 - Task `monitor_siem_logs`: Add in better error messages if the wrong region is provided"

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -5,5 +5,5 @@ validators==0.21.0
 parameterized==0.8.1
 python-dateutil==2.6.1
 jsonschema==3.2.0
-werkzeug==3.0.1
+werkzeug==3.0.3
 setuptools==65.5.1

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.11",
+      version="5.3.12",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -15,6 +15,7 @@ from komand_mimecast.util.constants import DATA_FIELD, DEFAULT_REGION
 DATE_TIME_NOW = datetime.now().strftime("%Y-%m-%dT%H:%M:%S%z")
 FILE_ZIP_CONTENT_1 = {"acc": "ABC123", "datetime": DATE_TIME_NOW}
 FILE_ZIP_CONTENT_2 = {"acc": "ABC1234", "datetime": DATE_TIME_NOW}
+FILE_ZIP_CONTENT_3 = {"acc": "ABC12345"}
 SIEM_LOGS_HEADERS_RESPONSE = {"mc-siem-token": "token123"}
 
 
@@ -53,6 +54,7 @@ class Util:
         file_contents = [
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_1]},
             {"type": "MTA", "data": [FILE_ZIP_CONTENT_2]},
+            {"type": "MTA", "data": [FILE_ZIP_CONTENT_3]},
         ]
         zip_file = BytesIO()
         with ZipFile(zip_file, "w") as myzip:


### PR DESCRIPTION
## Proposed Changes

### Description

We observed that mimecast had a response where an event did not have datetime field, this meant that we tried to do the filtertime to comparison to see if we should ingest the event it was erroring as it was trying to fetch a field that didn't exist. 
A fix has been added that will add in a default time of now to event object if the datetime field does not exist. This means thats we will ingest the data


Describe the proposed changes:

  - If there is no datetime timestamp in the response from Mimecast then we will not check to see if the that field is within teh filter time 
  - to bump the werkzeug package version 

https://rapid7.atlassian.net/browse/SOAR-17038
https://github.com/rapid7/insightconnect-plugins/pull/2509

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

A new unit test case was added to cover this new feature 

```
----------------------------------------------------------------------
Ran 41 tests in 0.077s

OK
```

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

testing locally using postman 

when the code is edited to ensure that there is no datetime field, we can see that it's correctly logged that key is missing and has ingested all of the events

```
The following filter time will be used: 2024-06-02 13:50:02.755521
First run...
Number of raw logs returned from Mimecast: 45
There was no datetime key for the following event: {'acc': 'CUSB19A18', 'Sender': 'rocky.emery@concept-variety.b41.one', 'SourceIP': '54.243.138.179', 'aCode': 'T1VamqqGPxqigvozicCu6Q', 'Recipient': 'rocky.emery@demo-int.rapid7.mime-api.com', 'SenderDomain': 'concept-variety.b41.one', 'Route': 'Inbound', 'Subject': "U.S. Portfolio Managers' Spotlight:December 8, 2000", 'MsgId': '<d35e98ec270668f3-365098@hapi.b41.one>', 'headerFrom': 'rocky.emery@concept-variety.b41.one'}
.
.
.
Number of returned logs after filtering performed: 45
Latest event time returned from Mimecast logs: 2024-06-03 13:50:05.911504
The token will be set to 'eNo9jstugkAUQP_lbofEGcWMkHQBYkqMjwZqIcYNHa92qsPYeYBN479ru-j-nJPzAxaFNyj3EMMsa9tF5_qP9OTqPTdlx9EI35jNepmYvH7jLJtPr9WWLKSxmSzm68uRvJOKkjpRpS6e-y77Knye5lXFBVm9RKuZJFdBfD9Ru0G4VCPZ7wanc_MpniAAfThYdBDTAKxEddbH3w9Ow-FwHAYgDDYOX6VCiBlnfMR5OKaURv-4-77gn96hsVK3Dy6ARgjt20cWppsyZVHCJnC7Ay87SjE' in the state.
Plugin task finished execution...
```

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
