### PR TITLE
[SOAR-17031] - Set 401 status_code if Okta domain is invalid

### DIFF
--- a/plugins/okta/.CHECKSUM
+++ b/plugins/okta/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "156fe783b411f058a02cb0453a02df3c",
-	"manifest": "6785023b2ce83e39920c7ca08154fb5d",
-	"setup": "237b1f2d526ca1c374dd1601ed44e348",
+	"spec": "5f51dd8bff0793bea8783bf3adc76d1d",
+	"manifest": "0ce3d2a9c0342004f26185e862693b24",
+	"setup": "62958ca36bef95f5841f8f748ca7c020",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",

--- a/plugins/okta/bin/komand_okta
+++ b/plugins/okta/bin/komand_okta
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Okta"
 Vendor = "rapid7"
-Version = "4.2.7"
+Version = "4.2.8"
 Description = "[Okta](https://www.okta.com/) is a SSO and account lifecycle management provider that allows companies to integrate their central user account system with a wide variety of other applications and services"
 
 

--- a/plugins/okta/help.md
+++ b/plugins/okta/help.md
@@ -1598,6 +1598,7 @@ Actions may fail depending on the state of the resource you attempt to operate o
 
 # Version History
 
+* 4.2.8 - Connection: Set appropriate error code when domain is invalid
 * 4.2.7 - Updated to include latest SDK v5.4.9 | Task `Monitor Logs` updated to increase max lookback cutoff to 7 days
 * 4.2.6 - Connection: Update to ensure subdomain is entered correctly. Plugin will now raise an error if this value is not present
 * 4.2.5 - Monitor Logs task: Update handing of custom_config parameter

--- a/plugins/okta/komand_okta/connection/connection.py
+++ b/plugins/okta/komand_okta/connection/connection.py
@@ -19,13 +19,9 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
         valid_url = validate_url(base_url)
 
-        if not valid_url:
-            raise PluginException(
-                cause="Invalid domain entered for input 'Okta Domain'.",
-                assistance="Please include a valid subdomain, e.g. 'example.okta.com', if using 'okta.com'.",
-                data=f"Provided Okta Domain: {okta_url}",
-            )
-        self.api_client = OktaAPI(params.get(Input.OKTAKEY, {}).get("secretKey"), base_url, logger=self.logger)
+        self.api_client = OktaAPI(
+            params.get(Input.OKTAKEY, {}).get("secretKey"), base_url, logger=self.logger, valid_url=valid_url
+        )
 
     def test(self):
         try:

--- a/plugins/okta/plugin.spec.yaml
+++ b/plugins/okta/plugin.spec.yaml
@@ -14,7 +14,7 @@ sdk:
   user: nobody
 description: "[Okta](https://www.okta.com/) is a SSO and account lifecycle management provider that allows companies
   to integrate their central user account system with a wide variety of other applications and services"
-version: 4.2.7
+version: 4.2.8
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/okta
@@ -30,6 +30,7 @@ hub_tags:
   keywords: [sso, provisioning, deprovisioning, saml, cloud_enabled]
   features: []
 version_history:
+  - "4.2.8 - Connection: Set appropriate error code when domain is invalid"
   - "4.2.7 - Updated to include latest SDK v5.4.9 | Task `Monitor Logs` updated to increase max lookback cutoff to 7 days"
   - "4.2.6 - Connection: Update to ensure subdomain is entered correctly. Plugin will now raise an error if this value is not present"
   - "4.2.5 - Monitor Logs task: Update handing of custom_config parameter"

--- a/plugins/okta/setup.py
+++ b/plugins/okta/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="okta-rapid7-plugin",
-      version="4.2.7",
+      version="4.2.8",
       description="[Okta](https://www.okta.com/) is a SSO and account lifecycle management provider that allows companies to integrate their central user account system with a wide variety of other applications and services",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Release of Okta 4.2.8

### Description

Ticket - https://rapid7.atlassian.net/browse/SOAR-17031

Describe the proposed changes:

  - https://github.com/rapid7/insightconnect-plugins/pull/2571
  - Raise an exception with a 401 status code if the Okta domain is invalid, so that integrations will enter an error state instead of continually retrying (i.e. when a 500 is returned)

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

- Evidence in ticket https://github.com/rapid7/insightconnect-plugins/pull/2571
- Confirmed test integration on staging continues to run successfully in new version
- Setup a new connection on ICON staging to test that the connection test still works as expected
- Successful [job run to test action / new connection ](https://komand-ui.komand-int-1.komand-staging.r7ops.com/745DD060CF3F424ED48F#/jobs/details/bbe15b7f-8b3d-4746-9fe0-e6d000d94ad5)
