### PR TITLE
SOAR-17021-Adding in a connection test for task

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "cafa29823fba633ad2c66d9b8c030551",
+	"spec": "d93a536bdf3c112e604809eeab7f14ee",
 	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
 	"setup": "d68363a9feac9751efa37d92abe9393e",
 	"schemas": [

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "d93a536bdf3c112e604809eeab7f14ee",
+	"spec": "81ae590a7dff160854b0f0d45ea33a60",
 	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
 	"setup": "d68363a9feac9751efa37d92abe9393e",
 	"schemas": [

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2d101ebff407edd94c5757f53b5c11be",
-	"manifest": "1ab68873d2a221ff0ffb1a412f9747b4",
-	"setup": "5b681969411ccd987549d822b165cc8d",
+	"spec": "cafa29823fba633ad2c66d9b8c030551",
+	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
+	"setup": "d68363a9feac9751efa37d92abe9393e",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.9
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.1
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.3
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.12"
+Version = "5.3.13"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,7 +1014,7 @@ Example output:
 
 # Version History
 
-* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.1
+* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9
 * 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,6 +1014,7 @@ Example output:
 
 # Version History
 
+* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.1
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9
 * 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7

--- a/plugins/mimecast/komand_mimecast/connection/connection.py
+++ b/plugins/mimecast/komand_mimecast/connection/connection.py
@@ -41,7 +41,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
     def test_task(self):
         try:
-            _, _, status_code = self.client.get_siem_logs()
+            _, _, _ = self.client.get_siem_logs("")
             return {"success": True}
         except ApiClientException as error:
             self.logger.error(error)

--- a/plugins/mimecast/komand_mimecast/connection/connection.py
+++ b/plugins/mimecast/komand_mimecast/connection/connection.py
@@ -1,5 +1,6 @@
 import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
+from komand_mimecast.util.exceptions import ApiClientException
 from komand_mimecast.util import util
 from komand_mimecast.util.api import MimecastAPI
 from .schema import ConnectionSchema, Input
@@ -37,3 +38,16 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 data=response.get(FAIL_FIELD),
             )
         return {"success": True}
+
+
+    def test_task(self):
+        try:
+            _, _, status_code = self.client.get_siem_logs()
+            return {"success": True}
+        except ApiClientException as error:
+            self.logger.error(error)
+            raise ConnectionTestException(
+                cause=error.cause,
+                assistance=error.assistance,
+                data=error.data
+            )

--- a/plugins/mimecast/komand_mimecast/connection/connection.py
+++ b/plugins/mimecast/komand_mimecast/connection/connection.py
@@ -39,15 +39,10 @@ class Connection(insightconnect_plugin_runtime.Connection):
             )
         return {"success": True}
 
-
     def test_task(self):
         try:
             _, _, status_code = self.client.get_siem_logs()
             return {"success": True}
         except ApiClientException as error:
             self.logger.error(error)
-            raise ConnectionTestException(
-                cause=error.cause,
-                assistance=error.assistance,
-                data=error.data
-            )
+            raise ConnectionTestException(cause=error.cause, assistance=error.assistance, data=error.data)

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -92,7 +92,7 @@ class MimecastAPI:
     def find_remediation_incidents(self, data: dict) -> dict:
         return self._handle_rest_call("POST", f"{API}/ttp/remediation/find-incidents", data=data)
 
-    def get_siem_logs(self, next_page_token: str) -> Union[List[Dict[str, Any]], Dict[str, Any], int]:
+    def get_siem_logs(self, next_page_token: str = "") -> Union[List[Dict[str, Any]], Dict[str, Any], int]:
         uri = f"{API}/audit/get-siem-logs"
         data = {"compress": True, "file_format": "JSON", "type": "MTA", "token": next_page_token}
 

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -92,7 +92,7 @@ class MimecastAPI:
     def find_remediation_incidents(self, data: dict) -> dict:
         return self._handle_rest_call("POST", f"{API}/ttp/remediation/find-incidents", data=data)
 
-    def get_siem_logs(self, next_page_token) -> Union[List[Dict[str, Any]], Dict[str, Any], int]:
+    def get_siem_logs(self, next_page_token: str) -> Union[List[Dict[str, Any]], Dict[str, Any], int]:
         uri = f"{API}/audit/get-siem-logs"
         data = {"compress": True, "file_format": "JSON", "type": "MTA", "token": next_page_token}
 

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -92,7 +92,7 @@ class MimecastAPI:
     def find_remediation_incidents(self, data: dict) -> dict:
         return self._handle_rest_call("POST", f"{API}/ttp/remediation/find-incidents", data=data)
 
-    def get_siem_logs(self, next_page_token: str = "") -> Union[List[Dict[str, Any]], Dict[str, Any], int]:
+    def get_siem_logs(self, next_page_token) -> Union[List[Dict[str, Any]], Dict[str, Any], int]:
         uri = f"{API}/audit/get-siem-logs"
         data = {"compress": True, "file_format": "JSON", "type": "MTA", "token": next_page_token}
 

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.5.1
+  version: 5.5.3
   user: nobody
 status: []
 resources:

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -40,7 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
-- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.1"
+- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"
 - "5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7"

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.12
+version: 5.3.13
 connection_version: 5
 supported_versions: ["Mimecast API 2024-05-09"]
 vendor: rapid7
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.4.9
+  version: 5.5.1
   user: nobody
 status: []
 resources:
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.1"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"
 - "5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7"

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.12",
+      version="5.3.13",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - bump SDK used to 5.5.1
  - Added in a connection test for tasks

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section

note as the testing was done using https://github.com/rapid7/komand-plugin-sdk-python/pull/161/files locally as this versoin of the SDK is not merged yet, the validatiors and docker make is failing for now on git, i'll re-run the checks after the sdk version has been released

given valid creds 

 
![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/ef43bed2-717d-4ea0-8ef4-0804c51e8442)


given invalid creds 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/8eea3568-8ce5-4d93-b1dd-93207d91c36a)


 