### PR TITLE
SOAR-17129-Fixing issue with logging MC-SIEM-TOKEN

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "81ae590a7dff160854b0f0d45ea33a60",
+	"spec": "99b48de458e0a6f969b04e788d9a1334",
 	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
 	"setup": "d68363a9feac9751efa37d92abe9393e",
 	"schemas": [

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,7 +1014,7 @@ Example output:
 
 # Version History
 
-* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3
+* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9
 * 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -214,15 +214,15 @@ class MimecastAPI:
                             combined_json_list += [log]
                     except json.decoder.JSONDecodeError as json_error:
                         self.logger.error(
-                            f"JSON decode error on file ({file_name}), will continue loop... ",
-                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                            f"JSON decode error on file ({file_name}), will continue loop... "
+                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                             f"error: {json_error}, contents: {contents}",
                         )
                         continue
                     except Exception as gen_exception:
                         self.logger.error(
-                            "Hit an unexpected error, will continue loop...",
-                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                            "Hit an unexpected error, will continue loop..."
+                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                             f"error: {gen_exception}",
                             exc_info=True,
                         )
@@ -232,15 +232,15 @@ class MimecastAPI:
             # empty response from Mimecast can hit this, which we know is not an error, don't log it
             if error.args[0] != "File is not a zip file":
                 self.logger.error(
-                    "Hit BadZipFile, returning []. ",
-                    f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                    "Hit BadZipFile, returning []. "
+                    f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                     f"Error: {error}",
                     exc_info=True,
                 )
         except Exception as exception_error:
             self.logger.error(
-                "Hit an unexpected error,",
-                f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                "Hit an unexpected error,"
+                f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                 f"returning []. Error: {exception_error}",
                 exc_info=True,
             )

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.5.3
+  version: 5.5.5
   user: nobody
 status: []
 resources:
@@ -40,7 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
-- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3"
+- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"
 - "5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7"

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -70,7 +70,7 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(new_state, test_state)  # we shouldn't change the state if we encounter an error
         mock_logger.assert_called()
         self.assertIn(
-            "There is no item named 'filename-2-from-mimecast.json' in the archive", mock_logger.call_args[0][2]
+            "There is no item named 'filename-2-from-mimecast.json' in the archive", mock_logger.call_args[0][0]
         )
 
     @patch("logging.Logger.error")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - fixed issue where the commas at the end of the end of the string was causing the string to be treated as seperate args not as one string, as a result the error was not being logger correctly
 

this will be released as part of the 5.3.13 release 

  
 This will be added to the 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

testing before on master, to recreate the issue using a bad file

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/e4c49ea1-f76c-4f53-a43c-09446f7e911e)


testing using postman we can see that the error is now being raised correctly when a bad file is used

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/c91fe960-b570-4db4-91c8-20ae6f90b06b)


#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
