### PR TITLE
Mimecast 5.3.13 release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "81ae590a7dff160854b0f0d45ea33a60",
+	"spec": "99b48de458e0a6f969b04e788d9a1334",
 	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
 	"setup": "d68363a9feac9751efa37d92abe9393e",
 	"schemas": [

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2d101ebff407edd94c5757f53b5c11be",
-	"manifest": "1ab68873d2a221ff0ffb1a412f9747b4",
-	"setup": "5b681969411ccd987549d822b165cc8d",
+	"spec": "81ae590a7dff160854b0f0d45ea33a60",
+	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
+	"setup": "d68363a9feac9751efa37d92abe9393e",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.9
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.3
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.12"
+Version = "5.3.13"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,6 +1014,7 @@ Example output:
 
 # Version History
 
+* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9
 * 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,7 +1014,7 @@ Example output:
 
 # Version History
 
-* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3
+* 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9
 * 5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7

--- a/plugins/mimecast/komand_mimecast/connection/connection.py
+++ b/plugins/mimecast/komand_mimecast/connection/connection.py
@@ -1,5 +1,6 @@
 import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
+from komand_mimecast.util.exceptions import ApiClientException
 from komand_mimecast.util import util
 from komand_mimecast.util.api import MimecastAPI
 from .schema import ConnectionSchema, Input
@@ -37,3 +38,11 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 data=response.get(FAIL_FIELD),
             )
         return {"success": True}
+
+    def test_task(self):
+        try:
+            _, _, _ = self.client.get_siem_logs("")
+            return {"success": True}
+        except ApiClientException as error:
+            self.logger.error(error)
+            raise ConnectionTestException(cause=error.cause, assistance=error.assistance, data=error.data)

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -214,15 +214,15 @@ class MimecastAPI:
                             combined_json_list += [log]
                     except json.decoder.JSONDecodeError as json_error:
                         self.logger.error(
-                            f"JSON decode error on file ({file_name}), will continue loop... ",
-                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                            f"JSON decode error on file ({file_name}), will continue loop... "
+                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                             f"error: {json_error}, contents: {contents}",
                         )
                         continue
                     except Exception as gen_exception:
                         self.logger.error(
-                            "Hit an unexpected error, will continue loop...",
-                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                            "Hit an unexpected error, will continue loop..."
+                            f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                             f"error: {gen_exception}",
                             exc_info=True,
                         )
@@ -232,15 +232,15 @@ class MimecastAPI:
             # empty response from Mimecast can hit this, which we know is not an error, don't log it
             if error.args[0] != "File is not a zip file":
                 self.logger.error(
-                    "Hit BadZipFile, returning []. ",
-                    f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                    "Hit BadZipFile, returning []. "
+                    f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                     f"Error: {error}",
                     exc_info=True,
                 )
         except Exception as exception_error:
             self.logger.error(
-                "Hit an unexpected error,",
-                f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', ",
+                "Hit an unexpected error,"
+                f"Mimecast request ID: '{request.headers.get('mc-siem-token')}', "
                 f"returning []. Error: {exception_error}",
                 exc_info=True,
             )

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.5.3
+  version: 5.5.5
   user: nobody
 status: []
 resources:
@@ -40,7 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
-- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3"
+- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"
 - "5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7"

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.12
+version: 5.3.13
 connection_version: 5
 supported_versions: ["Mimecast API 2024-05-09"]
 vendor: rapid7
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.4.9
+  version: 5.5.3
   user: nobody
 status: []
 resources:
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.3"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"
 - "5.3.10 - Task `monitor_siem_logs`: To move token to next file even if there is no files found | bump SDK to 5.4.7"

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.12",
+      version="5.3.13",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -70,7 +70,7 @@ class TestMonitorSiemLogs(TestCase):
         self.assertEqual(new_state, test_state)  # we shouldn't change the state if we encounter an error
         mock_logger.assert_called()
         self.assertIn(
-            "There is no item named 'filename-2-from-mimecast.json' in the archive", mock_logger.call_args[0][2]
+            "There is no item named 'filename-2-from-mimecast.json' in the archive", mock_logger.call_args[0][0]
         )
 
     @patch("logging.Logger.error")


### PR DESCRIPTION
release pr for the following 


https://rapid7.atlassian.net/browse/SOAR-17021
 - https://github.com/rapid7/insightconnect-plugins/pull/2581
   - bump SDK used to 5.5.1
   - Added in a connection test for tasks

 - https://github.com/rapid7/insightconnect-plugins/pull/2588
   - fixed issue where the commas at the end of the end of the string was causing the string to be treated as seperate args not as one string, as a result the error was not being logger correctly  