### PR TITLE
MImecast 5.3.14 Release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "99b48de458e0a6f969b04e788d9a1334",
-	"manifest": "8b809555540a84bd55faa2f3a0f131c5",
-	"setup": "d68363a9feac9751efa37d92abe9393e",
+	"spec": "b9cfab994d3472797e0ac07af31e554f",
+	"manifest": "cbcb74065e79e5722a0044b59a98836e",
+	"setup": "4ea76504a159426cb9aade44a1df84d4",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.5.5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.6.1
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.13"
+Version = "5.3.14"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,6 +1014,7 @@ Example output:
 
 # Version History
 
+* 5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1
 * 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used
 * 5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9

--- a/plugins/mimecast/komand_mimecast/connection/connection.py
+++ b/plugins/mimecast/komand_mimecast/connection/connection.py
@@ -40,9 +40,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
         return {"success": True}
 
     def test_task(self):
+        self.logger.info("Running a connection test to Mimecast")
         try:
             _, _, _ = self.client.get_siem_logs("")
+            self.logger.info("The connection test to Mimecast was successful")
             return {"success": True}
         except ApiClientException as error:
+            self.logger.info("The connection test to Mimecast has failed")
             self.logger.error(error)
             raise ConnectionTestException(cause=error.cause, assistance=error.assistance, data=error.data)

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.13
+version: 5.3.14
 connection_version: 5
 supported_versions: ["Mimecast API 2024-05-09"]
 vendor: rapid7
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.5.5
+  version: 5.6.1
   user: nobody
 status: []
 resources:
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1"
 - "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"
 - "5.3.11 - Task `monitor_siem_logs` to now use 24hrs as initial lookback, then 7 days for normal running | Task `monitor_siem_logs` allowing for a date to be supplied as a custom config | Task `monitor_siem_logs` to now log the request id of failed request to Mimecast | bump SDK to version 5.4.9"

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.13",
+      version="5.3.14",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
release pr for the following

https://rapid7.atlassian.net/browse/SOAR-17021

 - https://github.com/rapid7/insightconnect-plugins/pull/2619

    - bump SDK used to 5.6.1 to improve returned status code under an error 
    - Improve the logging around connection tests to make it clearer to the user what is running



an invalid test will now return as a 400 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/843fa2f7-0a8f-49cd-b1ab-676bb0210eee)

a valid test will now show better logging 

![image](https://github.com/rapid7/insightconnect-plugins/assets/144030336/25cc53ff-3890-41b2-bb10-3080f0070dd2)