### PR TITLE
[SOAR-17225] Bumping DomainTooling API to 2.0.0

### DIFF
--- a/plugins/domaintools/.CHECKSUM
+++ b/plugins/domaintools/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "77b1431014ad250d2a04209ba519f13d",
+	"spec": "3e1489c87e4f3a0467214e48b5598187",
 	"manifest": "0d39191650c5a89e3fd0f392f408a1db",
 	"setup": "80ae8ad71906ef50080c2196a15c33e6",
 	"schemas": [

--- a/plugins/domaintools/help.md
+++ b/plugins/domaintools/help.md
@@ -1131,7 +1131,7 @@ There is no troubleshooting for this Plugin
 
 # Version History
 
-* 2.0.1 - SDK Bump | bumping version of anyio used in requirements
+* 2.0.1 - 'SDK' Bump | adding 'anyio' into requirements and bumping 'DomainTools' to '2.0.0'
 * 2.0.0 - Update `DomainTools` to `1.0.1` | Update to latest SDK version | Fix import issues on all actions | Change `Days Back` input of `Name Server Monitor` to type `int` | Remove `Query` input from `Reverse IP WHOIS` | Add `Server` to `WHOIS History` output `Response` | Add `Reasons` to `Reputation` output `Response` | Change `Meta` to type `List` for `Domain Profile` output `Response`
 * 1.0.1 - New spec and help.md format for the Extension Library
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Bug fix logging credentials

--- a/plugins/domaintools/plugin.spec.yaml
+++ b/plugins/domaintools/plugin.spec.yaml
@@ -33,7 +33,7 @@ tags:
 - domain
 - intel
 version_history:
-- "2.0.1 - SDK Bump | bumping version of anyio used in requirements"
+- "2.0.1 - 'SDK' Bump | adding 'anyio' into requirements and bumping 'DomainTools' to '2.0.0'"
 - "2.0.0 - Update `DomainTools` to `1.0.1` | Update to latest SDK version | Fix import issues on all actions | Change `Days Back` input of `Name Server Monitor` to type `int` | Remove `Query` input from `Reverse IP WHOIS` | Add `Server` to `WHOIS History` output `Response` | Add `Reasons` to `Reputation` output `Response` | Change `Meta` to type `List` for `Domain Profile` output `Response`"
 - "1.0.1 - New spec and help.md format for the Extension Library"
 - "1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types | Bug fix logging credentials"

--- a/plugins/domaintools/requirements.txt
+++ b/plugins/domaintools/requirements.txt
@@ -1,6 +1,6 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-domaintools-api==1.0.1
+domaintools-api==2.0.0
 anyio==4.4.0
 parameterized==0.9.0


### PR DESCRIPTION
## Proposed Changes

### Description

The SDK has already been bumped, Plugin refreshed and Unit tests fixed in the previous commit https://github.com/rapid7/insightconnect-plugins/pull/2620

**Minor update to the plugin to bump the API.** 

  - Bumping Domain Tooling [API](https://github.com/DomainTools/python_api/blob/main/CHANGELOG.md) to 2.0.0
 
### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [x] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [x] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [x] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [x] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [x] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [x] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [x] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [x] Work fully completed
- [x] Functional
  - [x] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [x] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [x] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [x] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [x] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)
