### PR TITLE
[SOAR-17285] [WHOIS] Release v3.1.3

### DIFF
--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "efc7b926653bfac99de578e7414f5448",
-	"manifest": "5f82aaab9bf468adf16a58a9e608d320",
-	"setup": "5eed8b48c4c0c31225ef1fbf10af4c87",
+	"spec": "523fadce564d5932620b038c4e732efd",
+	"manifest": "258d04c58d4a652ad6d3cc3bdb6f4b8f",
+	"setup": "73a03985f1f58f49859993da8d79dfe7",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.4.7
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/whois/bin/komand_whois
+++ b/plugins/whois/bin/komand_whois
@@ -6,8 +6,8 @@ from sys import argv
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "3.1.2"
-Description = "WHOIS is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
+Version = "3.1.3"
+Description = "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
 
 
 def main():

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -1,8 +1,6 @@
 # Description
 
-[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying
-databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address
-block, or an autonomous system.
+[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system
 
 # Key Features
 
@@ -183,6 +181,7 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
+* 3.1.3 - Updated SDK to the latest version (v6.0.0) | Bump setuptools version to v70.0.0
 * 3.1.2 - Updated SDK to the latest version | Added validation for input parameters
 * 3.1.1 - Add empty `__init__.py` file to `unit_test` folder | Refresh with new tooling
 * 3.1.0 - Add support for `.monster` and `.nl` domains

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -3,15 +3,15 @@ extension: plugin
 products: [insightconnect]
 name: whois
 title: WHOIS
-description: WHOIS is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system
-version: 3.1.2
+description: "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
+version: 3.1.3
 vendor: rapid7
 support: community
 supported_versions: ["2024-04-26"]
 status: []
 sdk:
   type: slim
-  version: 5.4.7
+  version: 6.0.0
   user: nobody
   packages:
     - whois
@@ -31,6 +31,7 @@ key_features: ["Perform a WHOIS lookup for a provided IP address or domain to ga
 references: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 links: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 version_history:
+  - "3.1.3 - Updated SDK to the latest version (v6.0.0) | Bump setuptools version to v70.0.0"
   - "3.1.2 - Updated SDK to the latest version | Added validation for input parameters"
   - "3.1.1 - Add empty `__init__.py` file to `unit_test` folder | Refresh with new tooling"
   - "3.1.0 - Add support for `.monster` and `.nl` domains"

--- a/plugins/whois/requirements.txt
+++ b/plugins/whois/requirements.txt
@@ -2,6 +2,6 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 parameterized==0.8.1
-setuptools~=65.5.1
+setuptools==70.0.0
 validators==0.28.1
 git+https://github.com/komand/python-whois.git@0.7.0

--- a/plugins/whois/setup.py
+++ b/plugins/whois/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="3.1.2",
-      description="WHOIS is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system",
+      version="3.1.3",
+      description="[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system",
       author="rapid7",
       author_email="",
       url="",


### PR DESCRIPTION
Release of WHOIS v3.1.3 - [SOAR-17285](https://rapid7.atlassian.net/browse/SOAR-17285)

Changes:
- bump of SDK to latest version - v6.0.0
- bump of setuptools to version 70.0.0

Tests:
- integration tests passing
- ran workflow on staging with both cloud and orch version, happy and non-happy paths working as expected. Screenshots attached to ticket. 

[SOAR-17285]: https://rapid7.atlassian.net/browse/SOAR-17285?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ