### PR TITLE
Mimecast 5.3.15 release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "7f38756d845f40e9bac391c38176e487",
+	"spec": "83ac49e9775f2ec79ec1550224670b07",
 	"manifest": "0b173bd9da9430ec68d86dede277ea19",
 	"setup": "47f68d27c80384f8d01495519d1b0a39",
 	"schemas": [

--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b9cfab994d3472797e0ac07af31e554f",
-	"manifest": "cbcb74065e79e5722a0044b59a98836e",
-	"setup": "4ea76504a159426cb9aade44a1df84d4",
+	"spec": "7f38756d845f40e9bac391c38176e487",
+	"manifest": "0b173bd9da9430ec68d86dede277ea19",
+	"setup": "47f68d27c80384f8d01495519d1b0a39",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.6.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.14"
+Version = "5.3.15"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -16,7 +16,7 @@
 
 # Supported Product Versions
 
-* Mimecast API 2024-05-09
+* Mimecast API 2024-06-18
 
 # Documentation
 
@@ -1014,6 +1014,7 @@ Example output:
 
 # Version History
 
+* 5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.0 | Allow for the task connection tests to pass back a message along side a status
 * 5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1
 * 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,7 +1014,7 @@ Example output:
 
 # Version History
 
-* 5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.0 | Allow for the task connection tests to pass back a message along side a status
+* 5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.1 | Allow for the task connection tests to pass back a message along side a status
 * 5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1
 * 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error
 * 5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used

--- a/plugins/mimecast/komand_mimecast/connection/connection.py
+++ b/plugins/mimecast/komand_mimecast/connection/connection.py
@@ -43,9 +43,23 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.logger.info("Running a connection test to Mimecast")
         try:
             _, _, _ = self.client.get_siem_logs("")
-            self.logger.info("The connection test to Mimecast was successful")
-            return {"success": True}
+            message = "The connection test to Mimecast was successful"
+            self.logger.info(message)
+            return {"success": True}, message
         except ApiClientException as error:
-            self.logger.info("The connection test to Mimecast has failed")
+
+            return_message = ""
+
+            failed_message = "The connection test to Mimecast has failed"
+            self.logger.info(failed_message)
+            return_message += f"{failed_message}\n"
+
+            cause_message = f"This failure was caused by: '{error.cause}'"
+            self.logger.info(cause_message)
+            return_message += f"{cause_message}\n"
+
+            self.logger.info(error.assistance)
+            return_message += f"{error.assistance}\n"
+
             self.logger.error(error)
-            raise ConnectionTestException(cause=error.cause, assistance=error.assistance, data=error.data)
+            raise ConnectionTestException(cause=error.cause, assistance=error.assistance, data=return_message)

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 6.0.0
+  version: 6.0.1
   user: nobody
 status: []
 resources:
@@ -40,7 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
-- "5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.0 | Allow for the task connection tests to pass back a message along side a status"
+- "5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.1 | Allow for the task connection tests to pass back a message along side a status"
 - "5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1"
 - "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -5,7 +5,7 @@ name: mimecast
 title: Mimecast
 description: "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 key_features:
--  Email security
+- Email security
 - Malicious URL and attachment detection
 requirements:
 - Access API Key
@@ -17,15 +17,15 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.14
+version: 5.3.15
 connection_version: 5
-supported_versions: ["Mimecast API 2024-05-09"]
+supported_versions: ["Mimecast API 2024-06-18"]
 vendor: rapid7
 support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.6.1
+  version: 6.0.0
   user: nobody
 status: []
 resources:
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.0 | Allow for the task connection tests to pass back a message along side a status"
 - "5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1"
 - "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"
 - "5.3.12 - Task `monitor_siem_logs` to ingest events if there is no datetime field | bump version of werkzeug used"

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -6,4 +6,4 @@ parameterized==0.8.1
 python-dateutil==2.6.1
 jsonschema==3.2.0
 werkzeug==3.0.3
-setuptools==65.5.1
+setuptools==70.0.0

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.14",
+      version="5.3.15",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

Release pr for the following 

* https://github.com/rapid7/insightconnect-plugins/pull/2639 
  *  https://rapid7.atlassian.net/browse/SOAR-17270
     * Update setuptools to 70.0.0
     * Update version to 5.3.15
  * https://rapid7.atlassian.net/browse/SOAR-17272
After new changes to the SDK, we now support passing back a message to the SDK as part of the task connection test, this will allow for the use of the custom message to be shown in the UI for a task connection test, rather than have the end user see all of the available logs   
   
* https://github.com/rapid7/insightconnect-plugins/pull/2656
  * Bump the sdk used in Mimecast that was used 



