### PR TITLE
[SOAR-17284] python3_script Removing 'records' and 'zipp' & SDK Bump

### DIFF
--- a/plugins/python_3_script/.CHECKSUM
+++ b/plugins/python_3_script/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "a7dcb6c6d05f0030e5c902372e813032",
+	"spec": "50be11200d88205c27bc2a51aea871ec",
 	"manifest": "c2e4733a3993a54870ee3c0a2c047ad5",
 	"setup": "5374cb871cfa48bd7489ef400f592b56",
 	"schemas": [

--- a/plugins/python_3_script/Dockerfile
+++ b/plugins/python_3_script/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -2,20 +2,13 @@
 
 [Python](https://www.python.org/) is a programming language that lets you work quickly and integrate systems more effectively. This plugin allows you to run Python 3 code. It includes Python 3.9.19 and its standard library as well as the following 3rd party libraries:
 
- * [requests 2.31.0](https://requests.readthedocs.io/en/master/) 
- * [arrow 1.3.0](https://pypi.org/project/arrow/) 
- * [lxml 5.2.2](http://lxml.de/) 
- * [beautifulsoup 4.12.2](https://www.crummy.com/software/BeautifulSoup/) 
- * [pyyaml 6.0.1](http://pyyaml.org/) 
- * [records 0.6.0](https://github.com/kennethreitz/records) 
- * [zipp 3.19.2](https://pypi.org/project/zipp/) 
- * [parameterized 0.8.1](https://pypi.org/project/parameterized/) 
- * [setuptools 71.1.0](https://pypi.org/project/setuptools/)
- * [datetime 5.5](https://pypi.org/project/DateTime/) 
-
-The Python 3 Script plugin also allows you to load custom modules via its connection parameters.
-
-Also, this plugin allows you to provide additional credentials in the connection such as username, password, secret_key available in the script as Python variables (`username`, `password`, `secret_key`)
+* [arrow 1.3.0](https://pypi.org/project/arrow/) 
+* [lxml 5.2.2](http://lxml.de/) 
+* [beautifulsoup 4.12.2](https://www.crummy.com/software/BeautifulSoup/) 
+* [pyyaml 6.0.1](http://pyyaml.org/) 
+* [parameterized 0.8.1](https://pypi.org/project/parameterized/) 
+* [setuptools 71.1.0](https://pypi.org/project/setuptools/)
+* [datetime 5.5](https://pypi.org/project/DateTime/) 
 
 # Key Features
 
@@ -119,7 +112,7 @@ Some third-party modules defined in the Modules connection input (such as pandas
 
 # Version History
 
-* 5.0.0 - Updated SDK to the latest version | Addressing Snyk vulnerabilities by bumping dependencies | Replacing maya with arrow (maya not maintained)
+* 5.0.0 - Updated SDK to the latest version | Removing records as its not maintained | Replacing maya with arrow (maya not maintained)
 * 4.0.10 - Updated the SDK to the latest version | Updated Python version to `3.9.19` | Fixed issue with invalid unicode character
 * 4.0.9 - Updated the SDK to the latest version to address memory usage issues
 * 4.0.8 - Updated the SDK to latest version | Fix issue where input argument was too long

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -9,7 +9,11 @@
 * [pyyaml 6.0.1](http://pyyaml.org/) 
 * [parameterized 0.8.1](https://pypi.org/project/parameterized/) 
 * [setuptools 71.1.0](https://pypi.org/project/setuptools/)
-* [datetime 5.5](https://pypi.org/project/DateTime/) 
+* [datetime 5.5](https://pypi.org/project/DateTime/)
+
+The Python 3 Script plugin also allows you to load custom modules via its connection parameters.
+
+Also, this plugin allows you to provide additional credentials in the connection such as username, password, secret_key available in the script as Python variables (`username`, `password`, `secret_key`)
 
 # Key Features
 

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -2,6 +2,7 @@
 
 [Python](https://www.python.org/) is a programming language that lets you work quickly and integrate systems more effectively. This plugin allows you to run Python 3 code. It includes Python 3.9.19 and its standard library as well as the following 3rd party libraries:
 
+* [requests 2.31.0](https://requests.readthedocs.io/en/latest/)
 * [arrow 1.3.0](https://pypi.org/project/arrow/) 
 * [lxml 5.2.2](http://lxml.de/) 
 * [beautifulsoup 4.12.2](https://www.crummy.com/software/BeautifulSoup/) 

--- a/plugins/python_3_script/plugin.spec.yaml
+++ b/plugins/python_3_script/plugin.spec.yaml
@@ -12,7 +12,7 @@ connection_version: 4
 supported_versions: ["Python 3.9.19"]
 sdk:
   type: slim
-  version: 6.0.0
+  version: 6.0.1
   user: root
   packages:
     - libxslt-dev
@@ -40,7 +40,7 @@ references: ["[Python 3 Language Reference](https://docs.python.org/3/reference/
 links:
   - '[Python](https://www.python.org/)'
 version_history:
-  - '5.0.0 - Updated SDK to the latest version | Addressing Snyk vulnerabilities by bumping dependencies | Replacing maya with arrow (maya not maintained)'
+  - '5.0.0 - Updated SDK to the latest version | Removing records as its not maintained | Replacing maya with arrow (maya not maintained)'
   - '4.0.10 - Updated the SDK to the latest version | Updated Python version to `3.9.19` | Fixed issue with invalid unicode character'
   - '4.0.9 - Updated the SDK to the latest version to address memory usage issues'
   - '4.0.8 - Updated the SDK to latest version | Fix issue where input argument was too long'

--- a/plugins/python_3_script/requirements.txt
+++ b/plugins/python_3_script/requirements.txt
@@ -1,7 +1,3 @@
-# List third-party dependencies here, separated by newlines. 
-# All dependencies must be version-pinned, eg. requests==1.2.0
-# See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-records==0.6.0
 arrow==1.3.0
 lxml==5.2.2
 datetime==5.5
@@ -9,4 +5,3 @@ setuptools==71.1.0
 PyYAML==6.0.1
 beautifulsoup4==4.12.2
 parameterized==0.8.1
-zipp==3.19.2


### PR DESCRIPTION
## Proposed Changes

### Description

[Original PR](https://github.com/rapid7/insightconnect-plugins/pull/2644)

After testing the [records](https://pypi.org/project/records/) package it is concluded that it is no longer maintained and will not work. 

As the [records](https://pypi.org/project/records/) package caused the Snyk vulnerability, I took the zipp package out (as it was the solution to fix the snyk vulnerability) and the snyk tests pass.

Describe the proposed changes:

  - SDK Bump to 6.0.1
  - Removing 'records' and 'zipp'
  - Updating Plugin Spec and help.md


### Testing

#### Unit Tests

Unit test carried out:
![image](https://github.com/user-attachments/assets/3550c16b-eb17-4836-a0fd-204858ba3c66)


- [x] Unit tests written for any new or updated code

