### PR TITLE
[SOAR-17165] Carbon Black Response SDK Bump

### DIFF
--- a/plugins/carbon_black_response/.CHECKSUM
+++ b/plugins/carbon_black_response/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "01bacae24131c218cc5d3391c0189724",
+	"spec": "2b140eb31fcee9236b0c68c0be1de11b",
 	"manifest": "895c32b0a13cbde168d20f4352885d15",
 	"setup": "b9e53a59d334bb3c1b011b3656f00104",
 	"schemas": [

--- a/plugins/carbon_black_response/Dockerfile
+++ b/plugins/carbon_black_response/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.0.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.0.1
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/carbon_black_response/plugin.spec.yaml
+++ b/plugins/carbon_black_response/plugin.spec.yaml
@@ -48,7 +48,7 @@ version_history:
 - "0.1.0 - Initial plugin"
 sdk:
     type: full
-    version: 6.0.0
+    version: 6.0.1
     user: nobody
 troubleshooting: "This plugin does not contain any troubleshooting information."
 requirements:


### PR DESCRIPTION
## Proposed Changes

### Description

Was about to merge into Master and the validator failed as the SDK has been updated to 6.0.1

[RELEASE PR](https://github.com/rapid7/insightconnect-plugins/pull/2663)
[ORIGINAL PR](https://github.com/rapid7/insightconnect-plugins/pull/2642)

Describe the proposed changes:

  - SDK bump to 6.0.1