### PR TITLE
[SOAR-17274] html updating USER permissions 

### DIFF
--- a/plugins/html/.CHECKSUM
+++ b/plugins/html/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "691bd8a45792f1c3ff7c6f43ac2166b4",
+	"spec": "f5482a1cef5e1328c18792ff5c50d80d",
 	"manifest": "ff24d95d8572ec0b30dc435956525e48",
 	"setup": "e17dd73a961bd7a3bbdabe362a23d382",
 	"schemas": [

--- a/plugins/html/Dockerfile
+++ b/plugins/html/Dockerfile
@@ -17,7 +17,7 @@ ADD . /python/src
 
 RUN python setup.py build && python setup.py install
 
-# User to run plugin code. The two supported users are: root, nobody
-USER nobody
+# root is required for the conversion to work. If USER set to nobody, actions/tests will fail
+USER root
 
 ENTRYPOINT ["/usr/local/bin/icon_html"]

--- a/plugins/html/help.md
+++ b/plugins/html/help.md
@@ -271,7 +271,7 @@ Example output:
 
 # Version History
 
-* 1.2.6 - SDK Bump | Addressing Snyk vulnerabilities | Fixing Unit Tests
+* 1.2.6 - SDK Bump | Addressing Snyk vulnerabilities | Fixing Unit Tests | Dockerfile USER permission updated
 * 1.2.5 - Update requirements for pypandoc
 * 1.2.4 - Actions modified in order to implement PluginExceptions
 * 1.2.3 - Action HTML5: fix error with encoding to file

--- a/plugins/html/plugin.spec.yaml
+++ b/plugins/html/plugin.spec.yaml
@@ -28,14 +28,14 @@ hub_tags:
 sdk:
   type: slim
   version: 6.0.1
-  user: nobody
+  user: root
 connection_version: 1
 links:
 - "[W3 Validator](https://validator.w3.org)"
 key_features:
 - Convert an HTML document into another format to more easily export, share, or edit the document's contents
 version_history:
-- "1.2.6 - SDK Bump | Addressing Snyk vulnerabilities | Fixing Unit Tests"
+- "1.2.6 - SDK Bump | Addressing Snyk vulnerabilities | Fixing Unit Tests | Dockerfile USER permission updated"
 - "1.2.5 - Update requirements for pypandoc"
 - "1.2.4 - Actions modified in order to implement PluginExceptions"
 - "1.2.3 - Action HTML5: fix error with encoding to file"


### PR DESCRIPTION
## Proposed Changes

### Description

Convert actions were failing due to the USER permissions set to nobody. ([previous PR experienced same issue](https://github.com/rapid7/insightconnect-plugins/pull/2200))

****The validator will fail due to the change in USER permission but is required for the plugin to work****

Describe the proposed changes:

  - USER privileges changed to root

### Testing

Each action has been tested on postman to ensure the conversion occurs successfully:

- Dockx
![image](https://github.com/user-attachments/assets/39b07ff6-5584-4c2f-89f9-b65317631511)

- pdf
![image](https://github.com/user-attachments/assets/9564ca38-bd65-45cb-8dad-906e61172fde)

- epub
![image](https://github.com/user-attachments/assets/dfc2806c-82ef-470f-b0ad-69516f16735e)

- html5
![image](https://github.com/user-attachments/assets/86cae23f-3899-4447-9990-f5f90ed87a0d)

- markdown
![image](https://github.com/user-attachments/assets/7b00b715-9025-4785-bf75-dc1c407e3890)

- text
![image](https://github.com/user-attachments/assets/6ac246d7-020e-412a-af77-bb45672dc1e1)

- validate
![image](https://github.com/user-attachments/assets/1d8bbf78-727b-45b2-8676-a8660d604850)






#### Unit Tests

All unit tests have been tested and pass successfully