### PR TITLE
[SOAR-17274] html changing convert action for PDF

### DIFF
--- a/plugins/html/icon_html/actions/pdf/action.py
+++ b/plugins/html/icon_html/actions/pdf/action.py
@@ -23,7 +23,7 @@ class Pdf(insightconnect_plugin_runtime.Action):
             raise PluginException(cause="Invalid input.", assistance="Input must be of type HTML.")
 
         try:
-            pypandoc.convert(doc, "pdf", outputfile=temp_file, format="html")
+            pypandoc.convert_text(doc, "pdf", outputfile=temp_file, format="html")
         except RuntimeError as error:
             raise PluginException(cause="Error converting doc file. ", assistance="Check stack trace log.", data=error)
         with open(temp_file, "rb") as output:


### PR DESCRIPTION
## Proposed Changes

### Description

When testing the pdf action on Postman and against the Orchestrator in staging it passed but when I tested it against the cloud in staging it failed (but every other action passed).

Looking at the logs (`Error converting doc file.  Check stack trace log. Response was: Pandoc died with exitcode "-9" during conversion: b''`) this seems to be the only solution at the moment as the test works on postman and against the orchestrator 😕 

This change was also carried out on the other actions within the html plugin in the [previous pr](https://github.com/rapid7/insightconnect-plugins/pull/2653/files#diff-a141193a576d54dd9e613a220a4172372281b7d98af40c4236a29c98ac297c6f)

**The validator is expected to fail due to the USER privilege changing from nobody to root (for the pandoc package to work)**

Describe the proposed changes:

  - Changing the convert method to convert_text (to keep inline with previous action changes)

### Testing

Testing this via Postman and the tests pass as expected