### PR TITLE
[SOAR-17274] Bumping pypandoc for html plugin

### DIFF
--- a/plugins/html/requirements.txt
+++ b/plugins/html/requirements.txt
@@ -2,6 +2,6 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 beautifulsoup4==4.9.1
-pypandoc==1.5
+pypandoc==1.13
 wheel==0.38.0
 setuptools==70.0.0


### PR DESCRIPTION
## Proposed Changes

### Description

When testing the pdf action again (against the cloud) with the [convert action changes](https://github.com/rapid7/insightconnect-plugins/pull/2668), the error still occurs. The API bump is the only potential fix at the moment.

Looking at the logs (`Error converting doc file.  Check stack trace log. Response was: Pandoc died with exitcode "-9" during conversion: b''`) this seems to be the final solution at the moment as the test works on postman and against the orchestrator 😕 

**The validator is expected to fail due to the USER privilege changing from nobody to root (for the pandoc package to work)**

Describe the proposed changes:

  - Bumping pypandoc

### Testing

Testing this via Postman and the tests pass as expected