### PR TITLE
[SOAR-17320] Okta Removing ConnectionResetError exception

### DIFF
--- a/plugins/okta/komand_okta/connection/connection.py
+++ b/plugins/okta/komand_okta/connection/connection.py
@@ -57,10 +57,3 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 assistance="Please verify the URL specified is valid and reachable before attempting to connect again.",
                 data="Please ensure the URL specified can be reached and is valid before trying to reconnect.",
             )
-        except ConnectionResetError as error:
-            self.logger.error(f"Catching egress rules for connection: '{error}'")
-            raise ConnectionTestException(
-                cause="Failed to connect to the supplied URL.",
-                assistance="Please contact support if this issue persists.",
-                data="The connection to Okta has failed. Please ensure your details are correct before attempting to connect again.",
-            )


### PR DESCRIPTION
## Proposed Changes

### Description

When testing the connection task in staging, the 104 exception (invalid URL but correct structure) was being caught in the `ConnectionError` exception and not in the `ConnectionResetError`, meaning the exception is no longer needed (as the `ConnectionResetError` exception was only implemented to catch it).

[Original PR](https://github.com/rapid7/insightconnect-plugins/pull/2692) 

Describe the proposed changes:
  - Removing the ConnectionResetError exception

### Testing

The 104 error is being caught in the ConnectionError exception and not ConnectionResetError:
![image](https://github.com/user-attachments/assets/fd8aecad-b725-4df3-a456-05faae1fa6d2)


Tested on Postman that by sending a invalid URL (but correct structure) is caught in the ConnectionError exception:
![image](https://github.com/user-attachments/assets/9a0d6a3c-b436-418d-84fa-a2845b9871ff)
