### PR TITLE
Sentinelone remove task inputs

### DIFF
--- a/plugins/sentinelone/.CHECKSUM
+++ b/plugins/sentinelone/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "7cf50e827b442c746c91f6193f471a0a",
-	"manifest": "2ae31166158e32c09fe2f2b4fdeb4532",
-	"setup": "3ed8da815b0fcfb46e1e5ec5d89b88cf",
+	"spec": "f0c80e3b469f942bb01f370e883158ae",
+	"manifest": "8434101660bff3ff52f0200d8ddaf60c",
+	"setup": "ad5edd0e6642483b32bf9a3b802fb1cc",
 	"schemas": [
 		{
 			"identifier": "activities_list/schema.py",
@@ -129,7 +129,7 @@
 		},
 		{
 			"identifier": "monitor_logs/schema.py",
-			"hash": "d21d948aadbc16172cdcb888835d224f"
+			"hash": "5e04ff3d683807975295bc22a41a6322"
 		},
 		{
 			"identifier": "get_threats/schema.py",

--- a/plugins/sentinelone/Dockerfile
+++ b/plugins/sentinelone/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:5.6.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/sentinelone/bin/komand_sentinelone
+++ b/plugins/sentinelone/bin/komand_sentinelone
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "SentinelOne"
 Vendor = "rapid7"
-Version = "10.0.0"
+Version = "11.0.0"
 Description = "The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne"
 
 

--- a/plugins/sentinelone/help.md
+++ b/plugins/sentinelone/help.md
@@ -1722,22 +1722,8 @@ Example output:
 This task is used to monitor for new activities, device control events, and threats
 
 ##### Input
-
-|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|collectActivities|bool|True|False|Whether to collect activity logs (note requires appropriate permissions assigned to user)|None|False|True|Whether or not to query for new activity logs|
-|collectEvents|bool|True|False|Whether to collect device control events logs (note requires appropriate permissions assigned to user)|None|False|True|Whether or not to query for new device control event logs|
-|collectThreats|bool|True|False|Whether to collect threats logs (note requires appropriate permissions assigned to user)|None|False|True|Whether or not to query for new threat logs|
   
-Example input:
-
-```
-{
-  "collectActivities": true,
-  "collectEvents": true,
-  "collectThreats": true
-}
-```
+*This task does not contain any inputs.*
 
 ##### Output
 
@@ -2366,6 +2352,7 @@ Example output:
 
 # Version History
 
+* 11.0.0 - Removed `Monitor Activities and Events` task input options | Update SDK
 * 10.0.0 - Added `Monitor Activities and Events` task | Removed `User Type` from connection | A Service User API Key must now be provided to provide enhanced security
 * 9.1.2 - Retry functionality added to requests to SenintelOne that result in a 429 (too many requests) or 503 (service unavailable) error.
 * 9.1.1 - `Threats Fetch File`: Updated action to prevent possible movement through file system

--- a/plugins/sentinelone/komand_sentinelone/tasks/monitor_logs/schema.py
+++ b/plugins/sentinelone/komand_sentinelone/tasks/monitor_logs/schema.py
@@ -8,9 +8,7 @@ class Component:
 
 
 class Input:
-    COLLECTACTIVITIES = "collectActivities"
-    COLLECTEVENTS = "collectEvents"
-    COLLECTTHREATS = "collectThreats"
+    pass
 
 
 class State:
@@ -23,40 +21,7 @@ class Output:
 
 class MonitorLogsInput(insightconnect_plugin_runtime.Input):
     schema = json.loads(r"""
-   {
-  "type": "object",
-  "title": "Variables",
-  "properties": {
-    "collectActivities": {
-      "type": "boolean",
-      "title": "Collect Activities",
-      "description": "Whether to collect activity logs (note requires appropriate permissions assigned to user)",
-      "default": true,
-      "placeholder": true,
-      "tooltip": "Whether or not to query for new activity logs",
-      "order": 1
-    },
-    "collectEvents": {
-      "type": "boolean",
-      "title": "Collect Events",
-      "description": "Whether to collect device control events logs (note requires appropriate permissions assigned to user)",
-      "default": true,
-      "placeholder": true,
-      "tooltip": "Whether or not to query for new device control event logs",
-      "order": 2
-    },
-    "collectThreats": {
-      "type": "boolean",
-      "title": "Collect Threats",
-      "description": "Whether to collect threats logs (note requires appropriate permissions assigned to user)",
-      "default": true,
-      "placeholder": true,
-      "tooltip": "Whether or not to query for new threat logs",
-      "order": 3
-    }
-  },
-  "definitions": {}
-}
+   {}
     """)
 
     def __init__(self):

--- a/plugins/sentinelone/komand_sentinelone/tasks/monitor_logs/task.py
+++ b/plugins/sentinelone/komand_sentinelone/tasks/monitor_logs/task.py
@@ -156,9 +156,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 if cursor:
                     self.logger.info(f"Getting {log_type} using next page cursor: {cursor}...")
                 else:
-                    self.logger.info(
-                        f"Getting {log_type} between {lookback_timestamp} and {current_run_timestamp}..."
-                    )
+                    self.logger.info(f"Getting {log_type} between {lookback_timestamp} and {current_run_timestamp}...")
                 logs, total_forbidden_responses = self.get_generic_logs(
                     log_type,
                     state,

--- a/plugins/sentinelone/komand_sentinelone/tasks/monitor_logs/task.py
+++ b/plugins/sentinelone/komand_sentinelone/tasks/monitor_logs/task.py
@@ -63,12 +63,8 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         existing_state = state.copy()
         try:
             is_initial_run = self.check_initial_run(state)
-            queries = self.check_queries(params)
-            self.logger.info(
-                "Input options selected to query: " + ", ".join([f"{key}: {value}" for key, value in queries.items()])
-            )
             cursors = self.get_cursors(state)
-            total_queries = self.count_queries(queries)
+            total_queries = 3
             total_forbidden_responses = 0
             is_paginating = any(cursors.values())
             if is_paginating:
@@ -86,7 +82,6 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             )
 
             all_logs, total_forbidden_responses = self.collect_logs_handler(
-                queries,
                 cursors,
                 state,
                 lookback_timestamps,
@@ -120,16 +115,6 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             self.logger.info("State detected. Instantiating continuation run.")
         return not state
 
-    def check_queries(self, params: Dict) -> Tuple[str, str, str]:
-        """
-        Return whether to query a specific endpoint based on the input parameters
-        """
-        return {
-            ACTIVITIES_LOGS: params.get(Input.COLLECTACTIVITIES),
-            EVENTS_LOGS: params.get(Input.COLLECTEVENTS),
-            THREATS_LOGS: params.get(Input.COLLECTTHREATS),
-        }
-
     def get_cursors(self, state: Dict) -> Tuple[str, str, str]:
         """
         Return existing cursors for each endpoint
@@ -139,12 +124,6 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             EVENTS_LOGS: state.get(EVENTS_PAGE_CURSOR),
             THREATS_LOGS: state.get(THREATS_PAGE_CURSOR),
         }
-
-    def count_queries(self, queries: dict) -> int:
-        """
-        Count how many queries are to be made and return the value
-        """
-        return len(list(filter(lambda query: query is not None, queries.values())))
 
     def log_pagination_cycle(self, cursors) -> None:
         """
@@ -159,7 +138,6 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
 
     def collect_logs_handler(
         self,
-        queries: Dict,
         cursors: Dict,
         state: Dict,
         lookback_timestamps: Dict,
@@ -171,29 +149,28 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
         Handle whether to query each endpoint based on input and pagination, gather returned data and error responses
         """
         all_logs = []
-        for log_type, check in queries.items():
-            if check:
-                cursor = cursors.get(log_type)
-                lookback_timestamp = lookback_timestamps.get(log_type)
-                if is_paginating is False or (is_paginating is True and cursor):
-                    if cursor:
-                        self.logger.info(f"Getting {log_type} using next page cursor: {cursor}...")
-                    else:
-                        self.logger.info(
-                            f"Getting {log_type} between {lookback_timestamp} and {current_run_timestamp}..."
-                        )
-                    logs, total_forbidden_responses = self.get_generic_logs(
-                        log_type,
-                        state,
-                        total_forbidden_responses,
-                        current_run_timestamp,
-                        lookback_timestamp,
-                        cursor,
-                    )
-                    self.logger.info(f"{len(logs)} logs found in {log_type} query")
-                    all_logs.extend(logs)
+        for log_type in [ACTIVITIES_LOGS, EVENTS_LOGS, THREATS_LOGS]:
+            cursor = cursors.get(log_type)
+            lookback_timestamp = lookback_timestamps.get(log_type)
+            if is_paginating is False or (is_paginating is True and cursor):
+                if cursor:
+                    self.logger.info(f"Getting {log_type} using next page cursor: {cursor}...")
                 else:
-                    self.logger.info(f"Pagination in progress, skipping {log_type} collection...")
+                    self.logger.info(
+                        f"Getting {log_type} between {lookback_timestamp} and {current_run_timestamp}..."
+                    )
+                logs, total_forbidden_responses = self.get_generic_logs(
+                    log_type,
+                    state,
+                    total_forbidden_responses,
+                    current_run_timestamp,
+                    lookback_timestamp,
+                    cursor,
+                )
+                self.logger.info(f"{len(logs)} logs found in {log_type} query")
+                all_logs.extend(logs)
+            else:
+                self.logger.info(f"Pagination in progress, skipping {log_type} collection...")
         return all_logs, total_forbidden_responses
 
     def get_generic_logs(

--- a/plugins/sentinelone/plugin.spec.yaml
+++ b/plugins/sentinelone/plugin.spec.yaml
@@ -3,12 +3,12 @@ extension: plugin
 products: [insightconnect]
 name: sentinelone
 title: SentinelOne
-version: 10.0.0
+version: 11.0.0
 connection_version: 10
 cloud_ready: true
 sdk:
   type: slim
-  version: 5.6.1
+  version: 6.0.1
   user: nobody
 supported_versions: ["2.1.0"]
 description: The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne
@@ -3110,34 +3110,6 @@ tasks:
   monitor_logs:
     title: Monitor Logs
     description: Monitor for new activities, device control events, and threats
-    input:
-      collectActivities:
-        title: Collect Activities
-        description: Whether to collect activity logs (note requires appropriate permissions assigned to user)
-        type: bool
-        required: false
-        default: true
-        example: false
-        placeholder: true
-        tooltip: Whether or not to query for new activity logs
-      collectEvents:
-        title: Collect Events
-        description: Whether to collect device control events logs (note requires appropriate permissions assigned to user)
-        type: bool
-        required: false
-        default: true
-        example: false
-        placeholder: true
-        tooltip: Whether or not to query for new device control event logs
-      collectThreats:
-        title: Collect Threats
-        description: Whether to collect threats logs (note requires appropriate permissions assigned to user)
-        type: bool
-        required: false
-        default: true
-        example: false
-        placeholder: true
-        tooltip: Whether or not to query for new threat logs
     output:
       logs:
         title: Logs

--- a/plugins/sentinelone/setup.py
+++ b/plugins/sentinelone/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="sentinelone-rapid7-plugin",
-      version="10.0.0",
+      version="11.0.0",
       description="The SentinelOne plugin allows you to manage and mitigate all your security operations through SentinelOne",
       author="rapid7",
       author_email="",

--- a/plugins/sentinelone/unit_test/test_monitor_logs.py
+++ b/plugins/sentinelone/unit_test/test_monitor_logs.py
@@ -257,9 +257,7 @@ class TestMonitorLogs(TestCase):
     def test_monitor_logs_api_errors(
         self, mock_request, test_name, state, expected_status_code, expected_cause, expected_assistance
     ):
-        output, state, has_more_pages, status_code, error = self.task.run(
-            params={}, state=state
-        )
+        output, state, has_more_pages, status_code, error = self.task.run(params={}, state=state)
         self.assertEqual(False, has_more_pages)
         self.assertEqual(expected_status_code, status_code)
         self.assertEqual(expected_cause, error.cause)

--- a/plugins/sentinelone/unit_test/util.py
+++ b/plugins/sentinelone/unit_test/util.py
@@ -331,6 +331,10 @@ class Util:
                 return MockResponse(200, "name_not_available")
             return MockResponse(200, "name_available")
         elif args[1] == "https://rapid7.sentinelone.net/web/api/v2.1/threats":
+            if params.get("cursor") == "401":
+                return MockResponse(401)
+            if params.get("cursor") == "403":
+                return MockResponse(403)
             if params.get("ids") in [
                 ["valid_threat_id_1"],
                 ["valid_threat_id_2"],
@@ -413,5 +417,9 @@ class Util:
             elif json_data.get("data", {}).get("targetSiteId", "") == "1234567891234567891":
                 return MockResponse(200, "move_between_sites_data")
         elif args[1] == "https://rapid7.sentinelone.net/web/api/v2.1/device-control/events":
+            if params.get("cursor") == "401":
+                return MockResponse(401)
+            if params.get("cursor") == "403":
+                return MockResponse(403)
             return MockResponse(200, "monitor_logs_events")
         return MockResponse(404)


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Remove task inputs due to passing of string value instead of boolean from Bridge PCA causing validator failure

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
