### PR TITLE
Bitwarden 2.0.1 Release

### DIFF
--- a/plugins/bitwarden/.CHECKSUM
+++ b/plugins/bitwarden/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1c26b5a9a0d3a37144d642191a8b961c",
-	"manifest": "eb5f327e8f5bbabfc100f720a41fc38c",
-	"setup": "4b75a91e080bed856d850249778181dc",
+	"spec": "a8b8a761e09fb706a38576a892895793",
+	"manifest": "d8799057c50a196bd13b2361bf886047",
+	"setup": "c8c65697472372dfc119b63e62540746",
 	"schemas": [
 		{
 			"identifier": "createMember/schema.py",

--- a/plugins/bitwarden/Dockerfile
+++ b/plugins/bitwarden/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/bitwarden/bin/icon_bitwarden
+++ b/plugins/bitwarden/bin/icon_bitwarden
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Bitwarden"
 Vendor = "rapid7"
-Version = "2.0.0"
+Version = "2.0.1"
 Description = "Bitwarden is an integrated open source password management solution for individuals, teams, and business organizations"
 
 

--- a/plugins/bitwarden/help.md
+++ b/plugins/bitwarden/help.md
@@ -23,7 +23,7 @@ Bitwarden is an integrated open source password management solution for individu
 
 # Supported Product Versions
 
-* Cloud-hosted Bitwarden instance 2023.1.1
+* Cloud-hosted Bitwarden instance 2024.7.3
 
 # Documentation
 
@@ -572,6 +572,7 @@ Example output:
 
 # Version History
 
+* 2.0.1 - Use latest SDK version (6.1.0) and update the supported product version value to `2024.7.3`
 * 2.0.0 - Update enum values for `Create a Member`, `Update a Member` and `List all Members` organisation type to support new 'Custom' type. | Update account status type to include no number prefix.
 * 1.0.0 - Initial plugin - Actions: `Retrieve a Member`, `Update a Member`, `Delete a Member`, `Retrieve a Member's Group Ids`, `Update a Member's Groups`, `List All Members`, `Create a Member`, `Re-invite a Member`, `List All Groups`, `List All Collections`, `List Events`.
 

--- a/plugins/bitwarden/plugin.spec.yaml
+++ b/plugins/bitwarden/plugin.spec.yaml
@@ -4,12 +4,12 @@ products: [insightconnect]
 name: bitwarden
 title: Bitwarden
 description: Bitwarden is an integrated open source password management solution for individuals, teams, and business organizations
-version: 2.0.0
+version: 2.0.1
 vendor: rapid7
 support: rapid7
 cloud_ready: true
 status: []
-supported_versions: ["Cloud-hosted Bitwarden instance 2023.1.1"]
+supported_versions: ["Cloud-hosted Bitwarden instance 2024.7.3"]
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/bitwarden
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
@@ -40,7 +40,7 @@ hub_tags:
   features: []
 sdk:
   type: slim
-  version: 6.0.1
+  version: 6.1.0
   user: nobody
 connection_version: 2
 links:
@@ -49,6 +49,7 @@ references:
   - "[Bitwarden](https://bitwarden.com/)"
 troubleshooting: "[Bitwarden API Key Documentation](https://bitwarden.com/help/public-api/#authentication). Access to the Bitwarden Public API is available to customers on the Enterprise or Teams organizations plans."
 version_history:
+  - "2.0.1 - Use latest SDK version (6.1.0) and update the supported product version value to `2024.7.3`"
   - "2.0.0 - Update enum values for `Create a Member`, `Update a Member` and `List all Members` organisation type to support new 'Custom' type. | Update account status type to include no number prefix."
   - "1.0.0 - Initial plugin - Actions: `Retrieve a Member`, `Update a Member`, `Delete a Member`, `Retrieve a Member's Group Ids`, `Update a Member's Groups`, `List All Members`, `Create a Member`, `Re-invite a Member`, `List All Groups`, `List All Collections`, `List Events`."
 types:

--- a/plugins/bitwarden/setup.py
+++ b/plugins/bitwarden/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="bitwarden-rapid7-plugin",
-      version="2.0.0",
+      version="2.0.1",
       description="Bitwarden is an integrated open source password management solution for individuals, teams, and business organizations",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Release of Bitwarden 2.0.1

Changes:
- bump to latest SDK: 6.1.0
- update `supported product version` to latest Bitwarden version. 

Ticket:
- [SOAR-17462](https://rapid7.atlassian.net/browse/SOAR-17462)

Original PR:
- #2702 

Testing:
- Evidence on ticket; all actions passing on both cloud and orch.

[SOAR-17462]: https://rapid7.atlassian.net/browse/SOAR-17462?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ