### PR TITLE
[SOAR-17400] - Jira - bump the SDK to 6.1.0

### DIFF
--- a/plugins/jira/.CHECKSUM
+++ b/plugins/jira/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "4c61e328af43f3ae4afcf30ba9d5423b",
+	"spec": "cbdc6c2186e4ba7dfc00bc36f4b63fd2",
 	"manifest": "b21131965fd127bcec02ac11568a9ec3",
 	"setup": "28f1b643d3f2fd6da4e444f87b9c6f1c",
 	"schemas": [

--- a/plugins/jira/Dockerfile
+++ b/plugins/jira/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/jira/help.md
+++ b/plugins/jira/help.md
@@ -723,7 +723,7 @@ Example output:
 
 # Version History
 
-* 6.4.1 - Cloud enable the plugin | Bump SDK version to 6.0.1
+* 6.4.1 - Cloud enable the plugin | Bump SDK version to 6.1.0
 * 6.4.0 - Fix Issue Where Create Issue failed when multiple versions of the input Issue Type exists in Jira | Fix failed connection test response for PAT based connection | Include Fields input added to New Issue and Monitor Issues triggers, to specify whether to return Issue fields in the output | Removed empty Fields output from returned Issues when not requested or available
 * 6.3.0 - Add PAT authentication scheme for Jira on-prem
 * 6.2.1 - Fix issue in Find Issues action where normalize_user has an attribute error for labels | Changed Dockerfile to don't use slim version

--- a/plugins/jira/plugin.spec.yaml
+++ b/plugins/jira/plugin.spec.yaml
@@ -33,11 +33,11 @@ hub_tags:
   features: []
 sdk:
   type: slim
-  version: 6.0.1
+  version: 6.1.0
   user: nobody
 fedramp_ready: true
 version_history:
- - 6.4.1 - Cloud enable the plugin | Bump SDK version to 6.0.1
+ - 6.4.1 - Cloud enable the plugin | Bump SDK version to 6.1.0
  - 6.4.0 - Fix Issue Where Create Issue failed when multiple versions of the input Issue Type exists in Jira | Fix failed connection test response for PAT based connection | Include Fields input added to New Issue and Monitor Issues triggers, to specify whether to return Issue fields in the output | Removed empty Fields output from returned Issues when not requested or available
  - 6.3.0 - Add PAT authentication scheme for Jira on-prem
  - 6.2.1 - Fix issue in Find Issues action where normalize_user has an attribute error for labels | Changed Dockerfile to don't use slim version


### PR DESCRIPTION
after changes made in https://github.com/rapid7/insightconnect-plugins/pull/2687 to add fedramp ready flag we were seeing the following error

```
07 Aug 2024 10:54:30.356{ "log": "[2024-08-07 10:53:24,259] ERROR in app: Exception on /api/v1/info [GET]Traceback (most recent call last): File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.9/site-packages/flask/app.py\", line 1463, in wsgi_app response = self.full_dispatch_request() File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.9/site-packages/flask/app.py\", line 872, in full_dispatch_request rv = self.handle_user_exception(e) File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.9/site-packages/flask/app.py\", line 870, in full_dispatch_request rv = self.dispatch_request() File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.9/site-packages/flask/app.py\", line 855, in dispatch_request return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args) # type: ignore[no-any-return] File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.9/site-packages/insightconnect_plugin_runtime/api/endpoints.py\", line 332, in plugin_info plugin_spec_json = Endpoints.load_file_json_format( File \"/layers/paketo-buildpacks_pip-install/packages/lib/python3.9/site-packages/insightconnect_plugin_runtime/api/endpoints.py\", line 748, in load_file_json_format with open(filename, \"r\") as plugin_spec:FileNotFoundError: [Errno 2] No such file or directory: '/python/src/plugin.spec.yaml'{\"message\": \"500 Internal Server Error: The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.\", \"code\": 500, \"method\": \"GET\", \"url\": \"http://127.0.0.1:10001/api/v1/info\", \"error_description\": \"The server encountered an internal error and was unable to complete your request. Either the server is overloaded or there is an error in the application.\", \"request_path\": \"/api/v1/info\", \"request_id\": \"4fc4cb89-f556-436a-8a9c-0c142e7290a0\", \"level\": \"error\", \"timestamp\": \"2024-08-07 10:53.24\"}", "container_image": "registry.komand-int-1.komand-staging.r7ops.com/rapid7/jira:6.4.1-1723023139", "container_name": "rapid7-jira-6-4-1-1723023139", "host": "ip-10-0-190-82.ec2.internal", "namespace_name": "default", "pod_id": "bcf986ea-2f33-4a2e-a004-a615dd0fc80b", "pod_name": "rapid7-jira-6-4-1-1723023139-6476b6b77f-ld7m4" }
``` 

A fix was added in https://github.com/rapid7/komand-plugin-sdk-python/pull/178 to try and address this so the sdk is needed bumped to include the new changes 
