### PR TITLE
[SOAR-17400] - Jira - update the connection test to return as a dictionary

### DIFF
--- a/plugins/jira/.CHECKSUM
+++ b/plugins/jira/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "cbdc6c2186e4ba7dfc00bc36f4b63fd2",
-	"manifest": "b21131965fd127bcec02ac11568a9ec3",
-	"setup": "28f1b643d3f2fd6da4e444f87b9c6f1c",
+	"spec": "50f5d6de7f1678957f198ecd9f5703ad",
+	"manifest": "d21a103509b0be54ae31a05ad3af70c1",
+	"setup": "1ee13d8d5d3a2a8eb3a6c270eb477a40",
 	"schemas": [
 		{
 			"identifier": "assign_issue/schema.py",
@@ -21,7 +21,7 @@
 		},
 		{
 			"identifier": "create_user/schema.py",
-			"hash": "ecdcdffb55519c73a8059f42d3fb9210"
+			"hash": "241e3d5a1a9591dda84e640b06c64df6"
 		},
 		{
 			"identifier": "delete_user/schema.py",

--- a/plugins/jira/bin/komand_jira
+++ b/plugins/jira/bin/komand_jira
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Jira"
 Vendor = "rapid7"
-Version = "6.4.1"
+Version = "6.5.0"
 Description = "[Jira](https://www.atlassian.com/software/jira) is an issue tracking product developed by Atlassian that allows teams to plan, track, and release great software. This plugin uses the [Jira REST API](https://developer.atlassian.com/cloud/jira/platform/rest/v2/) to programmatically manage and create issues and users. The Jira plugin supports cloud and on-premise versions of Jira Software, Jira Server, and Jira ServiceDesk products from Atlassian"
 
 

--- a/plugins/jira/help.md
+++ b/plugins/jira/help.md
@@ -221,6 +221,7 @@ This action is used to create a user account
 |email|string|None|True|Email|None|user@example.com|None|None|
 |notify|boolean|False|True|Notify if true|[True, False]|True|None|None|
 |password|string|None|False|Password|None|mypassword|None|None|
+|products|array|None|False|Products the new user has access to|None|["jira-core", "jira-servicedesk", "jira-product-discovery", "jira-software"]|None|None|
 |username|string|None|False|Username|None|user1|None|None|
   
 Example input:
@@ -230,6 +231,12 @@ Example input:
   "email": "user@example.com",
   "notify": false,
   "password": "mypassword",
+  "products": [
+    "jira-core",
+    "jira-servicedesk",
+    "jira-product-discovery",
+    "jira-software"
+  ],
   "username": "user1"
 }
 ```
@@ -723,7 +730,7 @@ Example output:
 
 # Version History
 
-* 6.4.1 - Cloud enable the plugin | Bump SDK version to 6.1.0
+* 6.5.0 - Cloud enable the plugin | Bump SDK version to 6.1.0
 * 6.4.0 - Fix Issue Where Create Issue failed when multiple versions of the input Issue Type exists in Jira | Fix failed connection test response for PAT based connection | Include Fields input added to New Issue and Monitor Issues triggers, to specify whether to return Issue fields in the output | Removed empty Fields output from returned Issues when not requested or available
 * 6.3.0 - Add PAT authentication scheme for Jira on-prem
 * 6.2.1 - Fix issue in Find Issues action where normalize_user has an attribute error for labels | Changed Dockerfile to don't use slim version

--- a/plugins/jira/komand_jira/actions/create_user/action.py
+++ b/plugins/jira/komand_jira/actions/create_user/action.py
@@ -20,11 +20,24 @@ class CreateUser(insightconnect_plugin_runtime.Action):
         if not self.connection.is_cloud:
             username = params[Input.USERNAME]
 
-        success = self.connection.client.add_user(
-            fullname=params[Input.USERNAME],
-            email=params[Input.EMAIL],
-            password=params.get(Input.PASSWORD, None),
-            notify=params.get(Input.NOTIFY, False),
-            username=username,
-        )
+            success = self.connection.client.add_user(
+                fullname=params[Input.USERNAME],
+                email=params[Input.EMAIL],
+                password=params.get(Input.PASSWORD, None),
+                notify=params.get(Input.NOTIFY, False),
+                username=username,
+            )
+
+        else:
+            params = {
+                "displayName":params[Input.USERNAME],
+                "emailAddress":params[Input.EMAIL],
+                "password":params.get(Input.PASSWORD, None),
+                "notification":params.get(Input.NOTIFY, False),
+                "name":username,
+                "products": params.get(Input.PRODUCTS, [])
+            }
+            success = self.connection.rest_client.add_user(params)
+
+
         return {Output.SUCCESS: success}

--- a/plugins/jira/komand_jira/actions/create_user/action.py
+++ b/plugins/jira/komand_jira/actions/create_user/action.py
@@ -30,14 +30,13 @@ class CreateUser(insightconnect_plugin_runtime.Action):
 
         else:
             params = {
-                "displayName":params[Input.USERNAME],
-                "emailAddress":params[Input.EMAIL],
-                "password":params.get(Input.PASSWORD, None),
-                "notification":params.get(Input.NOTIFY, False),
-                "name":username,
-                "products": params.get(Input.PRODUCTS, [])
+                "displayName": params[Input.USERNAME],
+                "emailAddress": params[Input.EMAIL],
+                "password": params.get(Input.PASSWORD, None),
+                "notification": params.get(Input.NOTIFY, False),
+                "name": username,
+                "products": params.get(Input.PRODUCTS, []),
             }
             success = self.connection.rest_client.add_user(params)
-
 
         return {Output.SUCCESS: success}

--- a/plugins/jira/komand_jira/actions/create_user/schema.py
+++ b/plugins/jira/komand_jira/actions/create_user/schema.py
@@ -11,6 +11,7 @@ class Input:
     EMAIL = "email"
     NOTIFY = "notify"
     PASSWORD = "password"
+    PRODUCTS = "products"
     USERNAME = "username"
 
 
@@ -46,6 +47,11 @@ class CreateUserInput(insightconnect_plugin_runtime.Input):
       "title": "Password",
       "description": "Password",
       "order": 3
+    },
+    "products": {
+      "title": "Products",
+      "description": "Products the new user has access to",
+      "order": 5
     },
     "username": {
       "type": "string",

--- a/plugins/jira/komand_jira/connection/connection.py
+++ b/plugins/jira/komand_jira/connection/connection.py
@@ -56,12 +56,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
     def test_pat(self):
         headers = {"Authorization": f"Bearer {self.pat}", "Content-Type": "application/json"}
-        response = requests.get(self.url, headers=headers)
+        response = requests.get(self.url, headers=headers, timeout=60)
         return response
 
     def test_basic_auth(self):
         auth = HTTPBasicAuth(username=self.username, password=self.password)
-        response = requests.get(self.url, auth=auth)
+        response = requests.get(self.url, auth=auth, timeout=60)
         return response
 
     def test(self):

--- a/plugins/jira/komand_jira/connection/connection.py
+++ b/plugins/jira/komand_jira/connection/connection.py
@@ -71,7 +71,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
             response = self.test_basic_auth()
         # https://developer.atlassian.com/cloud/jira/platform/rest/v2/?utm_source=%2Fcloud%2Fjira%2Fplatform%2Frest%2F&utm_medium=302#error-responses
         if response.status_code == 200:
-            return True
+            return {"success": True}
         elif response.status_code == 401:
             raise ConnectionTestException(preset=ConnectionTestException.Preset.USERNAME_PASSWORD)
         elif response.status_code == 404:

--- a/plugins/jira/komand_jira/util/api.py
+++ b/plugins/jira/komand_jira/util/api.py
@@ -12,6 +12,29 @@ class JiraApi:
         self.session = jira_client._session
         self.base_url = jira_client._options["server"]
 
+    def add_user(self, params):
+
+        url = f"{self.base_url}/rest/api/latest/user/"
+
+        headers = {
+        "Accept": "application/json",
+        "Content-Type": "application/json"
+        }
+
+        payload = json.dumps(params)
+
+        response = self.session.post(
+            url,
+            data=payload,
+            headers=headers
+        )
+
+        if 200 <= response.status_code <= 299:
+            return True
+        else:
+            self.logger.error(response.status_code)
+            return False
+
     def delete_user(self, account_id):
         url = f"{self.base_url}/rest/api/latest/user/?accountId={account_id}"
         r = self.session.delete(url)

--- a/plugins/jira/komand_jira/util/api.py
+++ b/plugins/jira/komand_jira/util/api.py
@@ -16,18 +16,11 @@ class JiraApi:
 
         url = f"{self.base_url}/rest/api/latest/user/"
 
-        headers = {
-        "Accept": "application/json",
-        "Content-Type": "application/json"
-        }
+        headers = {"Accept": "application/json", "Content-Type": "application/json"}
 
         payload = json.dumps(params)
 
-        response = self.session.post(
-            url,
-            data=payload,
-            headers=headers
-        )
+        response = self.session.post(url, data=payload, headers=headers)
 
         if 200 <= response.status_code <= 299:
             return True

--- a/plugins/jira/plugin.spec.yaml
+++ b/plugins/jira/plugin.spec.yaml
@@ -15,7 +15,7 @@ requirements:
  - URL for Jira Software, Jira Server, or Jira ServiceDesk
  - Jira user email address and API key when using Jira Cloud
  - Jira username and password credentials when using on-prem Jira server
-version: 6.4.1
+version: 6.5.0
 connection_version: 6
 supported_versions: ["Jira Server 6.0", "Jira (Cloud)", "Jira ServiceDesk (Cloud)"]
 cloud_ready: true
@@ -37,7 +37,7 @@ sdk:
   user: nobody
 fedramp_ready: true
 version_history:
- - 6.4.1 - Cloud enable the plugin | Bump SDK version to 6.1.0
+ - 6.5.0 - Cloud enable the plugin | Bump SDK version to 6.1.0
  - 6.4.0 - Fix Issue Where Create Issue failed when multiple versions of the input Issue Type exists in Jira | Fix failed connection test response for PAT based connection | Include Fields input added to New Issue and Monitor Issues triggers, to specify whether to return Issue fields in the output | Removed empty Fields output from returned Issues when not requested or available
  - 6.3.0 - Add PAT authentication scheme for Jira on-prem
  - 6.2.1 - Fix issue in Find Issues action where normalize_user has an attribute error for labels | Changed Dockerfile to don't use slim version
@@ -475,6 +475,12 @@ actions:
           - true
           - false
         example: true
+      products:
+        title: Products
+        type: array
+        description: Products the new user has access to
+        required: false
+        example: ["jira-core", "jira-servicedesk", "jira-product-discovery", "jira-software"]
     output:
       success:
         title: Success

--- a/plugins/jira/setup.py
+++ b/plugins/jira/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="jira-rapid7-plugin",
-      version="6.4.1",
+      version="6.5.0",
       description="[Jira](https://www.atlassian.com/software/jira) is an issue tracking product developed by Atlassian that allows teams to plan, track, and release great software. This plugin uses the [Jira REST API](https://developer.atlassian.com/cloud/jira/platform/rest/v2/) to programmatically manage and create issues and users. The Jira plugin supports cloud and on-premise versions of Jira Software, Jira Server, and Jira ServiceDesk products from Atlassian",
       author="rapid7",
       author_email="",

--- a/plugins/jira/unit_test/test_create_user.py
+++ b/plugins/jira/unit_test/test_create_user.py
@@ -29,6 +29,15 @@ class MockClient:
             return {"result": "success"}
 
         return {"result": "failed"}
+    
+
+class MockRestClient:
+    def __init__(self):
+        self.client = "some fake thing"
+
+    def add_user(self, params: dict = {}):
+        self.params = params
+        return True
 
 
 class TestCreateUser(TestCase):
@@ -51,6 +60,7 @@ class TestCreateUser(TestCase):
 
         self.test_conn.is_cloud = True
         self.test_conn.client = MockClient(self.test_conn.is_cloud)
+        self.test_conn.rest_client = MockRestClient()
         self.test_action.connection = self.test_conn
 
         result = self.test_action.run(action_params)
@@ -67,6 +77,7 @@ class TestCreateUser(TestCase):
 
         self.test_conn.is_cloud = False
         self.test_conn.client = MockClient(self.test_conn.is_cloud)
+        self.test_conn.rest_client = MockRestClient()
         self.test_action.connection = self.test_conn
 
         result = self.test_action.run(action_params)

--- a/plugins/jira/unit_test/test_create_user.py
+++ b/plugins/jira/unit_test/test_create_user.py
@@ -29,7 +29,7 @@ class MockClient:
             return {"result": "success"}
 
         return {"result": "failed"}
-    
+
 
 class MockRestClient:
     def __init__(self):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

 - when trying to add a new cloud connection to jira we are seeing the following error 
   
   `"error": "json: cannot unmarshal bool into Go struct field PluginActionResponseBody.body.output of type map[string]interface {}"`
  
  this is due to the status of the connection test being returned incorrectly 

- Adding a timeout to the connection

- Moving create user to a rest api call due to a new required field that is not avaliable in the jira python package

  https://developer.atlassian.com/cloud/jira/platform/rest/v3/api-group-users/#api-rest-api-3-user-post

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
