### PR TITLE
[SOAR-17531] - PagerDuty fix send_trigger_event optional field

### DIFF
--- a/plugins/pagerduty/.CHECKSUM
+++ b/plugins/pagerduty/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "6527a68d9fd5097bbb7075b8b279d9b8",
-	"manifest": "825be40acb77734dcd402f0da001f41b",
-	"setup": "a4f3b2fabe8b53ce95d26b7439c5d3a8",
+	"spec": "43ffbb4c1a978803e031e66ac416c6b5",
+	"manifest": "a6d9e1f8efd33218abe9ee736e9c17d0",
+	"setup": "efa6d6a59131b0d2fd07474acf246830",
 	"schemas": [
 		{
 			"identifier": "create_user/schema.py",
@@ -29,11 +29,11 @@
 		},
 		{
 			"identifier": "send_resolve_event/schema.py",
-			"hash": "139114bf8815c249bac54e8ed9b61ad2"
+			"hash": "c13ada0ced9153f9ada705b02361e885"
 		},
 		{
 			"identifier": "send_trigger_event/schema.py",
-			"hash": "60c41049677bc3b99a28a2b941239d17"
+			"hash": "dba9298f697c59535f02a172c09ccf77"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/plugins/pagerduty/Dockerfile
+++ b/plugins/pagerduty/Dockerfile
@@ -1,4 +1,4 @@
-FROM rapid7/insightconnect-python-3-38-plugin:5
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.0
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/pagerduty/bin/komand_pagerduty
+++ b/plugins/pagerduty/bin/komand_pagerduty
@@ -6,8 +6,8 @@ from sys import argv
 
 Name = "PagerDuty"
 Vendor = "rapid7"
-Version = "3.0.0"
-Description = "Leverage PagerDuty for incident management and response"
+Version = "3.0.1"
+Description = "[PagerDuty](https://www.pagerduty.com/) provides enterprise-grade incident management that helps you orchestrate the ideal response to create better customer, employee, and business value. Use this plugin to manage users and incidents within workflows. The PagerDuty plugin makes requests to the V2 API"
 
 
 def main():

--- a/plugins/pagerduty/help.md
+++ b/plugins/pagerduty/help.md
@@ -1,33 +1,30 @@
 # Description
 
-[PagerDuty](https://www.pagerduty.com/) provides enterprise-grade incident management that helps you 
-orchestrate the ideal response to create better customer, employee, and business value. Use this plugin to manage users
-and incidents within workflows.
-The PagerDuty plugin makes requests to the V2 API.
+[PagerDuty](https://www.pagerduty.com/) provides enterprise-grade incident management that helps you orchestrate the ideal response to create better customer, employee, and business value. Use this plugin to manage users and incidents within workflows. The PagerDuty plugin makes requests to the V2 API
 
 # Key Features
-  
+
 * Create and manage PagerDuty incidents
 * Access PagerDuty user information
 
 # Requirements
-  
+
 * PagerDuty API key
 
 # Supported Product Versions
-  
-* 2023-10-12
+
+* 2024-08-15
 
 # Documentation
 
 ## Setup
-  
+
 The connection configuration accepts the following parameters:  
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|api_key|credential_secret_key|None|True|API Key|None|stRbCzL92kpAfwCkSiA9|
-  
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|api_key|credential_secret_key|None|True|API Key|None|stRbCzL92kpAfwCkSiA9|None|None|
+
 Example input:
 
 ```
@@ -42,22 +39,22 @@ Example input:
 
 
 #### Create User
-  
+
 This action is used to create a User
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|color|string|None|False|The schedule color|None|green|
-|email|string|None|True|The email address for the new account to be created|None|user1@example.com|
-|from_email|string|None|True|The email address of user that is creating the account|None|user2@example.com|
-|job_title|string|None|False|The description of the new user|None|job title|
-|license|object|None|False|The license of the new user|None|{'id': 'PTDVERC', 'type': 'license_reference'}|
-|name|string|None|True|Name|None|test user|
-|role|string|None|False|Role|['admin', 'limited_user', 'owner', 'read_only_user', 'user']|user|
-|time_zone|string|None|False|Time Zone, e.g. America/Lima|None|Europe/London|
-|user_description|string|None|False|The description of the new user|None|test description of the new use|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|color|string|None|False|The schedule color|None|green|None|None|
+|email|string|None|True|The email address for the new account to be created|None|user1@example.com|None|None|
+|from_email|string|None|True|The email address of user that is creating the account|None|user2@example.com|None|None|
+|job_title|string|None|False|The description of the new user|None|job title|None|None|
+|license|object|None|False|The license of the new user|None|{'id': 'PTDVERC', 'type': 'license_reference'}|None|None|
+|name|string|None|True|Name|None|test user|None|None|
+|role|string|None|False|Role|["admin", "limited_user", "owner", "read_only_user", "user"]|user|None|None|
+|time_zone|string|None|False|Time Zone, e.g. America/Lima|None|Europe/London|None|None|
+|user_description|string|None|False|The description of the new user|None|test description of the new use|None|None|
   
 Example input:
 
@@ -144,15 +141,15 @@ Example output:
 ```
 
 #### Delete User by ID
-  
+
 This action is used to delete a User by ID
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|email|string|None|True|The email address of a valid user associated with the account making the delete request|None|user1@example.com|
-|id|string|None|True|User ID|None|ABCD123|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|email|string|None|True|The email address of a valid user associated with the account making the delete request|None|user1@example.com|None|None|
+|id|string|None|True|User ID|None|ABCD123|None|None|
   
 Example input:
 
@@ -178,14 +175,14 @@ Example output:
 ```
 
 #### Get On-Call Users
-  
+
 This action is used to get list of on-call users
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|schedule_id|string|None|True|Schedule ID|None|ABC1234|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|schedule_id|string|None|True|Schedule ID|None|ABC1234|None|None|
   
 Example input:
 
@@ -205,70 +202,72 @@ Example output:
 
 ```
 {
-  "users": {
-    "avatar_url": "https://secure.gravatar.com/avatar/abcABC123456abcABC123456abcABC123456.png?d=mm&r=PG",
-    "billed": true,
-    "color": "purple",
-    "contact_methods": [
-      {
-        "html_url": null,
-        "id": "ABC1234",
-        "self": "https://api.pagerduty.com/users/ABCD123/contact_methods/ABC1234",
-        "summary": "Default",
-        "type": "email_contact_method_reference"
-      }
-    ],
-    "coordinated_incidents": [],
-    "description": "",
-    "email": "user1@example.com",
-    "html_url": "https://api.pagerduty.com/users/ABCD123",
-    "id": "ABCD123",
-    "invitation_sent": false,
-    "job_title": "",
-    "name": "Test account",
-    "notification_rules": [
-      {
-        "html_url": null,
-        "id": "ABC1234",
-        "self": "https://api.pagerduty.com/users/ABCD123/notification_rules/ABC1234",
-        "summary": "0 minutes: channel ABC1234",
-        "type": "assignment_notification_rule_reference"
-      },
-      {
-        "html_url": null,
-        "id": "ABC1234",
-        "self": "https://api.pagerduty.com/users/ABCD123/notification_rules/ABC1234",
-        "summary": "0 minutes: channel ABC1234",
-        "type": "assignment_notification_rule_reference"
-      }
-    ],
-    "role": "owner",
-    "self": "https://api.pagerduty.com/users/ABCD123",
-    "summary": "test summary",
-    "teams": [
-      {
-        "html_url": "https://api.pagerduty.com/teams/ABC1234",
-        "id": "ABC1234",
-        "self": "https://api.pagerduty.com/teams/ABC1234",
-        "summary": "Engineering",
-        "type": "team_reference"
-      }
-    ],
-    "time_zone": "Europe/London",
-    "type": "user"
-  }
+  "users": [
+    {
+      "avatar_url": "https://secure.gravatar.com/avatar/abcABC123456abcABC123456abcABC123456.png?d=mm&r=PG",
+      "billed": true,
+      "color": "purple",
+      "contact_methods": [
+        {
+          "html_url": null,
+          "id": "ABC1234",
+          "self": "https://api.pagerduty.com/users/ABCD123/contact_methods/ABC1234",
+          "summary": "Default",
+          "type": "email_contact_method_reference"
+        }
+      ],
+      "coordinated_incidents": [],
+      "description": "",
+      "email": "user1@example.com",
+      "html_url": "https://api.pagerduty.com/users/ABCD123",
+      "id": "ABCD123",
+      "invitation_sent": false,
+      "job_title": "",
+      "name": "Test account",
+      "notification_rules": [
+        {
+          "html_url": null,
+          "id": "ABC1234",
+          "self": "https://api.pagerduty.com/users/ABCD123/notification_rules/ABC1234",
+          "summary": "0 minutes: channel ABC1234",
+          "type": "assignment_notification_rule_reference"
+        },
+        {
+          "html_url": null,
+          "id": "ABC1234",
+          "self": "https://api.pagerduty.com/users/ABCD123/notification_rules/ABC1234",
+          "summary": "0 minutes: channel ABC1234",
+          "type": "assignment_notification_rule_reference"
+        }
+      ],
+      "role": "owner",
+      "self": "https://api.pagerduty.com/users/ABCD123",
+      "summary": "test summary",
+      "teams": [
+        {
+          "html_url": "https://api.pagerduty.com/teams/ABC1234",
+          "id": "ABC1234",
+          "self": "https://api.pagerduty.com/teams/ABC1234",
+          "summary": "Engineering",
+          "type": "team_reference"
+        }
+      ],
+      "time_zone": "Europe/London",
+      "type": "user"
+    }
+  ]
 }
 ```
 
 #### Get User by Their Email Address
-  
+
 This action is used to get a User from using their email address
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|user_email|string|None|True|User email address|None|user@example.com|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|user_email|string|None|True|User email address|None|user@example.com|None|None|
   
 Example input:
 
@@ -344,14 +343,14 @@ Example output:
 ```
 
 #### Get User by ID
-  
+
 This action is used to get a User by ID
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|id|string|None|True|User ID|None|ABC1234|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|id|string|None|True|User ID|None|ABC1234|None|None|
   
 Example input:
 
@@ -427,15 +426,15 @@ Example output:
 ```
 
 #### Send Acknowledge Event
-  
+
 This action is used to acknowledge an incident
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|email|string|None|True|The email address of a valid user associated with the account making the request|None|user1@example.com|
-|incident_id|string|None|True|The ID of the incident|None|Q1GXLD8EXPKU32|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|email|string|None|True|The email address of a valid user associated with the account making the request|None|user1@example.com|None|None|
+|incident_id|string|None|True|The ID of the incident|None|Q1GXLD8EXPKU32|None|None|
   
 Example input:
 
@@ -565,15 +564,15 @@ Example output:
 ```
 
 #### Send Resolve Event
-  
+
 This action is used to resolve an incident
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|email|string|None|True|The email address of a valid user associated with the account making the request|None|user1@example.com|
-|incident_id|string|None|True|The ID of the incident|None|Q1GXLD8EXPKU32|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|email|string|None|True|The email address of a valid user associated with the account making the request|None|user1@example.com|None|None|
+|incident_id|string|None|True|The ID of the incident|None|Q1GXLD8EXPKU32|None|None|
   
 Example input:
 
@@ -703,34 +702,36 @@ Example output:
 ```
 
 #### Send Trigger Event
-  
+
 This action is used to trigger an incident
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|assignments|[]assignee|None|False|Assign the incident to these assignees. Cannot be specified if an escalation policy is given|None|[{"assignee": {"id": "ABC1234", "type": "user_reference"}}]|
-|conference_bridge|conference_bridge_input|None|False|The conference bridge information attached to the incident. Only returned if the include[]=conference_bridge query parameter is provided|None|{'conference_number': '555-123-4567', 'conference_url': 'https://example.com/123-456-789'}|
-|email|string|None|True|The email address of a valid user associated with the account making the request|None|user1@example.com|
-|escalation_policy|escalation_policy_input|None|False|Assign the incident to this escalation policy. Cannot be specified if Assignments given|None|{'html_url': 'https://subdomain.pagerduty.com/escalation_policies/ABC1234', 'id': 'ABC1234', 'self': 'https://api.pagerduty.com/escalation_policies/ABC1234', 'summary': 'Another Escalation Policy', 'type': 'escalation_policy_reference'}|
-|incident_key|string|None|False|A string which identifies the incident. Sending subsequent requests referencing the same service and with the same incident_key will result in those requests being rejected if an open incident matches that incident_key|None|abcABC123456abcABC123456abcABC123456|
-|priority|priority_input|None|False|The priority that the incident is to be set to|None|{'id': 'ABC1234', 'type': 'priority_reference'}|
-|service|service_input|None|True|The service that the incident is related to|None|{'id': 'ABC1234', 'type': 'service_reference'}|
-|title|string|None|True|A description of the nature, symptoms, cause, or effect of the incident|None|The server is on fire.|
-|urgency|string|None|False|The urgency that the incident is to be set to|None|high|
-|body|body_input|None|False|Details to be added to the incident body|None|{'details': 'A disk is getting full on this machine. You should investigate what is causing the disk to fill.', 'type': 'incident_body'}|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|assignments|[]assignee|None|False|Assign the incident to these assignees. Cannot be specified if an escalation policy is given|None|[{"assignee": {"id": "ABC1234", "type": "user_reference"}}]|None|None|
+|body|body_input|None|False|Details to be added to the incident body|None|{'details': 'A disk is getting full on this machine. You should investigate what is causing the disk to fill.', 'type': 'incident_body'}|None|None|
+|conference_bridge|conference_bridge_input|None|False|The conference bridge information attached to the incident. Only returned if the include[]=conference_bridge query parameter is provided|None|{'conference_number': '555-123-4567', 'conference_url': 'https://example.com/123-456-789'}|None|None|
+|email|string|None|True|The email address of a valid user associated with the account making the request|None|user1@example.com|None|None|
+|escalation_policy|escalation_policy_input|None|False|Assign the incident to this escalation policy. Cannot be specified if Assignments given|None|{'html_url': 'https://subdomain.pagerduty.com/escalation_policies/ABC1234', 'id': 'ABC1234', 'self': 'https://api.pagerduty.com/escalation_policies/ABC1234', 'summary': 'Another Escalation Policy', 'type': 'escalation_policy_reference'}|None|None|
+|incident_key|string|None|False|A string which identifies the incident. Sending subsequent requests referencing the same service and with the same incident_key will result in those requests being rejected if an open incident matches that incident_key|None|abcABC123456abcABC123456abcABC123456|None|None|
+|priority|priority_input|None|False|The priority that the incident is to be set to|None|{'id': 'ABC1234', 'type': 'priority_reference'}|None|None|
+|service|service_input|None|True|The service that the incident is related to|None|{'id': 'ABC1234', 'type': 'service_reference'}|None|None|
+|title|string|None|True|A description of the nature, symptoms, cause, or effect of the incident|None|The server is on fire.|None|None|
+|urgency|string|None|False|The urgency that the incident is to be set to|None|high|None|None|
   
 Example input:
 
 ```
 {
-  "assignments": {
-    "assignee": {
-      "id": "ABC1234",
-      "type": "user_reference"
+  "assignments": [
+    {
+      "assignee": {
+        "id": "ABC1234",
+        "type": "user_reference"
+      }
     }
-  },
+  ],
   "body": {
     "details": "A disk is getting full on this machine. You should investigate what is causing the disk to fill.",
     "type": "incident_body"
@@ -907,10 +908,10 @@ Example output:
 
 |Name|Type|Default|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- |
-|acknowledgements|array|None|None|List of all acknowledgements for this incident. This list will be empty if the Incident.status is resolved or triggered. If the include[]=acknowledgers query parameter is provided, the full user or service definitions will be returned for each acknowledgement entry|[{'at': '2015-11-10T00:32:52Z', 'acknowledger': {'id': 'ABC1234', 'type': 'user_reference', 'summary': 'Test User', 'self': 'https://api.pagerduty.com/users/ABC1234', 'html_url': 'https://subdomain.pagerduty.com/users/ABC1234'}}]|
+|acknowledgements|array|None|None|List of all acknowledgements for this incident. This list will be empty if the Incident.status is resolved or triggered. If the include[]=acknowledgers query parameter is provided, the full user or service definitions will be returned for each acknowledgement entry|[{"at": "2015-11-10T00:32:52Z", "acknowledger": {"id": "ABC1234", "type": "user_reference", "summary": "Test User", "self": "https://api.pagerduty.com/users/ABC1234", "html_url": "https://subdomain.pagerduty.com/users/ABC1234"}}]|
 |alert_counts|object|None|None|The counts of alerts grouped into this incident|{'all': 0, 'resolved': 0, 'triggered': 0}|
 |assigned_via|string|None|None|How the current incident assignments were decided. Note that direct_assignment incidents will not escalate up the attached escalation_policy|escalation_policy|
-|assignments|array|None|None|Which accounts the incident will be assigned to|[{'at': '2015-11-10T00:31:52Z', 'assignee': {'id': 'ABC1234', 'type': 'user_reference', 'summary': 'Test User', 'self': 'https://api.pagerduty.com/users/ABC1234', 'html_url': 'https://subdomain.pagerduty.com/users/ABC1234'}}]|
+|assignments|array|None|None|Which accounts the incident will be assigned to|[{"at": "2015-11-10T00:31:52Z", "assignee": {"id": "ABC1234", "type": "user_reference", "summary": "Test User", "self": "https://api.pagerduty.com/users/ABC1234", "html_url": "https://subdomain.pagerduty.com/users/ABC1234"}}]|
 |conference_bridge|object|None|None|The conference bridge information attached to the incident. Only returned if the include[]=conference_bridge query parameter is provided|{'conference_number': '555-123-4567', 'conference_url': 'https://example.com/123-456-789'}|
 |created_at|string|None|None|The time the incident was first triggered|2015-10-06T21:30:42Z|
 |escalation_policy|object|None|None|The escalation policy attached to the service that the incident is on. If the include[]=escalation_policies query parameter is provided, the full escalation policy definition will be returned|{'id': 'ABC1234', 'type': 'escalation_policy_reference', 'summary': 'Another Escalation Policy', 'self': 'https://api.pagerduty.com/escalation_policies/ABC1234', 'html_url': 'https://subdomain.pagerduty.com/escalation_policies/ABC1234'}|
@@ -922,13 +923,13 @@ Example output:
 |is_mergeable|boolean|None|None|Whether the incident is mergeable. Only incidents that have alerts, or that are manually created can be merged|True|
 |last_status_change_at|string|None|None|The time the status of the incident last changed. If the incident is not currently acknowledged or resolved, this will be the incident's updated_at|2015-10-06T21:38:23Z|
 |last_status_change_by|object|None|None|The agent (user, service or integration) that created or modified the Incident Log Entry|{'id': 'ABC1234', 'type': 'user_reference', 'summary': 'Test User', 'self': 'https://api.pagerduty.com/users/ABC1234', 'html_url': 'https://subdomain.pagerduty.com/users/ABC1234'}|
-|pending_actions|array|None|None|The list of pending_actions on the incident. A pending_action object contains a type of action which can be escalate, unacknowledge, resolve or urgency_change. A pending_action object contains at, the time at which the action will take place. An urgency_change pending_action will contain to, the urgency that the incident will change to|[{'type': 'unacknowledge', 'at': '2015-11-10T01:02:52Z'}, {'type': 'resolve', 'at': '2015-11-10T04:31:52Z'}]|
+|pending_actions|array|None|None|The list of pending_actions on the incident. A pending_action object contains a type of action which can be escalate, unacknowledge, resolve or urgency_change. A pending_action object contains at, the time at which the action will take place. An urgency_change pending_action will contain to, the urgency that the incident will change to|[{"type": "unacknowledge", "at": "2015-11-10T01:02:52Z"}, {"type": "resolve", "at": "2015-11-10T04:31:52Z"}]|
 |priority|object|None|None|The priority of the object|{'id': 'ABC1234', 'type': 'priority_reference', 'summary': 'P2', 'self': 'https://api.pagerduty.com/priorities/ABC1234'}|
 |self|string|None|None|The API show URL at which the object is accessible|https://api.pagerduty.com/incidents/ABC1234|
 |service|object|None|None|The service the incident is on. If the include[]=services query parameter is provided, the full service definition will be returned|{'id': 'ABC1234', 'type': 'service_reference', 'summary': 'My Mail Service', 'self': 'https://api.pagerduty.com/services/ABC1234', 'html_url': 'https://subdomain.pagerduty.com/service-directory/ABC1234'}|
 |status|string|None|None|The current status of the incident|resolved|
-|summary|string|None|None|A short-form, server-generated string that provides succinct, important information about an object suitable for primary labelling of an entity in a client|[#1234] The server is on fire.|
-|teams|array|None|None|Teams that the alert is assigned to|[{'id': 'ABC1234', 'type': 'team_reference', 'summary': 'Engineering', 'self': 'https://api.pagerduty.com/teams/ABC1234', 'html_url': 'https://subdomain.pagerduty.com/teams/ABC1234'}]|
+|summary|string|None|None|A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier|[#1234] The server is on fire.|
+|teams|array|None|None|Teams that the alert is assigned to|[{"id": "ABC1234", "type": "team_reference", "summary": "Engineering", "self": "https://api.pagerduty.com/teams/ABC1234", "html_url": "https://subdomain.pagerduty.com/teams/ABC1234"}]|
 |title|string|None|None|A succinct description of the nature, symptoms, cause, or effect of the incident|The server is on fire.|
 |type|string|None|None|A string that determines the schema of the object|incident|
 |updated_at|string|None|None|The time the incident was last modified|2015-10-08T21:30:42Z|
@@ -982,15 +983,16 @@ Example output:
 
 ## Troubleshooting
   
-*There is no troubleshooting for this plugin.*
+*This plugin does not contain a troubleshooting.*
 
 # Version History
 
-* 3.0.0 - `Refactor`: Re-write plugin to use `requests` instead of `pypd` package | `Unit Tests`: Added for all actions.
+* 3.0.1 - Refresh plugin with latest SDK (6.1.0) | Fix to handle empty optional inputs for `send_trigger_event` action
+* 3.0.0 - `Refactor`: Re-write plugin to use `requests` instead of `pypd` package | `Unit Tests`: Added for all actions
 * 2.2.0 - Added Schedule ID optional input to Get On Call action
 * 2.1.0 - New action Get On Call
 * 2.0.1 - New spec and help.md format for the Extension Library
-* 2.0.0 - Fix issue to make 'service_key' required in Send Resolve Request action
+* 2.0.0 - Fix issue to make `service_key` required in Send Resolve Request action
 * 1.0.1 - Update to [PagerDuty REST API v2](https://v2.developer.pagerduty.com/docs/migrating-to-api-v2)
 * 1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types
 * 0.1.1 - SSL bug fix in SDK
@@ -998,8 +1000,8 @@ Example output:
 
 # Links
 
-* [PagerDuty API V2](https://v2.developer.pagerduty.com/v2/page/api-reference)
+* ['[PagerDuty API V2](https://v2.developer.pagerduty.com/v2/page/api-reference)']
 
 ## References
-  
-* [PagerDuty API V2](https://v2.developer.pagerduty.com/v2/page/api-reference)
+
+* ['[PagerDuty API V2](https://v2.developer.pagerduty.com/v2/page/api-reference)']

--- a/plugins/pagerduty/komand_pagerduty/actions/__init__.py
+++ b/plugins/pagerduty/komand_pagerduty/actions/__init__.py
@@ -4,6 +4,8 @@ from .get_on_call.action import GetOnCall
 
 from .get_user_by_id.action import GetUserById
 
+from .get_user_by_email.action import GetUserByEmail
+
 from .create_user.action import CreateUser
 
 from .delete_user_by_id.action import DeleteUserById
@@ -14,4 +16,3 @@ from .send_acknowledge_event.action import SendAcknowledgeEvent
 
 from .send_resolve_event.action import SendResolveEvent
 
-from .get_user_by_email.action import GetUserByEmail

--- a/plugins/pagerduty/komand_pagerduty/actions/send_resolve_event/schema.py
+++ b/plugins/pagerduty/komand_pagerduty/actions/send_resolve_event/schema.py
@@ -10,7 +10,6 @@ class Component:
 class Input:
     EMAIL = "email"
     INCIDENT_ID = "incident_id"
-    RESOLVE_MESSAGE = "resolve_message"
 
 
 class Output:

--- a/plugins/pagerduty/komand_pagerduty/actions/send_trigger_event/schema.py
+++ b/plugins/pagerduty/komand_pagerduty/actions/send_trigger_event/schema.py
@@ -96,8 +96,8 @@ class SendTriggerEventInput(insightconnect_plugin_runtime.Input):
   },
   "required": [
     "email",
-    "title",
-    "service"
+    "service",
+    "title"
   ],
   "definitions": {
     "service_input": {

--- a/plugins/pagerduty/komand_pagerduty/util/api.py
+++ b/plugins/pagerduty/komand_pagerduty/util/api.py
@@ -1,5 +1,5 @@
-from insightconnect_plugin_runtime.helper import clean
-from insightconnect_plugin_runtime.exceptions import PluginException, ConnectionTestException
+from insightconnect_plugin_runtime.helper import clean, clean_dict
+from insightconnect_plugin_runtime.exceptions import PluginException
 from logging import Logger
 from typing import Union
 import requests
@@ -73,6 +73,11 @@ class PagerDutyAPI:
 
         for key, value in dict_of_optional_fields.items():
             if value:
+                if isinstance(value, dict):
+                    optional_dict = clean_dict(value)  # check if there are non-empty nested values
+                    if not optional_dict:
+                        # don't add empty optional dict to payload
+                        continue
                 payload["incident"][key] = value
 
         return self.send_request(method="POST", path="/incidents/", payload=payload, from_email=email)

--- a/plugins/pagerduty/plugin.spec.yaml
+++ b/plugins/pagerduty/plugin.spec.yaml
@@ -3,17 +3,37 @@ extension: plugin
 products: [insightconnect]
 name: pagerduty
 title: PagerDuty
-description: Leverage PagerDuty for incident management and response
-version: 3.0.0
+description: "[PagerDuty](https://www.pagerduty.com/) provides enterprise-grade incident management that helps you orchestrate the ideal response to create better customer, employee, and business value. Use this plugin to manage users and incidents within workflows. The PagerDuty plugin makes requests to the V2 API"
+version: 3.0.1
 connection_version: 3
 vendor: rapid7
 support: community
-supported_versions: ["2023-10-12"]
+supported_versions: ["2024-08-15"]
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/pagerduty
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
   vendor_url: https://www.pagerduty.com/
+key_features:
+  - Create and manage PagerDuty incidents
+  - Access PagerDuty user information
+requirements:
+  - PagerDuty API key
+links:
+  - ["[PagerDuty API V2](https://v2.developer.pagerduty.com/v2/page/api-reference)"]
+references:
+  - ["[PagerDuty API V2](https://v2.developer.pagerduty.com/v2/page/api-reference)"]
+version_history:
+  - '3.0.1 - Refresh plugin with latest SDK (6.1.0) | Fix to handle empty optional inputs for `send_trigger_event` action'
+  - '3.0.0 - `Refactor`: Re-write plugin to use `requests` instead of `pypd` package | `Unit Tests`: Added for all actions'
+  - '2.2.0 - Added Schedule ID optional input to Get On Call action'
+  - '2.1.0 - New action Get On Call'
+  - '2.0.1 - New spec and help.md format for the Extension Library'
+  - '2.0.0 - Fix issue to make `service_key` required in Send Resolve Request action'
+  - '1.0.1 - Update to [PagerDuty REST API v2](https://v2.developer.pagerduty.com/docs/migrating-to-api-v2)'
+  - '1.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types'
+  - '0.1.1 - SSL bug fix in SDK'
+  - '0.1.0 - Initial plugin'
 tags:
 - incident response
 - incident management
@@ -22,8 +42,8 @@ hub_tags:
   keywords: [incident_response, incidents]
   features: []
 sdk: 
-  type: full 
-  version: 5 
+  type: slim
+  version: 6.1.0
   user: nobody
 connection:
   api_key:
@@ -95,7 +115,7 @@ types:
       type: string
       example: incident
     summary:
-      description: A short-form, server-generated string that provides succinct, important information about an object suitable for primary labelling of an entity in a client
+      description: A short-form, server-generated string that provides succinct, important information about an object suitable for primary labeling of an entity in a client. In many cases, this will be identical to name, though it is not intended to be an identifier
       type: string
       example: "[#1234] The server is on fire."
     self:

--- a/plugins/pagerduty/setup.py
+++ b/plugins/pagerduty/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 
 
 setup(name="pagerduty-rapid7-plugin",
-      version="3.0.0",
-      description="Leverage PagerDuty for incident management and response",
+      version="3.0.1",
+      description="[PagerDuty](https://www.pagerduty.com/) provides enterprise-grade incident management that helps you orchestrate the ideal response to create better customer, employee, and business value. Use this plugin to manage users and incidents within workflows. The PagerDuty plugin makes requests to the V2 API",
       author="rapid7",
       author_email="",
       url="",

--- a/plugins/pagerduty/unit_test/expected/trigger_event_additional_fields_assignments.json.exp
+++ b/plugins/pagerduty/unit_test/expected/trigger_event_additional_fields_assignments.json.exp
@@ -23,6 +23,10 @@
             "details": "A disk is getting full on this machine. You should investigate what is causing the disk to fill, and ensure that there is an automated process in place for ensuring data is rotated (eg. logs should have logrotate around them). If data is expected to stay on this disk forever, you should start planning to scale up to a larger disk."
         },
         "created_at": "2023-10-13T16:10:00Z",
+        "conference_bridge": {
+            "conference_number": "123456",
+            "conference_url": "https://dev-rapid7-conference.com"
+        },
         "description": "test additional fields assignments",
         "escalation_policy": {
             "html_url": "https://dev-rapid7.pagerduty.com/escalation_policies/P3LATBS",

--- a/plugins/pagerduty/unit_test/inputs/trigger_event_additional_fields_assignments.json.inp
+++ b/plugins/pagerduty/unit_test/inputs/trigger_event_additional_fields_assignments.json.inp
@@ -21,5 +21,9 @@
                 "type": "user_reference"
             }
         }
-    ]
+    ],
+    "conference_bridge": {
+        "conference_number": "123456",
+        "conference_url": "https://dev-rapid7-conference.com"
+    }
 }

--- a/plugins/pagerduty/unit_test/inputs/trigger_event_additional_fields_escalation.json.inp
+++ b/plugins/pagerduty/unit_test/inputs/trigger_event_additional_fields_escalation.json.inp
@@ -9,6 +9,10 @@
         "id": "PR0EVG8",
         "type": "priority"
     },
+    "conference_bridge": {
+        "conference_number": "",
+        "conference_url": ""
+    },
     "urgency": "high",
     "incident_key": "baf7cf21b1da41b4b0221008339ff361",
     "body": {

--- a/plugins/pagerduty/unit_test/responses/trigger_event_additional_fields_assignments.json.resp
+++ b/plugins/pagerduty/unit_test/responses/trigger_event_additional_fields_assignments.json.resp
@@ -23,6 +23,10 @@
             "details": "A disk is getting full on this machine. You should investigate what is causing the disk to fill, and ensure that there is an automated process in place for ensuring data is rotated (eg. logs should have logrotate around them). If data is expected to stay on this disk forever, you should start planning to scale up to a larger disk."
         },
         "created_at": "2023-10-13T16:10:00Z",
+        "conference_bridge": {
+            "conference_number": "123456",
+            "conference_url": "https://dev-rapid7-conference.com"
+        },
         "description": "test additional fields assignments",
         "escalation_policy": {
             "html_url": "https://dev-rapid7.pagerduty.com/escalation_policies/P3LATBS",


### PR DESCRIPTION
## Proposed Changes

### Description

https://rapid7.atlassian.net/browse/SOAR-17531

Describe the proposed changes:

  - Fix `send_trigger_event` action so that empty optional nested fields are not sent in payload
  - https://github.com/rapid7/insightconnect-plugins/pull/2711

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

- Tested on ICON staging. Screenshot shows action passing (with pagerduty events triggered), when optional fields are left empty and when they are populated. 

![image](https://github.com/user-attachments/assets/4f9e9eb3-cc21-417e-b8e5-c56df9ac4bb0)
