### PR TITLE
Okta 4.2.10

### DIFF
--- a/plugins/okta/.CHECKSUM
+++ b/plugins/okta/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a9a2aacf5cad511f44d123437623fc0c",
-	"manifest": "776a43f35f3c6c84ede0c4f661c46fa7",
-	"setup": "47bae9aa9e36a59aa32a487d490566a5",
+	"spec": "682c8c8ca89ce258dd285f46885d55eb",
+	"manifest": "1f68b95d50a9df7a60cb482eff65c5b6",
+	"setup": "998ad63c0126a7c38ec7ab6ed7f7de08",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",

--- a/plugins/okta/bin/komand_okta
+++ b/plugins/okta/bin/komand_okta
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Okta"
 Vendor = "rapid7"
-Version = "4.2.9"
+Version = "4.2.10"
 Description = "[Okta](https://www.okta.com/) is a SSO and account lifecycle management provider that allows companies to integrate their central user account system with a wide variety of other applications and services"
 
 

--- a/plugins/okta/help.md
+++ b/plugins/okta/help.md
@@ -1598,6 +1598,7 @@ Actions may fail depending on the state of the resource you attempt to operate o
 
 # Version History
 
+* 4.2.10 - Monitor Logs Task: Add exception handling if invalid subdomain provided
 * 4.2.9 - SDK Bump to 6.1.0 | Task Connection test added
 * 4.2.8 - Connection: Set appropriate error code when domain is invalid
 * 4.2.7 - Updated to include latest SDK v5.4.9 | Task `Monitor Logs` updated to increase max lookback cutoff to 7 days

--- a/plugins/okta/komand_okta/tasks/monitor_logs/task.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/task.py
@@ -78,7 +78,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 return [], state, False, error.status_code, error
             except ConnectionError as error:
                 self.logger.info(
-                    "The connection has failed, likely due to an invalid URL.\nPlease ensure the subdomain conforms to these potential formats: \n./*.okta.com ./*.oktapreview.com ./*.okta-emea.com\n"
+                    "The connection has failed, perhaps due to an invalid subdomain.\nPlease ensure the subdomain conforms to these potential formats: \n./*.okta.com ./*.oktapreview.com ./*.okta-emea.com\n"
                 )
                 return [], state, False, 401, PluginException(preset=PluginException.Preset.NOT_FOUND, data=error)
         except Exception as error:

--- a/plugins/okta/komand_okta/tasks/monitor_logs/task.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/task.py
@@ -78,7 +78,7 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
                 return [], state, False, error.status_code, error
             except ConnectionError as error:
                 self.logger.info(
-                    f"The connection has failed, likely due to an invalid URL.\nPlease ensure the subdomain conforms to these potential formats: \n./*.okta.com ./*.oktapreview.com ./*.okta-emea.com\n"
+                    "The connection has failed, likely due to an invalid URL.\nPlease ensure the subdomain conforms to these potential formats: \n./*.okta.com ./*.oktapreview.com ./*.okta-emea.com\n"
                 )
                 return [], state, False, 401, PluginException(preset=PluginException.Preset.NOT_FOUND, data=error)
         except Exception as error:

--- a/plugins/okta/komand_okta/tasks/monitor_logs/task.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/task.py
@@ -76,6 +76,11 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             except ApiException as error:
                 self.logger.info(f"An API Exception has been raised. Status code: {error.status_code}. Error: {error}")
                 return [], state, False, error.status_code, error
+            except ConnectionError as error:
+                self.logger.info(
+                    f"The connection has failed, likely due to an invalid URL.\nPlease ensure the subdomain conforms to these potential formats: \n./*.okta.com ./*.oktapreview.com ./*.okta-emea.com\n"
+                )
+                return [], state, False, 401, PluginException(preset=PluginException.Preset.NOT_FOUND, data=error)
         except Exception as error:
             self.logger.info(f"An Exception has been raised. Error: {error}")
             return [], state, False, 500, PluginException(preset=PluginException.Preset.UNKNOWN, data=error)

--- a/plugins/okta/plugin.spec.yaml
+++ b/plugins/okta/plugin.spec.yaml
@@ -14,7 +14,7 @@ sdk:
   user: nobody
 description: "[Okta](https://www.okta.com/) is a SSO and account lifecycle management provider that allows companies
   to integrate their central user account system with a wide variety of other applications and services"
-version: 4.2.9
+version: 4.2.10
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/okta
@@ -30,6 +30,7 @@ hub_tags:
   keywords: [sso, provisioning, deprovisioning, saml, cloud_enabled]
   features: []
 version_history:
+  - "4.2.10 - Monitor Logs Task: Add exception handling if invalid subdomain provided"
   - "4.2.9 - SDK Bump to 6.1.0 | Task Connection test added"
   - "4.2.8 - Connection: Set appropriate error code when domain is invalid"
   - "4.2.7 - Updated to include latest SDK v5.4.9 | Task `Monitor Logs` updated to increase max lookback cutoff to 7 days"

--- a/plugins/okta/setup.py
+++ b/plugins/okta/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="okta-rapid7-plugin",
-      version="4.2.9",
+      version="4.2.10",
       description="[Okta](https://www.okta.com/) is a SSO and account lifecycle management provider that allows companies to integrate their central user account system with a wide variety of other applications and services",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - `Monitor Logs`: Update task to break if subdomain doesn't match egress rules.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
