### PR TITLE
[SOAR-17793] Abnormal Security - Case ID issue

### DIFF
--- a/plugins/abnormal_security/.CHECKSUM
+++ b/plugins/abnormal_security/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "07ecd7b58170447bef5855554f15e265",
+	"spec": "82ca94bdef396a13ad6f7bd2906d6c94",
 	"manifest": "0b2490848001bba1d2e3304d5dcccdab",
 	"setup": "c2fad45b2ef6292be0a797d2449d3613",
 	"schemas": [

--- a/plugins/abnormal_security/.CHECKSUM
+++ b/plugins/abnormal_security/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "54821dd0f7e13a2ff4d93f0c05db1108",
-	"manifest": "42a45d3adc43907a028ba7ac0a2b3059",
-	"setup": "8447e8fc54f08c59ec4e4c585e395d88",
+	"spec": "9a28a7493d4873dc3093e704864b27db",
+	"manifest": "0b2490848001bba1d2e3304d5dcccdab",
+	"setup": "c2fad45b2ef6292be0a797d2449d3613",
 	"schemas": [
 		{
 			"identifier": "get_case_details/schema.py",

--- a/plugins/abnormal_security/.CHECKSUM
+++ b/plugins/abnormal_security/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "9a28a7493d4873dc3093e704864b27db",
+	"spec": "07ecd7b58170447bef5855554f15e265",
 	"manifest": "0b2490848001bba1d2e3304d5dcccdab",
 	"setup": "c2fad45b2ef6292be0a797d2449d3613",
 	"schemas": [

--- a/plugins/abnormal_security/Dockerfile
+++ b/plugins/abnormal_security/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:latest
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.3
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN	python setup.py build && python setup.py install
+RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/abnormal_security/bin/icon_abnormal_security
+++ b/plugins/abnormal_security/bin/icon_abnormal_security
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Abnormal Security"
 Vendor = "rapid7"
-Version = "2.0.2"
+Version = "2.0.3"
 Description = "Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks"
 
 

--- a/plugins/abnormal_security/help.md
+++ b/plugins/abnormal_security/help.md
@@ -4,11 +4,13 @@ Protect your Microsoft Office 365 and G-Suite environments with next-generation 
 
 # Key Features
 
-* This Plugin does not contain any Key Features.
+* Retrieve details of an individual case and list up to 100 cases identified by Abnormal Security.
+* Retrieve details of a single threat and list up to 100 threats identified by Abnormal Security.
+* Manage a case or threat.
 
 # Requirements
 
-* This Plugin does not contain any Requirements.
+* This plugin does not contain any Requirements.
 
 # Supported Product Versions
 
@@ -451,8 +453,8 @@ Example output:
 
 
 ## Troubleshooting
-
-There is no troubleshooting for this plugin.
+  
+*This plugin does not contain a troubleshooting.*
 
 # Version History
 

--- a/plugins/abnormal_security/help.md
+++ b/plugins/abnormal_security/help.md
@@ -473,4 +473,4 @@ Example output:
 
 ## References
 
-* [Abnormal Security](https://abnormalsecurity.com/)
+* [Abnormal Security](https://app.swaggerhub.com/apis-docs/abnormal-security/abx/1.4.1)

--- a/plugins/abnormal_security/help.md
+++ b/plugins/abnormal_security/help.md
@@ -3,28 +3,28 @@
 Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks
 
 # Key Features
-  
-*This plugin does not contain any key features.*
+
+* This Plugin does not contain any Key Features.
 
 # Requirements
-  
-*This plugin does not contain any requirements.*
+
+* This Plugin does not contain any Requirements.
 
 # Supported Product Versions
-  
+
 * abnormal-security API abx v1.4.2
 
 # Documentation
 
 ## Setup
-  
+
 The connection configuration accepts the following parameters:  
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|URL|string|https://api.abnormalplatform.com|True|Abnormal Security URL|None|https://api.abnormalplatform.com|
-|api_key|credential_secret_key|None|True|Abnormal Security API Key|None|9de5069c5afe602b2ea0a04b66beb2c0|
-  
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|URL|string|https://api.abnormalplatform.com|True|Abnormal Security URL|None|https://api.abnormalplatform.com|None|None|
+|api_key|credential_secret_key|None|True|Abnormal Security API Key|None|9de5069c5afe602b2ea0a04b66beb2c0|None|None|
+
 Example input:
 
 ```
@@ -40,14 +40,14 @@ Example input:
 
 
 #### Get Case Details
-  
+
 This action is used to get details of a case identified by Abnormal Security
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|case_id|string|None|True|A string representing the case|None|19377|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|case_id|string|None|True|A string representing the case|None|19377|None|None|
   
 Example input:
 
@@ -77,17 +77,17 @@ Example output:
 ```
 
 #### Get Cases
-  
+
 This action is used to get a list of up to 100 cases identified by Abnormal Security, if no input filter dates are 
 provided, it will return up to 100 latest results
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|filter_key|string|lastModifiedTime|False|This input enables you to select what timestamp to filter on, default is lastModifiedTime|['lastModifiedTime', 'createdTime', 'customerVisableTime', '']|lastModifiedTime|
-|from_date|string|None|False|This input enables you to filter your results from a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-01 21:11:38+00:00|
-|to_date|string|None|False|This input enables you to filter your results to a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-11 21:11:38+00:00|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|filter_key|string|lastModifiedTime|False|This input enables you to select what timestamp to filter on, default is lastModifiedTime|["lastModifiedTime", "createdTime", "customerVisableTime", ""]|lastModifiedTime|None|None|
+|from_date|string|None|False|This input enables you to filter your results from a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-01 21:11:38+00:00|None|None|
+|to_date|string|None|False|This input enables you to filter your results to a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-11 21:11:38+00:00|None|None|
   
 Example input:
 
@@ -109,22 +109,24 @@ Example output:
 
 ```
 {
-  "cases": {
-    "caseId": "19377",
-    "severity": "Potential Account Takeover"
-  }
+  "cases": [
+    {
+      "caseId": "19377",
+      "severity": "Potential Account Takeover"
+    }
+  ]
 }
 ```
 
 #### Get Threat Details
-  
+
 This action is used to get details of a threat identified by Abnormal Security
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|threat_id|string|None|True|A UUID representing the threat|None|184712ab-6d8b-47b3-89d3-a314efef79e2|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|threat_id|string|None|True|A UUID representing the threat|None|184712ab-6d8b-47b3-89d3-a314efef79e2|None|None|
   
 Example input:
 
@@ -248,16 +250,16 @@ Example output:
 ```
 
 #### Get Threats
-  
+
 This action is used to get a list of up to 100 threats identified in the Abnormal Security Threat Log, if no input 
 filter dates are provided, it will return up to 100 latest results
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|from_date|string|None|False|This input enables you to filter your results from a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-01 21:11:38+00:00|
-|to_date|string|None|False|This input enables you to filter your results to a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-11 21:11:38+00:00|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|from_date|string|None|False|This input enables you to filter your results from a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-01 21:11:38+00:00|None|None|
+|to_date|string|None|False|This input enables you to filter your results to a certain date, the date has to be in ISO 8601 format - YYYY-MM-DDTHH:MM:SSZ|None|2021-03-11 21:11:38+00:00|None|None|
   
 Example input:
 
@@ -278,22 +280,24 @@ Example output:
 
 ```
 {
-  "threats": {
-    "threatId": "184712ab-6d8b-47b3-89d3-a314efef79e2"
-  }
+  "threats": [
+    {
+      "threatId": "184712ab-6d8b-47b3-89d3-a314efef79e2"
+    }
+  ]
 }
 ```
 
 #### Manage Case
-  
+
 This action is used to manage an Abnormal Case
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|None|True|Acknowledge or take another remediation action on a case|['Action Required', 'Acknowledge in Progress', 'Acknowledge Resolved', 'Acknowledge not an Attack']|Action Required|
-|case_id|string|None|True|An ID representing the case|None|12345|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|action|string|None|True|Acknowledge or take another remediation action on a case|["Action Required", "Acknowledge in Progress", "Acknowledge Resolved", "Acknowledge not an Attack"]|Action Required|None|None|
+|case_id|string|None|True|An ID representing the case|None|12345|None|None|
   
 Example input:
 
@@ -324,15 +328,15 @@ Example output:
 ```
 
 #### Manage Threat
-  
+
 This action is used to manage a Threat identified by Abnormal Security
 
 ##### Input
 
-|Name|Type|Default|Required|Description|Enum|Example|
-| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|action|string|None|True|Remediate or unremediate a threat|['remediate', 'unremediate']|remediate|
-|threat_id|string|None|True|A UUID representing the threat|None|184712ab-6d8b-47b3-89d3-a314efef79e2|
+|Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|action|string|None|True|Remediate or unremediate a threat|["remediate", "unremediate"]|remediate|None|None|
+|threat_id|string|None|True|A UUID representing the threat|None|184712ab-6d8b-47b3-89d3-a314efef79e2|None|None|
   
 Example input:
 
@@ -447,17 +451,18 @@ Example output:
 
 
 ## Troubleshooting
-  
-*There is no troubleshooting for this plugin.*
+
+There is no troubleshooting for this plugin.
 
 # Version History
 
-* 2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions  
-* 2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions  
-* 2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version  
-* 1.3.0 - New logo and requirements update  
-* 1.2.0 - New actions Manage Case and Manage Threat  
-* 1.1.0 - New actions Get Cases and Get Case Details  
+* 2.0.3 - Fix issue where Case ID was being returned as an integer in the `get_cases` and `get_case_details` action
+* 2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions
+* 2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions
+* 2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version
+* 1.3.0 - New logo and requirements update
+* 1.2.0 - New actions Manage Case and Manage Threat
+* 1.1.0 - New actions Get Cases and Get Case Details
 * 1.0.0 - Initial plugin
 
 # Links

--- a/plugins/abnormal_security/icon_abnormal_security/actions/get_case_details/action.py
+++ b/plugins/abnormal_security/icon_abnormal_security/actions/get_case_details/action.py
@@ -14,4 +14,11 @@ class GetCaseDetails(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        return {Output.CASE_DETAILS: self.connection.api.get_case_details(params.get(Input.CASE_ID))}
+
+        # Solution to convert Case ID to string if it gets returned as an integer
+        case_id = params.get(Input.CASE_ID, "")
+
+        response = self.connection.api.get_case_details(case_id)
+        if isinstance(response.get("caseId"), int):
+            response["caseId"] = str(response.get("caseId"))
+        return {Output.CASE_DETAILS: response}

--- a/plugins/abnormal_security/icon_abnormal_security/actions/get_cases/action.py
+++ b/plugins/abnormal_security/icon_abnormal_security/actions/get_cases/action.py
@@ -11,10 +11,12 @@ class GetCases(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        return {
-            Output.CASES: self.connection.api.get_cases(
-                from_date=params.get(Input.FROM_DATE),
-                to_date=params.get(Input.TO_DATE),
-                filter_key=params.get(Input.FILTER_KEY, "lastModifiedTime"),
-            )
-        }
+        response = self.connection.api.get_cases(
+            from_date=params.get(Input.FROM_DATE),
+            to_date=params.get(Input.TO_DATE),
+            filter_key=params.get(Input.FILTER_KEY, "lastModifiedTime"),
+        )
+        # This is a possible solution to SI-25434
+        if isinstance(response.get("caseId"), int):
+            response["caseId"] = str(response["caseId"])
+        return {Output.CASES: response}

--- a/plugins/abnormal_security/icon_abnormal_security/actions/get_cases/action.py
+++ b/plugins/abnormal_security/icon_abnormal_security/actions/get_cases/action.py
@@ -16,7 +16,7 @@ class GetCases(insightconnect_plugin_runtime.Action):
             to_date=params.get(Input.TO_DATE),
             filter_key=params.get(Input.FILTER_KEY, "lastModifiedTime"),
         )
-        # This is a possible solution to SI-25434
+        # Solution to convert Case ID to string if it gets returned as an integer
         for case in response:
             if isinstance(case.get("caseId"), int):
                 case["caseId"] = str(case["caseId"])

--- a/plugins/abnormal_security/icon_abnormal_security/actions/get_cases/action.py
+++ b/plugins/abnormal_security/icon_abnormal_security/actions/get_cases/action.py
@@ -17,6 +17,7 @@ class GetCases(insightconnect_plugin_runtime.Action):
             filter_key=params.get(Input.FILTER_KEY, "lastModifiedTime"),
         )
         # This is a possible solution to SI-25434
-        if isinstance(response.get("caseId"), int):
-            response["caseId"] = str(response["caseId"])
+        for case in response:
+            if isinstance(case.get("caseId"), int):
+                case["caseId"] = str(case["caseId"])
         return {Output.CASES: response}

--- a/plugins/abnormal_security/plugin.spec.yaml
+++ b/plugins/abnormal_security/plugin.spec.yaml
@@ -40,7 +40,7 @@ version_history:
   - '1.1.0 - New actions Get Cases and Get Case Details'
   - '1.0.0 - Initial plugin'
 references:
-  - '[Abnormal Security](https://abnormalsecurity.com/)'
+  - '[Abnormal Security](https://app.swaggerhub.com/apis-docs/abnormal-security/abx/1.4.1)'
 links:
   - "[Abnormal Security](https://abnormalsecurity.com/)"
 types:

--- a/plugins/abnormal_security/plugin.spec.yaml
+++ b/plugins/abnormal_security/plugin.spec.yaml
@@ -25,10 +25,11 @@ resources:
   vendor_url: https://abnormalsecurity.com/
 enable_cache: true
 key_features:
-  - "This Plugin does not contain any Key Features."
+  - "Retrieve details of an individual case and list up to 100 cases identified by Abnormal Security."
+  - "Retrieve details of a single threat and list up to 100 threats identified by Abnormal Security."
+  - "Manage a case or threat."
 requirements:
-  - "This Plugin does not contain any Requirements."
-troubleshooting: "There is no troubleshooting for this plugin."
+  - "This plugin does not contain any Requirements."
 version_history:
   - '2.0.3 - Fix issue where Case ID was being returned as an integer in the `get_cases` and `get_case_details` action'
   - '2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions'

--- a/plugins/abnormal_security/plugin.spec.yaml
+++ b/plugins/abnormal_security/plugin.spec.yaml
@@ -4,11 +4,16 @@ products: [insightconnect]
 name: abnormal_security
 title: Abnormal Security
 description: Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks
-version: 2.0.2
+version: 2.0.3
+connection_version: 2
 supported_versions: ["abnormal-security API abx v1.4.2"]
 vendor: rapid7
 support: rapid7
 status: []
+sdk:
+  type: slim
+  version: 6.1.3
+  user: nobody
 tags: [investigate, malware, threat intel]
 hub_tags:
   use_cases: [threat_detection_and_response, vulnerability_management]
@@ -19,7 +24,13 @@ resources:
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
   vendor_url: https://abnormalsecurity.com/
 enable_cache: true
+key_features:
+  - "This Plugin does not contain any Key Features."
+requirements:
+  - "This Plugin does not contain any Requirements."
+troubleshooting: "There is no troubleshooting for this plugin."
 version_history:
+  - '2.0.3 - Fix issue where Case ID was being returned as an integer in the `get_cases` and `get_case_details` action'
   - '2.0.2 - Fix bug where toTime was being used as gte rather than lte in requests, used in the `get_cases` and `get_threats` actions'
   - '2.0.1 - To remove formatting of the fromTime or toTime values used in the `get_cases` and `get_threats` actions'
   - '2.0.0 - Add support to select the time filter filed in `get_cases` action | bump SDK version'
@@ -29,6 +40,8 @@ version_history:
   - '1.0.0 - Initial plugin'
 references:
   - '[Abnormal Security](https://abnormalsecurity.com/)'
+links:
+  - "[Abnormal Security](https://abnormalsecurity.com/)"
 types:
   threat:
     threatId:

--- a/plugins/abnormal_security/setup.py
+++ b/plugins/abnormal_security/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="abnormal_security-rapid7-plugin",
-      version="2.0.2",
+      version="2.0.3",
       description="Protect your Microsoft Office 365 and G-Suite environments with next-generation email security that uses the most advanced AI detection techniques to stop targeted phishing attacks",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

A customer is currently experiencing an issue with the `caseId` being returned as an int and not a string, as well as an issue arising when inputting the `caseId`, as it recognises the input as a integer and not string (which is what it is meant to be : https://app.swaggerhub.com/apis/abnormal-security/abx/1.4.3#/Cases/get_cases). 

Proposed change, converts the `caseId` to a string before being inputted and before being returned, to ensure the issue doesn't appear. Provided a custom plugin to the customer and this solution solved their problem.

SI Ticket: https://rapid7.atlassian.net/browse/SI-25434

Describe the proposed changes:

  - Format the `caseId` to a string when inputted and outputted from both actions
  - SDK Bump to 6.1.3 & Plugin Refresh