### PR TITLE
SOAR-17646-Only processing 7500 events per run

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "83ac49e9775f2ec79ec1550224670b07",
-	"manifest": "0b173bd9da9430ec68d86dede277ea19",
-	"setup": "47f68d27c80384f8d01495519d1b0a39",
+	"spec": "d4c13922e4697fbe238407bfead947a6",
+	"manifest": "17c12af7d004c29569412c88708d0dbe",
+	"setup": "6ba25ff17bf993b681d3d1ad000b7062",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.15"
+Version = "5.3.16"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1009,11 +1009,12 @@ Example output:
 
 
 ## Troubleshooting
-  
-*There is no troubleshooting for this plugin.*
+
+For the Create Managed URL action, the URL must include `http://` or `https://` e.g. `http://google.com` Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api-overview/global-base-urls/)
 
 # Version History
 
+* 5.3.16 - Task `monitor_siem_logs` Limit the number of events per run to 7500 | bump SDK to version 6.1.0
 * 5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.1 | Allow for the task connection tests to pass back a message along side a status
 * 5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1
 * 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -55,6 +55,8 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
             if not header_next_token:
                 self.logger.info("First run...")
+            elif last_log_line > 0:
+                self.logger.info("Subsequent run, continuing to process the previous file...")
             else:
                 self.logger.info("Subsequent run using header_next_token...")
 

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -67,6 +67,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     header_next_token = headers.get(self.HEADER_NEXT_TOKEN, header_next_token)
                     if not output:
                         self.logger.info("No new logs returned from Mimecast")
+                        last_log_line = 0
                         break
                 except ApiClientException as error:
                     self.logger.error(
@@ -113,7 +114,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
     def _filter_and_sort_recent_events(
         self, task_output: List[Dict[str, Any]], filter_time: datetime, last_log_line: int
-    ) -> List[Dict[str, Any]]:
+    ) -> tuple[List[Dict[str, Any]], int]:
         """
         Filters and sorts a list of events to retrieve only the recent events.
 
@@ -123,8 +124,11 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
         :param filter_time: how far back in time we filter events from
         :type: datetime
 
-        :return: A new list of dictionaries representing the filtered and sorted recent events.
-        :rtype: List[Dict[str, Any]]
+        :param last_log_line: how may lines of the log file has already been processed
+        :type: datetime
+
+        :return: A tuple containing, a new list of dictionaries representing the filtered and sorted recent events and a number of processed log lines.
+        :rtype: tuple[List[Dict[str, Any]], int]
         """
 
         self.logger.info(f"Number of raw logs returned from Mimecast: {len(task_output)}")

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -1,6 +1,7 @@
 from operator import itemgetter
 from time import time
 from datetime import datetime, date
+import hashlib
 
 import insightconnect_plugin_runtime
 from typing import Dict, List, Any, Tuple
@@ -159,7 +160,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
             key=itemgetter(EventLogs.FILTER_DATETIME),
         )
 
-        if len(task_output) >= MAX_EVENTS_PER_RUN:
+        if len(task_output) > MAX_EVENTS_PER_RUN:
             start_point = last_log_line
             end_point = start_point + MAX_EVENTS_PER_RUN
 
@@ -171,7 +172,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
             self.logger.info(
                 f"Number of returned logs after filtering performed was greater than {MAX_EVENTS_PER_RUN}, limiting to {MAX_EVENTS_PER_RUN}.\n"
-                f"fetching logs from {start_point} to {end_point}"
+                f"fetching logs from {start_point} to {end_point}, using the filter time of {filter_time}"
             )
 
             task_output = task_output[start_point:end_point]
@@ -192,7 +193,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
     def _check_hash_of_file_names(self, file_name_list: List[str]) -> str:
         file_name_list = sorted(file_name_list)
-        return hash(tuple(file_name_list))
+        return hashlib.md5(str(file_name_list).encode("utf-8")).hexdigest()  # nosec B303
 
     def _get_filter_time(self, custom_config: Dict[str, int], normal_running_cutoff: bool = False) -> int:
         """

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -84,14 +84,13 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     return [], state, has_more_pages, error.status_code, error
 
                 # check if the hashed file list from the previous run is the same as this run
-                if len(output) > max_events_per_run:
+                if previous_file_hash:
                     current_file_hash = self._check_hash_of_file_names(file_name_list)
 
                     # if the hash lists don't match then we want to reset the last log to 0 and start again
                     if last_log_line > 0 and current_file_hash != previous_file_hash:
+                        self.logger.info("The hashes between the current run and previous runs do not match, resetting the last log line to 0.")
                         last_log_line = 0
-
-                    previous_file_hash = current_file_hash
 
                 output, last_log_line = self._filter_and_sort_recent_events(
                     output, filter_time, last_log_line, max_events_per_run

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -219,14 +219,4 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
 
         self.logger.info(f"The following filter time will be used: {filter_time}")
 
-        custom_config_date = {}
-        filter_time = datetime(
-            custom_config_date.get("year", 2020),
-            custom_config_date.get("month", 1),
-            custom_config_date.get("day", 1),
-            custom_config_date.get("hour", 0),
-            custom_config_date.get("minute", 0),
-            custom_config_date.get("second", 0),
-        )
-
         return filter_time

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -15,7 +15,7 @@ from ...util.exceptions import ApiClientException
 
 FIRST_RUN_CUTOFF = 24
 NORMAL_RUNNING_CUTOFF = 24 * 7
-MAX_EVENTS_PER_RUN = 10
+MAX_EVENTS_PER_RUN = 7500
 
 
 class MonitorSiemLogs(insightconnect_plugin_runtime.Task):

--- a/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast/komand_mimecast/tasks/monitor_siem_logs/task.py
@@ -84,13 +84,17 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     return [], state, has_more_pages, error.status_code, error
 
                 # check if the hashed file list from the previous run is the same as this run
-                if previous_file_hash:
+                if len(output) > max_events_per_run:
                     current_file_hash = self._check_hash_of_file_names(file_name_list)
 
                     # if the hash lists don't match then we want to reset the last log to 0 and start again
                     if last_log_line > 0 and current_file_hash != previous_file_hash:
-                        self.logger.info("The hashes between the current run and previous runs do not match, resetting the last log line to 0.")
+                        self.logger.info(
+                            "The hashes between the current run and previous runs do not match, resetting the last log line to 0."
+                        )
                         last_log_line = 0
+                else:
+                    last_log_line = 0
 
                 output, last_log_line = self._filter_and_sort_recent_events(
                     output, filter_time, last_log_line, max_events_per_run

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -245,7 +245,7 @@ class MimecastAPI:
                 f"returning []. Error: {exception_error}",
                 exc_info=True,
             )
-        return []
+        return [], []
 
     def _prepare_header(self, uri: str) -> dict:
         # Generate request header values

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.15
+version: 5.3.16
 connection_version: 5
 supported_versions: ["Mimecast API 2024-06-18"]
 vendor: rapid7
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 6.0.1
+  version: 6.1.0
   user: nobody
 status: []
 resources:
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.16 - Task `monitor_siem_logs` Limit the number of events per run to 7500 | bump SDK to version 6.1.0"
 - "5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.1 | Allow for the task connection tests to pass back a message along side a status"
 - "5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1"
 - "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -3,7 +3,8 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 validators==0.21.0
 parameterized==0.8.1
-python-dateutil==2.6.1
+python-dateutil==2.7
 jsonschema==3.2.0
 werkzeug==3.0.3
 setuptools==70.0.0
+freezegun==1.5.1

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.15",
+      version="5.3.16",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -170,7 +170,7 @@ class TestMonitorSiemLogs(TestCase):
                 self.assertIn(f"{test.get('expected_filter_time')}", mock_logger.mock_calls[-6][1][0])
 
     @patch("logging.Logger.warning")
-    @patch("komand_mimecast.tasks.monitor_siem_logs.task.MAX_EVENTS_PER_RUN", new=1)
+    @patch("komand_mimecast.tasks.monitor_siem_logs.task.MAX_EVENTS_PER_RUN_DEFAULT", new=1)
     def test_monitor_siem_logs_success_split_files_across_runs(self, mock_logger, _mock_data):
         content = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, FILE_ZIP_CONTENT_3]
         token = SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -12,9 +12,8 @@ from komand_mimecast.connection.schema import Input
 from komand_mimecast.util.constants import DATA_FIELD, DEFAULT_REGION
 
 
-DATE_TIME_NOW = datetime.now().strftime("%Y-%m-%dT%H:%M:%S%z")
-FILE_ZIP_CONTENT_1 = {"acc": "ABC123", "datetime": DATE_TIME_NOW}
-FILE_ZIP_CONTENT_2 = {"acc": "ABC1234", "datetime": DATE_TIME_NOW}
+FILE_ZIP_CONTENT_1 = {"acc": "ABC123", "datetime": "2022-01-01T12:00:00"}
+FILE_ZIP_CONTENT_2 = {"acc": "ABC1234", "datetime": "2022-01-01T12:00:00"}
 FILE_ZIP_CONTENT_3 = {"acc": "ABC12345"}
 SIEM_LOGS_HEADERS_RESPONSE = {"mc-siem-token": "token123"}
 

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -193,6 +193,8 @@ class Util:
                 # try/except in `get_siem_logs`
                 headers["Content-Disposition"] = ""
                 resp = MockResponseZip(200, "this is bad json returned", headers, "throw json error")
+            # elif "test_multi_log_lines" in data:
+            #     has
             return resp
         return "Not implemented"
 


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - limit the number of events thats processed in a single run to 7500 events 
  - bumping sdk to version 6.1.0
  - added new unit test for new logic
  

https://rapid7.atlassian.net/browse/SOAR-17646

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

when using a mocked start time and limit of 100 (due to what data we have available in our instance)

1st run 
![image](https://github.com/user-attachments/assets/2bb95480-bfba-4229-b972-ef4d100da5c7)


2nd run (using state from 1st run)
![image](https://github.com/user-attachments/assets/2d69be5c-5f85-4954-9045-3138d6f02c89)


3rd run (using state from 2nd run)
![image](https://github.com/user-attachments/assets/864ca21b-e611-4636-ad4f-b08473db51e3)


4th run (using state from 3rd run)
![image](https://github.com/user-attachments/assets/6399e117-80f4-4fdf-bad9-688bac570423)


If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
