### PR TITLE
Mimecast 5.3.16 release

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "83ac49e9775f2ec79ec1550224670b07",
-	"manifest": "0b173bd9da9430ec68d86dede277ea19",
-	"setup": "47f68d27c80384f8d01495519d1b0a39",
+	"spec": "d4c13922e4697fbe238407bfead947a6",
+	"manifest": "17c12af7d004c29569412c88708d0dbe",
+	"setup": "6ba25ff17bf993b681d3d1ad000b7062",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/Dockerfile
+++ b/plugins/mimecast/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.0.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.15"
+Version = "5.3.16"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1009,11 +1009,12 @@ Example output:
 
 
 ## Troubleshooting
-  
-*There is no troubleshooting for this plugin.*
+
+For the Create Managed URL action, the URL must include `http://` or `https://` e.g. `http://google.com` Most common cloud [URLs](https://www.mimecast.com/tech-connect/documentation/api-overview/global-base-urls/)
 
 # Version History
 
+* 5.3.16 - Task `monitor_siem_logs` Limit the number of events per run to 7500 | bump SDK to version 6.1.0
 * 5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.1 | Allow for the task connection tests to pass back a message along side a status
 * 5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1
 * 5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error

--- a/plugins/mimecast/komand_mimecast/util/api.py
+++ b/plugins/mimecast/komand_mimecast/util/api.py
@@ -104,8 +104,8 @@ class MimecastAPI:
         self._check_rate_limiting(response)
 
         if "attachment" in response.headers.get("Content-Disposition", "") or self._is_last_token(response):
-            combined_json_list = self._handle_zip_file(response)
-            return combined_json_list, response.headers, response.status_code
+            combined_json_list, file_name_list = self._handle_zip_file(response)
+            return combined_json_list, response.headers, response.status_code, file_name_list
 
         # Due to how Mimecast returns a zip file in the response content, this error handling needs to happen after
         # the attempt to parse the content. Otherwise we hit json errors on the zipped content.
@@ -203,7 +203,8 @@ class MimecastAPI:
         try:
             with ZipFile(BytesIO(request.content)) as my_zip:
                 combined_json_list = []
-                for file_name in my_zip.namelist():
+                file_name_list = my_zip.namelist()
+                for file_name in file_name_list:
                     try:
                         # To avoid potential path traversal vulnerabilities, only valid files should be allowed.
                         # Due to the nature of the IO buffer, the filename cannot be checked until it is read in.
@@ -227,7 +228,7 @@ class MimecastAPI:
                             exc_info=True,
                         )
                         continue
-            return combined_json_list
+            return combined_json_list, file_name_list
         except BadZipFile as error:
             # empty response from Mimecast can hit this, which we know is not an error, don't log it
             if error.args[0] != "File is not a zip file":
@@ -244,7 +245,7 @@ class MimecastAPI:
                 f"returning []. Error: {exception_error}",
                 exc_info=True,
             )
-        return []
+        return [], []
 
     def _prepare_header(self, uri: str) -> dict:
         # Generate request header values

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.15
+version: 5.3.16
 connection_version: 5
 supported_versions: ["Mimecast API 2024-06-18"]
 vendor: rapid7
@@ -25,7 +25,7 @@ support: rapid7
 cloud_ready: true
 sdk:
   type: slim
-  version: 6.0.1
+  version: 6.1.0
   user: nobody
 status: []
 resources:
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.16 - Task `monitor_siem_logs` Limit the number of events per run to 7500 | bump SDK to version 6.1.0"
 - "5.3.15 - Fix snyk vulnerabilities | bump SDK to version 6.0.1 | Allow for the task connection tests to pass back a message along side a status"
 - "5.3.14 - Improving task connection tests logging | bump SDK to version 5.6.1"
 - "5.3.13 - Adding in task connection tests | bump SDK to version 5.5.5 | Fix issue with logging bad JSON error"

--- a/plugins/mimecast/requirements.txt
+++ b/plugins/mimecast/requirements.txt
@@ -3,7 +3,8 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 validators==0.21.0
 parameterized==0.8.1
-python-dateutil==2.6.1
+python-dateutil==2.7
 jsonschema==3.2.0
 werkzeug==3.0.3
 setuptools==70.0.0
+freezegun==1.5.1

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.15",
+      version="5.3.16",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/test_monitor_siem_logs.py
+++ b/plugins/mimecast/unit_test/test_monitor_siem_logs.py
@@ -5,6 +5,7 @@ import logging
 from jsonschema import validate
 from unittest import TestCase, skip
 from unittest.mock import patch
+from freezegun import freeze_time
 
 sys.path.append(os.path.abspath("../"))
 
@@ -15,6 +16,7 @@ from komand_mimecast.tasks.monitor_siem_logs.schema import MonitorSiemLogsOutput
 from util import Util, FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, FILE_ZIP_CONTENT_3, SIEM_LOGS_HEADERS_RESPONSE
 
 
+@freeze_time("2022-01-01T12:00:00")
 @patch("requests.request", side_effect=Util.mocked_request)
 class TestMonitorSiemLogs(TestCase):
     def setUp(self) -> None:
@@ -38,9 +40,11 @@ class TestMonitorSiemLogs(TestCase):
                 self.assertEqual(response, test.get("resp"))
                 self.assertEqual(status_code, 200)
                 if test.get("has_more_pages") == False:
-                    self.assertEqual(new_state, {"next_token": token, "normal_running_cutoff": True})
+                    self.assertEqual(
+                        new_state, {"next_token": token, "normal_running_cutoff": True, "last_log_line": 0}
+                    )
                 else:
-                    self.assertEqual(new_state, {"next_token": token})
+                    self.assertEqual(new_state, {"next_token": token, "last_log_line": 0})
                 if test.get("next_token") == "happy_token":
                     mock_logger.assert_called()
                     self.assertIn(
@@ -51,7 +55,7 @@ class TestMonitorSiemLogs(TestCase):
 
     def test_monitor_siem_logs_raises_401(self, _mock_data):
         # TODO: update 401 logic to successfully check is_last_token that was introduced in 5.3.3
-        state_params = {"next_token": "force_401"}
+        state_params = {"next_token": "force_401", "last_log_line": 0}
 
         response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=state_params)
 
@@ -62,7 +66,10 @@ class TestMonitorSiemLogs(TestCase):
 
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_stops_path_traversal(self, mock_logger, _mock_data):
-        test_state = {"next_token": "path_traversal"}  # this forces our mock util to append `../` into filenames
+        test_state = {
+            "next_token": "path_traversal",
+            "last_log_line": 0,
+        }  # this forces our mock util to append `../` into filenames
         response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=test_state)
         self.assertEqual(status_code, 200)
         self.assertEqual(has_more_pages, True)
@@ -75,7 +82,10 @@ class TestMonitorSiemLogs(TestCase):
 
     @patch("logging.Logger.error")
     def test_monitor_siem_logs_raises_json_error(self, mock_logger, _mock_data):
-        test_state = {"next_token": "request.json error"}  # this forces our mocked response to raise JSON encode error
+        test_state = {
+            "next_token": "request.json error",
+            "last_log_line": 0,
+        }  # this forces our mocked response to raise JSON encode error
         response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=test_state)
         self.assertEqual(status_code, 200)
         self.assertEqual(has_more_pages, False)
@@ -87,7 +97,10 @@ class TestMonitorSiemLogs(TestCase):
     @patch("logging.Logger.debug")
     @patch("komand_mimecast.util.api.MimecastAPI.get_siem_logs", side_effect=Exception("negative seek"))
     def test_monitor_siem_logs_raises_negative_seek(self, mock_siem_logs, mock_logger, _mock_data):
-        test_state = {"next_token": "negative_seek error"}  # this forces our mocked response to raise negative seek
+        test_state = {
+            "next_token": "negative_seek error",
+            "last_log_line": 0,
+        }  # this forces our mocked response to raise negative seek
         response, new_state, has_more_pages, status_code, error = self.task.run(params={}, state=test_state)
         self.assertEqual(status_code, 500)
         self.assertEqual(has_more_pages, False)
@@ -97,7 +110,7 @@ class TestMonitorSiemLogs(TestCase):
         self.assertIn("negative seek", mock_logger.call_args[0][0])
 
     @patch("logging.Logger.info")
-    @patch("insightconnect_plugin_runtime.helper.get_time_now", return_value=datetime.datetime(2024, 5, 13, 0, 0, 0))
+    @patch("insightconnect_plugin_runtime.helper.get_time_now", return_value=datetime.datetime(2022, 1, 1, 0, 0, 0))
     def test_monitor_siem_logs_get_filter_time(self, mock_time, mock_logger, _mock_data):
         content = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, FILE_ZIP_CONTENT_3]
         token = SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")
@@ -108,32 +121,32 @@ class TestMonitorSiemLogs(TestCase):
                 "has_more_pages": True,
                 "token": token,
                 "custom_config": {},
-                "expected_filter_time": "2024-05-12 00:00:00",
+                "expected_filter_time": "2021-12-31 00:00:00",
             },
             {
                 "resp": content,
                 "has_more_pages": True,
                 "token": token,
                 "custom_config": {
-                    "lookback": {"year": 2023, "month": 1, "day": 23, "hour": 22, "minute": 0, "second": 0}
+                    "lookback": {"year": 2021, "month": 1, "day": 23, "hour": 22, "minute": 0, "second": 0}
                 },
-                "expected_filter_time": "2023-01-23 22:00:00",
+                "expected_filter_time": "2021-01-23 22:00:00",
             },
             {
                 "resp": content,
                 "has_more_pages": True,
                 "token": token,
                 "custom_config": {
-                    "cutoff": {"date": {"year": 2023, "month": 1, "day": 23, "hour": 22, "minute": 0, "second": 0}}
+                    "cutoff": {"date": {"year": 2021, "month": 1, "day": 23, "hour": 22, "minute": 0, "second": 0}}
                 },
-                "expected_filter_time": "2023-01-23 22:00:00",
+                "expected_filter_time": "2021-01-23 22:00:00",
             },
             {
                 "resp": content,
                 "has_more_pages": True,
                 "token": token,
                 "custom_config": {"cutoff": {"hours": 72}},
-                "expected_filter_time": "2024-05-10 00:00:00",
+                "expected_filter_time": "2021-12-29 00:00:00",
             },
         ]
 
@@ -147,12 +160,55 @@ class TestMonitorSiemLogs(TestCase):
                 self.assertEqual(response, test.get("resp"))
                 self.assertEqual(status_code, 200)
                 if test.get("has_more_pages") == False:
-                    self.assertEqual(new_state, {"next_token": token, "normal_running_cutoff": True})
+                    self.assertEqual(
+                        new_state, {"next_token": token, "normal_running_cutoff": True, "last_log_line": 0}
+                    )
                 else:
-                    self.assertEqual(new_state, {"next_token": token})
+                    self.assertEqual(new_state, {"next_token": token, "last_log_line": 0})
                 validate(response, MonitorSiemLogsOutput.schema)
 
                 self.assertIn(f"{test.get('expected_filter_time')}", mock_logger.mock_calls[-6][1][0])
+
+    @patch("logging.Logger.warning")
+    @patch("komand_mimecast.tasks.monitor_siem_logs.task.MAX_EVENTS_PER_RUN_DEFAULT", new=1)
+    def test_monitor_siem_logs_success_split_files_across_runs(self, mock_logger, _mock_data):
+        content = [FILE_ZIP_CONTENT_1, FILE_ZIP_CONTENT_2, FILE_ZIP_CONTENT_3]
+        token = SIEM_LOGS_HEADERS_RESPONSE.get("mc-siem-token")
+        tests = [
+            {
+                "next_token": "test_multi_log_lines",
+                "resp": content,
+                "has_more_pages": True,
+                "token": token,
+                "state": {},
+                "run": 1,
+            },
+            {
+                "next_token": "test_multi_log_lines",
+                "resp": content,
+                "has_more_pages": True,
+                "token": token,
+                "state": {
+                    "last_log_line": 1,
+                    "last_runs_filter_time": "2022-01-01T12:00:00",
+                    "previous_file_hash": "9aabf6ac8a53ef0b93664b6507d2ce38",
+                },
+                "run": 2,
+            },
+        ]
+        for test in tests:
+            with self.subTest(f"Success test with token: {test.get('next_token')}"):
+                response, new_state, has_more_pages, status_code, _ = self.task.run(params={}, state=test.get("state"))
+
+                self.assertEqual(has_more_pages, test.get("has_more_pages"))
+                self.assertEqual(status_code, 200)
+
+                if test.get("run") == 1:
+                    self.assertEqual(response, [FILE_ZIP_CONTENT_1])
+                elif test.get("run") == 2:
+                    self.assertEqual(response, [FILE_ZIP_CONTENT_2])
+
+                validate(response, MonitorSiemLogsOutput.schema)
 
 
 class TestEventLogs(TestCase):

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -12,9 +12,8 @@ from komand_mimecast.connection.schema import Input
 from komand_mimecast.util.constants import DATA_FIELD, DEFAULT_REGION
 
 
-DATE_TIME_NOW = datetime.now().strftime("%Y-%m-%dT%H:%M:%S%z")
-FILE_ZIP_CONTENT_1 = {"acc": "ABC123", "datetime": DATE_TIME_NOW}
-FILE_ZIP_CONTENT_2 = {"acc": "ABC1234", "datetime": DATE_TIME_NOW}
+FILE_ZIP_CONTENT_1 = {"acc": "ABC123", "datetime": "2022-01-01T12:00:00"}
+FILE_ZIP_CONTENT_2 = {"acc": "ABC1234", "datetime": "2022-01-01T12:00:00"}
 FILE_ZIP_CONTENT_3 = {"acc": "ABC12345"}
 SIEM_LOGS_HEADERS_RESPONSE = {"mc-siem-token": "token123"}
 
@@ -193,6 +192,8 @@ class Util:
                 # try/except in `get_siem_logs`
                 headers["Content-Disposition"] = ""
                 resp = MockResponseZip(200, "this is bad json returned", headers, "throw json error")
+            # elif "test_multi_log_lines" in data:
+            #     has
             return resp
         return "Not implemented"
 


### PR DESCRIPTION
Release pr for the following 

https://rapid7.atlassian.net/browse/SOAR-17646
-  https://github.com/rapid7/insightconnect-plugins/pull/2759
  - limit the number of events thats processed in a single run to 7500 events
  - bumping sdk to version 6.1.0
  - added new unit test for new logic


testing on staging

we can see that the code looks to paginate as expected 
![image](https://github.com/user-attachments/assets/4ed0798e-c21c-4ec5-ae0a-827a4276d05b)
