### PR TITLE
[SOAR-17658] - Carbon Black Cloud - Splitting out the page size limits for alert_page_size and obervation_page_size

### DIFF
--- a/plugins/carbon_black_cloud/.CHECKSUM
+++ b/plugins/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a788752499d63f2874dc53c3d7226ea3",
-	"manifest": "c52109904f4e2f298b65be1b8129c85e",
-	"setup": "3fd852349ef3d6cb4ad81cf1c368feae",
+	"spec": "ecc1d3f00387ee045ce19c2c022c563f",
+	"manifest": "3c4a3f0f52e4a4d6b944ff9db72acef8",
+	"setup": "d5642fcbe70869d2fb91a5aed872c16d",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "VMware Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "2.2.4"
+Version = "2.2.5"
 Description = "The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin"
 
 

--- a/plugins/carbon_black_cloud/help.md
+++ b/plugins/carbon_black_cloud/help.md
@@ -440,6 +440,7 @@ Example output:
 
 # Version History
 
+* 2.2.5 - To split the PAGE_SIZE limit into ALERT_PAGE_SIZE and OBSERVATION_PAGE_SIZE
 * 2.2.4 - Add new connection tests for tasks | Update SDK to 6.1.0
 * 2.2.3 - Fix incorrect status code handling | Customise max pages returned in `Monitor Alerts and Observations` task | Bump to SDK 6.0.1
 * 2.2.2 - Connection updated to filter whitespace from connection inputs which resulted in unexpected results.

--- a/plugins/carbon_black_cloud/plugin.spec.yaml
+++ b/plugins/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
 description: The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin
-version: 2.2.4
+version: 2.2.5
 vendor: rapid7
 support: rapid7
 cloud_ready: true
@@ -18,6 +18,7 @@ requirements:
   - API Credentials
   - Base URL
 version_history:
+  - "2.2.5 - To split the PAGE_SIZE limit into ALERT_PAGE_SIZE and OBSERVATION_PAGE_SIZE"
   - "2.2.4 - Add new connection tests for tasks | Update SDK to 6.1.0"
   - "2.2.3 - Fix incorrect status code handling | Customise max pages returned in `Monitor Alerts and Observations` task | Bump to SDK 6.0.1"
   - "2.2.2 - `Connection updated to filter whitespace from connection inputs which resulted in unexpected results."

--- a/plugins/carbon_black_cloud/setup.py
+++ b/plugins/carbon_black_cloud/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="carbon_black_cloud-rapid7-plugin",
-      version="2.2.4",
+      version="2.2.5",
       description="The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin",
       author="rapid7",
       author_email="",

--- a/plugins/carbon_black_cloud/unit_test/test_monitor_alerts.py
+++ b/plugins/carbon_black_cloud/unit_test/test_monitor_alerts.py
@@ -43,7 +43,10 @@ import sys
 sys.path.append(os.path.abspath("../"))
 
 
-@patch("icon_carbon_black_cloud.tasks.monitor_alerts.task.PAGE_SIZE", new=2)  # force page size to be 2
+@patch("icon_carbon_black_cloud.tasks.monitor_alerts.task.ALERT_PAGE_SIZE_DEFAULT", new=2)  # force page size to be 2
+@patch(
+    "icon_carbon_black_cloud.tasks.monitor_alerts.task.OBSERVATION_PAGE_SIZE_DEFAULT", new=2
+)  # force page size to be 2
 @patch(
     "icon_carbon_black_cloud.tasks.monitor_alerts.task.MonitorAlerts._get_current_time",
     return_value=datetime(year=2024, month=4, day=25, hour=16, minute=00, tzinfo=timezone.utc),
@@ -371,7 +374,8 @@ class TestMonitorAlerts(TestCase):
                 {
                     LAST_OBSERVATION_TIME: "2024-04-25T15:35:00.000000Z",
                     LAST_ALERT_TIME: "2024-04-25T15:25:00.000000Z",
-                    "page_size": 2,
+                    "alert_page_size": 2,
+                    "observation_page_size": 2,
                 },
             ],
             [
@@ -395,13 +399,15 @@ class TestMonitorAlerts(TestCase):
                         "minute": 45,
                         "second": 55,
                     },
-                    "page_size": 7000,
+                    "alert_page_size": 7000,
+                    "observation_page_size": 7000,
                     "debug": True,
                 },
                 {
                     LAST_OBSERVATION_TIME: "2024-04-25T12:00:35.000000Z",
                     LAST_ALERT_TIME: "2024-04-20T10:45:55.000000Z",
-                    "page_size": 7000,
+                    "alert_page_size": 7000,
+                    "observation_page_size": 7000,
                     "debug": True,
                 },
             ],
@@ -435,10 +441,10 @@ class TestMonitorAlerts(TestCase):
         self.assertEqual(exp_values[LAST_OBSERVATION_TIME], requested_observation_time)
         self.assertEqual(exp_values[LAST_ALERT_TIME], requested_alert_time)
 
-        self.assertEqual(exp_values["page_size"], requested_observation_rows)
-        self.assertEqual(str(exp_values["page_size"]), requested_alert_rows)  # converted to string in the payload
+        self.assertEqual(exp_values["observation_page_size"], requested_observation_rows)
+        self.assertEqual(str(exp_values["alert_page_size"]), requested_alert_rows)  # converted to string in the payload
         self.assertEqual(
-            str(exp_values["page_size"]), trigger_observation_search_rows
+            str(exp_values["observation_page_size"]), trigger_observation_search_rows
         )  # formatted to string in the url
 
         if cps_config.get("debug", None):


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - to out the page size limits for alert_page_size and obervation_page_size so that they can be individually adjusted
  - updated the unit test to test the new vars 

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

The unit tests have been updated to reflect the new changes

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

when using a limit (10 in our case for testing) we can see the limits are correctly applied 

```
rapid7/VMware Carbon Black Cloud:2.2.5. Step name: monitor_alerts
No last_alert_time within state. No last_observation_time within state. Applying the following start times: alerts='2024-09-09T09:07:03.607607Z' and observations='2024-09-09T09:07:03.607607Z'. Max pages: alert_page_size='10, observation_page_size='10'.
No observation job ID found in state, triggering a new job...
Triggering observation search using parameters {'start': '2024-09-09T09:07:03.607607Z', 'end': '2024-09-09T09:12:03.607607Z'}
Saving observation job ID 2610e49b-e6a9-4b5b-b3de-f1cb4b8cb2e0-sqs to the state. Will query this after polling for alerts...
No last_observation_time in the state, saving checkpoint as 2024-09-09T09:07:03.607607Z
Querying alerts using parameters {'start': '2024-09-09T09:07:03.607607Z', 'end': '2024-09-09T09:12:03.607607Z'}
Expecting to dedupe a max of 0 based on previously stored hashes.
Received 2, and after dedupe there is 2 results.
Setting last_alert_time to last parsed time: '2024-09-09T09:07:13.754Z'
last_alert_time set to: 2024-09-09T09:07:13.754Z, has_more_pages=False
Get observation results from saved ID: 2610e49b-e6a9-4b5b-b3de-f1cb4b8cb2e0-sqs
Expecting to dedupe a max of 0 based on previously stored hashes.
Received 10, and after dedupe there is 10 results.
Setting last_observation_time to last parsed time: '2024-09-09T09:07:14.544Z'
More data is available on the API (num_found=418) - setting has_more_pages=True...
last_observation_time set to: 2024-09-09T09:07:14.544Z, has_more_pages=True
Returning a combined total of 12 alerts and observations, with has_more_pages=True
Plugin task finished execution...
```

testing with different limits set 
```
rapid7/VMware Carbon Black Cloud:2.2.5. Step name: monitor_alerts
No last_alert_time within state. No last_observation_time within state. Applying the following start times: alerts='2024-09-09T10:03:54.975434Z' and observations='2024-09-09T10:03:54.975434Z'. Max pages: alert_page_size='10, observation_page_size='2'.
No observation job ID found in state, triggering a new job...
Triggering observation search using parameters {'start': '2024-09-09T10:03:54.975434Z', 'end': '2024-09-09T10:08:54.975434Z'}
Saving observation job ID 656a1b2a-940d-49bb-9633-7cb483528678-sqs to the state. Will query this after polling for alerts...
No last_observation_time in the state, saving checkpoint as 2024-09-09T10:03:54.975434Z
Querying alerts using parameters {'start': '2024-09-09T10:03:54.975434Z', 'end': '2024-09-09T10:08:54.975434Z'}
Expecting to dedupe a max of 0 based on previously stored hashes.
Received 4, and after dedupe there is 4 results.
Setting last_alert_time to last parsed time: '2024-09-09T10:08:42.037Z'
last_alert_time set to: 2024-09-09T10:08:42.037Z, has_more_pages=False
Get observation results from saved ID: 656a1b2a-940d-49bb-9633-7cb483528678-sqs
Expecting to dedupe a max of 0 based on previously stored hashes.
Received 2, and after dedupe there is 2 results.
Setting last_observation_time to last parsed time: '2024-09-09T10:04:10.347Z'
More data is available on the API (num_found=216) - setting has_more_pages=True...
last_observation_time set to: 2024-09-09T10:04:10.347Z, has_more_pages=True
Returning a combined total of 6 alerts and observations, with has_more_pages=True
Plugin task finished execution...
```

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
