### PR TITLE
carbon_black_cloud 2.2.5 release

### DIFF
--- a/plugins/carbon_black_cloud/.CHECKSUM
+++ b/plugins/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a788752499d63f2874dc53c3d7226ea3",
-	"manifest": "c52109904f4e2f298b65be1b8129c85e",
-	"setup": "3fd852349ef3d6cb4ad81cf1c368feae",
+	"spec": "ecc1d3f00387ee045ce19c2c022c563f",
+	"manifest": "3c4a3f0f52e4a4d6b944ff9db72acef8",
+	"setup": "d5642fcbe70869d2fb91a5aed872c16d",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "VMware Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "2.2.4"
+Version = "2.2.5"
 Description = "The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin"
 
 

--- a/plugins/carbon_black_cloud/help.md
+++ b/plugins/carbon_black_cloud/help.md
@@ -440,6 +440,7 @@ Example output:
 
 # Version History
 
+* 2.2.5 - To split the PAGE_SIZE limit into ALERT_PAGE_SIZE and OBSERVATION_PAGE_SIZE
 * 2.2.4 - Add new connection tests for tasks | Update SDK to 6.1.0
 * 2.2.3 - Fix incorrect status code handling | Customise max pages returned in `Monitor Alerts and Observations` task | Bump to SDK 6.0.1
 * 2.2.2 - Connection updated to filter whitespace from connection inputs which resulted in unexpected results.

--- a/plugins/carbon_black_cloud/plugin.spec.yaml
+++ b/plugins/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
 description: The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin
-version: 2.2.4
+version: 2.2.5
 vendor: rapid7
 support: rapid7
 cloud_ready: true
@@ -18,6 +18,7 @@ requirements:
   - API Credentials
   - Base URL
 version_history:
+  - "2.2.5 - To split the PAGE_SIZE limit into ALERT_PAGE_SIZE and OBSERVATION_PAGE_SIZE"
   - "2.2.4 - Add new connection tests for tasks | Update SDK to 6.1.0"
   - "2.2.3 - Fix incorrect status code handling | Customise max pages returned in `Monitor Alerts and Observations` task | Bump to SDK 6.0.1"
   - "2.2.2 - `Connection updated to filter whitespace from connection inputs which resulted in unexpected results."

--- a/plugins/carbon_black_cloud/setup.py
+++ b/plugins/carbon_black_cloud/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="carbon_black_cloud-rapid7-plugin",
-      version="2.2.4",
+      version="2.2.5",
       description="The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin",
       author="rapid7",
       author_email="",

--- a/plugins/carbon_black_cloud/unit_test/test_monitor_alerts.py
+++ b/plugins/carbon_black_cloud/unit_test/test_monitor_alerts.py
@@ -43,7 +43,10 @@ import sys
 sys.path.append(os.path.abspath("../"))
 
 
-@patch("icon_carbon_black_cloud.tasks.monitor_alerts.task.PAGE_SIZE", new=2)  # force page size to be 2
+@patch("icon_carbon_black_cloud.tasks.monitor_alerts.task.ALERT_PAGE_SIZE_DEFAULT", new=2)  # force page size to be 2
+@patch(
+    "icon_carbon_black_cloud.tasks.monitor_alerts.task.OBSERVATION_PAGE_SIZE_DEFAULT", new=2
+)  # force page size to be 2
 @patch(
     "icon_carbon_black_cloud.tasks.monitor_alerts.task.MonitorAlerts._get_current_time",
     return_value=datetime(year=2024, month=4, day=25, hour=16, minute=00, tzinfo=timezone.utc),
@@ -371,7 +374,8 @@ class TestMonitorAlerts(TestCase):
                 {
                     LAST_OBSERVATION_TIME: "2024-04-25T15:35:00.000000Z",
                     LAST_ALERT_TIME: "2024-04-25T15:25:00.000000Z",
-                    "page_size": 2,
+                    "alert_page_size": 2,
+                    "observation_page_size": 2,
                 },
             ],
             [
@@ -395,13 +399,15 @@ class TestMonitorAlerts(TestCase):
                         "minute": 45,
                         "second": 55,
                     },
-                    "page_size": 7000,
+                    "alert_page_size": 7000,
+                    "observation_page_size": 7000,
                     "debug": True,
                 },
                 {
                     LAST_OBSERVATION_TIME: "2024-04-25T12:00:35.000000Z",
                     LAST_ALERT_TIME: "2024-04-20T10:45:55.000000Z",
-                    "page_size": 7000,
+                    "alert_page_size": 7000,
+                    "observation_page_size": 7000,
                     "debug": True,
                 },
             ],
@@ -435,10 +441,10 @@ class TestMonitorAlerts(TestCase):
         self.assertEqual(exp_values[LAST_OBSERVATION_TIME], requested_observation_time)
         self.assertEqual(exp_values[LAST_ALERT_TIME], requested_alert_time)
 
-        self.assertEqual(exp_values["page_size"], requested_observation_rows)
-        self.assertEqual(str(exp_values["page_size"]), requested_alert_rows)  # converted to string in the payload
+        self.assertEqual(exp_values["observation_page_size"], requested_observation_rows)
+        self.assertEqual(str(exp_values["alert_page_size"]), requested_alert_rows)  # converted to string in the payload
         self.assertEqual(
-            str(exp_values["page_size"]), trigger_observation_search_rows
+            str(exp_values["observation_page_size"]), trigger_observation_search_rows
         )  # formatted to string in the url
 
         if cps_config.get("debug", None):


### PR DESCRIPTION
Release pr for the following

https://rapid7.atlassian.net/browse/SOAR-17658
- https://github.com/rapid7/insightconnect-plugins/pull/2770
  - to out the page size limits for alert_page_size and obervation_page_size so that they can be individually adjusted
  - updated the unit test to test the new vars