### PR TITLE
[SOAR-17746] - Need root user to create cache

### DIFF
--- a/plugins/get_url/.CHECKSUM
+++ b/plugins/get_url/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "32e015b5f1dec2f990c6d0f351c852e5",
+	"spec": "f8855d5f40a49a6c84176230a378e16d",
 	"manifest": "b1c0373b43c1445dcfc785da96333de8",
 	"setup": "4efc28501a114feb9b7e91e3776aeebc",
 	"schemas": [

--- a/plugins/get_url/Dockerfile
+++ b/plugins/get_url/Dockerfile
@@ -15,6 +15,6 @@ ADD . /python/src
 RUN python setup.py build && python setup.py install
 
 # User to run plugin code. The two supported users are: root, nobody
-USER nobody
+USER root
 
 ENTRYPOINT ["/usr/local/bin/komand_get_url"]

--- a/plugins/get_url/plugin.spec.yaml
+++ b/plugins/get_url/plugin.spec.yaml
@@ -11,7 +11,7 @@ support: community
 sdk:
   type: slim
   version: 6.1.2
-  user: nobody
+  user: root
 status: []
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/get_url


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - After testing `get_url` fix on staging, hit issue with permissions:

```
rapid7/Get URL:2.1.0. Step name: get_file
[Errno 13] Permission denied: '/var/cache/7c774392df25c0990a337dc8b862b783cd881b51.meta'
```

  - Small fix to update user to `root` to resolve permissions issue when creating `/var/cache` directory


## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

- Tested locally after rebuilding image
