### PR TITLE
[SOAR-16967] Python 3 Script - Updated package installation

### DIFF
--- a/plugins/python_3_script/.CHECKSUM
+++ b/plugins/python_3_script/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "441f83b7f97f94804c7ae6ef98300add",
+	"spec": "c7ff086482db33567e135d3bc4f41537",
 	"manifest": "2c538fa19b6b5693104e6c71a09859e2",
 	"setup": "750744ab1e4d406ce443a91abe0c288d",
 	"schemas": [

--- a/plugins/python_3_script/Dockerfile
+++ b/plugins/python_3_script/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.2
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/python_3_script/icon_python_3_script/connection/connection.py
+++ b/plugins/python_3_script/icon_python_3_script/connection/connection.py
@@ -1,3 +1,4 @@
+import sys
 import os
 from subprocess import CalledProcessError, TimeoutExpired, check_output, run  # noqa: B404
 
@@ -5,6 +6,7 @@ import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
 
 from .schema import ConnectionSchema, Input
+from typing import Dict, Any
 
 
 class Connection(insightconnect_plugin_runtime.Connection):
@@ -13,50 +15,47 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.dependencies, self.timeout = None, None
         self.script_credentials = None
 
-    def connect(self, params={}):
-        self.timeout = params.get(Input.TIMEOUT)
-        self.dependencies = params.get(Input.MODULES)
+    def connect(self, params={}) -> None:
+        self.timeout = params.get(Input.TIMEOUT, 60)
+        self.dependencies = params.get(Input.MODULES, [])
         self.script_credentials = {
             "username": params.get(Input.SCRIPT_USERNAME_AND_PASSWORD, {}).get("username"),
             "password": params.get(Input.SCRIPT_USERNAME_AND_PASSWORD, {}).get("password"),
             "secret_key": params.get(Input.SCRIPT_SECRET_KEY, {}).get("secretKey"),
         }
 
-    def test(self):
-        connection_test_output = {"success": True}
-
+    def test(self) -> Dict[str, Any]:
         self.logger.info("[*] Performing Python version check...")
-        check = str(check_output(["python", "--version"]), "utf-8")  # noqa: B607,B603
-        self.logger.info(check)
+        python_version = str(check_output(["python", "--version"]), "utf-8")  # noqa: B607,B603
+        self.logger.info(python_version)
 
-        if "Python 3." not in check:
+        if "Python 3." not in python_version:
             raise ConnectionTestException(cause="[-] Python 3 is not installed correctly")
 
-        if not self.dependencies:
-            return connection_test_output
-
-        self.logger.info(f"[*] Installing user-specified dependencies ({self.dependencies})...")
-        self.install_dependencies()
-        self.logger.info("[*] Dependencies installed!\n")
-        return connection_test_output
+        if self.dependencies:
+            self.logger.info(f"[*] Installing user-specified dependencies ({self.dependencies})...")
+            self.install_dependencies()
+            self.logger.info("[*] Dependencies installed!\n")
+        return {"success": True}
 
     @staticmethod
-    def _set_pythonuserbase():
+    def _set_python_userbase() -> None:
         os.environ.update({"PYTHONUSERBASE": "/var/cache/python_dependencies"})
 
-    def install_dependencies(self):
-        dependencies = " ".join(self.dependencies)
-        command = f"pip install --user {dependencies}"
-
-        self._set_pythonuserbase()
-
+    def install_dependencies(self) -> None:
+        self._set_python_userbase()
         try:
-            run(args=command.split(" "), capture_output=True, timeout=self.timeout, check=True)  # noqa: B603
+            run(  # noqa: B603
+                args=[sys.executable, "-m", "pip", "install"] + self.dependencies,
+                capture_output=True,
+                timeout=self.timeout,
+                check=True,
+            )
         except TimeoutExpired:
             raise ConnectionTestException(
                 cause="Error: Installing Python dependencies exceeded timeout", assistance="Consider increasing timeout"
             )
         except CalledProcessError as error:
             raise ConnectionTestException(
-                cause=f"Error: Non-zero exit code returned. Message: {error.output.decode('UTF8')}"
+                cause=f"Error: Non-zero exit code returned. Message: {error.output.decode('utf-8')}"
             )

--- a/plugins/python_3_script/plugin.spec.yaml
+++ b/plugins/python_3_script/plugin.spec.yaml
@@ -13,7 +13,7 @@ supported_versions: ["Python 3.9.19"]
 fedramp_ready: true
 sdk:
   type: slim
-  version: 6.1.1
+  version: 6.1.2
   user: root
   packages:
     - libxslt-dev


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Updated package installation

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
