### PR TITLE
Palo alto retry creds 401

### DIFF
--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/tasks/monitor_alerts/task.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/tasks/monitor_alerts/task.py
@@ -78,12 +78,13 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
                 f"Unknown exception has occurred. No results returned. Error: {error} "
                 f"Existing state: {existing_state}"
             )
+            print(f"Error in general exception: {error = }")
             return (
                 [],
                 existing_state,
                 False,
                 500,
-                PluginException(preset=PluginException.Preset.UNKNOWN, data=error.data),
+                PluginException(preset=PluginException.Preset.UNKNOWN, data=error),
             )
 
     ###########################

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/tasks/monitor_alerts/task.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/tasks/monitor_alerts/task.py
@@ -78,7 +78,7 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
                 f"Unknown exception has occurred. No results returned. Error: {error} "
                 f"Existing state: {existing_state}"
             )
-            print(f"Error in general exception: {error = }")
+
             return (
                 [],
                 existing_state,

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
@@ -477,9 +477,9 @@ class CortexXdrAPI:
             self.logger.info(f"Received HTTP {response.status_code}, re-authenticating to Palo Alto Cortex XDR")
 
             new_headers = self._advanced_authentication(api_key=self.api_key, api_key_id=self.api_key_id)
-            response = self.build_request(url=url, headers=new_headers, post_body=post_body)
+            new_response = self.build_request(url=url, headers=new_headers, post_body=post_body)
 
-            return response
+            return new_response
 
         else:
             return response

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
@@ -11,8 +11,14 @@ import urllib
 from re import match
 from datetime import datetime, timezone
 from icon_palo_alto_cortex_xdr.util.util import Util
-from insightconnect_plugin_runtime.exceptions import PluginException, ConnectionTestException, ResponseExceptionData
+from insightconnect_plugin_runtime.exceptions import (
+    PluginException,
+    ConnectionTestException,
+    ResponseExceptionData,
+    HTTPStatusCodes,
+)
 from insightconnect_plugin_runtime.helper import extract_json, make_request
+from requests import Response
 
 
 class CortexXdrAPI:
@@ -434,16 +440,19 @@ class CortexXdrAPI:
         :param post_body: Object containing the post body (filters etc) to send in the requests
 
         """
+
         headers = self.get_headers()
         fqdn = self.get_url()
         endpoint = "public_api/v1/alerts/get_alerts"
 
         url = f"{fqdn}{endpoint}"
 
-        request = requests.Request(method="post", url=url, headers=headers, json=post_body)
-        response = make_request(_request=request, timeout=60, exception_data_location=ResponseExceptionData.RESPONSE)
+        response = self.build_request(url=url, headers=headers, post_body=post_body)
+
+        self._handle_401(response=response, url=url, post_body=post_body)
 
         response = extract_json(response)
+
         total_count = response.get("reply", {}).get("total_count")
         results_count = response.get("reply", {}).get("result_count")
         results = response.get("reply", {}).get("alerts", [])
@@ -457,3 +466,30 @@ class CortexXdrAPI:
             results_count = 0
 
         return results, results_count, total_count
+
+    def _handle_401(self, response: Response, url: str, post_body: dict):
+        """
+        In the event of 401 after 15 minutes when creds expire,
+        re-run the creds generation
+        """
+
+        print(f"Refresh creds hit")
+        if response.status_code == 401:
+            self.logger.info(f"Received HTTP {response.status_code}, re-authenticating to Palo Alto Cortex XDR")
+            response = self.build_request(url=url, headers=self.get_headers(), post_body=post_body)
+            print("new response hit")
+            return response
+
+    def build_request(self, url: str, headers: dict, post_body: dict):
+        """ """
+
+        request = requests.Request(method="post", url=url, headers=headers, json=post_body)
+
+        response = make_request(
+            _request=request,
+            timeout=60,
+            exception_data_location=ResponseExceptionData.RESPONSE,
+            allowed_status_codes=HTTPStatusCodes.UNAUTHORIZED,
+        )
+
+        return response


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - If `401`, rerun authentication for creds

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
