### PR TITLE
[NO-TICKET] Specify Python version for snyk

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -1,0 +1,3 @@
+version: v1.25.0
+language-settings: 
+  python: "3.9"


### PR DESCRIPTION
Specify the python version for snyk to run on the correct python version. 

Created .snyk file as mentioned on this [doc](https://docs.snyk.io/manage-risk/policies/the-.snyk-file#how-to-create-the-.snyk-file) to use version 1.25.0

And then matched the major.minor python version we want to scan for this repo - as we can't specify the patch version. Python docs in snyk [link](https://docs.snyk.io/supported-languages-package-managers-and-frameworks/python#pipenv-and-python-versions-supported)

Running on this version (3.9.18) passes whereas snyk is showing differently. 
Snyk: [snyk results](https://app.snyk.io/org/soar-insightconnect-new/project/64aad15a-e6ce-46a7-a9d4-967ae7261f16)
Local: 
```
(venv) joneill:mimecast/ (snyk-bump-python✗) $ python --version                                                            [14:48:57]
Python 3.9.18
(venv) joneill:mimecast/ (snyk-bump-python✗) $ snyk test                                                                   [14:49:01]

Testing /Users/joneill/insightconnect-plugins/plugins/mimecast...

Organization:      soar-insightconnect-new
Package manager:   pip
Target file:       requirements.txt
Project name:      mimecast
Open source:       no
Project path:      /Users/joneill/insightconnect-plugins/plugins/mimecast
Licenses:          enabled

✔ Tested 11 dependencies for known issues, no vulnerable paths found.

Next steps:
- Run `snyk monitor` to be notified about new related vulnerabilities.
- Run `snyk test` as part of your CI/test.
```

