### PR TITLE
[Carbon Black Cloud] Observability Window Restraint

### DIFF
--- a/plugins/carbon_black_cloud/.CHECKSUM
+++ b/plugins/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "66318d167ac1b5d373d20192eeeabf6c",
-	"manifest": "8edbe16f85abc5a43d8e13a86d5e0f4e",
-	"setup": "1aef9354d76d5741f137fe1af55f02ff",
+	"spec": "e65a2ba63a0336dd71483fe60f8fc09e",
+	"manifest": "cc99bad588629becc537d4e9726b339c",
+	"setup": "a3be16b44e39ce0215df20244b1b719d",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "VMware Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "2.2.6"
+Version = "2.2.7"
 Description = "The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin"
 
 

--- a/plugins/carbon_black_cloud/help.md
+++ b/plugins/carbon_black_cloud/help.md
@@ -440,6 +440,7 @@ Example output:
 
 # Version History
 
+* 2.2.7 - Restrain the observability window to a configurable amount if data collection falls behind
 * 2.2.6 - Update SDK to 6.1.4
 * 2.2.5 - To split the PAGE_SIZE limit into ALERT_PAGE_SIZE and OBSERVATION_PAGE_SIZE
 * 2.2.4 - Add new connection tests for tasks | Update SDK to 6.1.0

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
@@ -233,7 +233,8 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
                     )
                     has_more_pages = True
 
-            else:
+            # we use if not observations, vs else, to ensure we pick up on the case where we dedupe every observation
+            if not observations:
                 state[LAST_OBSERVATION_TIME] = state.get(OBSERVATION_QUERY_END_TIME)
 
             if not has_more_pages:
@@ -347,6 +348,7 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
                 if comparison_date > saved_time:
                     self.logger.info(f"Saved time ({saved_time}) exceeds cut off, moving to ({comparison_date}).")
                     state[cb_type_time] = comparison_date
+                    state.pop(OBSERVATION_JOB_OFFSET, None)
 
         alerts_start = state.get(LAST_ALERT_TIME)
         observation_start = state.get(LAST_OBSERVATION_TIME)

--- a/plugins/carbon_black_cloud/plugin.spec.yaml
+++ b/plugins/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
 description: The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin
-version: 2.2.6
+version: 2.2.7
 vendor: rapid7
 support: rapid7
 cloud_ready: true
@@ -18,6 +18,7 @@ requirements:
   - API Credentials
   - Base URL
 version_history:
+  - "2.2.7 - Restrain the observability window to a configurable amount if data collection falls behind"
   - "2.2.6 - Update SDK to 6.1.4"
   - "2.2.5 - To split the PAGE_SIZE limit into ALERT_PAGE_SIZE and OBSERVATION_PAGE_SIZE"
   - "2.2.4 - Add new connection tests for tasks | Update SDK to 6.1.0"

--- a/plugins/carbon_black_cloud/setup.py
+++ b/plugins/carbon_black_cloud/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="carbon_black_cloud-rapid7-plugin",
-      version="2.2.6",
+      version="2.2.7",
       description="The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin",
       author="rapid7",
       author_email="",

--- a/plugins/carbon_black_cloud/unit_test/responses/task_test_data.py
+++ b/plugins/carbon_black_cloud/unit_test/responses/task_test_data.py
@@ -1,6 +1,7 @@
 task_first_run = {}
 
 task_first_run_output = {
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
     "last_alert_hashes": ["b78568edeb07d22535d7b06454a4ce89a6589768"],
     "last_alert_time": "2024-04-25T15:38:38.389Z",
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
@@ -8,6 +9,7 @@ task_first_run_output = {
 }
 
 task_subsequent_output = {
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
     "last_alert_hashes": ["b78568edeb07d22535d7b06454a4ce89a6589768"],  # hash of last alert retrieved
     "last_alert_time": "2024-04-25T15:45:00.000000Z",  # now - 15 minutes as no new alerts returned
     "last_observation_hashes": ["c3fcde686f2fa6ed6b97b4f7f1b476dddfe19fab"],
@@ -20,10 +22,12 @@ task_subsequent_output_no_observation_job = {
     "last_alert_time": "2024-04-25T15:45:00.000000Z",  # now - 15 minutes as no new alerts returned
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
     "last_observation_time": "2024-04-25T15:39:38.389Z",
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
 }
 
 
 observations_more_pages = {
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
     "last_alert_hashes": ["9bceab49bf5441923e8fe8345195d5ec4d270193"],
     "last_alert_time": "2024-04-25T15:50:38.389Z",
     "last_observation_hashes": ["c3fcde686f2fa6ed6b97b4f7f1b476dddfe19fab"],
@@ -31,6 +35,7 @@ observations_more_pages = {
 }
 
 observation_job_not_finished = {
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
     "last_alert_hashes": ["9bceab49bf5441923e8fe8345195d5ec4d270193"],
     "last_alert_time": "2024-04-25T15:50:38.389Z",
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
@@ -46,9 +51,11 @@ task_rate_limit_getting_observations = {
     "last_observation_job": "1234-abcd-5678-sqs",
     "last_observation_job_time": "2024-04-25T16:00:00.000000Z",
     "rate_limited_until": "2024-04-25T16:05:00.000000Z",
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
 }
 
 task_401_on_second_request = {
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
     "last_alert_hashes": ["b78568edeb07d22535d7b06454a4ce89a6589768"],
     "last_alert_time": "2024-04-25T15:38:38.389Z",
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
@@ -59,6 +66,7 @@ task_401_on_second_request = {
 
 
 task_404_on_third_request = {
+    "observation_end_time": "2024-04-25T15:45:00.000000Z",
     "last_alert_hashes": ["9bceab49bf5441923e8fe8345195d5ec4d270193"],
     "last_alert_time": "2024-04-25T15:50:38.389Z",
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
@@ -67,15 +75,30 @@ task_404_on_third_request = {
 
 observation_job_exceeded = {
     "last_observation_job_time": "2024-04-01T13:34:03.626Z",
+    "observation_end_time": "2024-04-01T16:34:03.626Z",
     "last_observation_time": "2024-04-01T15:39:00.000000Z",  # job created 20 minutes ago
     "last_observation_job": "example-job-id",
 }
 
 observation_job_not_finished_but_parsed = {
+    "observation_end_time": "2024-04-01T16:34:03.626Z",
     "last_alert_hashes": ["b78568edeb07d22535d7b06454a4ce89a6589768"],
     "last_alert_time": "2024-04-25T15:38:38.389Z",
     "last_observation_hashes": ["f1c41f48654ec39d4614a0e924b2a6b96fa9f32e"],
     "last_observation_time": "2024-04-25T15:39:38.389Z",
+}
+
+no_logs_in_window = {
+    "last_observation_job_time": "2024-04-25T15:58:00.000000Z",
+    "observation_end_time": "2024-04-25T08:25:00.000000Z",
+    "last_observation_time": "2024-04-25T05:45:00.000000Z",
+    "last_observation_job": "example-job-id",
+}
+
+no_logs_in_window_back = {
+    "observation_end_time": "2024-04-25T08:25:00.000000Z",
+    "last_observation_time": "2024-04-25T08:25:00.000000Z",
+    "last_alert_time": "2024-04-25T15:45:00.000000Z",
 }
 
 # the same values for observations and hashes from the input as we don't get any new values, but add the


### PR DESCRIPTION
## Proposed Changes

### Description
Restrains the Observability window to a customizable window

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
