### PR TITLE
Palo Alto Cortex XDR | Updates

### DIFF
--- a/plugins/palo_alto_cortex_xdr/.CHECKSUM
+++ b/plugins/palo_alto_cortex_xdr/.CHECKSUM
@@ -33,7 +33,7 @@
 		},
 		{
 			"identifier": "monitor_alerts/schema.py",
-			"hash": "7751bc6eb4c8c6b9aaf465493f61928c"
+			"hash": "fa218a52dd4f09cd84af6fd581de5ff7"
 		},
 		{
 			"identifier": "get_alerts/schema.py",

--- a/plugins/palo_alto_cortex_xdr/.CHECKSUM
+++ b/plugins/palo_alto_cortex_xdr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "0021d4893d4c50661ed40749bfb99813",
-	"manifest": "9fd4cfed8de8d55916980ade6ac7ad3a",
-	"setup": "300ec46a66a2a1a2a434e9d68f841583",
+	"spec": "80c5cec0b5ce48e9cdb749e931679751",
+	"manifest": "094c90db12918a2d28277d8b94124397",
+	"setup": "67c9748687eb5d9ea0eccfccb53610e1",
 	"schemas": [
 		{
 			"identifier": "allow_file/schema.py",
@@ -33,7 +33,7 @@
 		},
 		{
 			"identifier": "monitor_alerts/schema.py",
-			"hash": "fa218a52dd4f09cd84af6fd581de5ff7"
+			"hash": "7751bc6eb4c8c6b9aaf465493f61928c"
 		},
 		{
 			"identifier": "get_alerts/schema.py",

--- a/plugins/palo_alto_cortex_xdr/bin/icon_palo_alto_cortex_xdr
+++ b/plugins/palo_alto_cortex_xdr/bin/icon_palo_alto_cortex_xdr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Palo Alto Cortex XDR"
 Vendor = "rapid7"
-Version = "4.0.2"
+Version = "4.0.3"
 Description = "Stop modern attacks with the industry's first extended detection and response platform that spans your endpoints, network and cloud data"
 
 

--- a/plugins/palo_alto_cortex_xdr/help.md
+++ b/plugins/palo_alto_cortex_xdr/help.md
@@ -927,6 +927,7 @@ Isolate Endpoint fails with 500 error - This will happen if an isolation action 
 
 # Version History
 
+* 4.0.3 - `Get Incidents` - Update `Hosts` output to map hostname and endpoint ID | `Monitor Incidents` - Add custom config exception handling
 * 4.0.2 - SDK bump to 6.1.4
 * 4.0.1 - SDK Bump to 6.1.3
 * 4.0.0 - `Get Alerts`: Fixed issue where trigger was failing due to empty and different typed output fields - updated to generic object | Added Monitor_alert tasks | SDK Bump to 6.1.2

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/triggers/get_incidents/trigger.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/triggers/get_incidents/trigger.py
@@ -33,7 +33,7 @@ class GetIncidents(insightconnect_plugin_runtime.Trigger):
             )
             # Separate the host identifier values
             for incident in incidents:
-                incident["hosts"] = Util.split_list_values(incident.get("hosts", []), ":")
+                incident["hosts"] = Util.split_list_values(incident.get("hosts", []))
             # Process incidents from oldest to newest
             for incident_time in Util.send_items_to_platform_for_trigger(
                 self, incidents, Output.INCIDENT, last_event_processed_time_ms, time_field

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
@@ -492,20 +492,20 @@ class CortexXdrAPI:
         request = requests.Request(method="post", url=url, headers=headers, json=post_body)
 
         custom_config_exceptions = {
-            HTTPStatusCodes.BAD_REQUEST: PluginException(cause=f"API Error. ", assistance="Bad request, invalid JSON."),
+            HTTPStatusCodes.BAD_REQUEST: PluginException(cause="API Error. ", assistance="Bad request, invalid JSON."),
             HTTPStatusCodes.UNAUTHORIZED: PluginException(
-                cause=f"API Error. ", assistance="Authorization failed. Check your API Key ID & API Key."
+                cause="API Error. ", assistance="Authorization failed. Check your API Key ID & API Key."
             ),
             HTTPStatusCodes.PAYMENT_REQUIRED: PluginException(
-                cause=f"API Error. ",
+                cause="API Error. ",
                 assistance="Unauthorized access. User does not have the required license type to run this API.",
             ),
             HTTPStatusCodes.FORBIDDEN: PluginException(
-                cause=f"API Error. ",
+                cause="API Error. ",
                 assistance="Forbidden. The provided API Key does not have the required RBAC permissions to run this API.",
             ),
             HTTPStatusCodes.NOT_FOUND: PluginException(
-                cause=f"API Error. ",
+                cause="API Error. ",
                 assistance=f"The object at {url} does not exist. Check the FQDN connection setting and try again.",
             ),
         }

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/api.py
@@ -491,9 +491,29 @@ class CortexXdrAPI:
 
         request = requests.Request(method="post", url=url, headers=headers, json=post_body)
 
+        custom_config_exceptions = {
+            HTTPStatusCodes.BAD_REQUEST: PluginException(cause=f"API Error. ", assistance="Bad request, invalid JSON."),
+            HTTPStatusCodes.UNAUTHORIZED: PluginException(
+                cause=f"API Error. ", assistance="Authorization failed. Check your API Key ID & API Key."
+            ),
+            HTTPStatusCodes.PAYMENT_REQUIRED: PluginException(
+                cause=f"API Error. ",
+                assistance="Unauthorized access. User does not have the required license type to run this API.",
+            ),
+            HTTPStatusCodes.FORBIDDEN: PluginException(
+                cause=f"API Error. ",
+                assistance="Forbidden. The provided API Key does not have the required RBAC permissions to run this API.",
+            ),
+            HTTPStatusCodes.NOT_FOUND: PluginException(
+                cause=f"API Error. ",
+                assistance=f"The object at {url} does not exist. Check the FQDN connection setting and try again.",
+            ),
+        }
+
         response = make_request(
             _request=request,
             timeout=60,
+            exception_custom_configs=custom_config_exceptions,
             exception_data_location=ResponseExceptionData.RESPONSE,
             allowed_status_codes=[HTTPStatusCodes.UNAUTHORIZED],
         )

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
@@ -29,8 +29,9 @@ class Util:
             if isinstance(item, str):
                 item_split = item.split(":")
                 if len(item_split) == 2:
-                    output_list.append({"hostname": item_split[0], "endpoint_id": item_split[1]})
-        # duplicates = set()
+                    output_list.append({'hostname': item_split[0], 'endpoint_id': item_split[1]})
+                else:
+                    output_list.append({"hostname": item_split[0]})
         return output_list
 
     @staticmethod

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
@@ -15,7 +15,7 @@ class Util:
         return int(time.time() * 1000)
 
     @staticmethod
-    def split_list_values(input_list: list, separator: str) -> list:
+    def split_list_values(input_list: list) -> list:
         """Splits each string in a list based on a separator and returns a list of all separated values
         :param input_list: Input list of string
         :type input_list: list, required
@@ -27,10 +27,11 @@ class Util:
         output_list = []
         for item in input_list:
             if isinstance(item, str):
-                item_split = item.split(separator)
-                output_list.extend(item_split)
-        duplicates = set()
-        return [item for item in output_list if not (item in duplicates or duplicates.add(item))]
+                item_split = item.split(":")
+                if len(item_split) == 2:
+                    output_list.append({"hostname": item_split[0], "endpoint_id": item_split[1]})
+        # duplicates = set()
+        return output_list
 
     @staticmethod
     def send_items_to_platform_for_trigger(

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
@@ -29,7 +29,7 @@ class Util:
             if isinstance(item, str):
                 item_split = item.split(":")
                 if len(item_split) == 2:
-                    output_list.append({'hostname': item_split[0], 'endpoint_id': item_split[1]})
+                    output_list.append({"hostname": item_split[0], "endpoint_id": item_split[1]})
                 else:
                     output_list.append({"hostname": item_split[0]})
         return output_list

--- a/plugins/palo_alto_cortex_xdr/plugin.spec.yaml
+++ b/plugins/palo_alto_cortex_xdr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: palo_alto_cortex_xdr
 title: Palo Alto Cortex XDR
 description: Stop modern attacks with the industry's first extended detection and response platform that spans your endpoints, network and cloud data
-version: 4.0.2
+version: 4.0.3
 connection_version: 2
 cloud_ready: true
 sdk:
@@ -38,6 +38,7 @@ key_features:
   - "Add files to the block or allow lists"
 troubleshooting: "Isolate Endpoint fails with 500 error - This will happen if an isolation action (Isolate or Unisolate) is in progress on the selected endpoint. Wait a few minutes and try again."
 version_history:
+  - "4.0.3 - `Get Incidents` - Update `Hosts` output to map hostname and endpoint ID | `Monitor Incidents` - Add custom config exception handling"
   - "4.0.2 - SDK bump to 6.1.4"
   - "4.0.1 - SDK Bump to 6.1.3"
   - "4.0.0 - `Get Alerts`: Fixed issue where trigger was failing due to empty and different typed output fields - updated to generic object | Added Monitor_alert tasks | SDK Bump to 6.1.2"

--- a/plugins/palo_alto_cortex_xdr/setup.py
+++ b/plugins/palo_alto_cortex_xdr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_cortex_xdr-rapid7-plugin",
-      version="4.0.2",
+      version="4.0.3",
       description="Stop modern attacks with the industry's first extended detection and response platform that spans your endpoints, network and cloud data",
       author="rapid7",
       author_email="",

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
@@ -46,7 +46,7 @@ def check_error():
             "host_count": 1,
             "xdr_url": "https://example.com/incident-view?caseId=1",
             "starred": False,
-            "hosts": ["example-host", "example-host-2"],
+            "hosts": [{"hostname": "example-host"}, {"hostname": "example-host-2"}],
             "users": ["administrator"],
             "incident_sources": ["XDR Agent"],
             "wildfire_hits": 4,
@@ -67,7 +67,7 @@ def check_error():
     }
     if MockTrigger.actual == expected:
         return True
-
+    TestCase.maxDiff = None
     TestCase.assertDictEqual(TestCase(), MockTrigger.actual, expected)
 
 

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_monitor_alerts.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_monitor_alerts.py
@@ -129,15 +129,23 @@ class TestMonitorAlerts(TestCase):
                 "Bad Request",
                 STUB_STATE_ERROR,
                 PluginException(
-                    data="An error occurred during plugin execution!\n\nThe server is unable to process the request. Verify your plugin input is correct and not malformed and try again. If the issue persists, please contact support."
+                    data="An error occurred during plugin execution!\n\nAPI Error.  Bad request, invalid JSON."
                 ),
                 400,
+            ],
+            [
+                "Wrong License",
+                STUB_STATE_ERROR,
+                PluginException(
+                    data="An error occurred during plugin execution!\n\nAPI Error.  Unauthorized access. User does not have the required license type to run this API."
+                ),
+                402,
             ],
             [
                 "Forbidden",
                 STUB_STATE_ERROR,
                 PluginException(
-                    data="An error occurred during plugin execution!\n\nThe account configured in your connection is unauthorized to access this service. Verify the permissions for your account and try again."
+                    data="An error occurred during plugin execution!\n\nAPI Error.  Forbidden. The provided API Key does not have the required RBAC permissions to run this API."
                 ),
                 403,
             ],
@@ -145,7 +153,7 @@ class TestMonitorAlerts(TestCase):
                 "Not Found",
                 STUB_STATE_ERROR,
                 PluginException(
-                    data="An error occurred during plugin execution!\n\nInvalid or unreachable endpoint provided. Verify the URLs or endpoints in your configuration are correct."
+                    data="An error occurred during plugin execution!\n\nAPI Error.  The object at https://example.com/public_api/v1/alerts/get_alerts does not exist. Check the FQDN connection setting and try again."
                 ),
                 404,
             ],
@@ -166,6 +174,7 @@ class TestMonitorAlerts(TestCase):
         error_msg: Union[str, PluginException],
         error_code: int,
     ) -> None:
+        self.maxDiff = None
         # This if statement is to handle the "if not type response" statement specifically
         if error_code == 500:
             mocked_response = mock_conditions(200, file_name="monitor_alerts_faulty_response")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

- Add custom config exception handling to match the error handling found in the regular API calls for actions and triggers
- Update the Get Incidents trigger to separate hostname and incident ID and properly map them in their own object

**Hosts Output from `Get Incidents` Trigger**
```
In [14]: split_list_values(x)
Out[14]:
[{'hostname': 'htc-smr-2194',
  'endpoint_id': '3d421251f17348469031227eea15ad5d'}]
```

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
