### PR TITLE
Palo Alto Cortex XDR | Undo change to list split for get incidents trigger

### DIFF
--- a/plugins/palo_alto_cortex_xdr/.CHECKSUM
+++ b/plugins/palo_alto_cortex_xdr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "80c5cec0b5ce48e9cdb749e931679751",
+	"spec": "5f65f97ed0704bd87cb78e24eb9dc1b3",
 	"manifest": "094c90db12918a2d28277d8b94124397",
 	"setup": "67c9748687eb5d9ea0eccfccb53610e1",
 	"schemas": [

--- a/plugins/palo_alto_cortex_xdr/help.md
+++ b/plugins/palo_alto_cortex_xdr/help.md
@@ -927,7 +927,7 @@ Isolate Endpoint fails with 500 error - This will happen if an isolation action 
 
 # Version History
 
-* 4.0.3 - `Get Incidents` - Update `Hosts` output to map hostname and endpoint ID | `Monitor Incidents` - Add custom config exception handling
+* 4.0.3 - `Monitor Incidents` - Add custom config exception handling
 * 4.0.2 - SDK bump to 6.1.4
 * 4.0.1 - SDK Bump to 6.1.3
 * 4.0.0 - `Get Alerts`: Fixed issue where trigger was failing due to empty and different typed output fields - updated to generic object | Added Monitor_alert tasks | SDK Bump to 6.1.2

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
@@ -29,7 +29,7 @@ class Util:
             if isinstance(item, str):
                 item_split = item.split(":")
                 output_list.extend(item_split)
-        
+
         duplicates = set()
 
         return [item for item in output_list if not (item in duplicates or duplicates.add(item))]

--- a/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
+++ b/plugins/palo_alto_cortex_xdr/icon_palo_alto_cortex_xdr/util/util.py
@@ -28,11 +28,11 @@ class Util:
         for item in input_list:
             if isinstance(item, str):
                 item_split = item.split(":")
-                if len(item_split) == 2:
-                    output_list.append({"hostname": item_split[0], "endpoint_id": item_split[1]})
-                else:
-                    output_list.append({"hostname": item_split[0]})
-        return output_list
+                output_list.extend(item_split)
+        
+        duplicates = set()
+
+        return [item for item in output_list if not (item in duplicates or duplicates.add(item))]
 
     @staticmethod
     def send_items_to_platform_for_trigger(

--- a/plugins/palo_alto_cortex_xdr/plugin.spec.yaml
+++ b/plugins/palo_alto_cortex_xdr/plugin.spec.yaml
@@ -38,7 +38,7 @@ key_features:
   - "Add files to the block or allow lists"
 troubleshooting: "Isolate Endpoint fails with 500 error - This will happen if an isolation action (Isolate or Unisolate) is in progress on the selected endpoint. Wait a few minutes and try again."
 version_history:
-  - "4.0.3 - `Get Incidents` - Update `Hosts` output to map hostname and endpoint ID | `Monitor Incidents` - Add custom config exception handling"
+  - "4.0.3 - `Monitor Incidents` - Add custom config exception handling"
   - "4.0.2 - SDK bump to 6.1.4"
   - "4.0.1 - SDK Bump to 6.1.3"
   - "4.0.0 - `Get Alerts`: Fixed issue where trigger was failing due to empty and different typed output fields - updated to generic object | Added Monitor_alert tasks | SDK Bump to 6.1.2"

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
@@ -46,7 +46,7 @@ def check_error():
             "host_count": 1,
             "xdr_url": "https://example.com/incident-view?caseId=1",
             "starred": False,
-            "hosts": [{"hostname": "example-host"}, {"hostname": "example-host-2"}],
+            "hosts": ['example-host', 'example-host-2'],
             "users": ["administrator"],
             "incident_sources": ["XDR Agent"],
             "wildfire_hits": 4,

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_get_incidents.py
@@ -46,7 +46,7 @@ def check_error():
             "host_count": 1,
             "xdr_url": "https://example.com/incident-view?caseId=1",
             "starred": False,
-            "hosts": ['example-host', 'example-host-2'],
+            "hosts": ["example-host", "example-host-2"],
             "users": ["administrator"],
             "incident_sources": ["XDR Agent"],
             "wildfire_hits": 4,

--- a/plugins/palo_alto_cortex_xdr/unit_test/test_monitor_alerts.py
+++ b/plugins/palo_alto_cortex_xdr/unit_test/test_monitor_alerts.py
@@ -174,7 +174,7 @@ class TestMonitorAlerts(TestCase):
         error_msg: Union[str, PluginException],
         error_code: int,
     ) -> None:
-        self.maxDiff = None
+
         # This if statement is to handle the "if not type response" statement specifically
         if error_code == 500:
             mocked_response = mock_conditions(200, file_name="monitor_alerts_faulty_response")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Undo change from previous PR regarding `Get Incidents` trigger fix

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
