### PR TITLE
[SOAR-18032] Cylance Protect Release - Reference changed

### DIFF
--- a/plugins/cylance_protect/.CHECKSUM
+++ b/plugins/cylance_protect/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "5ae384c8c6690b9fafc3e8f1ba6f0b4e",
-	"manifest": "17d10447d7ceac56e9b081f8a63467cd",
-	"setup": "8be114c0f4f76215211fbbcb6f11333d",
+	"spec": "42306d5023bce862a7c5306798b2b71e",
+	"manifest": "a4d921084b747f15f93abcf482f4ea3c",
+	"setup": "da0acb740f4328fffea859d619c0c043",
 	"schemas": [
 		{
 			"identifier": "blacklist/schema.py",

--- a/plugins/cylance_protect/bin/icon_cylance_protect
+++ b/plugins/cylance_protect/bin/icon_cylance_protect
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "BlackBerry CylancePROTECT"
 Vendor = "rapid7"
-Version = "1.5.2"
+Version = "1.5.3"
 Description = "The [BlackBerry CylancePROTECT](https://www.cylance.com/en-us/platform/products/cylance-protect.html) plugin allows you to automate response operations for CylancePROTECT and CylanceOPTICS"
 
 

--- a/plugins/cylance_protect/help.md
+++ b/plugins/cylance_protect/help.md
@@ -620,4 +620,4 @@ Example output:
 
 ## References
 
-* [BlackBerry CylancePROTECT API](https://documentation.securonix.com/bundle/securonix-on-prem-user-guide/page/content/active-deployment-guides/cylance-protect-api-kvp.htm)
+* [BlackBerry CylancePROTECT API](https://docs.blackberry.com/en/unified-endpoint-security/blackberry-ues/Cylance-API-user-guide/Application_Management)

--- a/plugins/cylance_protect/plugin.spec.yaml
+++ b/plugins/cylance_protect/plugin.spec.yaml
@@ -34,7 +34,7 @@ links:
 requirements:
   - CylancePROTECT configured with an Custom Application
 references:
-  - "[BlackBerry CylancePROTECT API](https://documentation.securonix.com/bundle/securonix-on-prem-user-guide/page/content/active-deployment-guides/cylance-protect-api-kvp.htm)"
+  - "[BlackBerry CylancePROTECT API](https://docs.blackberry.com/en/unified-endpoint-security/blackberry-ues/Cylance-API-user-guide/Application_Management)"
 version_history:
   - "1.5.3 - Bumping requirements.txt | SDK bump to 6.1.4"
   - "1.5.2 - Bumped the version of the SDK used | Bumped versions of all pythion packages used | Ran refresh to bring code up to latest standard | Added unit tests for all actions"

--- a/plugins/cylance_protect/setup.py
+++ b/plugins/cylance_protect/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="cylance_protect-rapid7-plugin",
-      version="1.5.2",
+      version="1.5.3",
       description="The [BlackBerry CylancePROTECT](https://www.cylance.com/en-us/platform/products/cylance-protect.html) plugin allows you to automate response operations for CylancePROTECT and CylanceOPTICS",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Changing the API referenced in the help.md

The original release was not kicked off by Jenkins (1.5.3) but this will kick it off as the version has been changed in each file now
Describe the proposed changes:

 - #2914 (Original PR)
 - #2913 (First PR already merged)
  - Changing reference in help.md

