### PR TITLE
SOAR-17972: bump SDK and remove inline comment from requirements.txt

### DIFF
--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b1e8b7c586c71fd8400f42e59e1081d6",
-	"manifest": "c073e033710bb75079c46d1d9d5d5038",
-	"setup": "9c3f4261176735eca46c01c8fd842f72",
+	"spec": "9145719b881a784092c317354561287b",
+	"manifest": "a95ee1b81a2944967e48aaca45022fa3",
+	"setup": "e7d0bf5db9c37f6d59ff44e5d735b165",
 	"schemas": [
 		{
 			"identifier": "execute_script/schema.py",

--- a/plugins/powershell/Dockerfile
+++ b/plugins/powershell/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/powershell/bin/icon_powershell
+++ b/plugins/powershell/bin/icon_powershell
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "PowerShell"
 Vendor = "rapid7"
-Version = "3.0.5"
+Version = "3.0.6"
 Description = "[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6) is a task-based command-line shell and scripting language from Microsoft that helps system administrators, power-users, and InsightConnect customers rapidly automate tasks that manage operating systems and processes. This plugin runs a PowerShell script on a remote host or locally on an InsightConnect Orchestrator"
 
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -199,6 +199,7 @@ Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw
 
 # Version History
 
+* 3.0.6 - Bump SDK to 6.2.0
 * 3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that the use of round-robin DNS lookups is not supported
 * 3.0.4 - Upgrade user from `nobody` to `root` | bump SDK to 6.0.1 and switch back to `Bullseye` based SDK image
 * 3.0.3 - Fix decoding error in `Execute Script` action | Update SDK | Update packages for alpine image

--- a/plugins/powershell/plugin.spec.yaml
+++ b/plugins/powershell/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: powershell
 title: PowerShell
 description: "[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6) is a task-based command-line shell and scripting language from Microsoft that helps system administrators, power-users, and InsightConnect customers rapidly automate tasks that manage operating systems and processes. This plugin runs a PowerShell script on a remote host or locally on an InsightConnect Orchestrator"
-version: 3.0.5
+version: 3.0.6
 connection_version: 3
 key_features:
   - "Run a PowerShell script to manage (remote) computers from the command line"
@@ -15,7 +15,7 @@ requirements:
   - "The use of round-robin DNS lookups is not supported"
 sdk:
   type: slim
-  version: 6.1.4
+  version: 6.2.0
   user: nobody
 links:
   - "[InsightConnect Powershell Plugin Guide](https://docs.rapid7.com/insightconnect/mass-delete-with-PowerShell/)"
@@ -42,8 +42,9 @@ hub_tags:
   keywords: [powershell, microsoft]
   features: []
 version_history:
+  - "3.0.5 - Bump SDK to 6.2.0"
   - "3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that the use of round-robin DNS lookups is not supported"
-  - "3.0.4 - Upgrade user from `nobody` to `root` | bump SDK to 6.0.1 and switch back to `Bullseye` based SDK image" 
+  - "3.0.4 - Upgrade user from `nobody` to `root` | bump SDK to 6.0.1 and switch back to `Bullseye` based SDK image"
   - "3.0.3 - Fix decoding error in `Execute Script` action | Update SDK | Update packages for alpine image"
   - "3.0.2 - Updated the SDK version to include output masking | Updated all the dependencies to the newest versions"
   - "3.0.1 - Bug fix - Fix issue where single quotes in password causes parsing error"

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -1,7 +1,7 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-git+https://github.com/komand/pywinrm.git@v0.3.1dev0#pywinrm
+git+https://github.com/komand/pywinrm.git@v0.3.1dev0
 requests-kerberos==0.14.0
 requests-credssp==2.0.0
 parameterized==0.8.1

--- a/plugins/powershell/setup.py
+++ b/plugins/powershell/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="powershell-rapid7-plugin",
-      version="3.0.5",
+      version="3.0.6",
       description="[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6) is a task-based command-line shell and scripting language from Microsoft that helps system administrators, power-users, and InsightConnect customers rapidly automate tasks that manage operating systems and processes. This plugin runs a PowerShell script on a remote host or locally on an InsightConnect Orchestrator",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Bump SDK version being used in the plugin and update that the requirements.txt doesn't contain inline comment causing snyk to fail.

Part of ticket: https://rapid7.atlassian.net/browse/SOAR-17972

Testing:
- Image builds locally
- `snyk test` now passes:
![Screenshot 2024-11-08 at 13 03 10](https://github.com/user-attachments/assets/7884b7d1-65f2-476c-ac57-2cb7ca6e737e)
