### PR TITLE
Mimecast Release v5.3.20

### DIFF
--- a/plugins/mimecast/.CHECKSUM
+++ b/plugins/mimecast/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "ab629f58d383334a20d036678e45b9f2",
-	"manifest": "9f9a8a2c45095798625a37f3878b8dd4",
-	"setup": "5ba5d7927984907d1551077e7dde11ac",
+	"spec": "6da6579eda4ddc4e9480be4896f78c16",
+	"manifest": "66b9e9d783bc569c9c4af45fd1fe92e7",
+	"setup": "2cb4c47c6fd5fc6f70a966d2e601e04c",
 	"schemas": [
 		{
 			"identifier": "add_group_member/schema.py",

--- a/plugins/mimecast/bin/komand_mimecast
+++ b/plugins/mimecast/bin/komand_mimecast
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Mimecast"
 Vendor = "rapid7"
-Version = "5.3.19"
+Version = "5.3.20"
 Description = "[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)"
 
 

--- a/plugins/mimecast/help.md
+++ b/plugins/mimecast/help.md
@@ -1014,6 +1014,7 @@ For the Create Managed URL action, the URL must include `http://` or `https://` 
 
 # Version History
 
+* 5.3.20 - Update Task `monitor_siem_logs` bump default rate limit period to 10 minutes and catch unexpected errors
 * 5.3.19 - Update Task `monitor_siem_logs` to delay retry if a rate limit error is returned from Mimecast | Update SDK to version 6.2.0
 * 5.3.18 - Fix task connection test | Trim whitespace from connection inputs | bump SDK to version 6.1.2
 * 5.3.17 - Task `monitor_siem_logs` update the mapping used for the USBCOM region

--- a/plugins/mimecast/komand_mimecast/util/util.py
+++ b/plugins/mimecast/komand_mimecast/util/util.py
@@ -6,7 +6,7 @@ from komand_mimecast.util.constants import BASE_HOSTNAME_MAP, DEFAULT_REGION
 
 class Utils:
     @staticmethod
-    def convert_epoch_to_readable(epoch_time: int) -> str:
+    def convert_epoch_to_readable(epoch_time: float) -> str:
         return datetime.utcfromtimestamp(epoch_time).strftime("%Y-%m-%d %H:%M:%S")
 
     @staticmethod

--- a/plugins/mimecast/plugin.spec.yaml
+++ b/plugins/mimecast/plugin.spec.yaml
@@ -17,7 +17,7 @@ links:
  - "[Mimecast](http://mimecast.com)"
 references:
  - "[Mimecast API](https://www.mimecast.com/developer/documentation)"
-version: 5.3.19
+version: 5.3.20
 connection_version: 5
 supported_versions: ["Mimecast API 2024-06-18"]
 vendor: rapid7
@@ -40,6 +40,7 @@ hub_tags:
   keywords: [mimecast, email, cloud_enabled]
   features: []
 version_history:
+- "5.3.20 - Update Task `monitor_siem_logs` bump default rate limit period to 10 minutes and catch unexpected errors"
 - "5.3.19 - Update Task `monitor_siem_logs` to delay retry if a rate limit error is returned from Mimecast | Update SDK to version 6.2.0"
 - "5.3.18 - Fix task connection test | Trim whitespace from connection inputs | bump SDK to version 6.1.2"
 - "5.3.17 - Task `monitor_siem_logs` update the mapping used for the USBCOM region"

--- a/plugins/mimecast/setup.py
+++ b/plugins/mimecast/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="mimecast-rapid7-plugin",
-      version="5.3.19",
+      version="5.3.20",
       description="[Mimecast](https://www.mimecast.com) is a set of cloud services designed to provide next generation protection against advanced email-borne threats such as malicious URLs, malware, impersonation attacks, as well as internally generated threats, with a focus on email security. This plugin utilizes the [Mimecast API](https://www.mimecast.com/developer/documentation)",
       author="rapid7",
       author_email="",

--- a/plugins/mimecast/unit_test/util.py
+++ b/plugins/mimecast/unit_test/util.py
@@ -186,7 +186,15 @@ class Util:
                         }
                     ],
                 }
-                headers = {"X-RateLimit-Reset": 600000}
+
+                # This value should be the amount of time in milliseconds until the next call is allowed
+                # in the mock make the customer wait 20 minutes. # todo - WHY IS THIS NOT WORKING
+                reset_value = "not an integer value" if "force_429_error" in data else "1200000"
+                headers = {"X-RateLimit-Reset": reset_value}
+
+                # default to calculate a new time in the task based on no return value
+                if "force_429_no_header" in data:
+                    del headers["X-RateLimit-Reset"]
                 resp = MockResponseZip(429, b"", headers, json.dumps(json_value))
             elif "force_json" in data:
                 resp = MockResponseZip(200, b'{ "type" : "MTA", "data" : ', headers, '{"meta": {"status": 200}}')


### PR DESCRIPTION
Release of Mimecast 5.3.20

Changes:
- Handle response heade combing back as string format.
- Add broader except to catch other errors when rate limiting being enforced.
- Bump back off period for rate limits to be 10 minutes from 5 minutes.
- Check rate limit value stored in the state correctly.

Original PR:
- #2958 

Testing:
- Unit test added and all passing.
- Integration tests passing.
- C2C rolled over internally with no issues.