### PR TITLE
[SOAR-18202] [Salesforce] Ensure date.now includes microseconds

### DIFF
--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e182e26e61f7d3375dc3a9bc3df8fc11",
-	"manifest": "4d555de9a1d8b4ead1868f7d8ae7c1b5",
-	"setup": "8d0731798d9f79b7c98d821e8abf0001",
+	"spec": "63b7270d95683b98e315808e4df20354",
+	"manifest": "391ed2bce80fc53ee24774278259d26e",
+	"setup": "295d03a5efdf6658a6a10babe80a9a06",
 	"schemas": [
 		{
 			"identifier": "advanced_search/schema.py",

--- a/plugins/salesforce/Dockerfile
+++ b/plugins/salesforce/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.1.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.2.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/salesforce/bin/komand_salesforce
+++ b/plugins/salesforce/bin/komand_salesforce
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Salesforce"
 Vendor = "rapid7"
-Version = "2.1.11"
+Version = "2.1.12"
 Description = "[Salesforce](https://www.salesforce.com) is a CRM solution that brings together all customer information in a single, integrated platform that enables building a customer-centered business from marketing right through to sales, customer service and business analysis. The Salesforce plugin allows you to search, update, and manage salesforce records. This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)"
 
 

--- a/plugins/salesforce/help.md
+++ b/plugins/salesforce/help.md
@@ -529,10 +529,11 @@ Example output:
 
 ## Troubleshooting
   
-*There is no troubleshooting for this plugin.*
+*This plugin does not contain a troubleshooting.*
 
 # Version History
 
+* 2.1.12 - Task Monitor Users: ensure datetime includes microseconds | Bump SDK to 6.2.0
 * 2.1.11 - Task Monitor Users: Return 500 for retry your request error | Bump SDK to 6.1.4
 * 2.1.10 - Set Monitor Users task output length | Fix to remove whitespace from connection inputs
 * 2.1.9 - SDK Bump to 6.1.0 | Task Connection test added

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: salesforce
 title: Salesforce
 description: "[Salesforce](https://www.salesforce.com) is a CRM solution that brings together all customer information in a single, integrated platform that enables building a customer-centered business from marketing right through to sales, customer service and business analysis. The Salesforce plugin allows you to search, update, and manage salesforce records. This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)"
-version: 2.1.11
+version: 2.1.12
 connection_version: 2
 vendor: rapid7
 support: community
@@ -13,7 +13,7 @@ status: []
 supported_versions: ["Salesforce API v58 2023-06-30"]
 sdk:
   type: full
-  version: 6.1.4
+  version: 6.2.0
   user: nobody
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/salesforce
@@ -37,6 +37,7 @@ references:
   - "[Connecting your app to the API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/quickstart.htm)"
   - "[SOQL](https://developer.salesforce.com/docs/atlas.en-us.216.0.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm)"
 version_history:
+  - "2.1.12 - Task Monitor Users: ensure datetime includes microseconds | Bump SDK to 6.2.0"
   - "2.1.11 - Task Monitor Users: Return 500 for retry your request error | Bump SDK to 6.1.4"
   - "2.1.10 - Set Monitor Users task output length | Fix to remove whitespace from connection inputs"
   - "2.1.9 - SDK Bump to 6.1.0 | Task Connection test added"

--- a/plugins/salesforce/setup.py
+++ b/plugins/salesforce/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="salesforce-rapid7-plugin",
-      version="2.1.11",
+      version="2.1.12",
       description="[Salesforce](https://www.salesforce.com) is a CRM solution that brings together all customer information in a single, integrated platform that enables building a customer-centered business from marketing right through to sales, customer service and business analysis. The Salesforce plugin allows you to search, update, and manage salesforce records. This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)",
       author="rapid7",
       author_email="",

--- a/plugins/salesforce/unit_test/expected/monitor_users_bad_request.json.exp
+++ b/plugins/salesforce/unit_test/expected/monitor_users_bad_request.json.exp
@@ -1,6 +1,6 @@
 {
   "state": {
-    "last_user_update_collection_timestamp": "2023-07-20 16:21:15.340262+00:00",
+    "last_user_update_collection_timestamp": "invalid",
     "next_user_collection_timestamp": "2023-07-20 16:21:15.340262+00:00",
     "next_user_login_collection_timestamp": "2023-07-20 16:21:15.340262+00:00",
     "last_user_login_collection_timestamp": "2023-07-20 15:21:15.340262+00:00"


### PR DESCRIPTION
## Proposed Changes
There is a quirk in the datetime library that if you run `now()` at a time that has the time microseconds being exactly `000000` later when we run `.isoformat()` this drops the microseconds from the string value. This PR addresses this to ensure we always have the microseconds to query the API and store this in the state as expected.

Some background changes on times in this plugin 😮‍💨  :
- We store the time values in the state **without** the `T` for .isoformat() -> `2024-11-14 10:06:00.663541+00:00`
- It looks like **previously** we used to store it with the `T` meaning it would be -> `2024-11-14T10:06:00.663541+00:00`
- The Salesforce API requires that we have the `T` delimiter otherwise the query fails on parsing the spaces.

Because of this there's a few strange mixture of string state values, and date objects in the task code. On top of the logic to only query certain endpoints on certain intervals. I have tried to add a comment in the state validator method to explain this and make the changes as easy to review as possible. More details below.

### Description
Describe the proposed changes:
  - Bumps the SDK to latest version.
  - Apply `timespec='microseconds'` when querying the API. This has been placed to anywhere we used to perform the string format to the datetime object.
  - Updated `is_valid_state` to now be `make_valid_state` that allows for the customer we have hit the bug on (and potentially others).
    -  this now iterates over each timestamp that we know that the state could contain and tries to format to the correct string format.

Misc changes:
- Originally the unit test `bad_request` that asserts against `monitor_users_bad_request` would expect the state to be updated to a format we now accept. This doesn't apply anymore as the state is ignored by PIF when we return a 400 and holds that state value. Updated unit tests to reflect this and now that `make_valid_state` doesn't update the state value if it's still wrong.

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing
- Manual testing of first run:
```
rapid7/Salesforce:2.1.12. Step name: monitor_users
Cut off time being applied: 2024-08-07 00:00:00+00:00, along with lookback time of 24 hours (2024-11-13 10:24:12.753498+00:00)
First run
Get updated users - start: 2024-11-13 10:24:12.753498+00:00 end: 2024-11-14 10:24:12.753498+00:00
Request to path: query
SalesforceAPI: Getting API token from https://login.salesforce.com/services/oauth2/token... 
SalesforceAPI: API token received
0 updated users added to output
Get all internal users
Request to path: query
6 internal users added to output
Get user login history - start: 2024-11-13 10:24:12.753498+00:00 end: 2024-11-14 10:24:12.753498+00:00
Request to path: query
Removed 296 duplicate from a total of 303 duplicate records.
7 users login history added to output
Plugin task finished execution...
```

-Manual testing of a 'broken state' with custom config to allow look back and it's subsequent run is as expected. Plugin logs and states below.
```
# Input state:
{
    "last_user_login_collection_timestamp": "2024-11-08 18:50:14.855131+00:00",
    "last_user_update_collection_timestamp": "2024-11-08 19:10:38+00:00",
    "next_user_collection_timestamp": "2024-11-08 20:08:42.498458+00:00",
    "next_user_login_collection_timestamp": "2024-11-08 19:50:14.855131+00:00"
}

Plugin task beginning execution...
rapid7/Salesforce:2.1.12. Step name: monitor_users
Cut off time being applied: 2024-08-07 00:00:00+00:00
Subsequent run
Get updated users - start: 2024-11-08 19:10:38+00:00 end: 2024-11-14 10:22:59.605899+00:00
Request to path: query
SalesforceAPI: Getting API token from https://login.salesforce.com/services/oauth2/token... 
SalesforceAPI: API token received
0 updated users added to output
Get all internal users
Request to path: query
6 internal users added to output
Get user login history - start: 2024-11-08 18:50:14.855131+00:00 end: 2024-11-14 10:22:59.605899+00:00
Request to path: query
Removed 1636 duplicate from a total of 1643 duplicate records.
7 users login history added to output
Plugin task finished execution...

# Output state for subsequent run
{
    "last_user_login_collection_timestamp": "2024-11-14 10:22:59.605899+00:00",
    "last_user_update_collection_timestamp": "2024-11-14 10:22:59.605899+00:00",
    "next_user_collection_timestamp": "2024-11-15 10:22:59.605899+00:00",
    "next_user_login_collection_timestamp": "2024-11-14 11:22:59.605899+00:00"
}

Plugin task beginning execution...
rapid7/Salesforce:2.1.12. Step name: monitor_users
Cut off time being applied: 2024-08-07 00:00:00+00:00
Subsequent run
Get updated users - start: 2024-11-14 10:22:59.605899+00:00 end: 2024-11-14 10:23:53.207986+00:00
Request to path: query
SalesforceAPI: Getting API token from https://login.salesforce.com/services/oauth2/token... 
SalesforceAPI: API token received
0 updated users added to output
Plugin task finished execution...
```
#### Unit Tests

- [X] Unit tests written for any new or updated code <- updated failing unit test to reflect new behaviour.



Output State:
```
"state": {
            "last_user_login_collection_timestamp": "2024-11-14 10:06:00.663541+00:00",
            "last_user_update_collection_timestamp": "2024-11-14 10:06:00.663541+00:00",
            "next_user_collection_timestamp": "2024-11-15 10:06:00.663541+00:00",
            "next_user_login_collection_timestamp": "2024-11-14 11:06:00.663541+00:00"
        },
```


