### PR TITLE
Salesforce Release 2.1.13

### DIFF
--- a/plugins/salesforce/.CHECKSUM
+++ b/plugins/salesforce/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e182e26e61f7d3375dc3a9bc3df8fc11",
-	"manifest": "4d555de9a1d8b4ead1868f7d8ae7c1b5",
-	"setup": "8d0731798d9f79b7c98d821e8abf0001",
+	"spec": "63b7270d95683b98e315808e4df20354",
+	"manifest": "391ed2bce80fc53ee24774278259d26e",
+	"setup": "295d03a5efdf6658a6a10babe80a9a06",
 	"schemas": [
 		{
 			"identifier": "advanced_search/schema.py",

--- a/plugins/salesforce/Dockerfile
+++ b/plugins/salesforce/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.1.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.2.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/salesforce/bin/komand_salesforce
+++ b/plugins/salesforce/bin/komand_salesforce
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Salesforce"
 Vendor = "rapid7"
-Version = "2.1.11"
+Version = "2.1.12"
 Description = "[Salesforce](https://www.salesforce.com) is a CRM solution that brings together all customer information in a single, integrated platform that enables building a customer-centered business from marketing right through to sales, customer service and business analysis. The Salesforce plugin allows you to search, update, and manage salesforce records. This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)"
 
 

--- a/plugins/salesforce/help.md
+++ b/plugins/salesforce/help.md
@@ -529,10 +529,11 @@ Example output:
 
 ## Troubleshooting
   
-*There is no troubleshooting for this plugin.*
+*This plugin does not contain a troubleshooting.*
 
 # Version History
 
+* 2.1.12 - Task Monitor Users: ensure datetime includes microseconds | Bump SDK to 6.2.0
 * 2.1.11 - Task Monitor Users: Return 500 for retry your request error | Bump SDK to 6.1.4
 * 2.1.10 - Set Monitor Users task output length | Fix to remove whitespace from connection inputs
 * 2.1.9 - SDK Bump to 6.1.0 | Task Connection test added

--- a/plugins/salesforce/plugin.spec.yaml
+++ b/plugins/salesforce/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: salesforce
 title: Salesforce
 description: "[Salesforce](https://www.salesforce.com) is a CRM solution that brings together all customer information in a single, integrated platform that enables building a customer-centered business from marketing right through to sales, customer service and business analysis. The Salesforce plugin allows you to search, update, and manage salesforce records. This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)"
-version: 2.1.11
+version: 2.1.12
 connection_version: 2
 vendor: rapid7
 support: community
@@ -13,7 +13,7 @@ status: []
 supported_versions: ["Salesforce API v58 2023-06-30"]
 sdk:
   type: full
-  version: 6.1.4
+  version: 6.2.0
   user: nobody
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/salesforce
@@ -37,6 +37,7 @@ references:
   - "[Connecting your app to the API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/quickstart.htm)"
   - "[SOQL](https://developer.salesforce.com/docs/atlas.en-us.216.0.soql_sosl.meta/soql_sosl/sforce_api_calls_soql.htm)"
 version_history:
+  - "2.1.12 - Task Monitor Users: ensure datetime includes microseconds | Bump SDK to 6.2.0"
   - "2.1.11 - Task Monitor Users: Return 500 for retry your request error | Bump SDK to 6.1.4"
   - "2.1.10 - Set Monitor Users task output length | Fix to remove whitespace from connection inputs"
   - "2.1.9 - SDK Bump to 6.1.0 | Task Connection test added"

--- a/plugins/salesforce/setup.py
+++ b/plugins/salesforce/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="salesforce-rapid7-plugin",
-      version="2.1.11",
+      version="2.1.12",
       description="[Salesforce](https://www.salesforce.com) is a CRM solution that brings together all customer information in a single, integrated platform that enables building a customer-centered business from marketing right through to sales, customer service and business analysis. The Salesforce plugin allows you to search, update, and manage salesforce records. This plugin utilizes the [Salesforce API](https://developer.salesforce.com/docs/atlas.en-us.216.0.api_rest.meta/api_rest/intro_what_is_rest_api.htm)",
       author="rapid7",
       author_email="",

--- a/plugins/salesforce/unit_test/expected/monitor_users_bad_request.json.exp
+++ b/plugins/salesforce/unit_test/expected/monitor_users_bad_request.json.exp
@@ -1,6 +1,6 @@
 {
   "state": {
-    "last_user_update_collection_timestamp": "2023-07-20 16:21:15.340262+00:00",
+    "last_user_update_collection_timestamp": "invalid",
     "next_user_collection_timestamp": "2023-07-20 16:21:15.340262+00:00",
     "next_user_login_collection_timestamp": "2023-07-20 16:21:15.340262+00:00",
     "last_user_login_collection_timestamp": "2023-07-20 15:21:15.340262+00:00"


### PR DESCRIPTION
Release of Salesforce v2.1.12

Changes:
- Bump SDK
- Allow for .now() to be executed with microseconds value of zero and account for this in state held values and querying Salesforce API. 

Testing -
- Unit tests passing
- Manual testing
- Reactivated integration on staging with a broken state value and plugin passed without errors. [Logs search](https://us.ops.insight.rapid7.com/op/73D74FD3120207F7E98B#/search?from=1731599598000&logs=%5B%22a9fe3bda-0c32-41ce-b347-a2fcbec2b49b%22%5D&query=where(0d5f69e4-1c7c-41a0-a0ac-a5ac9a4b41fb%20and%20%22Get%20updated%20users%20-%20start%22)&to=1731600078000)
  - broken state value is: `2024-11-08 19:10:38+00:00`

PRs:
- #2960