### PR TITLE
[SOAR-18258] Whois - Update address action

### DIFF
--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "651e527db096e0dd0ac0e9896a4b2756",
-	"manifest": "e4ca9901883c704390367efe46454f05",
-	"setup": "4f04c80ff4c28070c7ec483f1ea2b876",
+	"spec": "c321daf69a3679e488625f8dbd077985",
+	"manifest": "c35b3c929b1fa09020196cc79f5b701a",
+	"setup": "8ad9bdf0d891eb2e9bc3a2535f273e9d",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/whois/bin/komand_whois
+++ b/plugins/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "3.1.5"
+Version = "3.1.6"
 Description = "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
 
 

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -181,6 +181,7 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
+* 3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0
 * 3.1.5 - Action `Address`: Fixed issue with result parsing
 * 3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version
 * 3.1.3 - Updated SDK to the latest version (v6.0.0) | Bump setuptools version to v70.0.0

--- a/plugins/whois/komand_whois/actions/address/action.py
+++ b/plugins/whois/komand_whois/actions/address/action.py
@@ -23,7 +23,7 @@ class Address(insightconnect_plugin_runtime.Action):
             "address": "address",
             "country": "country",
             "org_abuse_email": "abuse-mailbox",
-            "description": "descr"
+            "description": "descr",
         },
         ARIN: {
             "netname": "NetName",

--- a/plugins/whois/komand_whois/actions/address/action.py
+++ b/plugins/whois/komand_whois/actions/address/action.py
@@ -17,12 +17,13 @@ class Address(insightconnect_plugin_runtime.Action):
             "nettype": "status",
             "netrange": "inetnum",
             "organization": "organisation",
-            "orgname": "descr",
+            "orgname": "org-name",
             "regdate": "created",
             "updated": "last-modified",
             "address": "address",
             "country": "country",
             "org_abuse_email": "abuse-mailbox",
+            "description": "descr"
         },
         ARIN: {
             "netname": "NetName",

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
-version: 3.1.5
+version: 3.1.6
 connection_version: 3
 vendor: rapid7
 support: community
@@ -12,7 +12,7 @@ supported_versions: ["2024-09-09"]
 status: []
 sdk:
   type: slim
-  version: 6.1.4
+  version: 6.2.0
   user: nobody
   packages:
     - whois
@@ -34,6 +34,7 @@ references: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 links: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 troubleshooting: "Multiple records can be returned by the server, this plugin currently only returns the first unique records found."
 version_history:
+  - "3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0"
   - "3.1.5 - Action `Address`: Fixed issue with result parsing"
   - "3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version"
   - "3.1.3 - Updated SDK to the latest version (v6.0.0) | Bump setuptools version to v70.0.0"

--- a/plugins/whois/setup.py
+++ b/plugins/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="3.1.5",
+      version="3.1.6",
       description="[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

A customer was experiencing an issue when proving an RIPE IP, the `orgname` would not return when using ICON, but it would return when using WhoIs website. This is cause the orgname pointed to the description.

As the description did not have an existing field, as the orgname pointed to it, I added a description field too.

[SI TICKET](https://rapid7.atlassian.net/browse/SI-26530)

Describe the proposed changes:

  - Update Address action (add `description` output field. Correct mapping for `orgname` field)
  - SDK bump to 6.2.0

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

When using the same IP the user used, it now returns the `orgname`:
![image](https://github.com/user-attachments/assets/0c61d9be-061d-434d-9fb2-2ce289236ebe)

As the above IP does not have a description, when using another RIPE IP, it returns the description too:
![image](https://github.com/user-attachments/assets/1c7d09ac-c76a-47b8-9a7a-fa2eeff22ce3)

When specifiying the registrar as RIPE, the mapping also works:
![image](https://github.com/user-attachments/assets/18639dbd-e8ff-4dfa-9fc8-ade477a3330c)

