### PR TITLE
[SOAR-18265] Palo Alto Pan OS 6.1.7 Release

### DIFF
--- a/plugins/palo_alto_pan_os/.CHECKSUM
+++ b/plugins/palo_alto_pan_os/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "4e7e4991077f7598ca5677952ca60355",
-	"manifest": "3e6147497a52840d1b21b61882289ead",
-	"setup": "c28b96c0343eafc1b11aee33318a848f",
+	"spec": "07e1f60e8ad5a8d8b2e49f30e70c7502",
+	"manifest": "8bac9240ef9e34d7fe118a91dcf5e7a5",
+	"setup": "d1c8ebcf988930ddb2730385228df605",
 	"schemas": [
 		{
 			"identifier": "add_address_object_to_group/schema.py",

--- a/plugins/palo_alto_pan_os/Dockerfile
+++ b/plugins/palo_alto_pan_os/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.0.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.2.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/palo_alto_pan_os/bin/komand_palo_alto_pan_os
+++ b/plugins/palo_alto_pan_os/bin/komand_palo_alto_pan_os
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Palo Alto Firewall"
 Vendor = "rapid7"
-Version = "6.1.6"
+Version = "6.1.7"
 Description = "[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto Firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama)"
 
 

--- a/plugins/palo_alto_pan_os/help.md
+++ b/plugins/palo_alto_pan_os/help.md
@@ -1114,6 +1114,7 @@ Action connection type
 
 # Version History
 
+* 6.1.7 - Fix issue in 'add_address_object_to_group' action | SDK bump to 6.2.0 | Bumping requirements.txt
 * 6.1.6 - Update SDK | Fix critical Snyk vulnerability
 * 6.1.5 - Bumping requirements of `gunicorn` and `validators` | update the SDK to 5.4.9 | Added examples to all actions | Updated unit tests to include schema checks
 * 6.1.4 - Add information to every action on whether it uses Panorama or a direct firewall connection

--- a/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_address_object_to_group/action.py
+++ b/plugins/palo_alto_pan_os/komand_palo_alto_pan_os/actions/add_address_object_to_group/action.py
@@ -79,6 +79,6 @@ class AddAddressObjectToGroup(insightconnect_plugin_runtime.Action):
     def make_xml(names, group_name):
         members = ""
         for name in names:
-            members = members.join(f"<member>{name}</member>")
+            members += f"<member>{name}</member>"
         xml_template = f"<entry name='{group_name}'><static>{members}</static></entry>"
         return xml_template

--- a/plugins/palo_alto_pan_os/plugin.spec.yaml
+++ b/plugins/palo_alto_pan_os/plugin.spec.yaml
@@ -4,10 +4,10 @@ products: [insightconnect]
 name: palo_alto_pan_os
 title: Palo Alto Firewall
 description: "[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto Firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama)"
-version: 6.1.6
+version: 6.1.7
 sdk:
   type: full
-  version: 6.0.0
+  version: 6.2.0
   user: nobody
 supported_versions: ["9.0.3"]
 connection_version: 6
@@ -32,6 +32,7 @@ requirements: ["Access to Palo Alto Next Generation firewall or Palo Alto Panora
 references: ["[Palo Alto PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api)"]
 links: ["[Palo Alto PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os)"]
 version_history:
+ - "6.1.7 - Fix issue in 'add_address_object_to_group' action | SDK bump to 6.2.0 | Bumping requirements.txt"
  - "6.1.6 - Update SDK | Fix critical Snyk vulnerability"
  - "6.1.5 - Bumping requirements of `gunicorn` and `validators` | update the SDK to 5.4.9 | Added examples to all actions | Updated unit tests to include schema checks" 
  - "6.1.4 - Add information to every action on whether it uses Panorama or a direct firewall connection"

--- a/plugins/palo_alto_pan_os/requirements.txt
+++ b/plugins/palo_alto_pan_os/requirements.txt
@@ -4,8 +4,7 @@
 gunicorn==22.0.0
 xmltodict==0.12.0
 dicttoxml==1.7.4
-validators==0.22.0
+validators==0.34.0
 IPy==1.01
-parameterized==0.8.1
-jsonschema==3.2.0
+parameterized==0.9.0
 setuptools==70.0.0

--- a/plugins/palo_alto_pan_os/setup.py
+++ b/plugins/palo_alto_pan_os/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="palo_alto_pan_os-rapid7-plugin",
-      version="6.1.6",
+      version="6.1.7",
       description="[PAN-OS](https://www.paloaltonetworks.com/documentation/80/pan-os) is the software that runs all Palo Alto Networks next-generation firewalls. This plugin utilizes the [PAN-OS API](https://www.paloaltonetworks.com/documentation/80/pan-os/xml-api) to provide programmatic management of the Palo Alto Firewall appliance(s). It supports managing firewalls individually or centralized via [Panorama](https://www.paloaltonetworks.com/network-security/panorama)",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Describe the proposed changes:

[TICKET](https://rapid7.atlassian.net/browse/SOAR-18265)

 The `.join()` operator should not be used due to it adding significantly large amount of duplicate data which leads to this error: `('Connection aborted.', BadStatusLine('<html>\r\n'))`. This is due to joining all of the previous IP's along with the new one in each iteration (eg if the list has abc and next element is def the input will be abcdef and not def)

Changing the `.join()` to just add the string via `+=` resolves this.


- #2976 
    - Fix `add_address_object_to_group` action (duplicate appending)
    - SDK bump to 6.2.0
    - Bumping requirements.txt
