### PR TITLE
[SOAR-18367] Rapid7 Insight Agent 3.0.1 Release

### DIFF
--- a/plugins/rapid7_insight_agent/.CHECKSUM
+++ b/plugins/rapid7_insight_agent/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "f59d87215ea0009e75b43538d52e2546",
-	"manifest": "681189443bca37d2d249637d7a37d0a0",
-	"setup": "f3957c38946f523d42c3e0f39d443645",
+	"spec": "84beb2a66c2d69fe169e28ef52286a6b",
+	"manifest": "7128ea302016efb7c4e1b205f30ddc63",
+	"setup": "9342d20648410079f107ce3d1bcd8d17",
 	"schemas": [
 		{
 			"identifier": "check_agent_status/schema.py",

--- a/plugins/rapid7_insight_agent/Dockerfile
+++ b/plugins/rapid7_insight_agent/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.2
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/rapid7_insight_agent/bin/icon_rapid7_insight_agent
+++ b/plugins/rapid7_insight_agent/bin/icon_rapid7_insight_agent
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 Insight Agent"
 Vendor = "rapid7"
-Version = "3.0.0"
+Version = "3.0.1"
 Description = "Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization"
 
 

--- a/plugins/rapid7_insight_agent/help.md
+++ b/plugins/rapid7_insight_agent/help.md
@@ -459,6 +459,7 @@ If the actions `Get Agent Details` and `Get All Agents by IP` return a `next cur
 
 # Version History
 
+* 3.0.1 - Update 'Get Agent Details' to allow no assets to be returned | SDK bump to latest version
 * 3.0.0 - Update `Get Agent Details` and `Get All Agents by IP` to return the next page token if more pages are available to search | Update `Get Agent Details` to return agent location details | Initial updates for fedramp compliance | Updated SDK to the latest version
 * 2.1.2 - Improve logging | Update SDK
 * 2.1.1 - `Get All Agents by IP Address`: Fixed issue where action failed when agent did not have a primary address, and extended output to include agent location details | `Get Agent Details`: Extended output to include agent's public IP address and location

--- a/plugins/rapid7_insight_agent/icon_rapid7_insight_agent/util/graphql_api/api_connection.py
+++ b/plugins/rapid7_insight_agent/icon_rapid7_insight_agent/util/graphql_api/api_connection.py
@@ -382,10 +382,8 @@ class ApiConnection:
         if agent:
             return agent, None
         else:
-            raise PluginException(
-                cause=f"Could not find agent matching {agent_input} of type {agent_type}. No more pages of data.",
-                assistance="Check the agent input value and try again.",
-            )
+            self.logger.info("No assets were found")
+            return None, None
 
     def _get_agents(self, agents_input: List[str]) -> [Tuple[str, dict]]:
         """

--- a/plugins/rapid7_insight_agent/plugin.spec.yaml
+++ b/plugins/rapid7_insight_agent/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insight_agent
 title: Rapid7 Insight Agent
 description: Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization
-version: 3.0.0
+version: 3.0.1
 connection_version: 2
 supported_versions: ["Rapid7 Insight Agent 2024-08-23"]
 vendor: rapid7
@@ -14,7 +14,7 @@ cloud_ready: true
 fedramp_ready: true
 sdk:
   type: slim
-  version: 6.1.0
+  version: 6.2.2
   user: nobody
 key_features:
   - "The agent is used by [Rapid7 InsightIDR](https://www.rapid7.com/products/insightidr/) and [InsightVM](https://www.rapid7.com/products/insightvm/) customers to monitor endpoints."
@@ -27,6 +27,7 @@ links:
 references:
   - "[Manage Platform API Keys](https://docs.rapid7.com/insight/managing-platform-api-keys/)"
 version_history:
+  - "3.0.1 - Update 'Get Agent Details' to allow no assets to be returned | SDK bump to latest version"
   - "3.0.0 - Update `Get Agent Details` and `Get All Agents by IP` to return the next page token if more pages are available to search | Update `Get Agent Details` to return agent location details | Initial updates for fedramp compliance | Updated SDK to the latest version"
   - "2.1.2 - Improve logging | Update SDK"
   - "2.1.1 - `Get All Agents by IP Address`: Fixed issue where action failed when agent did not have a primary address, and extended output to include agent location details | `Get Agent Details`: Extended output to include agent's public IP address and location"

--- a/plugins/rapid7_insight_agent/setup.py
+++ b/plugins/rapid7_insight_agent/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insight_agent-rapid7-plugin",
-      version="3.0.0",
+      version="3.0.1",
       description="Using the Insight Agent plugin from InsightConnect, you can quarantine, unquarantine and monitor potentially malicious IPs, addresses, hostnames, and devices across your organization",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insight_agent/unit_test/test_get_agent_details.py
+++ b/plugins/rapid7_insight_agent/unit_test/test_get_agent_details.py
@@ -27,13 +27,7 @@ class TestGetAgentDetails(TestCase):
         self.assertEqual(expect, actual)
 
     def test_get_agent_by_hostname_bad(self, mock_request: MagicMock) -> None:
-        with self.assertRaises(PluginException) as exception:
-            action = Util.default_connector(GetAgentDetails())
-            action.run({Input.AGENT: "badID"})
-        self.assertEqual(
-            exception.exception.cause, "Could not find agent matching badID of type Host Name. No more pages of data."
-        )
-        self.assertEqual(
-            exception.exception.assistance,
-            "Check the agent input value and try again.",
-        )
+        action = Util.default_connector(GetAgentDetails())
+        actual = action.run({Input.AGENT: "badID"})
+        expected = {}
+        self.assertEqual(actual, expected)


### PR DESCRIPTION
## Proposed Changes

### Description

Updating `get_agent_details` action to allow no results to be returned as it was returning a `400` previously if no results were returned (even though the action ran successfully)

Describe the proposed changes:

  - #2984
    - Update `get_agent_details` action to allow for an empty result to be returned
    - SDK bump to 6.2.2


