### PR TITLE
[SOAR-18495] Rapid7_InsightIDR Fix Schema (advanced_query_on_log)

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "f7a752d6162db43ab5a2af23d8fdded1",
+	"spec": "696ad2ef53e23becbc514ade6b807b86",
 	"manifest": "447c02c4e8eff1ffc54155a48b270af3",
 	"setup": "00df4e2ab481d3954b493d8e94670fca",
 	"schemas": [
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "5095f41c5b730886b330614a79dc0551"
+			"hash": "04f457e70ed006499969f3871fd60314"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "b5b2c8b6a3b884b33241f87004815459"
+			"hash": "651d3e1a7ce2676f00851d04e596584c"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",
@@ -113,7 +113,7 @@
 		},
 		{
 			"identifier": "query/schema.py",
-			"hash": "440b96851f6c0090adde3f3709aa6259"
+			"hash": "3a8132d5735fdbb53f9f26e40cb1ada9"
 		},
 		{
 			"identifier": "replace_indicators/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "1731102995c13b9e66eb3d167cc3b36e",
+	"spec": "fd4a1ba356fb9c3b51b5058cf8bee435",
 	"manifest": "bf5b8c1274de589f792fc43909fcb102",
 	"setup": "1964faaf291c2cbe3485c2bfd7ae7231",
 	"schemas": [
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "1f0d2740af4d48b6d202f8fe82bac40e"
+			"hash": "c29d038d9e7020d8e1327a8c6ad4e3d5"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "b5b2c8b6a3b884b33241f87004815459"
+			"hash": "6ecdb6192aa5e8c99cafc712a6c9d6fb"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "ed557ded0b51e5458aefc217bdfde130",
-	"manifest": "bf5b8c1274de589f792fc43909fcb102",
-	"setup": "1964faaf291c2cbe3485c2bfd7ae7231",
+	"spec": "f7a752d6162db43ab5a2af23d8fdded1",
+	"manifest": "447c02c4e8eff1ffc54155a48b270af3",
+	"setup": "00df4e2ab481d3954b493d8e94670fca",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "ef55d0eaab88354037eb0e7a0c1d5ca0",
-	"manifest": "a9dc8b0c15952a931013e92670cdf86b",
-	"setup": "8b4da6c79f36dd56dfc82e26d0009a8b",
+	"spec": "1731102995c13b9e66eb3d167cc3b36e",
+	"manifest": "bf5b8c1274de589f792fc43909fcb102",
+	"setup": "1964faaf291c2cbe3485c2bfd7ae7231",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "c25673288c3406030e64dc6f3451821d"
+			"hash": "1f0d2740af4d48b6d202f8fe82bac40e"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "ff689fccb0ed297d1c5f7f45877fd138"
+			"hash": "b5b2c8b6a3b884b33241f87004815459"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",
@@ -113,7 +113,7 @@
 		},
 		{
 			"identifier": "query/schema.py",
-			"hash": "ec57e897be9e044c6607e33ab15020b0"
+			"hash": "440b96851f6c0090adde3f3709aa6259"
 		},
 		{
 			"identifier": "replace_indicators/schema.py",

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "fd4a1ba356fb9c3b51b5058cf8bee435",
+	"spec": "ed557ded0b51e5458aefc217bdfde130",
 	"manifest": "bf5b8c1274de589f792fc43909fcb102",
 	"setup": "1964faaf291c2cbe3485c2bfd7ae7231",
 	"schemas": [
@@ -9,11 +9,11 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "c29d038d9e7020d8e1327a8c6ad4e3d5"
+			"hash": "5095f41c5b730886b330614a79dc0551"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",
-			"hash": "6ecdb6192aa5e8c99cafc712a6c9d6fb"
+			"hash": "b5b2c8b6a3b884b33241f87004815459"
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "10.3.4"
+Version = "10.3.5"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "10.3.5"
+Version = "11.0.0"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3094,7 +3094,7 @@ Example output:
 |LEQL|object|None|False|The LEQL 'WHERE' clause to match against|None|
 |Logs|array|None|False|Holds the Log ID of the matching log entry|None|
 |Search Stats|object|None|False|Holds data regarding the query execution|None|
-|Statement|object|None|False|Query command/operation executed|None|
+|statistics|statistics|None|False|Holds the overall statistical results|None|
   
 **statistics**
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3091,11 +3091,10 @@ Example output:
 
 |Name|Type|Default|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- |
-|leql|object|None|False|The LEQL 'WHERE' clause to match against|None|
-|logs|array|None|False|Holds the Log ID of the matching log entry|None|
-|search_stats|object|None|False|Holds data regarding the query execution|None|
-|statement|object|None|False|Query command/operation executed|None|
-|statistics|statistics|None|False|Holds the overall statistical results|None|
+|LEQL|object|None|False|The LEQL 'WHERE' clause to match against|None|
+|Logs|array|None|False|Holds the Log ID of the matching log entry|None|
+|Search Stats|object|None|False|Holds data regarding the query execution|None|
+|Statement|object|None|False|Query command/operation executed|None|
   
 **statistics**
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3410,7 +3410,7 @@ Example output:
 
 # Version History
 
-* 10.3.5 - Updating schema for 'advanced_query_on_log' action to account for missing keys
+* 11.0.0 - Updating schema for 'advanced_query_on_log' action to account for missing keys
 * 10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2
 * 10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0
 * 10.3.2 - Initial updates for fedramp compliance | Updated SDK to the latest version

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -146,7 +146,7 @@ Example input:
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of log entries found|10|
 |results_events|[]events|False|Query Results|[{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]|
-|results_statistical|statistics|False|Query Results|{"leql":{"during":{"from":1699579214000,"to":1699622414000},"statement":"groupby(r7_context.asset.name)"},"logs":["123456-abcd-1234-abcd-123456abc"],"search_stats":{"bytes_all":9961260,"bytes_checked":9961260,"duration_ms":19,"events_all":1640,"events_checked":1640,"events_matched":1639,"index_factor":0.0},"statistics":{"all_exact_result":true,"cardinality":0,"from":1699579214000,"granularity":4320000,"groups":[{"linux":{"count":1163.0}},{"windowsx64":{"count":476.0}}],"groups_timeseries":[{"linux":{"groups_timeseries":[],"series":[{"count":45.0},{"count":21.0},{"count":16.0},{"count":270.0},{"count":27.0},{"count":43.0},{"count":27.0},{"count":39.0},{"count":29.0},{"count":646.0}],"totals":{"count":1163.0}}},{"windowsx64":{"groups_timeseries":[],"series":[{"count":54.0},{"count":40.0},{"count":60.0},{"count":37.0},{"count":42.0},{"count":62.0},{"count":41.0},{"count":47.0},{"count":49.0},{"count":44.0}],"totals":{"count":476.0}}}],"others":{"series":[]},"stats":{},"status":200,"timeseries":{},"to":1699622414000,"type":"count"}}|
+|results_statistical|results_statistics|False|Query Results|{"leql":{"during":{"from":1699579214000,"to":1699622414000},"statement":"groupby(r7_context.asset.name)"},"logs":["123456-abcd-1234-abcd-123456abc"],"search_stats":{"bytes_all":9961260,"bytes_checked":9961260,"duration_ms":19,"events_all":1640,"events_checked":1640,"events_matched":1639,"index_factor":0.0},"statistics":{"all_exact_result":true,"cardinality":0,"from":1699579214000,"granularity":4320000,"groups":[{"linux":{"count":1163.0}},{"windowsx64":{"count":476.0}}],"groups_timeseries":[{"linux":{"groups_timeseries":[],"series":[{"count":45.0},{"count":21.0},{"count":16.0},{"count":270.0},{"count":27.0},{"count":43.0},{"count":27.0},{"count":39.0},{"count":29.0},{"count":646.0}],"totals":{"count":1163.0}}},{"windowsx64":{"groups_timeseries":[],"series":[{"count":54.0},{"count":40.0},{"count":60.0},{"count":37.0},{"count":42.0},{"count":62.0},{"count":41.0},{"count":47.0},{"count":49.0},{"count":44.0}],"totals":{"count":476.0}}}],"others":{"series":[]},"stats":{},"status":200,"timeseries":{},"to":1699622414000,"type":"count"}}|
   
 Example output:
 
@@ -3087,6 +3087,16 @@ Example output:
 |Sequence Number|integer|None|None|Sequence number|None|
 |Timestamp|integer|None|None|Timestamp|None|
   
+**results_statistics**
+
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|leql|object|None|False|The LEQL 'WHERE' clause to match against|None|
+|logs|array|None|False|Holds the Log ID of the matching log entry|None|
+|search_stats|object|None|False|Holds data regarding the query execution|None|
+|statement|object|None|False|Query command/operation executed|None|
+|statistics|statistics|None|False|Holds the overall statistical results|None|
+  
 **statistics**
 
 |Name|Type|Default|Required|Description|Example|
@@ -3401,6 +3411,7 @@ Example output:
 
 # Version History
 
+* 10.3.5 - Updating schema for 'advanced_query_on_log' action to account for missing keys
 * 10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2
 * 10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0
 * 10.3.2 - Initial updates for fedramp compliance | Updated SDK to the latest version

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -377,7 +377,7 @@ Example input:
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of log entries found|10|
 |results_events|[]events|False|Query Results|[{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]|
-|results_statistical|statistics|False|Query Results|{"leql":{"during":{"from":1699579214000,"to":1699622414000},"statement":"groupby(r7_context.asset.name)"},"logs":["123456-abcd-1234-abcd-123456abc"],"search_stats":{"bytes_all":9961260,"bytes_checked":9961260,"duration_ms":19,"events_all":1640,"events_checked":1640,"events_matched":1639,"index_factor":0.0},"statistics":{"all_exact_result":true,"cardinality":0,"from":1699579214000,"granularity":4320000,"groups":[{"linux":{"count":1163.0}},{"windowsx64":{"count":476.0}}],"groups_timeseries":[{"linux":{"groups_timeseries":[],"series":[{"count":45.0},{"count":21.0},{"count":16.0},{"count":270.0},{"count":27.0},{"count":43.0},{"count":27.0},{"count":39.0},{"count":29.0},{"count":646.0}],"totals":{"count":1163.0}}},{"windowsx64":{"groups_timeseries":[],"series":[{"count":54.0},{"count":40.0},{"count":60.0},{"count":37.0},{"count":42.0},{"count":62.0},{"count":41.0},{"count":47.0},{"count":49.0},{"count":44.0}],"totals":{"count":476.0}}}],"others":{"series":[]},"stats":{},"status":200,"timeseries":{},"to":1699622414000,"type":"count"}}|
+|results_statistical|results_statistics|False|Query Results|{"leql":{"during":{"from":1699579214000,"to":1699622414000},"statement":"groupby(r7_context.asset.name)"},"logs":["123456-abcd-1234-abcd-123456abc"],"search_stats":{"bytes_all":9961260,"bytes_checked":9961260,"duration_ms":19,"events_all":1640,"events_checked":1640,"events_matched":1639,"index_factor":0.0},"statistics":{"all_exact_result":true,"cardinality":0,"from":1699579214000,"granularity":4320000,"groups":[{"linux":{"count":1163.0}},{"windowsx64":{"count":476.0}}],"groups_timeseries":[{"linux":{"groups_timeseries":[],"series":[{"count":45.0},{"count":21.0},{"count":16.0},{"count":270.0},{"count":27.0},{"count":43.0},{"count":27.0},{"count":39.0},{"count":29.0},{"count":646.0}],"totals":{"count":1163.0}}},{"windowsx64":{"groups_timeseries":[],"series":[{"count":54.0},{"count":40.0},{"count":60.0},{"count":37.0},{"count":42.0},{"count":62.0},{"count":41.0},{"count":47.0},{"count":49.0},{"count":44.0}],"totals":{"count":476.0}}}],"others":{"series":[]},"stats":{},"status":200,"timeseries":{},"to":1699622414000,"type":"count"}}|
   
 Example output:
 
@@ -3068,13 +3068,16 @@ Example output:
 
 |Name|Type|Default|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- |
-|Computer Name|string|None|None|None|None|
-|Event Code|integer|None|None|None|None|
-|Event Data|eventData|None|None|None|None|
-|Is Domain Controller|boolean|None|None|None|None|
-|SID|string|None|None|None|None|
-|Source Name|string|None|None|None|None|
-|Time Written|string|None|None|None|None|
+|Destination Asset|string|None|None|None|None|
+|Destination Asset Address|string|None|None|None|None|
+|Destination Local Account|string|None|None|None|None|
+|Logon Type|string|None|None|None|None|
+|New Authentication|string|None|None|None|None|
+|Result|string|None|None|None|None|
+|Service|string|None|None|None|None|
+|Source Asset Address|string|None|None|None|None|
+|Source JSON|source_json|None|None|None|None|
+|Timestamp|string|None|None|None|None|
   
 **events**
 
@@ -3085,6 +3088,7 @@ Example output:
 |Log ID|string|None|None|Log ID|None|
 |Message|message|None|None|Message|None|
 |Sequence Number|integer|None|None|Sequence number|None|
+|Sequence Number String|string|None|None|Sequence number string|None|
 |Timestamp|integer|None|None|Timestamp|None|
   
 **results_statistics**
@@ -3113,6 +3117,19 @@ Example output:
 |Time Series|object|None|False|Holds the query results for each timeslice (each partition of the time_range), for non-'groupby' queries|None|
 |To|integer|None|False|The end of the time range for the query, as a UNIX timestamp in milliseconds|None|
 |Type|string|None|False|The type of function performed, for example, "count", "max", "average", "standarddeviation"|None|
+  
+**source_json**
+
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Computer Name|string|None|False|None|None|
+|Event Code|integer|None|False|None|None|
+|Event Data|eventData|None|False|None|None|
+|Insertion Strings|[]string|None|False|Insertion Strings|None|
+|Is Domain Controller|boolean|None|False|None|None|
+|SID|string|None|False|None|None|
+|Source Name|string|None|False|Source Name|None|
+|Time Written|string|None|False|None|None|
   
 **links**
 
@@ -3410,7 +3427,7 @@ Example output:
 
 # Version History
 
-* 11.0.0 - Updating schema for 'advanced_query_on_log' action to account for missing keys
+* 11.0.0 - Updating schema for query actions (`advanced_query_on_log`, `advanced_query_on_log_set` & `query`) to account for missing keys/invalid mapping in the schema
 * 10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2
 * 10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0
 * 10.3.2 - Initial updates for fedramp compliance | Updated SDK to the latest version

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -122,7 +122,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "order": 1
     },
     "results_statistical": {
-      "$ref": "#/definitions/statistics",
+      "$ref": "#/definitions/results_statistics",
       "title": "Query Results (Statistical)",
       "description": "Query Results",
       "order": 2
@@ -164,7 +164,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
           "order": 4
         },
         "message": {
-          "type": ["object", "string"],
+          "$ref": "#/definitions/message",
           "title": "Message",
           "description": "Message",
           "order": 5
@@ -177,6 +177,47 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
             "$ref": "#/definitions/link"
           },
           "order": 6
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "title": "message",
+      "properties": {
+        "sourceName": {
+          "type": "string",
+          "title": "Source Name",
+          "order": 1
+        },
+        "eventCode": {
+          "type": "integer",
+          "title": "Event Code",
+          "order": 2
+        },
+        "computerName": {
+          "type": "string",
+          "title": "Computer Name",
+          "order": 3
+        },
+        "sid": {
+          "type": "string",
+          "title": "SID",
+          "order": 4
+        },
+        "isDomainController": {
+          "type": "boolean",
+          "title": "Is Domain Controller",
+          "order": 5
+        },
+        "eventData": {
+          "$ref": "#/definitions/eventData",
+          "title": "Event Data",
+          "order": 6
+        },
+        "timeWritten": {
+          "type": "string",
+          "title": "Time Written",
+          "order": 7
         }
       }
     },
@@ -354,6 +395,41 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
           "title": "HREF",
           "description": "HREF",
           "order": 2
+        }
+      }
+    },
+    "results_statistics": {
+      "type": "object",
+      "title": "results_statistics",
+      "properties": {
+        "statistics": {
+          "$ref": "#/definitions/statistics",
+          "title": "statistics",
+          "description": "Holds the overall statistical results",
+          "order": 1
+        },
+        "leql": {
+          "type": "object",
+          "title": "leql",
+          "description": "The LEQL 'WHERE' clause to match against",
+          "order": 2
+        },
+        "logs": {
+          "title": "logs",
+          "description": "Holds the Log ID of the matching log entry",
+          "order": 3
+        },
+        "search_stats": {
+          "type": "object",
+          "title": "search_stats",
+          "description": "Holds data regarding the query execution",
+          "order": 4
+        },
+        "statement": {
+          "type": "object",
+          "title": "statement",
+          "description": "Query command/operation executed",
+          "order": 5
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -177,6 +177,12 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
             "$ref": "#/definitions/link"
           },
           "order": 6
+        },
+        "sequence_number_str": {
+          "type": "string",
+          "title": "Sequence Number String",
+          "description": "Sequence number string",
+          "order": 7
         }
       }
     },
@@ -184,40 +190,106 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "type": "object",
       "title": "message",
       "properties": {
+        "timestamp": {
+          "type": "string",
+          "title": "Timestamp",
+          "order": 1
+        },
+        "destination_asset": {
+          "type": "string",
+          "title": "Destination Asset",
+          "order": 2
+        },
+        "source_asset_address": {
+          "type": "string",
+          "title": "Source Asset Address",
+          "order": 3
+        },
+        "destination_asset_address": {
+          "type": "string",
+          "title": "Destination Asset Address",
+          "order": 4
+        },
+        "destination_local_account": {
+          "type": "string",
+          "title": "Destination Local Account",
+          "order": 5
+        },
+        "logon_type": {
+          "type": "string",
+          "title": "Logon Type",
+          "order": 6
+        },
+        "result": {
+          "type": "string",
+          "title": "Result",
+          "order": 7
+        },
+        "new_authentication": {
+          "type": "string",
+          "title": "New Authentication",
+          "order": 8
+        },
+        "service": {
+          "type": "string",
+          "title": "Service",
+          "order": 9
+        },
+        "source_json": {
+          "$ref": "#/definitions/source_json",
+          "title": "Source JSON",
+          "order": 10
+        }
+      }
+    },
+    "source_json": {
+      "type": "object",
+      "title": "source_json",
+      "properties": {
         "sourceName": {
           "type": "string",
           "title": "Source Name",
+          "description": "Source Name",
           "order": 1
+        },
+        "insertionStrings": {
+          "type": "array",
+          "title": "Insertion Strings",
+          "description": "Insertion Strings",
+          "items": {
+            "type": "string"
+          },
+          "order": 2
         },
         "eventCode": {
           "type": "integer",
           "title": "Event Code",
-          "order": 2
+          "order": 3
         },
         "computerName": {
           "type": "string",
           "title": "Computer Name",
-          "order": 3
+          "order": 4
         },
         "sid": {
           "type": "string",
           "title": "SID",
-          "order": 4
+          "order": 5
         },
         "isDomainController": {
           "type": "boolean",
           "title": "Is Domain Controller",
-          "order": 5
+          "order": 6
         },
         "eventData": {
           "$ref": "#/definitions/eventData",
           "title": "Event Data",
-          "order": 6
+          "order": 7
         },
         "timeWritten": {
           "type": "string",
           "title": "Time Written",
-          "order": 7
+          "order": 8
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -114,7 +114,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
     },
     "results_events": {
       "type": "array",
-      "title": "Query Results (Events)",
+      "title": "Results Events",
       "description": "Query Results",
       "items": {
         "$ref": "#/definitions/events"
@@ -123,7 +123,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
     },
     "results_statistical": {
       "$ref": "#/definitions/results_statistics",
-      "title": "Query Results (Statistical)",
+      "title": "Results Statistical",
       "description": "Query Results",
       "order": 2
     }
@@ -402,124 +402,28 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "type": "object",
       "title": "results_statistics",
       "properties": {
-        "statistics": {
-          "$ref": "#/definitions/statistics",
-          "title": "statistics",
-          "description": "Holds the overall statistical results",
-          "order": 1
-        },
         "leql": {
           "type": "object",
-          "title": "leql",
+          "title": "LEQL",
           "description": "The LEQL 'WHERE' clause to match against",
-          "order": 2
+          "order": 1
         },
         "logs": {
-          "title": "logs",
+          "title": "Logs",
           "description": "Holds the Log ID of the matching log entry",
-          "order": 3
+          "order": 2
         },
         "search_stats": {
           "type": "object",
-          "title": "search_stats",
+          "title": "Search Stats",
           "description": "Holds data regarding the query execution",
-          "order": 4
+          "order": 3
         },
         "statement": {
           "type": "object",
-          "title": "statement",
+          "title": "Statement",
           "description": "Query command/operation executed",
-          "order": 5
-        }
-      }
-    },
-    "statistics": {
-      "type": "object",
-      "title": "statistics",
-      "properties": {
-        "stats": {
-          "type": "object",
-          "title": "Stats",
-          "description": "Holds the overall result when query does not contain a 'groupby' clause",
-          "order": 1
-        },
-        "groups": {
-          "type": "array",
-          "title": "Groups",
-          "description": "Holds the overall result for each group in a 'groupby' query",
-          "items": {
-            "type": "object"
-          },
-          "order": 2
-        },
-        "granularity": {
-          "type": "integer",
-          "title": "Granularity",
-          "description": "The time window in milliseconds for each time slice in the time series",
-          "order": 3
-        },
-        "timeseries": {
-          "type": "object",
-          "title": "Time Series",
-          "description": "Holds the query results for each timeslice (each partition of the time_range), for non-'groupby' queries",
           "order": 4
-        },
-        "groups_timeseries": {
-          "type": "array",
-          "title": "Groups Time Series",
-          "description": "For 'groupby' queries, holds the timeseries object for each group",
-          "items": {
-            "type": "object"
-          },
-          "order": 5
-        },
-        "from": {
-          "type": "integer",
-          "title": "From",
-          "description": "The start of the time range for the query, as a UNIX timestamp in milliseconds",
-          "order": 6
-        },
-        "to": {
-          "type": "integer",
-          "title": "To",
-          "description": "The end of the time range for the query, as a UNIX timestamp in milliseconds",
-          "order": 7
-        },
-        "type": {
-          "type": "string",
-          "title": "Type",
-          "description": "The type of function performed, for example, \"count\", \"max\", \"average\", \"standarddeviation\"",
-          "order": 8
-        },
-        "key": {
-          "type": "string",
-          "title": "Key",
-          "description": "The key which the function of the 'calculate' clause is applied to",
-          "order": 9
-        },
-        "cardinality": {
-          "type": "integer",
-          "title": "Cardinality",
-          "description": "Always 0",
-          "order": 10
-        },
-        "others": {
-          "type": "object",
-          "title": "Others",
-          "description": "Not yet implemented",
-          "order": 11
-        },
-        "status": {
-          "type": "integer",
-          "title": "Status",
-          "description": "Holds a status code for the query, potentially different from the status code of the response",
-          "order": 12
-        },
-        "all_exact_results": {
-          "type": "boolean",
-          "title": "All Exact Results",
-          "description": "Boolean indicating whether groups are calculated approximately (approximated if a groupby query involves over 10,000 groups)",
-          "order": 13
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -114,7 +114,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
     },
     "results_events": {
       "type": "array",
-      "title": "Results Events",
+      "title": "Query Results (Events)",
       "description": "Query Results",
       "items": {
         "$ref": "#/definitions/events"
@@ -123,7 +123,7 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
     },
     "results_statistical": {
       "$ref": "#/definitions/results_statistics",
-      "title": "Results Statistical",
+      "title": "Query Results (Statistical)",
       "description": "Query Results",
       "order": 2
     }
@@ -402,28 +402,118 @@ class AdvancedQueryOnLogOutput(insightconnect_plugin_runtime.Output):
       "type": "object",
       "title": "results_statistics",
       "properties": {
+        "statistics": {
+          "$ref": "#/definitions/statistics",
+          "title": "statistics",
+          "description": "Holds the overall statistical results",
+          "order": 1
+        },
         "leql": {
           "type": "object",
           "title": "LEQL",
           "description": "The LEQL 'WHERE' clause to match against",
-          "order": 1
+          "order": 2
         },
         "logs": {
           "title": "Logs",
           "description": "Holds the Log ID of the matching log entry",
-          "order": 2
+          "order": 3
         },
         "search_stats": {
           "type": "object",
           "title": "Search Stats",
           "description": "Holds data regarding the query execution",
+          "order": 4
+        }
+      }
+    },
+    "statistics": {
+      "type": "object",
+      "title": "statistics",
+      "properties": {
+        "stats": {
+          "type": "object",
+          "title": "Stats",
+          "description": "Holds the overall result when query does not contain a 'groupby' clause",
+          "order": 1
+        },
+        "groups": {
+          "type": "array",
+          "title": "Groups",
+          "description": "Holds the overall result for each group in a 'groupby' query",
+          "items": {
+            "type": "object"
+          },
+          "order": 2
+        },
+        "granularity": {
+          "type": "integer",
+          "title": "Granularity",
+          "description": "The time window in milliseconds for each time slice in the time series",
           "order": 3
         },
-        "statement": {
+        "timeseries": {
           "type": "object",
-          "title": "Statement",
-          "description": "Query command/operation executed",
+          "title": "Time Series",
+          "description": "Holds the query results for each timeslice (each partition of the time_range), for non-'groupby' queries",
           "order": 4
+        },
+        "groups_timeseries": {
+          "type": "array",
+          "title": "Groups Time Series",
+          "description": "For 'groupby' queries, holds the timeseries object for each group",
+          "items": {
+            "type": "object"
+          },
+          "order": 5
+        },
+        "from": {
+          "type": "integer",
+          "title": "From",
+          "description": "The start of the time range for the query, as a UNIX timestamp in milliseconds",
+          "order": 6
+        },
+        "to": {
+          "type": "integer",
+          "title": "To",
+          "description": "The end of the time range for the query, as a UNIX timestamp in milliseconds",
+          "order": 7
+        },
+        "type": {
+          "type": "string",
+          "title": "Type",
+          "description": "The type of function performed, for example, \"count\", \"max\", \"average\", \"standarddeviation\"",
+          "order": 8
+        },
+        "key": {
+          "type": "string",
+          "title": "Key",
+          "description": "The key which the function of the 'calculate' clause is applied to",
+          "order": 9
+        },
+        "cardinality": {
+          "type": "integer",
+          "title": "Cardinality",
+          "description": "Always 0",
+          "order": 10
+        },
+        "others": {
+          "type": "object",
+          "title": "Others",
+          "description": "Not yet implemented",
+          "order": 11
+        },
+        "status": {
+          "type": "integer",
+          "title": "Status",
+          "description": "Holds a status code for the query, potentially different from the status code of the response",
+          "order": 12
+        },
+        "all_exact_results": {
+          "type": "boolean",
+          "title": "All Exact Results",
+          "description": "Boolean indicating whether groups are calculated approximately (approximated if a groupby query involves over 10,000 groups)",
+          "order": 13
         }
       }
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -132,7 +132,7 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
     },
     "results_events": {
       "type": "array",
-      "title": "Query Results (Events)",
+      "title": "Results Events",
       "description": "Query Results",
       "items": {
         "$ref": "#/definitions/events"
@@ -141,7 +141,7 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
     },
     "results_statistical": {
       "$ref": "#/definitions/statistics",
-      "title": "Query Results (Statistical)",
+      "title": "Results Statistical",
       "description": "Query Results",
       "order": 2
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -182,7 +182,7 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
           "order": 4
         },
         "message": {
-          "type": ["object", "string"],
+          "$ref": "#/definitions/message",
           "title": "Message",
           "description": "Message",
           "order": 5
@@ -195,6 +195,47 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
             "$ref": "#/definitions/link"
           },
           "order": 6
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "title": "message",
+      "properties": {
+        "sourceName": {
+          "type": "string",
+          "title": "Source Name",
+          "order": 1
+        },
+        "eventCode": {
+          "type": "integer",
+          "title": "Event Code",
+          "order": 2
+        },
+        "computerName": {
+          "type": "string",
+          "title": "Computer Name",
+          "order": 3
+        },
+        "sid": {
+          "type": "string",
+          "title": "SID",
+          "order": 4
+        },
+        "isDomainController": {
+          "type": "boolean",
+          "title": "Is Domain Controller",
+          "order": 5
+        },
+        "eventData": {
+          "$ref": "#/definitions/eventData",
+          "title": "Event Data",
+          "order": 6
+        },
+        "timeWritten": {
+          "type": "string",
+          "title": "Time Written",
+          "order": 7
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -140,7 +140,7 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
       "order": 1
     },
     "results_statistical": {
-      "$ref": "#/definitions/statistics",
+      "$ref": "#/definitions/results_statistics",
       "title": "Query Results (Statistical)",
       "description": "Query Results",
       "order": 2
@@ -195,6 +195,12 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
             "$ref": "#/definitions/link"
           },
           "order": 6
+        },
+        "sequence_number_str": {
+          "type": "string",
+          "title": "Sequence Number String",
+          "description": "Sequence number string",
+          "order": 7
         }
       }
     },
@@ -202,40 +208,106 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
       "type": "object",
       "title": "message",
       "properties": {
+        "timestamp": {
+          "type": "string",
+          "title": "Timestamp",
+          "order": 1
+        },
+        "destination_asset": {
+          "type": "string",
+          "title": "Destination Asset",
+          "order": 2
+        },
+        "source_asset_address": {
+          "type": "string",
+          "title": "Source Asset Address",
+          "order": 3
+        },
+        "destination_asset_address": {
+          "type": "string",
+          "title": "Destination Asset Address",
+          "order": 4
+        },
+        "destination_local_account": {
+          "type": "string",
+          "title": "Destination Local Account",
+          "order": 5
+        },
+        "logon_type": {
+          "type": "string",
+          "title": "Logon Type",
+          "order": 6
+        },
+        "result": {
+          "type": "string",
+          "title": "Result",
+          "order": 7
+        },
+        "new_authentication": {
+          "type": "string",
+          "title": "New Authentication",
+          "order": 8
+        },
+        "service": {
+          "type": "string",
+          "title": "Service",
+          "order": 9
+        },
+        "source_json": {
+          "$ref": "#/definitions/source_json",
+          "title": "Source JSON",
+          "order": 10
+        }
+      }
+    },
+    "source_json": {
+      "type": "object",
+      "title": "source_json",
+      "properties": {
         "sourceName": {
           "type": "string",
           "title": "Source Name",
+          "description": "Source Name",
           "order": 1
+        },
+        "insertionStrings": {
+          "type": "array",
+          "title": "Insertion Strings",
+          "description": "Insertion Strings",
+          "items": {
+            "type": "string"
+          },
+          "order": 2
         },
         "eventCode": {
           "type": "integer",
           "title": "Event Code",
-          "order": 2
+          "order": 3
         },
         "computerName": {
           "type": "string",
           "title": "Computer Name",
-          "order": 3
+          "order": 4
         },
         "sid": {
           "type": "string",
           "title": "SID",
-          "order": 4
+          "order": 5
         },
         "isDomainController": {
           "type": "boolean",
           "title": "Is Domain Controller",
-          "order": 5
+          "order": 6
         },
         "eventData": {
           "$ref": "#/definitions/eventData",
           "title": "Event Data",
-          "order": 6
+          "order": 7
         },
         "timeWritten": {
           "type": "string",
           "title": "Time Written",
-          "order": 7
+          "order": 8
         }
       }
     },
@@ -413,6 +485,35 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
           "title": "HREF",
           "description": "HREF",
           "order": 2
+        }
+      }
+    },
+    "results_statistics": {
+      "type": "object",
+      "title": "results_statistics",
+      "properties": {
+        "statistics": {
+          "$ref": "#/definitions/statistics",
+          "title": "statistics",
+          "description": "Holds the overall statistical results",
+          "order": 1
+        },
+        "leql": {
+          "type": "object",
+          "title": "LEQL",
+          "description": "The LEQL 'WHERE' clause to match against",
+          "order": 2
+        },
+        "logs": {
+          "title": "Logs",
+          "description": "Holds the Log ID of the matching log entry",
+          "order": 3
+        },
+        "search_stats": {
+          "type": "object",
+          "title": "Search Stats",
+          "description": "Holds data regarding the query execution",
+          "order": 4
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/schema.py
@@ -132,7 +132,7 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
     },
     "results_events": {
       "type": "array",
-      "title": "Results Events",
+      "title": "Query Results (Events)",
       "description": "Query Results",
       "items": {
         "$ref": "#/definitions/events"
@@ -141,7 +141,7 @@ class AdvancedQueryOnLogSetOutput(insightconnect_plugin_runtime.Output):
     },
     "results_statistical": {
       "$ref": "#/definitions/statistics",
-      "title": "Results Statistical",
+      "title": "Query Results (Statistical)",
       "description": "Query Results",
       "order": 2
     }

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/schema.py
@@ -98,7 +98,7 @@ class QueryOutput(insightconnect_plugin_runtime.Output):
           "order": 4
         },
         "message": {
-          "type": ["object", "string"],
+          "$ref": "#/definitions/message",
           "title": "Message",
           "description": "Message",
           "order": 5
@@ -111,6 +111,47 @@ class QueryOutput(insightconnect_plugin_runtime.Output):
             "$ref": "#/definitions/link"
           },
           "order": 6
+        }
+      }
+    },
+    "message": {
+      "type": "object",
+      "title": "message",
+      "properties": {
+        "sourceName": {
+          "type": "string",
+          "title": "Source Name",
+          "order": 1
+        },
+        "eventCode": {
+          "type": "integer",
+          "title": "Event Code",
+          "order": 2
+        },
+        "computerName": {
+          "type": "string",
+          "title": "Computer Name",
+          "order": 3
+        },
+        "sid": {
+          "type": "string",
+          "title": "SID",
+          "order": 4
+        },
+        "isDomainController": {
+          "type": "boolean",
+          "title": "Is Domain Controller",
+          "order": 5
+        },
+        "eventData": {
+          "$ref": "#/definitions/eventData",
+          "title": "Event Data",
+          "order": 6
+        },
+        "timeWritten": {
+          "type": "string",
+          "title": "Time Written",
+          "order": 7
         }
       }
     },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/schema.py
@@ -111,6 +111,12 @@ class QueryOutput(insightconnect_plugin_runtime.Output):
             "$ref": "#/definitions/link"
           },
           "order": 6
+        },
+        "sequence_number_str": {
+          "type": "string",
+          "title": "Sequence Number String",
+          "description": "Sequence number string",
+          "order": 7
         }
       }
     },
@@ -118,40 +124,106 @@ class QueryOutput(insightconnect_plugin_runtime.Output):
       "type": "object",
       "title": "message",
       "properties": {
+        "timestamp": {
+          "type": "string",
+          "title": "Timestamp",
+          "order": 1
+        },
+        "destination_asset": {
+          "type": "string",
+          "title": "Destination Asset",
+          "order": 2
+        },
+        "source_asset_address": {
+          "type": "string",
+          "title": "Source Asset Address",
+          "order": 3
+        },
+        "destination_asset_address": {
+          "type": "string",
+          "title": "Destination Asset Address",
+          "order": 4
+        },
+        "destination_local_account": {
+          "type": "string",
+          "title": "Destination Local Account",
+          "order": 5
+        },
+        "logon_type": {
+          "type": "string",
+          "title": "Logon Type",
+          "order": 6
+        },
+        "result": {
+          "type": "string",
+          "title": "Result",
+          "order": 7
+        },
+        "new_authentication": {
+          "type": "string",
+          "title": "New Authentication",
+          "order": 8
+        },
+        "service": {
+          "type": "string",
+          "title": "Service",
+          "order": 9
+        },
+        "source_json": {
+          "$ref": "#/definitions/source_json",
+          "title": "Source JSON",
+          "order": 10
+        }
+      }
+    },
+    "source_json": {
+      "type": "object",
+      "title": "source_json",
+      "properties": {
         "sourceName": {
           "type": "string",
           "title": "Source Name",
+          "description": "Source Name",
           "order": 1
+        },
+        "insertionStrings": {
+          "type": "array",
+          "title": "Insertion Strings",
+          "description": "Insertion Strings",
+          "items": {
+            "type": "string"
+          },
+          "order": 2
         },
         "eventCode": {
           "type": "integer",
           "title": "Event Code",
-          "order": 2
+          "order": 3
         },
         "computerName": {
           "type": "string",
           "title": "Computer Name",
-          "order": 3
+          "order": 4
         },
         "sid": {
           "type": "string",
           "title": "SID",
-          "order": 4
+          "order": 5
         },
         "isDomainController": {
           "type": "boolean",
           "title": "Is Domain Controller",
-          "order": 5
+          "order": 6
         },
         "eventData": {
           "$ref": "#/definitions/eventData",
           "title": "Event Data",
-          "order": 6
+          "order": 7
         },
         "timeWritten": {
           "type": "string",
           "title": "Time Written",
-          "order": 7
+          "order": 8
         }
       }
     },

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -36,7 +36,7 @@ sdk:
   version: 6.2.2
   user: nobody
 version_history:
-  - "11.0.0 - Updating schema for 'advanced_query_on_log' action to account for missing keys"
+  - "11.0.0 - Updating schema for query actions (`advanced_query_on_log`, `advanced_query_on_log_set` & `query`) to account for missing keys/invalid mapping in the schema"
   - "10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2"
   - "10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0"
   - "10.3.2 - Initial updates for fedramp compliance | Updated SDK to the latest version"
@@ -403,27 +403,36 @@ types:
       description: Last full scan age
       required: false
   message:
-    sourceName:
-      title: Source Name
+    timestamp:
+      title: Timestamp
       type: string
-    eventCode:
-      title: Event Code
-      type: integer
-    computerName:
-      title: Computer Name
+    destination_asset:
+      title: Destination Asset
       type: string
-    sid:
-      title: SID
+    source_asset_address:
+      title: Source Asset Address
       type: string
-    isDomainController:
-      title: Is Domain Controller
-      type: boolean
-    eventData:
-      title: Event Data
-      type: eventData
-    timeWritten:
-      title: Time Written
+    destination_asset_address:
+      title: Destination Asset Address
       type: string
+    destination_local_account:
+      title: Destination Local Account
+      type: string
+    logon_type:
+      title: Logon Type
+      type: string
+    result:
+      title: Result
+      type: string
+    new_authentication:
+      title: New Authentication
+      type: string
+    service:
+      title: Service
+      type: string
+    source_json:
+      title: Source JSON
+      type: source_json
   events:
     labels:
       title: Labels
@@ -449,6 +458,10 @@ types:
       title: Links
       description: Links
       type: "[]link"
+    sequence_number_str:
+      title: Sequence Number String
+      description: Sequence number string
+      type: string
   results_statistics:
     statistics:
       title: statistics
@@ -535,6 +548,41 @@ types:
       title: All Exact Results
       description: Boolean indicating whether groups are calculated approximately (approximated if a groupby query involves over 10,000 groups)
       type: boolean
+      required: false
+  source_json:
+    sourceName:
+      title: Source Name
+      type: string
+      description: Source Name
+      required: false
+    insertionStrings:
+      title: Insertion Strings
+      type: "[]string"
+      description: Insertion Strings
+      required: false
+    eventCode:
+      title: Event Code
+      type: integer
+      required: false
+    computerName:
+      title: Computer Name
+      type: string
+      required: false
+    sid:
+      title: SID
+      type: string
+      required: false
+    isDomainController:
+      title: Is Domain Controller
+      type: boolean
+      required: false
+    eventData:
+      title: Event Data
+      type: eventData
+      required: false
+    timeWritten:
+      title: Time Written
+      type: string
       required: false
   links:
     href:
@@ -2103,7 +2151,7 @@ actions:
       results_statistical:
         title: Query Results (Statistical)
         description: Query Results
-        type: statistics
+        type: results_statistics
         required: false
         example: '{"leql":{"during":{"from":1699579214000,"to":1699622414000},"statement":"groupby(r7_context.asset.name)"},"logs":["123456-abcd-1234-abcd-123456abc"],"search_stats":{"bytes_all":9961260,"bytes_checked":9961260,"duration_ms":19,"events_all":1640,"events_checked":1640,"events_matched":1639,"index_factor":0.0},"statistics":{"all_exact_result":true,"cardinality":0,"from":1699579214000,"granularity":4320000,"groups":[{"linux":{"count":1163.0}},{"windowsx64":{"count":476.0}}],"groups_timeseries":[{"linux":{"groups_timeseries":[],"series":[{"count":45.0},{"count":21.0},{"count":16.0},{"count":270.0},{"count":27.0},{"count":43.0},{"count":27.0},{"count":39.0},{"count":29.0},{"count":646.0}],"totals":{"count":1163.0}}},{"windowsx64":{"groups_timeseries":[],"series":[{"count":54.0},{"count":40.0},{"count":60.0},{"count":37.0},{"count":42.0},{"count":62.0},{"count":41.0},{"count":47.0},{"count":49.0},{"count":44.0}],"totals":{"count":476.0}}}],"others":{"series":[]},"stats":{},"status":200,"timeseries":{},"to":1699622414000,"type":"count"}}'
       count:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 10.3.5
+version: 11.0.0
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2024-09-10."]
 vendor: rapid7
@@ -36,7 +36,7 @@ sdk:
   version: 6.2.2
   user: nobody
 version_history:
-  - "10.3.5 - Updating schema for 'advanced_query_on_log' action to account for missing keys"
+  - "11.0.0 - Updating schema for 'advanced_query_on_log' action to account for missing keys"
   - "10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2"
   - "10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0"
   - "10.3.2 - Initial updates for fedramp compliance | Updated SDK to the latest version"

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -450,28 +450,23 @@ types:
       description: Links
       type: "[]link"
   results_statistics:
-    statistics:
-      title: statistics
-      description: Holds the overall statistical results
-      type: statistics
-      required: false
     leql:
-      title: leql
+      title: LEQL
       description: The LEQL 'WHERE' clause to match against
       type: object
       required: false
     logs:
-      title: logs
+      title: Logs
       description: Holds the Log ID of the matching log entry
       type: array
       required: false
     search_stats:
-      title: search_stats
+      title: Search Stats
       description: Holds data regarding the query execution
       type: object
       required: false
     statement:
-      title: statement
+      title: Statement
       description: Query command/operation executed
       type: object
       required: false
@@ -1998,13 +1993,13 @@ actions:
         order: 7
     output:
       results_events:
-        title: Query Results (Events)
+        title: Results Events
         description: Query Results
         type: "[]events"
         required: false
         example: '[{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]'
       results_statistical:
-        title: Query Results (Statistical)
+        title: Results Statistical
         description: Query Results
         type: results_statistics
         required: false
@@ -2100,13 +2095,13 @@ actions:
           - Web Proxy Activity
     output:
       results_events:
-        title: Query Results (Events)
+        title: Results Events
         description: Query Results
         type: "[]events"
         required: false
         example: '[{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]'
       results_statistical:
-        title: Query Results (Statistical)
+        title: Results Statistical
         description: Query Results
         type: statistics
         required: false

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -450,6 +450,11 @@ types:
       description: Links
       type: "[]link"
   results_statistics:
+    statistics:
+      title: statistics
+      description: Holds the overall statistical results
+      type: statistics
+      required: false
     leql:
       title: LEQL
       description: The LEQL 'WHERE' clause to match against
@@ -463,11 +468,6 @@ types:
     search_stats:
       title: Search Stats
       description: Holds data regarding the query execution
-      type: object
-      required: false
-    statement:
-      title: Statement
-      description: Query command/operation executed
       type: object
       required: false
   statistics:
@@ -1993,13 +1993,13 @@ actions:
         order: 7
     output:
       results_events:
-        title: Results Events
+        title: Query Results (Events)
         description: Query Results
         type: "[]events"
         required: false
         example: '[{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]'
       results_statistical:
-        title: Results Statistical
+        title: Query Results (Statistical)
         description: Query Results
         type: results_statistics
         required: false
@@ -2095,13 +2095,13 @@ actions:
           - Web Proxy Activity
     output:
       results_events:
-        title: Results Events
+        title: Query Results (Events)
         description: Query Results
         type: "[]events"
         required: false
         example: '[{"labels": [],"timestamp": 1601598638768,"sequence_number": 123456789123456789,"log_id": "64z0f0p9-1a99-4501-xe36-a6d03687f313","message": {"timestamp": "2020-10-02T00:29:14.649Z","destination_asset": "iagent-win7","source_asset_address": "192.168.100.50","destination_asset_address": "example-host","destination_local_account": "user","logon_type": "NETWORK","result": "SUCCESS","new_authentication": "false","service": "ntlmssp ","source_json": {"sourceName": "Microsoft-Windows-Security-Auditing","insertionStrings": ["S-1-0-0","-","-","0x0","X-X-X-XXXXXXXXXXX","user@example.com","example-host","0x204f163c","3","NtLmSsp ","NTLM","","{00000000-0000-0000-0000-000000000000}","-","NTLM V2","128","0x0","-","192.168.50.1","59090"],"eventCode": 4624,"computerName": "example-host","sid": "","isDomainController": false,"eventData": null,"timeWritten": "2020-10-02T00:29:13.670722000Z"}},"links": [{"rel": "Context","href": "https://us.api.insight.rapid7.com/log_search/query/context/xxxx"}],"sequence_number_str": "123456789123456789"}]'
       results_statistical:
-        title: Results Statistical
+        title: Query Results (Statistical)
         description: Query Results
         type: statistics
         required: false

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 10.3.4
+version: 10.3.5
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2024-09-10."]
 vendor: rapid7
@@ -36,6 +36,7 @@ sdk:
   version: 6.2.2
   user: nobody
 version_history:
+  - "10.3.5 - Updating schema for 'advanced_query_on_log' action to account for missing keys"
   - "10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2"
   - "10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0"
   - "10.3.2 - Initial updates for fedramp compliance | Updated SDK to the latest version"
@@ -448,6 +449,32 @@ types:
       title: Links
       description: Links
       type: "[]link"
+  results_statistics:
+    statistics:
+      title: statistics
+      description: Holds the overall statistical results
+      type: statistics
+      required: false
+    leql:
+      title: leql
+      description: The LEQL 'WHERE' clause to match against
+      type: object
+      required: false
+    logs:
+      title: logs
+      description: Holds the Log ID of the matching log entry
+      type: array
+      required: false
+    search_stats:
+      title: search_stats
+      description: Holds data regarding the query execution
+      type: object
+      required: false
+    statement:
+      title: statement
+      description: Query command/operation executed
+      type: object
+      required: false
   statistics:
     stats:
       title: Stats
@@ -1979,7 +2006,7 @@ actions:
       results_statistical:
         title: Query Results (Statistical)
         description: Query Results
-        type: statistics
+        type: results_statistics
         required: false
         example: '{"leql":{"during":{"from":1699579214000,"to":1699622414000},"statement":"groupby(r7_context.asset.name)"},"logs":["123456-abcd-1234-abcd-123456abc"],"search_stats":{"bytes_all":9961260,"bytes_checked":9961260,"duration_ms":19,"events_all":1640,"events_checked":1640,"events_matched":1639,"index_factor":0.0},"statistics":{"all_exact_result":true,"cardinality":0,"from":1699579214000,"granularity":4320000,"groups":[{"linux":{"count":1163.0}},{"windowsx64":{"count":476.0}}],"groups_timeseries":[{"linux":{"groups_timeseries":[],"series":[{"count":45.0},{"count":21.0},{"count":16.0},{"count":270.0},{"count":27.0},{"count":43.0},{"count":27.0},{"count":39.0},{"count":29.0},{"count":646.0}],"totals":{"count":1163.0}}},{"windowsx64":{"groups_timeseries":[],"series":[{"count":54.0},{"count":40.0},{"count":60.0},{"count":37.0},{"count":42.0},{"count":62.0},{"count":41.0},{"count":47.0},{"count":49.0},{"count":44.0}],"totals":{"count":476.0}}}],"others":{"series":[]},"stats":{},"status":200,"timeseries":{},"to":1699622414000,"type":"count"}}'
       count:

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="10.3.5",
+      version="11.0.0",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="10.3.4",
+      version="10.3.5",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

An [SI ticket](https://rapid7.atlassian.net/browse/SI-26849) was made in accordance to the schema being incorrect. The customer cannot access some of the keys due to the formatting in the pluginspec and other fields such as `statement` were missing altogether.

Describe the proposed changes:

  - Update schema for `advanced_query_on_log`, `advanced_query_on_log_set` & `query` to account for missing keys and invalid mapping

### Testing

Fields now show in the schema output:
![image](https://github.com/user-attachments/assets/26500bda-2294-4a27-b1c4-1da27ee73334)
![image](https://github.com/user-attachments/assets/7574818f-4bab-40ba-82f3-d72f96777f84)

