### PR TITLE
SOAR-18473: bump SDK and address vulnerabilities

### DIFF
--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "c321daf69a3679e488625f8dbd077985",
-	"manifest": "c35b3c929b1fa09020196cc79f5b701a",
-	"setup": "8ad9bdf0d891eb2e9bc3a2535f273e9d",
+	"spec": "4d67f7597ca0c9b43ff85bc3d161836e",
+	"manifest": "1588546a33ea7ad727ddb4da7cccf361",
+	"setup": "d096809ce9406aab15b8953507d6afe0",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.2
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/whois/bin/komand_whois
+++ b/plugins/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "3.1.6"
+Version = "3.1.7"
 Description = "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
 
 

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -181,6 +181,7 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
+* 3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities
 * 3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0
 * 3.1.5 - Action `Address`: Fixed issue with result parsing
 * 3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
-version: 3.1.6
+version: 3.1.7
 connection_version: 3
 vendor: rapid7
 support: community
@@ -12,7 +12,7 @@ supported_versions: ["2024-09-09"]
 status: []
 sdk:
   type: slim
-  version: 6.2.0
+  version: 6.2.2
   user: nobody
   packages:
     - whois
@@ -34,6 +34,7 @@ references: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 links: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 troubleshooting: "Multiple records can be returned by the server, this plugin currently only returns the first unique records found."
 version_history:
+  - "3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
   - "3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0"
   - "3.1.5 - Action `Address`: Fixed issue with result parsing"
   - "3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version"

--- a/plugins/whois/setup.py
+++ b/plugins/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="3.1.6",
+      version="3.1.7",
       description="[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Part of a long list of plugins being bumped to latest SDK.

note all tests pass locally, but fail on here due to needing to install whois via the docker file

```
❯ python3 -m unittest *
....
----------------------------------------------------------------------
Ran 4 tests in 0.016s

OK
```