### PR TITLE
Dig Release v2.0.4

### DIFF
--- a/plugins/dig/.CHECKSUM
+++ b/plugins/dig/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d8d50c9db39ba033e610719769fd8ca1",
-	"manifest": "268c1317febaf06659794c9325f8141b",
-	"setup": "449d4e32ca0d63cb46e14c20f625e0bc",
+	"spec": "8ff0f3308351b1a44cf24084dbf42ce8",
+	"manifest": "2e3c5a1e4029c779bf99991d18b47a67",
+	"setup": "b5a0e6ff2254c0ce4138185e153bfe5c",
 	"schemas": [
 		{
 			"identifier": "forward/schema.py",

--- a/plugins/dig/Dockerfile
+++ b/plugins/dig/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.1.2
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.2.2
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/dig/bin/komand_dig
+++ b/plugins/dig/bin/komand_dig
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "DNS"
 Vendor = "rapid7"
-Version = "2.0.3"
+Version = "2.0.4"
 Description = "The DNS plugin is used for forward and reverse DNS lookups. This plugin uses [Dig](https://linux.die.net/man/1/dig), or Domain Information Groper, which is a network administration command-line tool for querying Domain Name System (DNS) name servers"
 
 

--- a/plugins/dig/help.md
+++ b/plugins/dig/help.md
@@ -186,6 +186,7 @@ Common examples:
 
 # Version History
 
+* 2.0.4 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities
 * 2.0.3 - Initial updates for fedramp compliance | Updated SDK to the latest
 * 2.0.2 - Updated SDK to the latest version | Added validation for input parameters
 * 2.0.1 - Added `__init__.py` file to `unit_test` folder | Refreshed with new Tooling

--- a/plugins/dig/plugin.spec.yaml
+++ b/plugins/dig/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: dig
 title: DNS
 description: The DNS plugin is used for forward and reverse DNS lookups. This plugin uses [Dig](https://linux.die.net/man/1/dig), or Domain Information Groper, which is a network administration command-line tool for querying Domain Name System (DNS) name servers
-version: 2.0.3
+version: 2.0.4
 connection_version: 2
 vendor: rapid7
 support: community
@@ -12,7 +12,7 @@ supported_versions: ["2024-09-10"]
 status: []
 sdk:
   type: full
-  version: 6.1.2
+  version: 6.2.2
   user: nobody
   packages:
     - bind-tools
@@ -63,6 +63,7 @@ references:
   - "[Dig](https://linux.die.net/man/1/dig)"
   - "[DNS Status Code](https://www.iana.org/assignments/dns-parameters/dns-parameters.xhtml)"
 version_history:
+  - "2.0.4 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
   - "2.0.3 - Initial updates for fedramp compliance | Updated SDK to the latest"
   - "2.0.2 - Updated SDK to the latest version | Added validation for input parameters"
   - "2.0.1 - Added `__init__.py` file to `unit_test` folder | Refreshed with new Tooling"

--- a/plugins/dig/setup.py
+++ b/plugins/dig/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="dig-rapid7-plugin",
-      version="2.0.3",
+      version="2.0.4",
       description="The DNS plugin is used for forward and reverse DNS lookups. This plugin uses [Dig](https://linux.die.net/man/1/dig), or Domain Information Groper, which is a network administration command-line tool for querying Domain Name System (DNS) name servers",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Release of Dig v2.0.4 to bump to latest SDK and fix any vulnerabilities.

Original PR: #3001 

Validator failing due to installs in Dockerfile which is expected. 