### PR TITLE
Release Rapid7 InsightVM Console v8.0.8

### DIFF
--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "6099ff1718aec952d1591cda08e21497",
-	"manifest": "f2a7c7fc917326def786ef96670f98d5",
-	"setup": "f07635c7bdffcd4737a2ff58f82232ab",
+	"spec": "56723b3b629afb9f25004fc228cc4270",
+	"manifest": "21c5769aa39fc81c6b1539f6a274836c",
+	"setup": "acf3a983a67ab01ab4061df14bb7c0b6",
 	"schemas": [
 		{
 			"identifier": "add_scan_engine_pool_engine/schema.py",

--- a/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
+++ b/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightVM Console"
 Vendor = "rapid7"
-Version = "8.0.8"
+Version = "8.0.9"
 Description = "InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans"
 
 

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -4012,6 +4012,7 @@ Example output:
 
 # Version History
 
+* 8.0.9 - Address vulnerabilities in buildpack
 * 8.0.8 - Bumping requirements.txt | SDK bump to 6.2.2
 * 8.0.7 - Bumping requirements.txt | SDK bump to 6.2.0
 * 8.0.6 - Trigger `New Exception Request`: Updated the trigger with retry mechanism

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightvm
 title: Rapid7 InsightVM Console
 description: InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans
-version: 8.0.8
+version: 8.0.9
 connection_version: 8
 supported_versions: ["Rapid7 InsightVM API v3 2022-05-25"]
 fedramp_ready: true
@@ -26,6 +26,7 @@ links:
 references:
   - "[InsightVM API 3](https://help.rapid7.com/insightvm/en-us/api/index.html)"
 version_history:
+  - "8.0.9 - Address vulnerabilities in buildpack"
   - "8.0.8 - Bumping requirements.txt | SDK bump to 6.2.2"
   - "8.0.7 - Bumping requirements.txt | SDK bump to 6.2.0"
   - "8.0.6 - Trigger `New Exception Request`: Updated the trigger with retry mechanism"

--- a/plugins/rapid7_insightvm/setup.py
+++ b/plugins/rapid7_insightvm/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightvm-rapid7-plugin",
-      version="8.0.8",
+      version="8.0.9",
       description="InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
Release of InsightVM Console v8.0.8

Original PR: #3020 

Note: verifying we want this release as it's not marked as cloud ready. 

Update: Chatted to Igor around this and we still want to include these changes. 