### PR TITLE
[SOAR-18559] insightagent

### DIFF
--- a/plugins/rapid7_insight_agent/.CHECKSUM
+++ b/plugins/rapid7_insight_agent/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "068f90d6f4a93addc62a6c00ad1aa085",
+	"spec": "40959d25471f8645178e8e15095f7a3b",
 	"manifest": "fbc1b04c51c6c8816dac6cee216341c2",
 	"setup": "7f65232e4808ae89ad79c06f1b2dc5a2",
 	"schemas": [

--- a/plugins/rapid7_insight_agent/help.md
+++ b/plugins/rapid7_insight_agent/help.md
@@ -461,7 +461,7 @@ Example output:
 
 # Version History
 
-* 3.0.2 - Updated to use latest buildpack to address vulnerabilities
+* 3.0.2 - Updated to use latest buildpack to address vulnerabilities | Update `Get Agent Details`:  extended output to include `agent` field when no assets are found
 * 3.0.1 - Update 'Get Agent Details' to allow no assets to be returned | SDK bump to latest version
 * 3.0.0 - Update `Get Agent Details` and `Get All Agents by IP` to return the next page token if more pages are available to search | Update `Get Agent Details` to return agent location details | Initial updates for fedramp compliance | Updated SDK to the latest version
 * 2.1.2 - Improve logging | Update SDK

--- a/plugins/rapid7_insight_agent/icon_rapid7_insight_agent/util/graphql_api/api_connection.py
+++ b/plugins/rapid7_insight_agent/icon_rapid7_insight_agent/util/graphql_api/api_connection.py
@@ -383,7 +383,7 @@ class ApiConnection:
             return agent, None
         else:
             self.logger.info("No assets were found")
-            return None, None
+            return {}, None
 
     def _get_agents(self, agents_input: List[str]) -> [Tuple[str, dict]]:
         """

--- a/plugins/rapid7_insight_agent/plugin.spec.yaml
+++ b/plugins/rapid7_insight_agent/plugin.spec.yaml
@@ -28,7 +28,7 @@ links:
 references:
   - "[Manage Platform API Keys](https://docs.rapid7.com/insight/managing-platform-api-keys/)"
 version_history:
-  - "3.0.2 - Updated to use latest buildpack to address vulnerabilities"
+  - "3.0.2 - Updated to use latest buildpack to address vulnerabilities | Update `Get Agent Details`:  extended output to include `agent` field when no assets are found"
   - "3.0.1 - Update 'Get Agent Details' to allow no assets to be returned | SDK bump to latest version"
   - "3.0.0 - Update `Get Agent Details` and `Get All Agents by IP` to return the next page token if more pages are available to search | Update `Get Agent Details` to return agent location details | Initial updates for fedramp compliance | Updated SDK to the latest version"
   - "2.1.2 - Improve logging | Update SDK"

--- a/plugins/rapid7_insight_agent/unit_test/test_get_agent_details.py
+++ b/plugins/rapid7_insight_agent/unit_test/test_get_agent_details.py
@@ -29,5 +29,5 @@ class TestGetAgentDetails(TestCase):
     def test_get_agent_by_hostname_bad(self, mock_request: MagicMock) -> None:
         action = Util.default_connector(GetAgentDetails())
         actual = action.run({Input.AGENT: "badID"})
-        expected = {}
+        expected = {"agent": {}}
         self.assertEqual(actual, expected)


### PR DESCRIPTION
## Proposed Changes

### Description

Regarding an [SI ticket](https://rapid7.atlassian.net/browse/SI-26673), a suggestion was made to clean up the output for the `get_agent_details` action to include the `agent` field but not populate it if there is no assets found (as it currently only returns `{}`). This will make it easier for the customers to understand when reading and will allow them to build workflows around the action easier as there is a field to check in the output.

Describe the proposed changes:

  - Update `get_agent_details` action to include `agent` in the output when no assets found
  - Unit test updated to reflect above

### Testing

Tested it locally and the agents field is now returned:
<img width="1187" alt="image" src="https://github.com/user-attachments/assets/8e4bf3a2-2a8b-4df4-82f6-f40745c5ebc0" />
