### PR TITLE
Okta plugin.spec sync

### DIFF
--- a/plugins/okta/.CHECKSUM
+++ b/plugins/okta/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "c52fa69769d8388de102d29fa011df8e",
+	"spec": "a8ad8ec4b8abc7671ab7bdc628101543",
 	"manifest": "2db4eb90f95f2a5eec67e4e28f1a736d",
 	"setup": "2913648b2ac528d2c75f3b1032a57d60",
 	"schemas": [
@@ -73,7 +73,7 @@
 		},
 		{
 			"identifier": "monitor_logs/schema.py",
-			"hash": "c7846002b9cb1c3069e098b40868f0d2"
+			"hash": "e099836cf02d62fce308a9c2043b79e1"
 		},
 		{
 			"identifier": "users_added_removed_from_group/schema.py",

--- a/plugins/okta/help.md
+++ b/plugins/okta/help.md
@@ -661,15 +661,6 @@ Example output:
 }
 ```
 
-When no groups are found, the action returns:
-
-```
-{
-  "success": false,
-  "groups": []
-}
-```
-
 #### Remove User from Group
 
 This action is used to remove a user from an existing group
@@ -847,14 +838,6 @@ Example output:
   "login": "user@example.com",
   "success": true,
   "userId": "00a0a1qwertYUIoplK0j6"
-}
-```
-
-When the user is not found, the action returns:
-
-```
-{
-  "success": false
 }
 ```
 
@@ -1594,7 +1577,7 @@ Example output:
 
 ## Troubleshooting
 
-Actions may fail depending on the state of the resource you attempt to operate over. They will return a best-effort message indicating why the Okta API responded the way it did when possible. Depending on the API endpoint, this message is either provided by Okta themselves, or constructed by the plugin based on the information it has at hand.
+* Actions may fail depending on the state of the resource you attempt to operate over. They will return a best-effort message indicating why the Okta API responded the way it did when possible. Depending on the API endpoint, this message is either provided by Okta themselves, or constructed by the plugin based on the information it has at hand.
 
 # Version History
 

--- a/plugins/okta/komand_okta/tasks/monitor_logs/schema.py
+++ b/plugins/okta/komand_okta/tasks/monitor_logs/schema.py
@@ -43,9 +43,7 @@ class MonitorLogsOutput(insightconnect_plugin_runtime.Output):
   "type": "array",
   "title": "Logs",
   "description": "All system logs within the specified time range",
-  "items": {
-    "type": "object"
-  },
+  "items": {},
   "required": [
     "logs"
   ],

--- a/plugins/okta/plugin.spec.yaml
+++ b/plugins/okta/plugin.spec.yaml
@@ -30,7 +30,8 @@ hub_tags:
   use_cases: [application_management, user_management]
   keywords: [sso, provisioning, deprovisioning, saml, cloud_enabled]
   features: []
-troubleshooting: "Actions may fail depending on the state of the resource you attempt to operate over. They will return a best-effort message indicating why the Okta API responded the way it did when possible. Depending on the API endpoint, this message is either provided by Okta themselves, or constructed by the plugin based on the information it has at hand."
+troubleshooting:
+  - "Actions may fail depending on the state of the resource you attempt to operate over. They will return a best-effort message indicating why the Okta API responded the way it did when possible. Depending on the API endpoint, this message is either provided by Okta themselves, or constructed by the plugin based on the information it has at hand."
 version_history:
   - "4.2.12 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
   - "4.2.11 - Initial updates for fedramp compliance | Updated SDK to the latest version"


### PR DESCRIPTION
## Proposed Changes

### Description

Updating the `plugin.spec` to be in sync with the `help.md`. There is no way to add the extra details in the plugin.spec so the user knows the action output when there is no users/groups, but I think it can be removed as it's common sense 😅 

This will get bundled alongside #3012 
Describe the proposed changes:

  - Updating `plugin.spec`

