### PR TITLE
Duo Admin plugin.spec sync

### DIFF
--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "678168c70a95dacd186d109a0623ac45",
+	"spec": "4a94a77c37f17820e8768bb2850f6ee5",
 	"manifest": "672f0da4df4edb87ab669d69e435c5c7",
 	"setup": "8a8919e13bd1afe4849427d3dae6dbf4",
 	"schemas": [
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "get_logs/schema.py",
-			"hash": "eb18c676af3b2653f5cf7bc13ea67b9a"
+			"hash": "3502cb177351d18ff8a31266a49db228"
 		},
 		{
 			"identifier": "get_phones_by_user_id/schema.py",

--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "73c2331db15a7ec15ca36e7e166746d4",
+	"spec": "678168c70a95dacd186d109a0623ac45",
 	"manifest": "672f0da4df4edb87ab669d69e435c5c7",
 	"setup": "8a8919e13bd1afe4849427d3dae6dbf4",
 	"schemas": [
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "get_logs/schema.py",
-			"hash": "ee359e5ea79a88b4597a5afaa739b793"
+			"hash": "eb18c676af3b2653f5cf7bc13ea67b9a"
 		},
 		{
 			"identifier": "get_phones_by_user_id/schema.py",
@@ -49,7 +49,7 @@
 		},
 		{
 			"identifier": "monitor_logs/schema.py",
-			"hash": "4119a8c82613406e16d830d7b48e0c86"
+			"hash": "26f03015b329bc573a7e6f3a688fb861"
 		}
 	]
 }

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -175,73 +175,14 @@ Example output:
 ```
 
 #### Get Authentication Logs
-
+  
 This action is used to get auth logs, limited to past 180 days.
-[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.
+[Currentmillis.com](https://currentmillis.com/) is 
+useful for finding a usable UNIX timestamp.
 
-Available inputs for parameters:
-
-* `factors` - a comma-separated list of factors, if left empty, the action returns the authentication logs for all factors used for an authentication attempt
-    * bypass_code
-    * digipass_go_7_token
-    * duo_mobile_passcode
-    * duo_push
-    * hardware_token
-    * not_available
-    * passcode
-    * phone_call
-    * remembered_device
-    * sms_passcode
-    * sms_refresh
-    * trusted_network
-    * u2f_token
-    * yubikey_code
-* `reasons` - a comma-separated list of reasons, if left empty, the action returns the authentication logs for all reasons associated with an authentication attempt
-    * allow_unenrolled_user
-    * allow_unenrolled_user_on_trusted_network
-    * allowed_by_policy
-    * anomalous_push
-    * anonymous_ip
-    * bypass_user
-    * call_timed_out
-    * could_not_determine_if_endpoint_was_trusted
-    * denied_by_policy
-    * deny_unenrolled_user
-    * endpoint_failed_google_verification
-    * endpoint_is_not_in_management_system
-    * endpoint_is_not_trusted
-    * error
-    * factor_restricted
-    * invalid_device
-    * invalid_management_certificate_collection_state
-    * invalid_passcode
-    * invalid_referring_hostname_provided
-    * location_restricted
-    * locked_out
-    * no_activated_duo_mobile_account
-    * no_disk_encryption
-    * no_duo_certificate_present
-    * no_keys_pressed
-    * no_referring_hostname_provided
-    * no_response
-    * no_screen_lock
-    * no_web_referer_match
-    * out_of_date
-    * platform_restricted
-    * remembered_device
-    * rooted_device
-    * software_restricted
-    * touch_id_disabled
-    * trusted_location
-    * trusted_network
-    * user_approved
-    * user_cancelled
-    * user_disabled
-    * user_marked_fraud
-    * user_not_in_permitted_group
-    * user_provided_invalid_certificate
-    * valid_passcode
-    * version_restricted
+Available inputs for parameters can be found on [Duo Admin API 
+docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)
+ 
 
 ##### Input
 
@@ -1006,7 +947,7 @@ Example output:
 
 ## Troubleshooting
 
-Many actions in this plugin take a User ID as input. A User ID is not the username - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained by passing a username to the Get User Status action.
+* Many actions in this plugin take a User ID as input. A User ID is not the username - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained by passing a username to the Get User Status action.
 
 # Version History
 

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -180,9 +180,8 @@ This action is used to get auth logs, limited to past 180 days.
 [Currentmillis.com](https://currentmillis.com/) is 
 useful for finding a usable UNIX timestamp.
 
-Available inputs for parameters can be found on [Duo Admin API 
+Available inputs for parameters can be found in [Duo Admin API 
 docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)
- 
 
 ##### Input
 

--- a/plugins/duo_admin/komand_duo_admin/actions/get_logs/schema.py
+++ b/plugins/duo_admin/komand_duo_admin/actions/get_logs/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Get auth logs, limited to past 180 days"
+    DESCRIPTION = "This action is used to get auth logs, limited to past 180 days.[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.Available inputs for parameters can be found on [Duo Admin's API docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)"
 
 
 class Input:

--- a/plugins/duo_admin/komand_duo_admin/actions/get_logs/schema.py
+++ b/plugins/duo_admin/komand_duo_admin/actions/get_logs/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "This action is used to get auth logs, limited to past 180 days.[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.Available inputs for parameters can be found on [Duo Admin's API docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)"
+    DESCRIPTION = "This action is used to get auth logs, limited to past 180 days.[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.Available inputs for parameters can be found in [Duo Admin API docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)"
 
 
 class Input:

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/schema.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/schema.py
@@ -64,9 +64,7 @@ class MonitorLogsOutput(insightconnect_plugin_runtime.Output):
   "type": "array",
   "title": "Logs",
   "description": "List of administrator, authentication and trust monitor event logs within the specified time range",
-  "items": {
-    "type": "object"
-  },
+  "items": {},
   "required": [
     "logs"
   ],

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -47,8 +47,8 @@ links:
 - "[Duo Security](https://duo.com/)"
 references:
 - "[Duo Admin API](https://duo.com/docs/adminapi)"
-troubleshooting: "Many actions in this plugin take a User ID as input. A User ID is not the username - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained by passing a username to the Get User Status action."
-
+troubleshooting:
+  - "Many actions in this plugin take a User ID as input. A User ID is not the username - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained by passing a username to the Get User Status action."
 version_history:
 - "5.0.2 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
 - "5.0.1 - Update to enable Plugin as FedRAMP ready | Update SDK (`6.1.2`)"
@@ -1075,7 +1075,7 @@ actions:
         example: { "alias1": "alias1", "alias2": "alias2", "alias3": "alias3", "alias4": "alias4", "aliases": { "alias1": "alias1", "alias2": "alias2", "alias3": "alias3", "alias4": "alias4" }, "created": 1684765611, "email": "user@example.com", "isEnrolled": false, "notes": "Example", "realname": "Example", "status": "active", "userId": "DUCUULF6HBMZ43IG9MBH", "username": "Example" }
   get_logs:
     title: Get Authentication Logs
-    description: Get auth logs, limited to past 180 days
+    description: "This action is used to get auth logs, limited to past 180 days.\n[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.\n\nAvailable inputs for parameters can be found on [Duo Admin's API docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)"
     input:
       mintime:
         title: Mintime

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -1075,7 +1075,7 @@ actions:
         example: { "alias1": "alias1", "alias2": "alias2", "alias3": "alias3", "alias4": "alias4", "aliases": { "alias1": "alias1", "alias2": "alias2", "alias3": "alias3", "alias4": "alias4" }, "created": 1684765611, "email": "user@example.com", "isEnrolled": false, "notes": "Example", "realname": "Example", "status": "active", "userId": "DUCUULF6HBMZ43IG9MBH", "username": "Example" }
   get_logs:
     title: Get Authentication Logs
-    description: "This action is used to get auth logs, limited to past 180 days.\n[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.\n\nAvailable inputs for parameters can be found on [Duo Admin's API docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)"
+    description: "This action is used to get auth logs, limited to past 180 days.\n[Currentmillis.com](https://currentmillis.com/) is useful for finding a usable UNIX timestamp.\n\nAvailable inputs for parameters can be found in [Duo Admin API docs](https://duo.com/docs/adminapi#logs:~:text=The%20factor%20or%20method%20used%20for%20an%20authentication%20attempt.%20One%20of%3A)"
     input:
       mintime:
         title: Mintime


### PR DESCRIPTION
## Proposed Changes

### Description

Updating the plugin.spec to be in sync with the help.md. Due to the large description for the get_logs action, I am unable to add it in the plugin.spec although I found the docs where all inputs parameters are linked and added that in the spec.

PR will be bundled alongside:
- https://github.com/rapid7/insightconnect-plugins/pull/3021

- Update `plugin.spec` to be in sync

