### PR TITLE
SOAR-18525: rename to defender for endpoint

### DIFF
--- a/plugins/microsoft_atp/.CHECKSUM
+++ b/plugins/microsoft_atp/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "b247f2cc2b894b70b8e6bc2d9f630077",
-	"manifest": "e15eee3183e32aca45667b79fbdca373",
-	"setup": "d291d680acf58e924d74b9baf70b537e",
+	"spec": "d157b791788b17b2b6d2de127320f5c1",
+	"manifest": "8f26bd28e949cfda8dfce9f0036777a3",
+	"setup": "9ceeb89f2b17b0f547706b3639287496",
 	"schemas": [
 		{
 			"identifier": "blacklist/schema.py",

--- a/plugins/microsoft_atp/bin/komand_microsoft_atp
+++ b/plugins/microsoft_atp/bin/komand_microsoft_atp
@@ -4,10 +4,10 @@ import os
 import json
 from sys import argv
 
-Name = "Microsoft Windows Defender ATP"
+Name = "Microsoft Defender for Endpoint"
 Vendor = "rapid7"
 Version = "6.0.1"
-Description = "The Windows Defender Advanced Threat Protection plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files"
+Description = "The Microsoft Defender for Endpoint plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files"
 
 
 def main():

--- a/plugins/microsoft_atp/help.md
+++ b/plugins/microsoft_atp/help.md
@@ -1,6 +1,6 @@
 # Description
 
-The Windows Defender Advanced Threat Protection plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files
+The Microsoft Defender for Endpoint plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files
 
 # Key Features
 
@@ -21,10 +21,6 @@ The Windows Defender Advanced Threat Protection plugin allows Rapid7 InsightConn
 
 ## Setup
 
-This plugin uses the Windows Defender ATP API. It will use an Azure application to connect to the API and run actions from InsightConnect.
-
-For information on how to setup your application and assign permissions go here:
-https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/exposed-apis-create-app-webapp
 The connection configuration accepts the following parameters:  
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
@@ -1330,12 +1326,12 @@ Example output:
 
 
 ## Troubleshooting
-  
-*This plugin does not contain a troubleshooting.*
+
+* For information on how to setup your Azure application and assign permissions go [here](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/exposed-apis-create-app-webapp)
 
 # Version History
 
-* 6.0.1 - Update to latest SDK (v6.2.2) | Address vulnerabilities
+* 6.0.1 - Update to latest SDK (v6.2.2) | Address vulnerabilities | Rebrand to `Microsoft Defender for Endpoint`
 * 6.0.0 - Updated SDK to the latest version | Initial updates for fedramp compliance
 * 5.2.0 - Add new action: Update Alert
 * 5.1.0 - Adding the following as new action types to `blacklist` action ['Warn', 'Block', 'Audit'] | Add a new flag in the `blacklist` action to toggle generateAlerts flag | Bump SDK to version 5.4.9

--- a/plugins/microsoft_atp/plugin.spec.yaml
+++ b/plugins/microsoft_atp/plugin.spec.yaml
@@ -2,8 +2,8 @@ plugin_spec_version: v2
 extension: plugin
 products: ["insightconnect"]
 name: microsoft_atp
-title: Microsoft Windows Defender ATP
-description: The Windows Defender Advanced Threat Protection plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files
+title: Microsoft Defender for Endpoint
+description: The Microsoft Defender for Endpoint plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files
 version: 6.0.1
 connection_version: 6
 supported_versions: ["2024-05-21"]
@@ -29,13 +29,15 @@ sdk:
   type: full 
   version: 6.2.2
   user: nobody
+troubleshooting:
+  - "For information on how to setup your Azure application and assign permissions go [here](https://docs.microsoft.com/en-us/windows/security/threat-protection/microsoft-defender-atp/exposed-apis-create-app-webapp)"
 links:
  - "[Windows Defender ATP](https://www.microsoft.com/en-us/windowsforbusiness/windows-atp)"
 references:
  - "[Windows Defender ATP API Start Page](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-atp/use-apis)"
  - "[Windows Defender ATP API Endpoints](https://docs.microsoft.com/en-us/windows/security/threat-protection/windows-defender-atp/exposed-apis-list)"
 version_history:
- - "6.0.1 - Update to latest SDK (v6.2.2) | Address vulnerabilities"
+ - "6.0.1 - Update to latest SDK (v6.2.2) | Address vulnerabilities | Rebrand to `Microsoft Defender for Endpoint`"
  - "6.0.0 - Updated SDK to the latest version | Initial updates for fedramp compliance"
  - "5.2.0 - Add new action: Update Alert"
  - "5.1.0 - Adding the following as new action types to `blacklist` action ['Warn', 'Block', 'Audit'] | Add a new flag in the `blacklist` action to toggle generateAlerts flag | Bump SDK to version 5.4.9"

--- a/plugins/microsoft_atp/setup.py
+++ b/plugins/microsoft_atp/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(name="microsoft_atp-rapid7-plugin",
       version="6.0.1",
-      description="The Windows Defender Advanced Threat Protection plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files",
+      description="The Microsoft Defender for Endpoint plugin allows Rapid7 InsightConnect users to quickly take remediation actions across their organization. This plugin can isolate machines, run virus scans, and quarantine files",
       author="rapid7",
       author_email="",
       url="",


### PR DESCRIPTION
Additional to change to existing 6.0.1 in develop to allow for the update of the product name to be "Microsoft Defender for Endpoint".

Rejigged the plugin.spec / help.md to move the set up link into troubleshooting so that running `refresh` doesn't lose any info. 