### PR TITLE
[SOAR-18528] Whois 3.1.7 Release (fedRAMP)

### DIFF
--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "bd19980a894fe29ad2516339a3668832",
+	"spec": "7e7877aeeb7f184f54f5225194b355de",
 	"manifest": "1588546a33ea7ad727ddb4da7cccf361",
 	"setup": "d096809ce9406aab15b8953507d6afe0",
 	"schemas": [

--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "4d67f7597ca0c9b43ff85bc3d161836e",
+	"spec": "bd19980a894fe29ad2516339a3668832",
 	"manifest": "1588546a33ea7ad727ddb4da7cccf361",
 	"setup": "d096809ce9406aab15b8953507d6afe0",
 	"schemas": [

--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "7e7877aeeb7f184f54f5225194b355de",
+	"spec": "d02ec7e3c36dd302c5c63a95cb53d983",
 	"manifest": "1588546a33ea7ad727ddb4da7cccf361",
 	"setup": "d096809ce9406aab15b8953507d6afe0",
 	"schemas": [

--- a/plugins/whois/.CHECKSUM
+++ b/plugins/whois/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "c321daf69a3679e488625f8dbd077985",
-	"manifest": "c35b3c929b1fa09020196cc79f5b701a",
-	"setup": "8ad9bdf0d891eb2e9bc3a2535f273e9d",
+	"spec": "4d67f7597ca0c9b43ff85bc3d161836e",
+	"manifest": "1588546a33ea7ad727ddb4da7cccf361",
+	"setup": "d096809ce9406aab15b8953507d6afe0",
 	"schemas": [
 		{
 			"identifier": "address/schema.py",

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -14,7 +14,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN python setup.py build && python setup.py install
+RUN pip install .
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.0
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.2
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/whois/Dockerfile
+++ b/plugins/whois/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.2
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.3
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/whois/bin/komand_whois
+++ b/plugins/whois/bin/komand_whois
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "WHOIS"
 Vendor = "rapid7"
-Version = "3.1.6"
+Version = "3.1.7"
 Description = "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
 
 

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -181,6 +181,7 @@ Multiple records can be returned by the server, this plugin currently only retur
 
 # Version History
 
+* 3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities
 * 3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0
 * 3.1.5 - Action `Address`: Fixed issue with result parsing
 * 3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -177,7 +177,7 @@ Example output:
 
 ## Troubleshooting
 
-Multiple records can be returned by the server, this plugin currently only returns the first unique records found.
+* Multiple records can be returned by the server, this plugin currently only returns the first unique records found.
 
 # Version History
 

--- a/plugins/whois/help.md
+++ b/plugins/whois/help.md
@@ -181,7 +181,7 @@ Example output:
 
 # Version History
 
-* 3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities
+* 3.1.7 - Updated SDK to the latest version (v6.2.3) | Address vulnerabilities | Updated `Whois` dependency
 * 3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0
 * 3.1.5 - Action `Address`: Fixed issue with result parsing
 * 3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -16,7 +16,7 @@ sdk:
   user: nobody
   packages:
     - whois
-    - git -y
+    - git
 cloud_ready: true
 fedramp_ready: true
 resources:

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: whois
 title: WHOIS
 description: "[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system"
-version: 3.1.6
+version: 3.1.7
 connection_version: 3
 vendor: rapid7
 support: community
@@ -12,7 +12,7 @@ supported_versions: ["2024-09-09"]
 status: []
 sdk:
   type: slim
-  version: 6.2.0
+  version: 6.2.2
   user: nobody
   packages:
     - whois
@@ -34,6 +34,7 @@ references: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 links: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 troubleshooting: "Multiple records can be returned by the server, this plugin currently only returns the first unique records found."
 version_history:
+  - "3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
   - "3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0"
   - "3.1.5 - Action `Address`: Fixed issue with result parsing"
   - "3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version"

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -12,7 +12,7 @@ supported_versions: ["2024-09-09"]
 status: []
 sdk:
   type: slim
-  version: 6.2.2
+  version: 6.2.3
   user: nobody
   packages:
     - whois
@@ -35,7 +35,7 @@ links: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 troubleshooting:
   - "Multiple records can be returned by the server, this plugin currently only returns the first unique records found."
 version_history:
-  - "3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
+  - "3.1.7 - Updated SDK to the latest version (v6.2.3) | Address vulnerabilities | Updated `Whois` dependency"
   - "3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0"
   - "3.1.5 - Action `Address`: Fixed issue with result parsing"
   - "3.1.4 - Initial updates for fedramp compliance | Updated SDK to the latest version"

--- a/plugins/whois/plugin.spec.yaml
+++ b/plugins/whois/plugin.spec.yaml
@@ -16,7 +16,7 @@ sdk:
   user: nobody
   packages:
     - whois
-    - git
+    - git -y
 cloud_ready: true
 fedramp_ready: true
 resources:
@@ -32,7 +32,8 @@ hub_tags:
 key_features: ["Perform a WHOIS lookup for a provided IP address or domain to gain information on who is responsible for a domain or IP"]
 references: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
 links: ["[WHOIS](https://en.wikipedia.org/wiki/WHOIS)"]
-troubleshooting: "Multiple records can be returned by the server, this plugin currently only returns the first unique records found."
+troubleshooting:
+  - "Multiple records can be returned by the server, this plugin currently only returns the first unique records found."
 version_history:
   - "3.1.7 - Updated SDK to the latest version (v6.2.2) | Address vulnerabilities"
   - "3.1.6 - Fix mapping issue (RIPE) for address action. Adding 'description' output field for RIPE (address action) | SDK bump to 6.2.0"

--- a/plugins/whois/requirements.txt
+++ b/plugins/whois/requirements.txt
@@ -3,4 +3,4 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 parameterized==0.8.1
 validators==0.34.0
-git+https://github.com/komand/python-whois.git@0.7.0
+git+https://github.com/komand/python-whois.git@0.7.1

--- a/plugins/whois/setup.py
+++ b/plugins/whois/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="whois-rapid7-plugin",
-      version="3.1.6",
+      version="3.1.7",
       description="[WHOIS](https://en.wikipedia.org/wiki/WHOIS) is a query and response protocol that is widely used for querying databases that store the registered users or assignee's of an Internet resource, such as a domain name, an IP address block, or an autonomous system",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

Wiki Page detailing the decency changes and why: https://rapid7.atlassian.net/wiki/spaces/KOMAND/pages/1337360485/Whois+fedRAMP
  - SDK bump to 6.2.3
  - Whois dependency updated
  - Plugin.spec sync

Original PR's:
- https://github.com/rapid7/insightconnect-plugins/pull/3047
- https://github.com/rapid7/insightconnect-plugins/pull/2997
- https://github.com/rapid7/insightconnect-plugins/pull/3052
- https://github.com/rapid7/insightconnect-plugins/pull/3054

Validator is expected to fail due to **CloudReady**