### PR TITLE
[SOAR-18533] Insight IDR Update Advanced Query on Log action description

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "696ad2ef53e23becbc514ade6b807b86",
-	"manifest": "447c02c4e8eff1ffc54155a48b270af3",
-	"setup": "00df4e2ab481d3954b493d8e94670fca",
+	"spec": "1c9f296df5aaa8404b7c39fd561067b7",
+	"manifest": "e39481668448008f285f6b0e8116b830",
+	"setup": "af4fa71cbbd18152bf7d3f61be3628ba",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "advanced_query_on_log/schema.py",
-			"hash": "04f457e70ed006499969f3871fd60314"
+			"hash": "0b4a760f15d71f696775bcb2aadc86c7"
 		},
 		{
 			"identifier": "advanced_query_on_log_set/schema.py",

--- a/plugins/rapid7_insightidr/Dockerfile
+++ b/plugins/rapid7_insightidr/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.2.2
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.2.4
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN python setup.py build && python setup.py install
+RUN pip install .
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "11.0.0"
+Version = "11.0.1"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -112,7 +112,8 @@ Example output:
 
 This action is used to realtime query an InsightIDR log. This will query individual logs for results. Note only 500 
 results will be returned from a single call, if all results are required for this query please use smaller timeranges. 
-If both a log name and log ID are provided, the log ID will used over the log name
+If both a log name and a log ID are provided, the log ID will be used. However, either the log name OR log ID is 
+required for the action to execute
 
 ##### Input
 
@@ -3427,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 11.0.1 - Updating `Advanced Query on Log` description
 * 11.0.0 - Updating schema for query actions (`advanced_query_on_log`, `advanced_query_on_log_set` & `query`) to account for missing keys/invalid mapping in the schema
 * 10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2
 * 10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges. If both a log name and log ID are provided, the log ID will used over the log name"
+    DESCRIPTION = "Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges. If both a log name and a log ID are provided, the log ID will be used. However, either the log name or log ID is required for the action to execute"
 
 
 class Input:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 11.0.0
+version: 11.0.1
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2024-09-10."]
 vendor: rapid7
@@ -33,9 +33,10 @@ key_features:
   - "Incident Response and Investigations"
 sdk:
   type: full
-  version: 6.2.2
+  version: 6.2.4
   user: nobody
 version_history:
+  - "11.0.1 - Updating `Advanced Query on Log` description"
   - "11.0.0 - Updating schema for query actions (`advanced_query_on_log`, `advanced_query_on_log_set` & `query`) to account for missing keys/invalid mapping in the schema"
   - "10.3.4 - Bumping requirements.txt | SDK bump to 6.2.2"
   - "10.3.3 - Bumping requirements.txt | SDK bump to 6.2.0"
@@ -1974,7 +1975,7 @@ actions:
         example: '[{"log": {"id": "0b9a242d-d2fb-4e42-8656-eb5ff64d652f","name": "Windows Defender","tokens": ["bc38a911-65f1-4755-cca3-a330a6336b3a"],"structures": ["1238a911-65f1-4755-cca3-a330a6336b3a"],"user_data": {"platform_managed": "true"},"source_type": "token","token_seed": null,"retention_period": "default","links": [{"rel": "Related","href": "https://example.com"}],"rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:log:bc38a911-65f1-4755-cca3-a330a6336b3a","logsets_info": [{"id": "bc38a911-65f1-4755-cca3-a330a6336b3a","name": "Unparsed Data","rrn": "rrn:logsearch:us:bc38a911-65f1-4755-cca3-a330a6336b3a:logset:bc38a911-65f1-4755-cca3-a330a6336b3a","links": [{"rel": "Self","href": "https://example.com/3e966a63-bf3a-4a3c-8903-979c7e90ce85"}]}]}}]'
   advanced_query_on_log:
     title: Advanced Query on Log
-    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges. If both a log name and log ID are provided, the log ID will used over the log name
+    description: Realtime query an InsightIDR log. This will query individual logs for results. Note only 500 results will be returned from a single call, if all results are required for this query please use smaller timeranges. If both a log name and a log ID are provided, the log ID will be used. However, either the log name or log ID is required for the action to execute
     input:
       query:
         title: Query

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="rapid7_insightidr-rapid7-plugin",
-      version="11.0.0",
+      version="11.0.1",
       description="This plugin allows you to add indicators to a threat and see the status of investigations",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

The advance query on log action requires either a `log name` or `log ID` to be provided for the action to run. As we allow either or, both are set to required:false as we can't specify a certain one as required in the event the other user wants to use the other input. 

This updates the description to specify that one of the fields are required for the action to run, to avoid confusion for the customer.

  - Update description for 'Advanced Query on Log' action
  - SDK bump to 6.2.4


