### PR TITLE
MS Teams Release v7.0.1 (take 2)

### DIFF
--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "1f1b06ee0e8c07231b2d8d5d9ce4f92f",
+	"spec": "3b16084861ac1ce3360a9ab684e7dcd6",
 	"manifest": "6e3a33a6892559dce7cbc5e6770d13f1",
 	"setup": "4779d39fd740747ae73079eabcfd8cd4",
 	"schemas": [

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -3,13 +3,7 @@ extension: plugin
 products: [insightconnect]
 name: microsoft_teams
 title: Microsoft Teams
-description: '[Microsoft Teams](https://products.office.com/en-us/microsoft-teams/group-chat-software)
-  is a unified communications platform that combines persistent workplace chat, video
-  meetings, file storage, and application integration. The Microsoft Teams plugin
-  allows you to send and trigger workflows on new messages. The plugin will also allow
-  for teams management with the ability to add and remove teams, channels, and users.
-  This plugin uses the [Microsoft Teams API](https://docs.microsoft.com/en-us/graph/api/resources/teams-api-overview?view=graph-rest-1.0)
-  to interact with Microsoft Teams'
+description: 'The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users'
 key_features:
 - Communication Management for all microsoft products
 requirements:


### PR DESCRIPTION
Updating the release plugin.spec to have a shorter description now that  we've discovered the description in plugin.spec is used for the overview field which has a limit of 500 characters. 

Notes:
- Validator is failing as I haven't bumped the version again
- Unit tests are failing due to an on-going issue we've noticed that something has changed in our pipelines causing unit tests to no longer like the `os.sys('..')` line. 

Original PR:
- https://github.com/rapid7/insightconnect-plugins/pull/3146

TODO:
- delete old tag / release on github as it might hit a conflict that these already exist?