### PR TITLE
Mimecast V2 continue file reading bug

### DIFF
--- a/plugins/mimecast_v2/icon_mimecast_v2/tasks/monitor_siem_logs/task.py
+++ b/plugins/mimecast_v2/icon_mimecast_v2/tasks/monitor_siem_logs/task.py
@@ -212,7 +212,7 @@ class MonitorSiemLogs(insightconnect_plugin_runtime.Task):
                     page_size=page_size,
                     max_threads=thead_count,
                     starting_url=log_type_config.get(SAVED_FILE_URL),
-                    starting_position=log_type_config.get(SAVED_FILE_POSITION),
+                    starting_position=log_type_config.get(SAVED_FILE_POSITION, 0),
                     log_size_limit=log_size_limit,
                 )
                 log_hash_size_limit = LARGE_LOG_HASH_SIZE_LIMIT if log_type == RECEIPT else SMALL_LOG_HASH_SIZE_LIMIT

--- a/plugins/mimecast_v2/icon_mimecast_v2/util/api.py
+++ b/plugins/mimecast_v2/icon_mimecast_v2/util/api.py
@@ -81,7 +81,7 @@ class API:
                         batch_logs = batch_logs[: (batch_logs_count - leftover_logs_count)]
                         logs.extend(batch_logs)
                         saved_file = self.strip_query_params(url)
-                        saved_position = len(batch_logs)
+                        saved_position = len(batch_logs) + starting_position
                         caught_up = False
                         result_next_page = next_page
                         self.logger.info(f"API: Log limit reached for log type {log_type} at {log_size_limit}")


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - If a file is saved to be read again in the next run, we store the position in that file as the number of logs read in that file. If we have to use the file in three or more runs, we start the file at the same position as the second run. By adding the previous position to the number of logs returned in this run, we can properly finish the file..

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
