### PR TITLE
[SOAR-18906] Bump `tldextract` to latest version for FIPs compliance

### DIFF
--- a/plugins/extractit/.CHECKSUM
+++ b/plugins/extractit/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "c709d22013fba7785ab3d44d9aa18fd4",
-	"manifest": "224f8748d269918219d092fc84102261",
-	"setup": "eaa749b128bef3b77aa9feebf63bd95e",
+	"spec": "1566341189f4da142d677a275e7f0534",
+	"manifest": "8480f6a4f64c7af478927d6bb7ffdba5",
+	"setup": "8378930acf54329a742b9ba3564d958d",
 	"schemas": [
 		{
 			"identifier": "cve_extractor/schema.py",

--- a/plugins/extractit/bin/icon_extractit
+++ b/plugins/extractit/bin/icon_extractit
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "ExtractIt"
 Vendor = "rapid7"
-Version = "3.0.10"
+Version = "3.0.11"
 Description = "The ExtractIt plugin is a collection of data extraction actions. This plugin allows users to extract various pieces of information from blocks of text. The pieces of information this plugin can extract include IPs, URLs, file paths, dates, domains, hashes, MAC addresses, and email addresses"
 
 

--- a/plugins/extractit/help.md
+++ b/plugins/extractit/help.md
@@ -673,6 +673,7 @@ Example output:
 
 # Version History
 
+* 3.0.11 - Updated tldextract to v5.1.3
 * 3.0.10 - Updated SDK to the latest version (6.2.5)
 * 3.0.9 - Initial updates for fedramp compliance | Updated SDK to the latest version
 * 3.0.8 - Adding in extra logic to handle wrapping of lines in pdfs

--- a/plugins/extractit/icon_extractit/util/extractor.py
+++ b/plugins/extractit/icon_extractit/util/extractor.py
@@ -257,7 +257,7 @@ def strip_subdomains(matches: list) -> list:
                 subdomains = subdomain.split(".")
                 matches[match[0]] = f"{subdomains[len(subdomains) - 1]}.{suffix}"
         else:
-            matches[match[0]] = ".".join(stripped_domain[1:3])
+            matches[match[0]] = f"{stripped_domain.domain}.{stripped_domain.suffix}"
     return list(dict.fromkeys(matches))
 
 

--- a/plugins/extractit/plugin.spec.yaml
+++ b/plugins/extractit/plugin.spec.yaml
@@ -3,8 +3,11 @@ extension: plugin
 products: [insightconnect]
 name: extractit
 title: ExtractIt
-description: The ExtractIt plugin is a collection of data extraction actions. This plugin allows users to extract various pieces of information from blocks of text. The pieces of information this plugin can extract include IPs, URLs, file paths, dates, domains, hashes, MAC addresses, and email addresses
-version: 3.0.10
+description: The ExtractIt plugin is a collection of data extraction actions. This
+  plugin allows users to extract various pieces of information from blocks of text.
+  The pieces of information this plugin can extract include IPs, URLs, file paths,
+  dates, domains, hashes, MAC addresses, and email addresses
+version: 3.0.11
 connection_version: 3
 vendor: rapid7
 support: rapid7
@@ -43,6 +46,7 @@ key_features:
 - Extract CVEs from a string or file for use in subsequent workflow actions
 - Extract all indicators from a string or file for use in subsequent workflow actions
 version_history:
+- 3.0.11 - Updated tldextract to v5.1.3
 - 3.0.10 - Updated SDK to the latest version (6.2.5)
 - 3.0.9 - Initial updates for fedramp compliance | Updated SDK to the latest version
 - 3.0.8 - Adding in extra logic to handle wrapping of lines in pdfs

--- a/plugins/extractit/requirements.txt
+++ b/plugins/extractit/requirements.txt
@@ -1,7 +1,7 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-tldextract==3.4.4
+tldextract==5.1.3
 regex==2023.8.8
 validators==0.34.0
 pdfplumber==0.11.4

--- a/plugins/extractit/setup.py
+++ b/plugins/extractit/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="extractit-rapid7-plugin",
-      version="3.0.10",
+      version="3.0.11",
       description="The ExtractIt plugin is a collection of data extraction actions. This plugin allows users to extract various pieces of information from blocks of text. The pieces of information this plugin can extract include IPs, URLs, file paths, dates, domains, hashes, MAC addresses, and email addresses",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes
Bumping to latest package of tldextract so that we are FIPs compliant. 

### Description
Describe the proposed changes:
  - Package bump
  - Latest package does allow direct access of the domain / suffix attributes like we previously did so accessing these using the attribute name


### Testing
- Tested comparing the output on 3.0.9 vs 3.0.11 and action works as expected for subdomain true/false.
- Tested deploying debug image to govcloud and it spins up without FIPs warning. 
- Unit tests passing.

Coverage is a breaking change in icon-ci tooling that needs fixed

Debug window of how the values were accessed before:
<img width="931" alt="extractit_debug" src="https://github.com/user-attachments/assets/a8c4e951-bd75-416d-bb43-4e6bec4079e3" />
