### PR TITLE
[SOAR-19013] Powershell Snyk vuln & SDK bump

### DIFF
--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "83aaad93d431da06ba5cb00715586576",
-	"manifest": "61de88b740ca64a1828d828542d76aeb",
-	"setup": "6e825188d75fce9536419c1f67bacd39",
+	"spec": "6d727a7846e1f30dc014f7a097314ba5",
+	"manifest": "a7493e0e762cb8729f7879f210126a6b",
+	"setup": "8bf6c8e3597437048722cda7f93baac1",
 	"schemas": [
 		{
 			"identifier": "execute_script/schema.py",

--- a/plugins/powershell/.CHECKSUM
+++ b/plugins/powershell/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "6d727a7846e1f30dc014f7a097314ba5",
+	"spec": "7a78a602acad865514b45891a09c9b88",
 	"manifest": "a7493e0e762cb8729f7879f210126a6b",
 	"setup": "8bf6c8e3597437048722cda7f93baac1",
 	"schemas": [

--- a/plugins/powershell/Dockerfile
+++ b/plugins/powershell/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.5
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -41,7 +41,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN python setup.py build && python setup.py install
+RUN pip install .
 
 # User to run plugin code. The two supported users are: root, nobody
 USER root

--- a/plugins/powershell/bin/icon_powershell
+++ b/plugins/powershell/bin/icon_powershell
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "PowerShell"
 Vendor = "rapid7"
-Version = "3.0.7"
+Version = "3.0.8"
 Description = "[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6) is a task-based command-line shell and scripting language from Microsoft that helps system administrators, power-users, and InsightConnect customers rapidly automate tasks that manage operating systems and processes. This plugin runs a PowerShell script on a remote host or locally on an InsightConnect Orchestrator"
 
 

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -21,7 +21,7 @@
 
 ## Setup
 
-The connection configuration accepts the following parameters. SSL is enforced for all ports except 5985:
+The connection configuration accepts the following parameters:  
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
@@ -160,11 +160,11 @@ Example output:
 * When using the Kerberos connection option the username must be a domain account that has permission to join computers to the domain.
 * This plugin can connect over HTTP, the default port for this is 5985.
 It should be noted that this type of connection is not secure as all information passed is in plain text. In addition, Windows will not allow HTTP connections by default.
-
+ 
 The following commands must be run on the Windows computer that you want to connect to.
 
 For more information see [Compromising Yourself with WinRM's AllowUnencrypted = True](https://blogs.msdn.microsoft.com/PowerShell/2015/10/27/compromising-yourself-with-winrms-allowunencrypted-true/)
-
+ 
 ```
 winrm set winrm/config/client/auth '@{Basic="true"}'
 winrm set winrm/config/service/auth '@{Basic="true"}'
@@ -176,7 +176,7 @@ This plugin will join the Komand docker instance to the Windows domain as a comp
 For the Execute Script action PowerShell code should be submitted as base64. This can be done by copying a `.txt` file with the PowerShell code into the plugin.
 
 _This plugin does not validate the PowerShell code._
-Any errors generated on the remote computer by the PowerShell code are forwarded to the log file.
+ Any errors generated on the remote computer by the PowerShell code are forwarded to the log file.
 
 Run this PowerShell command on a Windows host first to set up a unsigned certificate for authentication:
 This will not be needed if the host already has a SSL certificate set up for Winrm
@@ -184,9 +184,11 @@ This will not be needed if the host already has a SSL certificate set up for Win
 ```
 Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))
 ```
+* SSL is not configured for port `5985`
 
 # Version History
 
+* 3.0.8 - Updated SDK to the latest version (6.2.5) | bumping `cryptography` package
 * 3.0.7 - Updated dependencies | Updated SDK to the latest version
 * 3.0.6 - Bump SDK to 6.2.0
 * 3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that the use of round-robin DNS lookups is not supported

--- a/plugins/powershell/help.md
+++ b/plugins/powershell/help.md
@@ -188,7 +188,7 @@ Invoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw
 
 # Version History
 
-* 3.0.8 - Updated SDK to the latest version (6.2.5) | bumping `cryptography` package
+* 3.0.8 - Updated clean message | Updated SDK to the latest version (6.2.5) | bumping `cryptography` package
 * 3.0.7 - Updated dependencies | Updated SDK to the latest version
 * 3.0.6 - Bump SDK to 6.2.0
 * 3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that the use of round-robin DNS lookups is not supported

--- a/plugins/powershell/icon_powershell/util/util.py
+++ b/plugins/powershell/icon_powershell/util/util.py
@@ -12,7 +12,7 @@ class FixWinrmSession(winrm.Session):
         encoded_ps = base64.b64encode(script.encode("utf_16_le")).decode("ascii")
         rs = self.run_cmd(f"powershell -encodedcommand {encoded_ps}")
         if len(rs.std_err):
-            rs.std_err = self._clean_error_msg(rs.std_err.decode(DECODING_TYPE))
+            rs.std_err = self._clean_error_msg(rs.std_err)
         return rs
 
 

--- a/plugins/powershell/plugin.spec.yaml
+++ b/plugins/powershell/plugin.spec.yaml
@@ -112,7 +112,7 @@ troubleshooting:
   ```"
 - SSL is not configured for port `5985`
 version_history:
-- 3.0.8 - Updated SDK to the latest version (6.2.5) | bumping `cryptography` package
+- 3.0.8 - Updated clean message | Updated SDK to the latest version (6.2.5) | bumping `cryptography` package
 - 3.0.7 - Updated dependencies | Updated SDK to the latest version
 - 3.0.6 - Bump SDK to 6.2.0
 - 3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that

--- a/plugins/powershell/plugin.spec.yaml
+++ b/plugins/powershell/plugin.spec.yaml
@@ -3,57 +3,67 @@ extension: plugin
 products: [insightconnect]
 name: powershell
 title: PowerShell
-description: "[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6) is a task-based command-line shell and scripting language from Microsoft that helps system administrators, power-users, and InsightConnect customers rapidly automate tasks that manage operating systems and processes. This plugin runs a PowerShell script on a remote host or locally on an InsightConnect Orchestrator"
-version: 3.0.7
+description: '[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6)
+  is a task-based command-line shell and scripting language from Microsoft that helps
+  system administrators, power-users, and InsightConnect customers rapidly automate
+  tasks that manage operating systems and processes. This plugin runs a PowerShell
+  script on a remote host or locally on an InsightConnect Orchestrator'
+version: 3.0.8
 connection_version: 3
 key_features:
-  - "Run a PowerShell script to manage (remote) computers from the command line"
+- Run a PowerShell script to manage (remote) computers from the command line
 requirements:
-  - "For local Orchestrator execution, ensure connectivity to any network resources the script will use"
-  - "For remote server execution, a PowerShell-enabled server and administrative credentials"
-  - "When adding a password for the script, try to avoid special or escape characters such as single or double quotes"
-  - "The use of round-robin DNS lookups is not supported"
+- For local Orchestrator execution, ensure connectivity to any network resources the
+  script will use
+- For remote server execution, a PowerShell-enabled server and administrative credentials
+- When adding a password for the script, try to avoid special or escape characters
+  such as single or double quotes
+- The use of round-robin DNS lookups is not supported
 sdk:
   type: slim
-  version: 6.2.3
+  version: 6.2.5
   user: root
   custom_cmd:
-    - "# Add any package dependencies here"
-    - ENV DEBIAN_FRONTEND noninteractive
-    - "# Kerberos dependencies"
-    - "RUN apt-get update && apt-get install -y \\"
-    - "    apt-transport-https \\"
-    - "    curl \\"
-    - "    gcc python-dev libkrb5-dev \\"
-    - "    git \\"
-    - "    gnupg \\"
-    - "    krb5-user \\"
-    - "    libssl1.1 \\"
-    - "    ntp adcli sssd \\"
-    - "    samba-common \\"
-    - "    software-properties-common \\"
-    - "    sudo \\"
-    - "    realmd \\"
-    - "    wget"
-    - ""
-    - "# Local PowerShell dependencies"
-    - 'RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" | sudo tee -a /etc/apt/sources.list.d/bionic.list && \'
-    - "    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32 && sudo apt-get update && apt-cache policy libssl1.0-dev && \\"
-    - "    sudo apt-get install -y libssl1.0-dev && \\"
-    - "    wget http://mirrors.kernel.org/ubuntu/pool/main/i/icu/libicu52_52.1-3ubuntu0.8_amd64.deb && \\"
-    - "    sudo apt install -y ./libicu52_52.1-3ubuntu0.8_amd64.deb && \\"
-    - "    rm ./libicu52_52.1-3ubuntu0.8_amd64.deb && \\"
-    - "    wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/powershell_7.4.6-1.deb_amd64.deb && \\"
-    - "    sudo apt install -y ./powershell_7.4.6-1.deb_amd64.deb && \\"
-    - "    rm ./powershell_7.4.6-1.deb_amd64.deb"
+  - '# Add any package dependencies here'
+  - ENV DEBIAN_FRONTEND noninteractive
+  - '# Kerberos dependencies'
+  - RUN apt-get update && apt-get install -y \
+  - '    apt-transport-https \'
+  - '    curl \'
+  - '    gcc python-dev libkrb5-dev \'
+  - '    git \'
+  - '    gnupg \'
+  - '    krb5-user \'
+  - '    libssl1.1 \'
+  - '    ntp adcli sssd \'
+  - '    samba-common \'
+  - '    software-properties-common \'
+  - '    sudo \'
+  - '    realmd \'
+  - '    wget'
+  - ''
+  - '# Local PowerShell dependencies'
+  - RUN echo "deb http://security.ubuntu.com/ubuntu bionic-security main" | sudo tee
+    -a /etc/apt/sources.list.d/bionic.list && \
+  - '    sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 3B4FE6ACC0B21F32
+    && sudo apt-get update && apt-cache policy libssl1.0-dev && \'
+  - '    sudo apt-get install -y libssl1.0-dev && \'
+  - '    wget http://mirrors.kernel.org/ubuntu/pool/main/i/icu/libicu52_52.1-3ubuntu0.8_amd64.deb
+    && \'
+  - '    sudo apt install -y ./libicu52_52.1-3ubuntu0.8_amd64.deb && \'
+  - '    rm ./libicu52_52.1-3ubuntu0.8_amd64.deb && \'
+  - '    wget https://github.com/PowerShell/PowerShell/releases/download/v7.4.6/powershell_7.4.6-1.deb_amd64.deb
+    && \'
+  - '    sudo apt install -y ./powershell_7.4.6-1.deb_amd64.deb && \'
+  - '    rm ./powershell_7.4.6-1.deb_amd64.deb'
 links:
-  - "[InsightConnect Powershell Plugin Guide](https://docs.rapid7.com/insightconnect/mass-delete-with-PowerShell/)"
+- '[InsightConnect Powershell Plugin Guide](https://docs.rapid7.com/insightconnect/mass-delete-with-PowerShell/)'
 references:
-  - "[pywinrm library](https://pypi.python.org/pypi/pywinrm)"
-  - "[samba-common](https://packages.debian.org/sid/samba-common)"
-  - "[krb5-user](https://packages.debian.org/search?keywords=krb5-user)"
-  - "[realmd](https://packages.debian.org/jessie/admin/realmd)"
-supported_versions: ["PowerShell 7.4.6"]
+- '[pywinrm library](https://pypi.python.org/pypi/pywinrm)'
+- '[samba-common](https://packages.debian.org/sid/samba-common)'
+- '[krb5-user](https://packages.debian.org/search?keywords=krb5-user)'
+- '[realmd](https://packages.debian.org/jessie/admin/realmd)'
+supported_versions: [PowerShell 7.4.6]
 vendor: rapid7
 support: community
 status: []
@@ -63,44 +73,76 @@ resources:
   vendor_url: https://www.microsoft.com
   docs_url: https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/
 tags:
-  - powershell
-  - microsoft
+- powershell
+- microsoft
 hub_tags:
   use_cases: [data_utility]
   keywords: [powershell, microsoft]
   features: []
 troubleshooting:
-  - "The use of round-robin DNS lookups is not supported"
-  - "If Auth Type is set to \"None\" the PowerShell script will execute locally on the Komand host. This can also be accomplished by leaving the address field blank."
-  - "The username supplied must have local admin privileges on the remote host Windows computer."
-  - "When using a domain account with NTLM the username must be in the following format MYDOMAIN\\username"
-  - "When using the Kerberos connection option the username must be a domain account that has permission to join computers to the domain."
-  - "This plugin can connect over HTTP, the default port for this is 5985.\nIt should be noted that this type of connection is not secure as all information passed is in plain text. In addition, Windows will not allow HTTP connections by default.\n\nThe following commands must be run on the Windows computer that you want to connect to.\n\nFor more information see [Compromising Yourself with WinRM's AllowUnencrypted = True](https://blogs.msdn.microsoft.com/PowerShell/2015/10/27/compromising-yourself-with-winrms-allowunencrypted-true/)\n\n```\nwinrm set winrm/config/client/auth '@{Basic=\"true\"}'\nwinrm set winrm/config/service/auth '@{Basic=\"true\"}'\nwinrm set winrm/config/service '@{AllowUnencrypted=\"true\"}'\n```\n"
-  - "When using the Kerberos connection option, the username should not include an @example.com or other domain identifier. These will be added by the plugin as needed.\nThis plugin will join the Komand docker instance to the Windows domain as a computer if the Kerberos option is used.\nFor the Execute Script action PowerShell code should be submitted as base64. This can be done by copying a `.txt` file with the PowerShell code into the plugin.\n\n_This plugin does not validate the PowerShell code._\nAny errors generated on the remote computer by the PowerShell code are forwarded to the log file.\n\nRun this PowerShell command on a Windows host first to set up a unsigned certificate for authentication:\nThis will not be needed if the host already has a SSL certificate set up for Winrm\n\n```\nInvoke-Expression ((New-Object System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))\n```"
+- The use of round-robin DNS lookups is not supported
+- If Auth Type is set to "None" the PowerShell script will execute locally on the
+  Komand host. This can also be accomplished by leaving the address field blank.
+- The username supplied must have local admin privileges on the remote host Windows
+  computer.
+- When using a domain account with NTLM the username must be in the following format
+  MYDOMAIN\username
+- When using the Kerberos connection option the username must be a domain account
+  that has permission to join computers to the domain.
+- "This plugin can connect over HTTP, the default port for this is 5985.\nIt should
+  be noted that this type of connection is not secure as all information passed is
+  in plain text. In addition, Windows will not allow HTTP connections by default.\n
+  \nThe following commands must be run on the Windows computer that you want to connect
+  to.\n\nFor more information see [Compromising Yourself with WinRM's AllowUnencrypted
+  = True](https://blogs.msdn.microsoft.com/PowerShell/2015/10/27/compromising-yourself-with-winrms-allowunencrypted-true/)\n
+  \n```\nwinrm set winrm/config/client/auth '@{Basic=\"true\"}'\nwinrm set winrm/config/service/auth
+  '@{Basic=\"true\"}'\nwinrm set winrm/config/service '@{AllowUnencrypted=\"true\"\
+  }'\n```\n"
+- "When using the Kerberos connection option, the username should not include an @example.com
+  or other domain identifier. These will be added by the plugin as needed.\nThis plugin
+  will join the Komand docker instance to the Windows domain as a computer if the
+  Kerberos option is used.\nFor the Execute Script action PowerShell code should be
+  submitted as base64. This can be done by copying a `.txt` file with the PowerShell
+  code into the plugin.\n\n_This plugin does not validate the PowerShell code._\n
+  Any errors generated on the remote computer by the PowerShell code are forwarded
+  to the log file.\n\nRun this PowerShell command on a Windows host first to set up
+  a unsigned certificate for authentication:\nThis will not be needed if the host
+  already has a SSL certificate set up for Winrm\n\n```\nInvoke-Expression ((New-Object
+  System.Net.Webclient).DownloadString('https://raw.githubusercontent.com/ansible/ansible/devel/examples/scripts/ConfigureRemotingForAnsible.ps1'))\n\
+  ```"
+- SSL is not configured for port `5985`
 version_history:
-  - "3.0.7 - Updated dependencies | Updated SDK to the latest version"
-  - "3.0.6 - Bump SDK to 6.2.0"
-  - "3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that the use of round-robin DNS lookups is not supported"
-  - "3.0.4 - Upgrade user from `nobody` to `root` | bump SDK to 6.0.1 and switch back to `Bullseye` based SDK image"
-  - "3.0.3 - Fix decoding error in `Execute Script` action | Update SDK | Update packages for alpine image"
-  - "3.0.2 - Updated the SDK version to include output masking | Updated all the dependencies to the newest versions"
-  - "3.0.1 - Bug fix - Fix issue where single quotes in password causes parsing error"
-  - "3.0.0 - Move custom script credentials to Connection | Update runtime to insightconnect_plugin_runtime"
-  - "2.2.0 - Add custom credentials in Execute Script and PowerShell String actions | Update plugin to allow unencrypted connections when connection is targeting port 5985"
-  - "2.1.4 - Update `docs_url` in plugin spec with a new link to [plugin setup guide](https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/)"
-  - "2.1.3 - Correct spelling in help.md"
-  - "2.1.2 - Add `docs_url` to plugin spec with link to [plugin setup guide](https://insightconnect.help.rapid7.com/docs/mass-delete-with-powershell)"
-  - "2.1.1 - New spec and help.md format for the Extension Library"
-  - "2.1.0 - Add functionality to allow CredSSP connections"
-  - "2.0.1 - Fix issue with unicode characters"
-  - "2.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update to new credential types"
-  - "1.1.0 - Add functionality to allow PowerShell to execute locally"
-  - "1.0.2 - Bug fix for NTLM version `stdout` output property name in String action"
-  - "1.0.1 - Bug fix for `stdout` output property name in String action"
-  - "1.0.0 - Updated PyWinrm, bugfixes, add PowerShell String action"
-  - "0.2.1 - Bug fix and improved error handling"
-  - "0.2.0 - Allow connections on a Windows domain with Kerberos"
-  - "0.1.0 - Initial plugin"
+- 3.0.8 - Updated SDK to the latest version (6.2.5) | bumping `cryptography` package
+- 3.0.7 - Updated dependencies | Updated SDK to the latest version
+- 3.0.6 - Bump SDK to 6.2.0
+- 3.0.5 - Bump requirements.txt | Bump SDK to 6.1.4 | Update help.md to enforce that
+  the use of round-robin DNS lookups is not supported
+- 3.0.4 - Upgrade user from `nobody` to `root` | bump SDK to 6.0.1 and switch back
+  to `Bullseye` based SDK image
+- 3.0.3 - Fix decoding error in `Execute Script` action | Update SDK | Update packages
+  for alpine image
+- 3.0.2 - Updated the SDK version to include output masking | Updated all the dependencies
+  to the newest versions
+- 3.0.1 - Bug fix - Fix issue where single quotes in password causes parsing error
+- 3.0.0 - Move custom script credentials to Connection | Update runtime to insightconnect_plugin_runtime
+- 2.2.0 - Add custom credentials in Execute Script and PowerShell String actions |
+  Update plugin to allow unencrypted connections when connection is targeting port
+  5985
+- 2.1.4 - Update `docs_url` in plugin spec with a new link to [plugin setup guide](https://docs.rapid7.com/insightconnect/mass-delete-with-powershell/)
+- 2.1.3 - Correct spelling in help.md
+- 2.1.2 - Add `docs_url` to plugin spec with link to [plugin setup guide](https://insightconnect.help.rapid7.com/docs/mass-delete-with-powershell)
+- 2.1.1 - New spec and help.md format for the Extension Library
+- 2.1.0 - Add functionality to allow CredSSP connections
+- 2.0.1 - Fix issue with unicode characters
+- 2.0.0 - Update to v2 Python plugin architecture | Support web server mode | Update
+  to new credential types
+- 1.1.0 - Add functionality to allow PowerShell to execute locally
+- 1.0.2 - Bug fix for NTLM version `stdout` output property name in String action
+- 1.0.1 - Bug fix for `stdout` output property name in String action
+- 1.0.0 - Updated PyWinrm, bugfixes, add PowerShell String action
+- 0.2.1 - Bug fix and improved error handling
+- 0.2.0 - Allow connections on a Windows domain with Kerberos
+- 0.1.0 - Initial plugin
 enable_cache: false
 language: python
 types:
@@ -136,10 +178,10 @@ connection:
     description: Authentication type
     type: string
     enum:
-      - NTLM
-      - Kerberos
-      - CredSSP
-      - None
+    - NTLM
+    - Kerberos
+    - CredSSP
+    - None
     default: None
     required: true
     example: Kerberos
@@ -151,13 +193,15 @@ connection:
     example: '{"kdc": "10.0.1.11", "domain": "EXAMPLE.domain"}'
   script_secret_key:
     title: Script Secret Key
-    description: Credential secret key available in script as PowerShell variable (`$secret_key`)
+    description: Credential secret key available in script as PowerShell variable
+      (`$secret_key`)
     type: credential_secret_key
     required: false
     example: 9de5069c5afe602b2ea0a04b66beb2c0
   script_username_and_password:
     title: Script Username and Password
-    description: Username and password available in script as PowerShell variables (`$username`, `$password`)
+    description: Username and password available in script as PowerShell variables
+      (`$username`, `$password`)
     type: credential_username_password
     required: false
     example: '{"username": "user", "password": "mypassword"}'
@@ -168,7 +212,8 @@ actions:
     input:
       script:
         title: Script
-        description: PowerShell script as base64. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection
+        description: PowerShell script as base64. In this action you can use `$username`,
+          `$password`, `$secret_key` variables if defined in connection
         type: bytes
         required: true
         example: R2V0LURhdGU=
@@ -198,14 +243,15 @@ actions:
         description: PowerShell standard error
         type: string
         required: false
-        example: "Fatal error." 
+        example: Fatal error.
   powershell_string:
     title: PowerShell String
     description: Execute PowerShell script in the form of a string
     input:
       script:
         title: Script
-        description: PowerShell script as a string. In this action you can use `$username`, `$password`, `$secret_key` variables if defined in connection
+        description: PowerShell script as a string. In this action you can use `$username`,
+          `$password`, `$secret_key` variables if defined in connection
         type: string
         required: true
         example: Get-Date
@@ -235,4 +281,4 @@ actions:
         description: PowerShell standard error
         type: string
         required: false
-        example: "Fatal error."
+        example: Fatal error.

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -1,9 +1,9 @@
 # List third-party dependencies here, separated by newlines. 
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-pywinrm==0.5.0
+pywinrm[kerberos]==0.5.0
 requests-kerberos==0.15.0
 requests-credssp==2.0.0
-requests==2.32.3
+parameterized==0.9.0
 cryptography==44.0.1
 idna==3.10

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -4,7 +4,6 @@
 pywinrm==0.5.0
 requests-kerberos==0.15.0
 requests-credssp==2.0.0
-parameterized==0.8.1
 requests==2.32.3
-cryptography==44.0.0
+cryptography==44.0.1
 idna==3.10

--- a/plugins/powershell/requirements.txt
+++ b/plugins/powershell/requirements.txt
@@ -5,5 +5,6 @@ pywinrm[kerberos]==0.5.0
 requests-kerberos==0.15.0
 requests-credssp==2.0.0
 parameterized==0.9.0
+requests==2.32.3
 cryptography==44.0.1
 idna==3.10

--- a/plugins/powershell/setup.py
+++ b/plugins/powershell/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 
 setup(name="powershell-rapid7-plugin",
-      version="3.0.7",
+      version="3.0.8",
       description="[PowerShell](https://docs.microsoft.com/en-us/powershell/scripting/overview?view=powershell-6) is a task-based command-line shell and scripting language from Microsoft that helps system administrators, power-users, and InsightConnect customers rapidly automate tasks that manage operating systems and processes. This plugin runs a PowerShell script on a remote host or locally on an InsightConnect Orchestrator",
       author="rapid7",
       author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

The `cryptography` package has introduced a snyk vulnerability, this will bump it to the latest version. 

The following text was originally mentioned in the setup section within the help.md but there is no way to alter this in the plugin.spec so not be deleted when running `refresh` so I have reworded it and added it under troubleshooting:

SSL is `configured for all ports except 5985`-> `SSL is not configured for port 5985`

  - Bumping `cryptography` package
  - SDK bump to 6.2.5


### Testing

Snyk test after bumping cryptography:
<img width="1082" alt="image" src="https://github.com/user-attachments/assets/3104b5de-a690-4603-9e4a-d68a52730acd" />


#### Unit Tests

<img width="1128" alt="image" src="https://github.com/user-attachments/assets/456a4b5e-23c1-4362-963a-7a9b7e232c8e" />