### PR TITLE
Advanced Regex - (SDK Automation prep)

### DIFF
--- a/plugins/advanced_regex/.CHECKSUM
+++ b/plugins/advanced_regex/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "6bee222090075470d4cf287e74857113",
-	"manifest": "a4a60a936d84bf95984315779ecdf960",
-	"setup": "a05182f1000be90d1e136294814df647",
+	"spec": "9cc3daad10a3bdf81205688c90f4908f",
+	"manifest": "0c6732a253c8ad369dc57aade1692b9f",
+	"setup": "1e567e4cd92ea225c6277889a3affaa4",
 	"schemas": [
 		{
 			"identifier": "data_extraction/schema.py",
-			"hash": "428193756350c4a3e660d57c649bab94"
+			"hash": "1a2216f85950075d68066e4972f28c1e"
 		},
 		{
 			"identifier": "replace/schema.py",

--- a/plugins/advanced_regex/Dockerfile
+++ b/plugins/advanced_regex/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.1.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.2.5
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -12,7 +12,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ADD . /python/src
 
-RUN python setup.py build && python setup.py install
+RUN pip install .
 
 # User to run plugin code. The two supported users are: root, nobody
 USER nobody

--- a/plugins/advanced_regex/bin/icon_advanced_regex
+++ b/plugins/advanced_regex/bin/icon_advanced_regex
@@ -6,8 +6,8 @@ from sys import argv
 
 Name = "Advanced Regex"
 Vendor = "rapid7"
-Version = "1.0.4"
-Description = "Perform advanced regular expression operations on a string using Python regex"
+Version = "1.0.5"
+Description = "The Advanced Regex plugin is used to extract or manipulate targeted text using regular expressions operations on a string using Python specific regex"
 
 
 def main():

--- a/plugins/advanced_regex/help.md
+++ b/plugins/advanced_regex/help.md
@@ -1,6 +1,6 @@
 # Description
 
-The Advanced Regex plugin is used to extract or manipulate targeted text using regular expressions operations on a string using Python specific regex.
+The Advanced Regex plugin is used to extract or manipulate targeted text using regular expressions operations on a string using Python specific regex
 
 # Key Features
 
@@ -182,6 +182,7 @@ Example output:
 
 # Version History
 
+* 1.0.5 - Updated SDK to the latest version (6.2.5)
 * 1.0.4 - Initial updates for fedramp compliance | Updated SDK to the latest version
 * 1.0.3 - Update to make replace string non-required
 * 1.0.2 - Update to v4 Python plugin runtime | Add example inputs

--- a/plugins/advanced_regex/plugin.spec.yaml
+++ b/plugins/advanced_regex/plugin.spec.yaml
@@ -3,20 +3,22 @@ extension: plugin
 products: [insightconnect]
 name: advanced_regex
 title: Advanced Regex
-description: Perform advanced regular expression operations on a string using Python regex
-version: 1.0.4
+description: The Advanced Regex plugin is used to extract or manipulate targeted text
+  using regular expressions operations on a string using Python specific regex
+version: 1.0.5
 connection_version: 1
 support: community
-supported_versions: ["2024-10-01"]
+supported_versions: ['2024-10-01']
 fedramp_ready: true
 vendor: rapid7
 status: []
 resources:
-  source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/advanced_regex
+  source_url: 
+    https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/advanced_regex
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
 tags:
-  - data manipulation
-  - utility
+- data manipulation
+- utility
 hub_tags:
   use_cases: [data_utility]
   keywords: [data manipulation, utility]
@@ -25,22 +27,23 @@ enable_cache: true
 language: python
 sdk:
   type: slim
-  version: 6.1.3
+  version: 6.2.5
   user: nobody
 key_features:
-  - Data extraction
-  - Search and replace text
-  - Split text
+- Data extraction
+- Search and replace text
+- Split text
 version_history:
-  - "1.0.4 - Initial updates for fedramp compliance | Updated SDK to the latest version"
-  - "1.0.3 - Update to make replace string non-required"
-  - "1.0.2 - Update to v4 Python plugin runtime | Add example inputs"
-  - "1.0.1 - New spec and help.md format for the Extension Library"
-  - "1.0.0 - Initial plugin"
+- 1.0.5 - Updated SDK to the latest version (6.2.5)
+- 1.0.4 - Initial updates for fedramp compliance | Updated SDK to the latest version
+- 1.0.3 - Update to make replace string non-required
+- 1.0.2 - Update to v4 Python plugin runtime | Add example inputs
+- 1.0.1 - New spec and help.md format for the Extension Library
+- 1.0.0 - Initial plugin
 links:
-  - "[Python Regex](https://docs.python.org/library/re.html)"
+- '[Python Regex](https://docs.python.org/library/re.html)'
 references:
-  - "[Python Regex](https://docs.python.org/library/re.html)"
+- '[Python Regex](https://docs.python.org/library/re.html)'
 actions:
   data_extraction:
     title: Data Extraction
@@ -51,13 +54,14 @@ actions:
         description: Input string
         type: string
         required: true
-        example: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sapien ex, lorems odales"
+        example: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
+          sapien ex, lorems odales
       in_regex:
         title: Regex
         description: Regex to use for data extraction
         type: string
         required: true
-        example: "lorem"
+        example: lorem
       ignorecase:
         title: Ignore Case
         description: Make regex non-case sensitive
@@ -90,7 +94,7 @@ actions:
       matches:
         title: Matches
         description: An array of string arrays matching the output of Python re.findall()
-        type: "[][]string"
+        type: '[][]string'
         required: true
         example: '[["lorem"]]'
   replace:
@@ -102,19 +106,20 @@ actions:
         description: Input string
         type: string
         required: true
-        example: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sapien ex, lorems odales"
+        example: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
+          sapien ex, lorems odales
       replace_string:
         title: New String
         description: The string to replace matches with
         type: string
         required: false
-        example: "REPLACED"
+        example: REPLACED
       in_regex:
         title: Regex
         description: Regex to match
         type: string
         required: true
-        example: "lorem"
+        example: lorem
       max_replace:
         title: Max Replace
         description: Max occurrences to replace - if zero all will be replaced
@@ -156,7 +161,8 @@ actions:
         description: The result of the replace operation
         type: string
         required: true
-        example: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sapien ex, REPLACEDs odales"
+        example: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
+          sapien ex, REPLACEDs odales
   split:
     title: Split by Regex
     description: Split a string into array using regex
@@ -166,13 +172,14 @@ actions:
         description: Input string
         type: string
         required: true
-        example: "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sapien ex, lorems odales sed"
+        example: Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
+          sapien ex, lorems odales sed
       in_regex:
         title: Regex
         description: Regex to split string on matches
         type: string
         required: true
-        example: "lorem"
+        example: lorem
       max_split:
         title: Max Split
         description: Max splits - if non-zero last element is remainder of string
@@ -212,6 +219,7 @@ actions:
       result:
         title: Result Strings
         description: An array of the strings returned by the split operation
-        type: "[]string"
+        type: '[]string'
         required: true
-        example: '["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam sapien ex, ", "s odales sed"]'
+        example: '["Lorem ipsum dolor sit amet, consectetur adipiscing elit. Aliquam
+          sapien ex, ", "s odales sed"]'

--- a/plugins/advanced_regex/setup.py
+++ b/plugins/advanced_regex/setup.py
@@ -3,8 +3,8 @@ from setuptools import setup, find_packages
 
 
 setup(name="advanced_regex-rapid7-plugin",
-      version="1.0.4",
-      description="Perform advanced regular expression operations on a string using Python regex",
+      version="1.0.5",
+      description="The Advanced Regex plugin is used to extract or manipulate targeted text using regular expressions operations on a string using Python specific regex",
       author="rapid7",
       author_email="",
       url="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - SDK bump to 6.2.5
  - spec file refactor

At the moment, when we run refresh it will change the schema file for the `data_extraction` action to remove the need for `[][]`. When testing locally, I seen that it does need to support [][] as the output for groups are in their own array within an array:

```
"output": {
            "matches": [
                [
                    "startTime:1739447174230\n",
                    "1739447174230"
                ],
                [
                    "startTime:9999999999999",
                    "9999999999999"
                ]
            ]
        }
```

This will require the tooling to be updated to allow for the support of `[][]` but at the moment this needs to be manually reverted back and MD5 ran on it to ensure the CHECKSUM is up to date.

![image](https://github.com/user-attachments/assets/32cc852a-5ae9-46c2-b6e2-931ee0c1777d)
