### PR TITLE
[SOAR-19079] Update Linter check

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -4,19 +4,19 @@ on: [push]
 
 jobs:
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - name: Set up Python 3.9
-        uses: actions/setup-python@v4
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.11'
       - name: Install dependencies
         run: |
-          pip install black==22.3.0
+          pip install black==24.10.0
       - name: Lint
         run: |
           CHANGED_FILES=()

--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -6,17 +6,32 @@ jobs:
   lint:
     runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@v1
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set up Python 3.9
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
-
+          python-version: '3.9'
       - name: Install dependencies
         run: |
           pip install black==22.3.0
-
       - name: Lint
         run: |
-          black . --check
+          CHANGED_FILES=()
+          for OUTPUT in $(git diff --no-commit-id --name-only --no-renames HEAD..origin/master)
+          do
+            if [[ -f ${OUTPUT} ]] && [[ ${OUTPUT} == *.py ]]
+            then
+              echo "${OUTPUT}"
+              CHANGED_FILES+=( ${OUTPUT} )
+            fi
+          done
+          
+          if ! [[ ${#CHANGED_FILES[*]} == 0 ]]
+          then
+            echo ${CHANGED_FILES[*]} | xargs black --check
+          else
+            echo "No Python files were changed."
+          fi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,4 @@
 [tool.black]
 line-length = 120
 target-version = ['py36', 'py37', 'py38']
-exclude = '(schema.py|setup.py|__init__.py|ec2_investigations)'
+exclude = '(ec2_investigations)'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,4 +1,0 @@
-[tool.black]
-line-length = 120
-target-version = ['py36', 'py37', 'py38']
-exclude = '(ec2_investigations)'


### PR DESCRIPTION
## Proposed Changes

### Description

At the moment, the linter check runs different on **insightconnect-plugins** vs **komand-plugins**. This repo currently runs the check via `black . --check` whereas **komand-plugins** runs it on `CHANGED_FILES=()`. 

From testing it is clear that **insightconnect-plugins** does not detect files which require black changes due to this check whereas **komand-plugins** does. This PR will have the 2 checks in sync. I am currently making an update to the tooling which will add functionality into the refresh function to allow us to ensure we are always passing the linter without manually needing to run black and MD5.

PR for komand-plugins: https://github.com/rapid7/komand-plugins/pull/2138

Describe the proposed changes:

  - Update Linter check
