### PR TITLE
Fixing Linter check for 120 char

### DIFF
--- a/.github/workflows/black.yml
+++ b/.github/workflows/black.yml
@@ -31,7 +31,7 @@ jobs:
           
           if ! [[ ${#CHANGED_FILES[*]} == 0 ]]
           then
-            echo ${CHANGED_FILES[*]} | xargs black --check
+            echo ${CHANGED_FILES[*]} | xargs black --check --line-length 120
           else
             echo "No Python files were changed."
           fi


### PR DESCRIPTION
## Proposed Changes

### Description

Linter check defaults to 88 char which is not is inline with the 120 character length we have changed to. This will enforce this.

Describe the proposed changes:

  - Change to 120 char check

