### PR TITLE
[NO-TICKET] Adding NotMalicious value within determination field - update_incidents

### DIFF
--- a/plugins/microsoft_defender_incidents/.CHECKSUM
+++ b/plugins/microsoft_defender_incidents/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "1e2686e494af8930c85edb77d7756b7f",
-	"manifest": "ea28fec7a9622ed873dfaedbce912923",
-	"setup": "aa42c6b3c34412de11997c20462acd93",
+	"spec": "89e8980596925b03e5e2f84c756f0ea2",
+	"manifest": "65d1ab400f96032324aa0b7a9f3aee4d",
+	"setup": "552c14e7907c0255abab65ffa8e3e6a4",
 	"schemas": [
 		{
 			"identifier": "get_incident/schema.py",
@@ -13,11 +13,11 @@
 		},
 		{
 			"identifier": "update_incident/schema.py",
-			"hash": "fc36d830fdbc5c22126ee2ee274ef331"
+			"hash": "c9577f84306fcb4c0374f7a4b0ba2650"
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "06f8237f2dc293743c8fbf08f7847751"
+			"hash": "1fba79e4a92c59e9ee16261fa4d3f231"
 		},
 		{
 			"identifier": "get_new_incidents/schema.py",

--- a/plugins/microsoft_defender_incidents/bin/icon_microsoft_defender_incidents
+++ b/plugins/microsoft_defender_incidents/bin/icon_microsoft_defender_incidents
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Defender Incidents"
 Vendor = "rapid7"
-Version = "2.0.2"
+Version = "2.0.3"
 Description = "Manage security incidents with Microsoft Defender 365"
 
 

--- a/plugins/microsoft_defender_incidents/help.md
+++ b/plugins/microsoft_defender_incidents/help.md
@@ -26,7 +26,7 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |client_id|string|None|True|The application ID that the application registration portal assigned to your app|None|5cdad72f-c848-4df0-8aaa-ffe033e75d57|None|None|
-|client_secret|credential_secret_key|None|True|The application secret that you generated for your app in the appregistration portal|None|5cdad72f-c848-4df0-8aaa-ffe033e75d57|None|None|
+|client_secret|credential_secret_key|None|True|The application secret that you generated for your app in the app registration portal|None|5cdad72f-c848-4df0-8aaa-ffe033e75d57|None|None|
 |tenant_id|string|None|True|This is the Active Directory ID|None|5cdad72f-c848-4df0-8aaa-ffe033e75d57|None|None|
 
 Example input:
@@ -233,7 +233,7 @@ This action is used to updates specific incident by ID
 |assignedTo|string|None|False|Owner of the incident|None|ExampleOwner|None|None|
 |classification|string|None|False|Incident's classification|["", "TruePositive", "FalsePositive", "InformationalExpectedActivity"]|TruePositive|None|None|
 |comments|string|None|False|Comment to be added to the incident|None|Example Comment|None|None|
-|determination|string|None|False|Specifies the determination of the incident|["", "MultiStagedAttack", "MaliciousUserActivity", "CompromisedAccount", "Malware", "Phishing", "UnwantedSoftware", "SecurityTesting", "LineOfBusinessApplication", "NoEnoughDataToValidate", "ConfirmedActivity", "Other"]|Phishing|None|None|
+|determination|string|None|False|Specifies the determination of the incident|["", "MultiStagedAttack", "MaliciousUserActivity", "CompromisedAccount", "Malware", "Phishing", "UnwantedSoftware", "SecurityTesting", "LineOfBusinessApplication", "NoEnoughDataToValidate", "ConfirmedActivity", "Other", "NotMalicious"]|Phishing|None|None|
 |identifier|integer|None|True|Incident's ID|None|1|None|None|
 |status|string|None|False|Specifies the current status of incidents to show|["", "Active", "Resolved", "Redirected", "InProgress"]|Active|None|None|
 |tags|[]string|None|False|List of incident tags|None|["Tag1", "Tag2"]|None|None|
@@ -264,7 +264,7 @@ Example input:
 |classification|string|True|Specification for the incident, where possible values are - InformationalExpectedActivity, FalsePositive, and TruePositive|TruePositive|
 |comments|[]comment|True|Array of comments created by secops when managing the incident|[{"comment": "pen testing", "createdBy": "user@example.com", "createdTime": "2021-05-02T09:34:21.5519738Z"}, {"comment": "valid incident", "createdBy": "user@example.com", "createdTime": "2021-05-02T09:36:27.6652581Z"}]|
 |createdTime|date|True|Time when incident was first created|2022-05-06T12:20:18.364306|
-|determination|string|True|Specifies the determination of the incident, where possible values are - MultiStagedAttack, MaliciousUserActivity, CompromisedAccount, Malware, Phishing, UnwantedSoftware, SecurityTesting, LineOfBusinessApplication, NoEnoughDataToValidate, ConfirmedActivity and Other|Malware|
+|determination|string|True|Specifies the determination of the incident, where possible values are - MultiStagedAttack, MaliciousUserActivity, CompromisedAccount, Malware, Phishing, UnwantedSoftware, SecurityTesting, LineOfBusinessApplication, NoEnoughDataToValidate, ConfirmedActivity, NotMalicious and Other|Malware|
 |incidentId|integer|True|Identifier of incident|1|
 |incidentName|string|True|String value containing incident's name|IncidentName|
 |lastUpdateTime|date|True|Time when incident was last updated on the backend|2022-05-06T12:20:18.364306|
@@ -524,6 +524,7 @@ Example output:
 
 # Version History
 
+* 2.0.3 - Allowing `NotMalicious` to be used in `determination` field for `update_incident`
 * 2.0.2 - Updating `update_incident` input values to correlate with documentation
 * 2.0.1 - Adding additional `determination` values | SDK bump to 6.2.6
 * 2.0.0 - Add better error handling for missing output values

--- a/plugins/microsoft_defender_incidents/icon_microsoft_defender_incidents/actions/update_incident/schema.py
+++ b/plugins/microsoft_defender_incidents/icon_microsoft_defender_incidents/actions/update_incident/schema.py
@@ -79,7 +79,8 @@ class UpdateIncidentInput(insightconnect_plugin_runtime.Input):
         "LineOfBusinessApplication",
         "NoEnoughDataToValidate",
         "ConfirmedActivity",
-        "Other"
+        "Other",
+        "NotMalicious"
       ],
       "order": 5
     },
@@ -172,7 +173,7 @@ class UpdateIncidentOutput(insightconnect_plugin_runtime.Output):
     "determination": {
       "type": "string",
       "title": "Determination",
-      "description": "Specifies the determination of the incident, where possible values are - MultiStagedAttack, MaliciousUserActivity, CompromisedAccount, Malware, Phishing, UnwantedSoftware, SecurityTesting, LineOfBusinessApplication, NoEnoughDataToValidate, ConfirmedActivity and Other",
+      "description": "Specifies the determination of the incident, where possible values are - MultiStagedAttack, MaliciousUserActivity, CompromisedAccount, Malware, Phishing, UnwantedSoftware, SecurityTesting, LineOfBusinessApplication, NoEnoughDataToValidate, ConfirmedActivity, NotMalicious and Other",
       "order": 7
     },
     "incidentId": {

--- a/plugins/microsoft_defender_incidents/icon_microsoft_defender_incidents/connection/schema.py
+++ b/plugins/microsoft_defender_incidents/icon_microsoft_defender_incidents/connection/schema.py
@@ -25,7 +25,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
     "client_secret": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Client Secret",
-      "description": "The application secret that you generated for your app in the appregistration portal",
+      "description": "The application secret that you generated for your app in the app registration portal",
       "order": 2
     },
     "tenant_id": {

--- a/plugins/microsoft_defender_incidents/plugin.spec.yaml
+++ b/plugins/microsoft_defender_incidents/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: microsoft_defender_incidents
 title: Microsoft Defender Incidents
 description: Manage security incidents with Microsoft Defender 365
-version: 2.0.2
+version: 2.0.3
 connection_version: 2
 key_features: ["List All Incidents", "Get Incident", "Update Incident", "Get New Incidents Trigger"]
 requirements: ["Requires a set of Azure credentials such as application (client) ID, tenant ID, and client secret key with necessary permissions (Microsoft Threat Protection -> Incident.Read.All, Incident.ReadWrite.All, and AdvancedHunting.Read.All) to monitor and modify Microsoft Defender Incidents"]
@@ -34,6 +34,7 @@ links:
 references:
   - "[Microsoft Defender XDR API Documentation](https://learn.microsoft.com/en-us/defender-xdr/)"
 version_history:
+  - "2.0.3 - Allowing `NotMalicious` to be used in `determination` field for `update_incident`"
   - "2.0.2 - Updating `update_incident` input values to correlate with documentation"
   - "2.0.1 - Adding additional `determination` values | SDK bump to 6.2.6"
   - "2.0.0 - Add better error handling for missing output values"
@@ -47,7 +48,7 @@ connection:
     example: 5cdad72f-c848-4df0-8aaa-ffe033e75d57
   client_secret:
     title: Client Secret
-    description: The application secret that you generated for your app in the appregistration portal
+    description: The application secret that you generated for your app in the app registration portal
     type: credential_secret_key
     required: true
     example: 5cdad72f-c848-4df0-8aaa-ffe033e75d57
@@ -566,6 +567,7 @@ actions:
           - NoEnoughDataToValidate
           - ConfirmedActivity
           - Other
+          - NotMalicious
         type: string
         required: false
         example: Phishing
@@ -620,7 +622,7 @@ actions:
         example: TruePositive
       determination:
         title: Determination
-        description: Specifies the determination of the incident, where possible values are - MultiStagedAttack, MaliciousUserActivity, CompromisedAccount, Malware, Phishing, UnwantedSoftware, SecurityTesting, LineOfBusinessApplication, NoEnoughDataToValidate, ConfirmedActivity and Other
+        description: Specifies the determination of the incident, where possible values are - MultiStagedAttack, MaliciousUserActivity, CompromisedAccount, Malware, Phishing, UnwantedSoftware, SecurityTesting, LineOfBusinessApplication, NoEnoughDataToValidate, ConfirmedActivity, NotMalicious and Other
         type: string
         required: true
         example: Malware

--- a/plugins/microsoft_defender_incidents/setup.py
+++ b/plugins/microsoft_defender_incidents/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="microsoft_defender_incidents-rapid7-plugin",
-    version="2.0.2",
+    version="2.0.3",
     description="Manage security incidents with Microsoft Defender 365",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

The `Clean` value was [previously removed](https://github.com/rapid7/insightconnect-plugins/pull/3302) due to it not working, and it seems Microsoft have changed it's value to NotMalicious (even though the documentation does not state this, the customer found the renaming when using the UI). This will add the value in. 

![image](https://github.com/user-attachments/assets/19dbb765-8c9f-4c71-ac6e-349c389d5d18)


Describe the proposed changes:

  - Adding `NotMalicious` value


### Testing

Locally I am able to update an incident with the field:
<img width="1144" alt="image" src="https://github.com/user-attachments/assets/98f35202-1e22-4a10-ab62-093f235b7c59" />

