### PR TITLE
[SOAR-19228] Adding Fetch Depth - Workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,6 +9,9 @@ jobs:
     
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
+
     - uses: actions/setup-python@v5
       with:
         python-version: '3.11'

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -9,9 +9,10 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
     steps:
     - uses: actions/checkout@v4
+      with:
+        fetch-depth: 0
 
     - uses: actions/setup-python@v5
       with:

--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -10,6 +10,8 @@ jobs:
     steps:
       - name: Checkout Repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5


### PR DESCRIPTION
## Proposed Changes

### Description

When bumping the ubuntu and python version in our workflows, there were a few with no fetch depth added, causing them to fail:
```
subprocess.CalledProcessError: Command '['git', 'diff', '--name-only', 'origin/master..origin/BRANCH']' returned non-zero exit status 128.
161
```

This will add it in for the broken workflows.

