### PR TITLE
POC - Limited flag inputs | Unit Test updated

### DIFF
--- a/plugins/jq/.CHECKSUM
+++ b/plugins/jq/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "b79ad1d1542a7e370c374b4285554656",
+	"spec": "9b5205649b161c1e85275a03b4322884",
 	"manifest": "ae49d48ddce4fea6fe43735319adbf1f",
 	"setup": "41bc91f7d88b1a6523b00f8d557d43ac",
 	"schemas": [

--- a/plugins/jq/.CHECKSUM
+++ b/plugins/jq/.CHECKSUM
@@ -1,11 +1,11 @@
 {
-	"spec": "9b5205649b161c1e85275a03b4322884",
+	"spec": "83f879f56b21d2420575fb3b50a86646",
 	"manifest": "ae49d48ddce4fea6fe43735319adbf1f",
 	"setup": "41bc91f7d88b1a6523b00f8d557d43ac",
 	"schemas": [
 		{
 			"identifier": "run_jq/schema.py",
-			"hash": "aede37a87bfd226e3ff92b14eac7f764"
+			"hash": "d910e49f5035fcb00d30ea0599d84bdf"
 		},
 		{
 			"identifier": "connection/schema.py",

--- a/plugins/jq/help.md
+++ b/plugins/jq/help.md
@@ -89,7 +89,7 @@ Example output:
 
 # Version History
 
-* 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to block certain filter inputs on cloud and `flag` field unavailable when used on cloud | Updated SDK to the latest version (6.3.3) | Unit Tests added
+* 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to block certain filter inputs and limit `flag` inputs | Updated SDK to the latest version (6.3.3) | Unit Tests added
 * 2.0.5 - New spec and help.md format for the Extension Library | Changed docker image from `komand/python-3-slim-plugin:2` to `komand/python-3-37-slim-plugin` | Change mutable function parameter to immutable | Removed comments | Changed concatenation to format in loggers
 * 2.0.4 - Fix issue where jq was not available in the docker image | Update to python | Update to use the `komand/python-3-slim-plugin:2` Docker image to reduce plugin size | Set a default `timeout` of 15 seconds in the Run action
 * 2.0.3 - Add `utilities` plugin tag for Marketplace searchability

--- a/plugins/jq/help.md
+++ b/plugins/jq/help.md
@@ -33,8 +33,8 @@ This action is used to pass the given JSON to the jq command, using the given fl
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|filter|string|None|True|Filter expression to be used by the jq command not in surrounding quotes|None|.user.name|None|None|
-|flags|[]string|None|False|Flags with which to invoke the jq command (e.g. -c)|None|[]|None|None|
+|filter|string|None|False|Filter expression to be used by the jq command not in surrounding quotes|None|.user.name|None|None|
+|flags|[]string|None|False|Flags with which to invoke the jq command (e.g. ["-c"]). Multiple flags are supported in one action: ["-c", "-r", "--tab"]|None|[]|None|None|
 |json_in|object|None|True|Data in JSON format to be passed to jq|None|{'user': {'name': 'Alice', 'age': 30}}|None|None|
 |timeout|integer|15|False|Timeout in seconds during which the jq command runs|None|15|None|None|
   
@@ -89,7 +89,7 @@ Example output:
 
 # Version History
 
-* 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to block certain filter inputs and limit `flag` inputs | Updated SDK to the latest version (6.3.3) | Unit Tests added
+* 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to limit `flag` inputs | 'filter` input no longer required for action to run | Updated SDK to the latest version (6.3.3) | Unit Tests added
 * 2.0.5 - New spec and help.md format for the Extension Library | Changed docker image from `komand/python-3-slim-plugin:2` to `komand/python-3-37-slim-plugin` | Change mutable function parameter to immutable | Removed comments | Changed concatenation to format in loggers
 * 2.0.4 - Fix issue where jq was not available in the docker image | Update to python | Update to use the `komand/python-3-slim-plugin:2` Docker image to reduce plugin size | Set a default `timeout` of 15 seconds in the Run action
 * 2.0.3 - Add `utilities` plugin tag for Marketplace searchability

--- a/plugins/jq/icon_jq/actions/run_jq/action.py
+++ b/plugins/jq/icon_jq/actions/run_jq/action.py
@@ -39,19 +39,33 @@ class RunJq(insightconnect_plugin_runtime.Action):
             raise PluginException("The timeout must be greater than 0 seconds.")
 
         jq_cmd_array = ["jq"]
+        accepted_flags = ["-c", "-r", "-R"]
 
-        # Only allows flag field to be used on orchestrator
-        if not is_running_in_cloud():
-            flags = params.get(Input.FLAGS)
-            if len(flags) > 0:
-                string_flags = " ".join(flags)
-                jq_cmd_array.append(string_flags)
-        else:
-            blocked_patterns = [r"/proc/", r"/dev/", r'import\s+"']
-            #  Prevents possible malicious injections
-            for pattern in blocked_patterns:
-                if re.search(pattern, filter_, re.IGNORECASE):
-                    raise PluginException(f"Blocked pattern found in filter: {pattern}")
+        flags = params.get(Input.FLAGS)
+
+        if flags:
+            # Cleaning input of whitespace and splitting
+            flag_list = []
+            for item in flags:
+                split_items = item.split(",")
+                cleaned = [flag.strip() for flag in split_items if flag.strip()]
+                flag_list.extend(cleaned)
+
+            # Validate
+            if all(f in accepted_flags for f in flag_list):
+                jq_cmd_array.extend(flag_list)
+            else:
+                invalid_flags = [f for f in flag_list if f not in accepted_flags]
+                raise PluginException(
+                    f"The following flag(s) are not supported: {invalid_flags}. "
+                    f"Please ensure your input meets the criteria of the following flags: {accepted_flags}"
+                )
+
+        blocked_patterns = [r"/proc/", r"/dev/", r'import\s+"']
+        #  Prevents possible malicious injections
+        for pattern in blocked_patterns:
+            if re.search(pattern, filter_, re.IGNORECASE):
+                raise PluginException(f"Blocked pattern found in filter: {pattern}")
 
         jq_cmd_array.append(filter_)
 

--- a/plugins/jq/icon_jq/actions/run_jq/schema.py
+++ b/plugins/jq/icon_jq/actions/run_jq/schema.py
@@ -34,7 +34,7 @@ class RunJqInput(insightconnect_plugin_runtime.Input):
     "flags": {
       "type": "array",
       "title": "Flags",
-      "description": "Flags with which to invoke the jq command (e.g. -c)",
+      "description": "Flags with which to invoke the jq command (e.g. [\"-c\"]). Multiple flags are supported in one action: [\"-c\", \"-r\", \"--tab\"]",
       "items": {
         "type": "string"
       },
@@ -55,7 +55,6 @@ class RunJqInput(insightconnect_plugin_runtime.Input):
     }
   },
   "required": [
-    "filter",
     "json_in"
   ],
   "definitions": {}

--- a/plugins/jq/plugin.spec.yaml
+++ b/plugins/jq/plugin.spec.yaml
@@ -52,7 +52,8 @@ links:
 references:
 - '[jq](https://stedolan.github.io/jq/)'
 version_history:
-- 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to block certain filter inputs and limit `flag` inputs | Updated SDK to the latest version (6.3.3) | Unit Tests added
+- 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to limit `flag` inputs | 'filter` input no longer required for action to run
+  | Updated SDK to the latest version (6.3.3) | Unit Tests added
 - 2.0.5 - New spec and help.md format for the Extension Library | Changed docker image
   from `komand/python-3-slim-plugin:2` to `komand/python-3-37-slim-plugin` | Change
   mutable function parameter to immutable | Removed comments | Changed concatenation
@@ -84,7 +85,7 @@ actions:
         example: {user: {name: Alice, age: 30}}
       flags:
         title: Flags
-        description: Flags with which to invoke the jq command (e.g. -c)
+        description: "Flags with which to invoke the jq command (e.g. [\"-c\"]). Multiple flags are supported in one action: [\"-c\", \"-r\", \"--tab\"]"
         type: '[]string'
         required: false
         example: []
@@ -93,7 +94,7 @@ actions:
         description: Filter expression to be used by the jq command not in surrounding
           quotes
         type: string
-        required: true
+        required: false
         example: .user.name
       timeout:
         title: Timeout

--- a/plugins/jq/plugin.spec.yaml
+++ b/plugins/jq/plugin.spec.yaml
@@ -52,7 +52,7 @@ links:
 references:
 - '[jq](https://stedolan.github.io/jq/)'
 version_history:
-- 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to block certain filter inputs on cloud and `flag` field unavailable when used on cloud | Updated SDK to the latest version (6.3.3) | Unit Tests added
+- 3.0.0 - Enabled plugin as `cloud_ready` | Updated `run` action to block certain filter inputs and limit `flag` inputs | Updated SDK to the latest version (6.3.3) | Unit Tests added
 - 2.0.5 - New spec and help.md format for the Extension Library | Changed docker image
   from `komand/python-3-slim-plugin:2` to `komand/python-3-37-slim-plugin` | Change
   mutable function parameter to immutable | Removed comments | Changed concatenation

--- a/plugins/jq/unit_test/test_run_jq.py
+++ b/plugins/jq/unit_test/test_run_jq.py
@@ -49,6 +49,6 @@ class TestRunJq(TestCase):
             self.action.run(input_param)
 
         self.assertIn(
-            "The following flag(s) are not supported: ['--rawfile']. Please ensure your input meets the criteria of the following flags: ['-c', '-r', '-R']",
+            "The following flag(s) are not supported: ['--rawfile']",
             str(context.exception),
         )

--- a/plugins/jq/unit_test/test_run_jq.py
+++ b/plugins/jq/unit_test/test_run_jq.py
@@ -1,6 +1,8 @@
 import unittest
 from unittest import TestCase
 from unittest.mock import patch, MagicMock
+
+from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 from icon_jq.actions.run_jq import RunJq
 
@@ -34,23 +36,19 @@ class TestRunJq(TestCase):
         self.assertEqual(expected, actual)
 
     @patch("subprocess.Popen")
-    @patch.dict("os.environ", {"PLUGIN_RUNTIME_ENVIRONMENT": "cloud"})
-    def test_flag_not_passed_in_cloud(self, mock_popen):
-
-        mock_process = MagicMock()
-        mock_process.communicate.return_value = (b'"Alice"', b"")
-        mock_process.returncode = 0
-        mock_popen.return_value = mock_process
+    def test_unsupported_flag(self, mock_popen):
 
         input_param = {
             "json_in": {"user": {"name": "Alice", "age": 30}},
-            "flags": ["--rawfile"],
+            "flags": ["--rawfile"],  # Unsupported flag
             "filter": ".user.name",
             "timeout": 1,
         }
 
-        self.action.run(input_param)
+        with self.assertRaises(PluginException) as context:
+            self.action.run(input_param)
 
-        mock_popen.assert_called_once()
-        args, _ = mock_popen.call_args
-        self.assertNotIn("--rawfile", args[0])
+        self.assertIn(
+            "The following flag(s) are not supported: ['--rawfile']. Please ensure your input meets the criteria of the following flags: ['-c', '-r', '-R']",
+            str(context.exception),
+        )


### PR DESCRIPTION
## Proposed Changes

### Description

Another possible POC to ensure jq is secure whilst cloud enabling is to heavily limit the flags that can be used. We originally were going to disable the field completely although after talking we think it is best not to reduce functionality but to heavily sanitise it via limited options. We still need to find a way to select multiple flags (string input? multiple enums?)

This also updates the unit test to test a flag not allowed cannot be used and correct exception raised

Some filters also blocked to prevent importing and other possible leaks.

Describe the proposed changes:

  - Heavily limit flag input fields
  - Unit test updated

