### PR TITLE
[NO-TICKET] Unit Test Coverage- Resolve deprecation of v3

### DIFF
--- a/.github/workflows/prospector.yml
+++ b/.github/workflows/prospector.yml
@@ -18,6 +18,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install prospector[with_bandit]==1.16.1
+          # Version 3.0.0 raised KeyError, this pins it to working version
           pip install snowballstemmer==2.2.0
 
       - name: Prospector

--- a/.github/workflows/prospector.yml
+++ b/.github/workflows/prospector.yml
@@ -17,7 +17,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          pip install prospector[with_bandit]==1.9.0
+          pip install prospector[with_bandit]==1.16.1
+          pip install snowballstemmer==2.2.0
 
       - name: Prospector
         run: |

--- a/.github/workflows/unit_test_coverage.yml
+++ b/.github/workflows/unit_test_coverage.yml
@@ -68,7 +68,7 @@ jobs:
           done
 
       - name: Upload Coverage
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: coverage
           path: coverageDir


### PR DESCRIPTION
## Proposed Changes

### Description

V3 of upload-artifact is being deprecated. This is preventing the unit test coverage being generated. This will update to v4

Snowballstemmer 3.0.0 is causing issues. Specifying an older version works.

https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Describe the proposed changes:

  - Update upload-artifact to v4 
  - Install prior version of `snowballstemmer`

