### PR TITLE
[SOAR-19381] Python 3 Script - Addition of 3 secret connection fields

### DIFF
--- a/plugins/python_3_script/.CHECKSUM
+++ b/plugins/python_3_script/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "8a3b2625358288b449e97ae902f5f42d",
-	"manifest": "342965e663c39ac1cc5804d20e26ce8a",
-	"setup": "7b3ac2869c7a9537e263f5ce78e01f8e",
+	"spec": "c2ecc126b36948bf5859d1086353b991",
+	"manifest": "bd13dc8f26f4e25fb21d279120adc1b3",
+	"setup": "d144183455734d0dd4da2ae335ea3e02",
 	"schemas": [
 		{
 			"identifier": "run/schema.py",
@@ -9,7 +9,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "97586d619ebb0c8d02d0a5e81096b9ea"
+			"hash": "977ddef5892530113cd5d1e539e50971"
 		}
 	]
 }

--- a/plugins/python_3_script/bin/icon_python_3_script
+++ b/plugins/python_3_script/bin/icon_python_3_script
@@ -6,8 +6,8 @@ from sys import argv
 
 Name = "Python 3 Script"
 Vendor = "rapid7"
-Version = "5.1.2"
-Description = "[Python](https://www.python.org/) is a language for fast development and system integration. This plugin runs Python 3.12.8 with its standard library and other libraries such as:* [requests](https://requests.readthedocs.io/en/latest/)* [arrow](https://pypi.org/project/arrow/)* [lxml](http://lxml.de/)* [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)It supports loading custom modules and passing credentials (`username`, `password`, `secret_key`)"
+Version = "5.2.0"
+Description = "[Python](https://www.python.org/) is a language for fast development and integration. The plugin runs Python 3.12.8 with standard library and libraries like:* [requests](https://requests.readthedocs.io/en/latest/)* [arrow](https://pypi.org/project/arrow/)* [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)It supports loading custom modules and passing credentials (`username`, `password`, `secret_key`, `secret_credential_1`, `secret_credential_2`, `secret_credential_3`)"
 
 
 def main():

--- a/plugins/python_3_script/help.md
+++ b/plugins/python_3_script/help.md
@@ -1,13 +1,12 @@
 # Description
 
-[Python](https://www.python.org/) is a language for fast development and system integration. This plugin runs Python 3.12.8 with its standard library and other libraries such as:
+[Python](https://www.python.org/) is a language for fast development and integration. The plugin runs Python 3.12.8 with standard library and libraries like:
 
 * [requests](https://requests.readthedocs.io/en/latest/)
 * [arrow](https://pypi.org/project/arrow/)
-* [lxml](http://lxml.de/)
 * [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)
 
-It supports loading custom modules and passing credentials (`username`, `password`, `secret_key`)
+It supports loading custom modules and passing credentials (`username`, `password`, `secret_key`, `secret_credential_1`, `secret_credential_2`, `secret_credential_3`)
 
 # Key Features
 
@@ -32,6 +31,9 @@ The connection configuration accepts the following parameters:
 |modules|[]string|None|False|List of third-party modules to install for use in the supplied Python script|None|["pandas", "numpy"]|None|None|
 |script_secret_key|credential_secret_key|None|False|Credential secret key available in script as python variable (`secret_key`)|None|{"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"}|None|None|
 |script_username_and_password|credential_username_password|None|False|Username and password available in script as python variables (`username`, `password`)|None|{"username": "user", "password": "mypassword"}|None|None|
+|secret_credential_1|credential_secret_key|None|False|Additional secret connection field available in script as Python variable (`secret_credential_1`)|None|{"secretKey": "s083jh3ggJbsunb92hwbvacaiNAvsiz"}|None|None|
+|secret_credential_2|credential_secret_key|None|False|Additional secret connection field available in script as Python variable (`secret_credential_2`)|None|{"secretKey": "PXctwsnevfobd9sbskb2cXistwb0"}|None|None|
+|secret_credential_3|credential_secret_key|None|False|Additional secret connection field available in script as Python variable (`secret_credential_3`)|None|{"secretKey": "Mhga68YusiBo00shVsziapan7wgbw"}|None|None|
 |timeout|integer|60|True|Timeout (in seconds) for installing third-party modules|None|120|None|None|
 
 Example input:
@@ -48,6 +50,15 @@ Example input:
   "script_username_and_password": {
     "password": "mypassword",
     "username": "user"
+  },
+  "secret_credential_1": {
+    "secretKey": "s083jh3ggJbsunb92hwbvacaiNAvsiz"
+  },
+  "secret_credential_2": {
+    "secretKey": "PXctwsnevfobd9sbskb2cXistwb0"
+  },
+  "secret_credential_3": {
+    "secretKey": "Mhga68YusiBo00shVsziapan7wgbw"
   },
   "timeout": 60
 }
@@ -114,6 +125,7 @@ Example output:
 
 # Version History
 
+* 5.2.0 - Added 3 additional `Secret Credential Fields` as optional connection inputs
 * 5.1.2 - `timeout` description updated within `run` action | Updated SDK to the latest version (6.3.3)
 * 5.1.1 - Updated SDK to the latest version (6.2.5)
 * 5.1.0 - Action `Run`: Added `timeout` optional parameter | Updated SDK to the latest version

--- a/plugins/python_3_script/icon_python_3_script/actions/run/action.py
+++ b/plugins/python_3_script/icon_python_3_script/actions/run/action.py
@@ -164,7 +164,7 @@ class Run(insightconnect_plugin_runtime.Action):
     ) -> str:
         """
         This function adds credentials to the function entered by the user. It looks for connection script
-        credentials: username, password, secret_key, and adds all of them to variables inside the function.
+        credentials: username, password, secret_key, secret_credential_1, secret_credential_2, secret_credential_3 and adds all of them to variables inside the function.
         :param function_: Python script function
         :type: str
 

--- a/plugins/python_3_script/icon_python_3_script/connection/connection.py
+++ b/plugins/python_3_script/icon_python_3_script/connection/connection.py
@@ -22,6 +22,9 @@ class Connection(insightconnect_plugin_runtime.Connection):
             "username": params.get(Input.SCRIPT_USERNAME_AND_PASSWORD, {}).get("username"),
             "password": params.get(Input.SCRIPT_USERNAME_AND_PASSWORD, {}).get("password"),
             "secret_key": params.get(Input.SCRIPT_SECRET_KEY, {}).get("secretKey"),
+            "secret_credential_1": params.get(Input.SECRET_CREDENTIAL_1, {}).get("secretKey"),
+            "secret_credential_2": params.get(Input.SECRET_CREDENTIAL_2, {}).get("secretKey"),
+            "secret_credential_3": params.get(Input.SECRET_CREDENTIAL_3, {}).get("secretKey"),
         }
 
     def test(self) -> Dict[str, Any]:

--- a/plugins/python_3_script/icon_python_3_script/connection/schema.py
+++ b/plugins/python_3_script/icon_python_3_script/connection/schema.py
@@ -7,6 +7,9 @@ class Input:
     MODULES = "modules"
     SCRIPT_SECRET_KEY = "script_secret_key"
     SCRIPT_USERNAME_AND_PASSWORD = "script_username_and_password"
+    SECRET_CREDENTIAL_1 = "secret_credential_1"
+    SECRET_CREDENTIAL_2 = "secret_credential_2"
+    SECRET_CREDENTIAL_3 = "secret_credential_3"
     TIMEOUT = "timeout"
 
 
@@ -24,26 +27,44 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "items": {
         "type": "string"
       },
-      "order": 1
+      "order": 6
     },
     "script_secret_key": {
       "$ref": "#/definitions/credential_secret_key",
       "title": "Script Secret Key",
       "description": "Credential secret key available in script as python variable (`secret_key`)",
-      "order": 3
+      "order": 1
     },
     "script_username_and_password": {
       "$ref": "#/definitions/credential_username_password",
       "title": "Script Username and Password",
       "description": "Username and password available in script as python variables (`username`, `password`)",
+      "order": 2
+    },
+    "secret_credential_1": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "Secret Credential 1",
+      "description": "Additional secret connection field available in script as Python variable (`secret_credential_1`)",
+      "order": 3
+    },
+    "secret_credential_2": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "Secret Credential 2",
+      "description": "Additional secret connection field available in script as Python variable (`secret_credential_2`)",
       "order": 4
+    },
+    "secret_credential_3": {
+      "$ref": "#/definitions/credential_secret_key",
+      "title": "Secret Credential 3",
+      "description": "Additional secret connection field available in script as Python variable (`secret_credential_3`)",
+      "order": 5
     },
     "timeout": {
       "type": "integer",
       "title": "Timeout",
       "description": "Timeout (in seconds) for installing third-party modules",
       "default": 60,
-      "order": 2
+      "order": 7
     }
   },
   "required": [

--- a/plugins/python_3_script/icon_python_3_script/util/constants.py
+++ b/plugins/python_3_script/icon_python_3_script/util/constants.py
@@ -12,11 +12,17 @@ parser = ArgumentParser()
 parser.add_argument("--username")
 parser.add_argument("--password")
 parser.add_argument("--secret_key")
+parser.add_argument("--secret_credential_1")
+parser.add_argument("--secret_credential_2")
+parser.add_argument("--secret_credential_3")
 
 arguments = parser.parse_args()
 username = arguments.username
 password = arguments.password
 secret_key = arguments.secret_key
+secret_credential_1 = arguments.secret_credential_1
+secret_credential_2 = arguments.secret_credential_2
+secret_credential_3 = arguments.secret_credential_3
 
 {function_}
 sys.stdout.write("{execution_id}" + json.dumps({function_name}({parameters})))

--- a/plugins/python_3_script/plugin.spec.yaml
+++ b/plugins/python_3_script/plugin.spec.yaml
@@ -6,13 +6,8 @@ title: Python 3 Script
 vendor: rapid7
 support: rapid7
 status: []
-description: "[Python](https://www.python.org/) is a language for fast development\
-  \ and system integration. This plugin runs Python 3.12.8 with its standard library\
-  \ and other libraries such as:\n\n* [requests](https://requests.readthedocs.io/en/latest/)\n\
-  * [arrow](https://pypi.org/project/arrow/)\n* [lxml](http://lxml.de/)\n* [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)\n\
-  \nIt supports loading custom modules and passing credentials (`username`, `password`,\
-  \ `secret_key`)"
-version: 5.1.2
+description: "[Python](https://www.python.org/) is a language for fast development and integration. The plugin runs Python 3.12.8 with standard library and libraries like:\n\n* [requests](https://requests.readthedocs.io/en/latest/)\n* [arrow](https://pypi.org/project/arrow/)\n* [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)\n\nIt supports loading custom modules and passing credentials (`username`, `password`, `secret_key`, `secret_credential_1`, `secret_credential_2`, `secret_credential_3`)"
+version: 5.2.0
 connection_version: 4
 supported_versions: [Python 3.12.8]
 fedramp_ready: true
@@ -53,7 +48,9 @@ references: ['[Python 3 Language Reference](https://docs.python.org/3/reference/
 links:
 - '[Python](https://www.python.org/)'
 version_history:
-- 5.1.2 - `timeout` description updated within `run` action | Updated SDK to the latest version (6.3.3)
+- 5.2.0 - Added 3 additional `Secret Credential Fields` as optional connection inputs
+- 5.1.2 - `timeout` description updated within `run` action | Updated SDK to the latest
+  version (6.3.3)
 - 5.1.1 - Updated SDK to the latest version (6.2.5)
 - '5.1.0 - Action `Run`: Added `timeout` optional parameter | Updated SDK to the latest
   version'
@@ -94,26 +91,13 @@ version_history:
 - 1.0.1 - SSL bug fix in SDK
 - 0.1.0 - Initial plugin
 connection:
-  modules:
-    title: Third-Party Modules
-    description: List of third-party modules to install for use in the supplied Python
-      script
-    type: '[]string'
-    required: false
-    example: '["pandas", "numpy"]'
-  timeout:
-    title: Timeout
-    description: Timeout (in seconds) for installing third-party modules
-    type: integer
-    required: true
-    default: 60
-    example: 120
   script_secret_key:
     title: Script Secret Key
     description: Credential secret key available in script as python variable (`secret_key`)
     type: credential_secret_key
     required: false
     example: '{"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"}'
+    order: 1
   script_username_and_password:
     title: Script Username and Password
     description: Username and password available in script as python variables (`username`,
@@ -121,6 +105,44 @@ connection:
     type: credential_username_password
     required: false
     example: '{"username": "user", "password": "mypassword"}'
+    order: 2
+  secret_credential_1:
+    title: Secret Credential 1
+    description: Additional secret connection field available in script as Python variable (`secret_credential_1`)
+    type: credential_secret_key
+    required: false
+    example: '{"secretKey": "s083jh3ggJbsunb92hwbvacaiNAvsiz"}'
+    order: 3
+  secret_credential_2:
+    title: Secret Credential 2
+    description: Additional secret connection field available in script as Python variable (`secret_credential_2`)
+    type: credential_secret_key
+    required: false
+    example: '{"secretKey": "PXctwsnevfobd9sbskb2cXistwb0"}'
+    order: 4
+  secret_credential_3:
+    title: Secret Credential 3
+    description: Additional secret connection field available in script as Python variable (`secret_credential_3`)
+    type: credential_secret_key
+    required: false
+    example: '{"secretKey": "Mhga68YusiBo00shVsziapan7wgbw"}'
+    order: 5
+  modules:
+    title: Third-Party Modules
+    description: List of third-party modules to install for use in the supplied Python
+      script
+    type: '[]string'
+    required: false
+    example: '["pandas", "numpy"]'
+    order: 6
+  timeout:
+    title: Timeout
+    description: Timeout (in seconds) for installing third-party modules
+    type: integer
+    required: true
+    default: 60
+    example: 120
+    order: 7
 actions:
   run:
     title: Run Function

--- a/plugins/python_3_script/setup.py
+++ b/plugins/python_3_script/setup.py
@@ -4,8 +4,8 @@ from setuptools import setup, find_packages
 
 setup(
     name="python_3_script-rapid7-plugin",
-    version="5.1.2",
-    description="[Python](https://www.python.org/) is a language for fast development and system integration. This plugin runs Python 3.12.8 with its standard library and other libraries such as:* [requests](https://requests.readthedocs.io/en/latest/)* [arrow](https://pypi.org/project/arrow/)* [lxml](http://lxml.de/)* [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)It supports loading custom modules and passing credentials (`username`, `password`, `secret_key`)",
+    version="5.2.0",
+    description="[Python](https://www.python.org/) is a language for fast development and integration. The plugin runs Python 3.12.8 with standard library and libraries like:* [requests](https://requests.readthedocs.io/en/latest/)* [arrow](https://pypi.org/project/arrow/)* [beautifulsoup](https://www.crummy.com/software/BeautifulSoup/)It supports loading custom modules and passing credentials (`username`, `password`, `secret_key`, `secret_credential_1`, `secret_credential_2`, `secret_credential_3`)",
     author="rapid7",
     author_email="",
     url="",

--- a/plugins/python_3_script/unit_test/inputs/connection_with_credentials.json.inp
+++ b/plugins/python_3_script/unit_test/inputs/connection_with_credentials.json.inp
@@ -7,5 +7,14 @@
   },
   "script_secret_key": {
     "secretKey": "1111243354"
+  },
+  "secret_credential_1": {
+    "secretKey": "s083jh3ggJbsunb92hwbvacaiNAvsiz"
+  },
+  "secret_credential_2": {
+    "secretKey": "PXctwsnevfobd9sbskb2cXistwb0"
+  },
+  "secret_credential_3": {
+    "secretKey": "Mhga68YusiBo00shVsziapan7wgbw"
   }
 }


### PR DESCRIPTION
## Proposed Changes

### Description

Customers have voiced the security concerns of having to hardcore their credentials in their script to be accessed instead of deriving it from the connection fields (`client_id` etc). This will allow them to use 3 more **optional** connection fields if they wish.


Describe the proposed changes:

  - Adding 3 more optional connection fields (`secret_credential1`, `secret_credential2`, `secret_credential3`)
  - Change description as it's >500 (with addition of new fields)
  - Updated Unit Test



