### PR TITLE
[SOAR-19518] InsightIDR - Adding additional enum values for disposition field

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "d6ce5b02ac6ab11cd4aa9380908a6d58",
-	"manifest": "d2efd7366f383bf6e5ab40ffc9514347",
-	"setup": "63fb00e8d7801ea60db7f292c46581f5",
+	"spec": "e68bff68a02cd2532f878575897d5756",
+	"manifest": "57ce2026adcb77c39e4f2e12591168e2",
+	"setup": "741516d644a85513418276460472c83b",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -29,7 +29,7 @@
 		},
 		{
 			"identifier": "create_investigation/schema.py",
-			"hash": "a0538409101e9018eec1c3c52e674c0a"
+			"hash": "ed4ab7d62bc66454d976ab7dda67b189"
 		},
 		{
 			"identifier": "create_threat/schema.py",
@@ -69,7 +69,7 @@
 		},
 		{
 			"identifier": "get_alert_information/schema.py",
-			"hash": "48461d148def77b3d963ff81bb14866a"
+			"hash": "b638bc385299b7c8cdbd03b4bb65515c"
 		},
 		{
 			"identifier": "get_all_logs/schema.py",
@@ -125,7 +125,7 @@
 		},
 		{
 			"identifier": "search_alerts/schema.py",
-			"hash": "e557bb0c7ca5ffc74bb4c18155e7a20e"
+			"hash": "32ac097f9bbbfee2346b46eac3c6c8be"
 		},
 		{
 			"identifier": "search_investigations/schema.py",
@@ -145,7 +145,7 @@
 		},
 		{
 			"identifier": "update_alert/schema.py",
-			"hash": "71cbe6b5ef3a9901f4cf821da9343575"
+			"hash": "b85d84292fbe3569542806a6bb9388d4"
 		},
 		{
 			"identifier": "update_investigation/schema.py",
@@ -161,7 +161,7 @@
 		},
 		{
 			"identifier": "get_new_alerts/schema.py",
-			"hash": "2efa90f87eb6b301a972f56f1a554375"
+			"hash": "7c7f3d33a7271231f88ecac04aa93300"
 		},
 		{
 			"identifier": "get_new_investigations/schema.py",

--- a/plugins/rapid7_insightidr/Dockerfile
+++ b/plugins/rapid7_insightidr/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.3 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.5 AS builder
 
 WORKDIR /python/src
 
@@ -11,7 +11,7 @@ ADD . /python/src
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.5
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "11.0.5"
+Version = "11.0.6"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -19,7 +19,7 @@ This plugin allows you to add indicators to a threat and see the status of inves
 
 # Supported Product Versions
 
-* Latest release successfully tested on 2024-09-10.
+* Latest release successfully tested on 2025-06-11.
 
 # Documentation
 
@@ -743,7 +743,7 @@ This action is used to allows to create investigation manually
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|disposition|string|None|False|Investigation's disposition|["", "BENIGN", "MALICIOUS", "NOT_APPLICABLE"]|BENIGN|None|None|
+|disposition|string|None|False|Investigation's disposition|["", "UNDECIDED", "BENIGN", "MALICIOUS", "NOT_APPLICABLE"]|BENIGN|None|None|
 |email|string|None|False|A user's email address for investigation to be assigned|None|user@example.com|None|None|
 |priority|string|None|False|Investigation's priority|["", "LOW", "MEDIUM", "HIGH", "CRITICAL"]|LOW|None|None|
 |status|string|None|False|Investigation's status|["", "OPEN", "CLOSED"]|OPEN|None|None|
@@ -2569,7 +2569,7 @@ This action is used to updates information for a single alert
 |alert_rrn|string|None|True|The unique identifier of the alert|None|rrn:alerts:us1:12345678-abcd-cdef-1234-12345abc:alert:1:12345678-abcd-cdef-1234-12345abg|None|None|
 |assignee_id|string|None|False|The new user to assign to the alert|None|8205375a-1234-4652-8098-870d656bc693|None|None|
 |comment|string|None|False|The reason for updating the alert, which is captured in the alert audit log for tracking purposes|None|Updated alert priority by automation through InsightConnect|None|None|
-|disposition|string|None|False|The alert disposition|["", "UNMAPPED", "UNDECIDED", "MALICIOUS", "BENIGN", "UNKNOWN", "NOT_APPLICABLE"]|MALICIOUS|None|None|
+|disposition|string|None|False|The alert disposition|["", "UNMAPPED", "UNDECIDED", "MALICIOUS", "BENIGN", "UNKNOWN", "NOT_APPLICABLE", "SECURITY_TEST", "FALSE_POSITIVE"]|MALICIOUS|None|None|
 |investigation_rrn|string|None|False|The RRN of the investigation to add the alert to|None|rrn:investigation:us:12345678-abcd-cdef-1234-12345abc:investigation:ABCDEFGHI|None|None|
 |priority|string|None|False|The alert priority|["", "UNMAPPED", "INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"]|INFO|None|None|
 |status|string|None|False|The alert status|["", "UNMAPPED", "OPEN", "INVESTIGATING", "WAITING", "CLOSED"]|OPEN|None|None|
@@ -3428,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.5
 * 11.0.5 - Added new disposition of the alert
 * 11.0.4 - Added support for parsing improperly formatted JSON-like strings | SDK bump to 6.3.3
 * 11.0.3 - Added log entry validation using regular expressions | SDK bump to 6.2.6

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/schema.py
@@ -32,6 +32,7 @@ class CreateInvestigationInput(insightconnect_plugin_runtime.Input):
       "description": "Investigation's disposition",
       "enum": [
         "",
+        "UNDECIDED",
         "BENIGN",
         "MALICIOUS",
         "NOT_APPLICABLE"

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/schema.py
@@ -229,7 +229,8 @@ class GetAlertInformationOutput(insightconnect_plugin_runtime.Output):
             "BENIGN",
             "UNKNOWN",
             "NOT_APPLICABLE",
-            "SECURITY_TEST"
+            "SECURITY_TEST",
+            "FALSE_POSITIVE"
           ],
           "order": 21
         },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/schema.py
@@ -487,7 +487,8 @@ class SearchAlertsOutput(insightconnect_plugin_runtime.Output):
             "BENIGN",
             "UNKNOWN",
             "NOT_APPLICABLE",
-            "SECURITY_TEST"
+            "SECURITY_TEST",
+            "FALSE_POSITIVE"
           ],
           "order": 21
         },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_alert/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_alert/schema.py
@@ -57,7 +57,9 @@ class UpdateAlertInput(insightconnect_plugin_runtime.Input):
         "MALICIOUS",
         "BENIGN",
         "UNKNOWN",
-        "NOT_APPLICABLE"
+        "NOT_APPLICABLE",
+        "SECURITY_TEST",
+        "FALSE_POSITIVE"
       ],
       "order": 3
     },
@@ -285,7 +287,8 @@ class UpdateAlertOutput(insightconnect_plugin_runtime.Output):
             "BENIGN",
             "UNKNOWN",
             "NOT_APPLICABLE",
-            "SECURITY_TEST"
+            "SECURITY_TEST",
+            "FALSE_POSITIVE"
           ],
           "order": 21
         },

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/schema.py
@@ -372,7 +372,8 @@ class GetNewAlertsOutput(insightconnect_plugin_runtime.Output):
             "BENIGN",
             "UNKNOWN",
             "NOT_APPLICABLE",
-            "SECURITY_TEST"
+            "SECURITY_TEST",
+            "FALSE_POSITIVE"
           ],
           "order": 21
         },

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,9 +4,9 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 11.0.5
+version: 11.0.6
 connection_version: 5
-supported_versions: ["Latest release successfully tested on 2024-09-10."]
+supported_versions: ["Latest release successfully tested on 2025-06-11."]
 vendor: rapid7
 cloud_ready: true
 resources:
@@ -32,9 +32,10 @@ key_features:
   - "Incident Response and Investigations"
 sdk:
   type: full
-  version: 6.3.3
+  version: 6.3.5
   user: nobody
 version_history:
+  - "11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.5"
   - "11.0.5 - Added new disposition of the alert"
   - "11.0.4 - Added support for parsing improperly formatted JSON-like strings | SDK bump to 6.3.3"
   - "11.0.3 - Added log entry validation using regular expressions | SDK bump to 6.2.6"
@@ -961,6 +962,7 @@ types:
         - UNKNOWN
         - NOT_APPLICABLE
         - SECURITY_TEST
+        - FALSE_POSITIVE
     investigation_rrn:
       title: Investigation RRN
       description: The RRN of the investigation that the alert is part of.
@@ -1577,6 +1579,7 @@ actions:
         type: string
         enum:
           - ""
+          - UNDECIDED
           - BENIGN
           - MALICIOUS
           - NOT_APPLICABLE
@@ -2834,6 +2837,8 @@ actions:
           - BENIGN
           - UNKNOWN
           - NOT_APPLICABLE
+          - SECURITY_TEST
+          - FALSE_POSITIVE
         required: false
         example: MALICIOUS
       priority:

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="11.0.5",
+    version="11.0.6",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

SI issue due to the disposition field not being up to date with the API changes ([X](https://help.rapid7.com/insightidr/en-us/api/v2/docs.html#tag/Investigations/operation/createInvestigation), [Y](https://docs.rapid7.com/insightidr/analyze-an-investigation/#:~:text=New%20investigations%20are%20assigned%20a%20disposition%20by%20default.%20Automatically%20created%20investigations%20inherit%20their%20disposition%20from%20alerts%20and%20detections.%20Manually%20created%20investigations%20have%20a%20disposition%20of%20Undecided.), [Z](https://docs.rapid7.com/insightidr/api/alert-triage/#tag/Alerts/operation/patchAlerts)). Additional enum values need added

Describe the proposed changes:

  - SDK bump to 6.3.5
  - Adding additional enum values for `disposition`


### Testing
Sent post requests to all actions which required the enum value addition and it works as expected:
<img width="1179" alt="image" src="https://github.com/user-attachments/assets/27c38f43-2785-4b96-a846-32124cbafea7" />
