### PR TITLE
[SI-29846] Support a request ID for non cloud deployments

### DIFF
--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
@@ -33,7 +33,7 @@ class AddIndicatorsToAThreat(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
@@ -33,7 +33,7 @@ class AddIndicatorsToAThreat(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -51,7 +51,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         if log_id and log_name:
             self.logger.info(
                 "Values were provided for both log ID and log name, the value for log id will be used",
-                **self.connection.log_values,
+                **self.connection.cloud_log_values,
             )
 
         if not log_id:
@@ -69,7 +69,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                 self.connection, insightconnect_plugin_runtime.helper.clean(log_entries)
             )
 
-        self.logger.info("Sending results to orchestrator.", **self.connection.log_values)
+        self.logger.info("Sending results to orchestrator.", **self.connection.cloud_log_values)
 
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
@@ -102,18 +102,18 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         :param statistical: bool - Whether to fetch statistical results or event logs.
         :return: list of log entries or statistical data.
         """
-        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.log_values)
+        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.cloud_log_values)
         counter = timeout
 
         while callback_url and counter > 0:
             response = self.connection.session.get(callback_url)
-            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.log_values)
+            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
 
             try:
                 # IDR seems to return both `raise_for_status` and `status_code` - value is in `status_code` / `raise_for_status` just returns `None`
                 response.raise_for_status()
             except Exception as error:
-                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.log_values)
+                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.cloud_log_values)
                 raise PluginException(
                     cause="Failed to get logs from InsightIDR",
                     assistance=f"Could not get logs from: {callback_url}",
@@ -123,24 +123,24 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
             results_object = response.json()
 
             if "progress" in results_object:
-                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.log_values)
+                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.cloud_log_values)
                 while "progress" in results_object and counter > 0:
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.log_values
+                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.cloud_log_values
                     )
-                    self.logger.info(f"Time left: {counter} seconds", **self.connection.log_values)
+                    self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
                     response = self.connection.session.get(callback_url)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}", **self.connection.log_values
+                                f"Updated Progress: {results_object.get('progress')}", **self.connection.cloud_log_values
                             )
                     except Exception as e:
-                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.log_values)
+                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values)
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -157,25 +157,25 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
             next_link = next((link for link in results_object.get("links", []) if link.get("rel") == "Next"), None)
 
             if "progress" not in results_object:
-                self.logger.info("No more results to process. Exiting.", **self.connection.log_values)
+                self.logger.info("No more results to process. Exiting.", **self.connection.cloud_log_values)
                 return log_entries
 
             elif next_link:
                 self.logger.info(
                     "Over 500 results are available for this query, but only a limited number will be returned. Please use a more specific query to get all results.",
-                    **self.connection.log_values,
+                    **self.connection.cloud_log_values,
                 )
                 callback_url = next_link.get("href")
 
             counter -= 1
             if counter <= 0:
-                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.log_values)
+                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.cloud_log_values)
                 raise PluginException(
                     cause="Time out exceeded",
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.log_values)
+        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values)
         return {}
 
     def maybe_get_log_entries(
@@ -203,8 +203,8 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         if not statistical:
             params["per_page"] = 500
 
-        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.log_values)
-        self.logger.info(f"Using parameters: {params}", **self.connection.log_values)
+        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.cloud_log_values)
+        self.logger.info(f"Using parameters: {params}", **self.connection.cloud_log_values)
         response = self.connection.session.get(endpoint, params=params)
         try:
             response.raise_for_status()
@@ -219,7 +219,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
 
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
-            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.log_values)
+            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
             stats_response = self.connection.session.get(stats_endpoint, params=params)
             try:
                 stats_response.raise_for_status()

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -54,7 +54,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 self.connection, insightconnect_plugin_runtime.helper.clean(log_entries)
             )
 
-        self.logger.info("Sending results to orchestrator.", **self.connection.log_values)
+        self.logger.info("Sending results to orchestrator.", **self.connection.cloud_log_values)
 
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
@@ -87,18 +87,18 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         :param statistical: bool - Whether to fetch statistical results or event logs.
         :return: list of log entries or statistical data.
         """
-        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.log_values)
+        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.cloud_log_values)
         counter = timeout
 
         while callback_url and counter > 0:
             response = self.connection.session.get(callback_url)
-            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.log_values)
+            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
 
             try:
                 # IDR seems to return both `raise_for_status` and `status_code` - value is in `status_code` / `raise_for_status` just returns `None`
                 response.raise_for_status()
             except Exception as error:
-                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.log_values)
+                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.cloud_log_values)
                 raise PluginException(
                     cause="Failed to get logs from InsightIDR",
                     assistance=f"Could not get logs from: {callback_url}",
@@ -108,24 +108,24 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             results_object = response.json()
 
             if "progress" in results_object:
-                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.log_values)
+                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.cloud_log_values)
                 while "progress" in results_object and counter > 0:
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.log_values
+                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.cloud_log_values
                     )
-                    self.logger.info(f"Time left: {counter} seconds", **self.connection.log_values)
+                    self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
                     response = self.connection.session.get(callback_url)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}", **self.connection.log_values
+                                f"Updated Progress: {results_object.get('progress')}", **self.connection.cloud_log_values
                             )
                     except Exception as e:
-                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.log_values)
+                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values)
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -142,24 +142,24 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             next_link = next((link for link in results_object.get("links", []) if link.get("rel") == "Next"), None)
 
             if "progress" not in results_object:
-                self.logger.info("No more results to process. Exiting.", **self.connection.log_values)
+                self.logger.info("No more results to process. Exiting.", **self.connection.cloud_log_values)
                 return log_entries
             elif next_link:
                 self.logger.info(
                     "Over 500 results are available for this query, but only a limited number will be returned. Please use a more specific query to get all results.",
-                    **self.connection.log_values,
+                    **self.connection.cloud_log_values,
                 )
                 callback_url = next_link.get("href")
 
             counter -= 1
             if counter <= 0:
-                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.log_values)
+                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.cloud_log_values)
                 raise PluginException(
                     cause="Time out exceeded",
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.log_values)
+        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values)
         return {}
 
     def maybe_get_log_entries(
@@ -187,8 +187,8 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if not statistical:
             params["per_page"] = 500
 
-        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.log_values)
-        self.logger.info(f"Using parameters: {params}", **self.connection.log_values)
+        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.cloud_log_values)
+        self.logger.info(f"Using parameters: {params}", **self.connection.cloud_log_values)
         response = self.connection.session.get(endpoint, params=params)
         try:
             response.raise_for_status()
@@ -203,7 +203,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
 
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
-            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.log_values)
+            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
             stats_response = self.connection.session.get(stats_endpoint, params=params)
             try:
                 stats_response.raise_for_status()
@@ -222,7 +222,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             potential_results = results_object.get("events")
 
         if potential_results:
-            self.logger.info("Got results immediately, returning.", **self.connection.log_values)
+            self.logger.info("Got results immediately, returning.", **self.connection.cloud_log_values)
             if results_object.get("links", [{}])[0].get("rel") == "Next":
                 self.logger.info(
                     "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -54,7 +54,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 self.connection, insightconnect_plugin_runtime.helper.clean(log_entries)
             )
 
-        self.logger.info("Sending results to orchestrator.", **get_logging_context())
+        self.logger.info("Sending results to orchestrator.", **self.connection.log_values)
 
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
@@ -87,18 +87,18 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         :param statistical: bool - Whether to fetch statistical results or event logs.
         :return: list of log entries or statistical data.
         """
-        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **get_logging_context())
+        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.log_values)
         counter = timeout
 
         while callback_url and counter > 0:
             response = self.connection.session.get(callback_url)
-            self.logger.info(f"IDR Response Status Code: {response.status_code}", **get_logging_context())
+            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.log_values)
 
             try:
                 # IDR seems to return both `raise_for_status` and `status_code` - value is in `status_code` / `raise_for_status` just returns `None`
                 response.raise_for_status()
             except Exception as error:
-                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **get_logging_context())
+                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.log_values)
                 raise PluginException(
                     cause="Failed to get logs from InsightIDR",
                     assistance=f"Could not get logs from: {callback_url}",
@@ -108,24 +108,24 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             results_object = response.json()
 
             if "progress" in results_object:
-                self.logger.info(f"Progress: {results_object.get('progress')}", **get_logging_context())
+                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.log_values)
                 while "progress" in results_object and counter > 0:
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again.", **get_logging_context()
+                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.log_values
                     )
-                    self.logger.info(f"Time left: {counter} seconds", **get_logging_context())
+                    self.logger.info(f"Time left: {counter} seconds", **self.connection.log_values)
                     response = self.connection.session.get(callback_url)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}", **get_logging_context()
+                                f"Updated Progress: {results_object.get('progress')}", **self.connection.log_values
                             )
                     except Exception as e:
-                        self.logger.error(f"Failed to get logs during progress check: {e}", **get_logging_context())
+                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.log_values)
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -142,24 +142,24 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             next_link = next((link for link in results_object.get("links", []) if link.get("rel") == "Next"), None)
 
             if "progress" not in results_object:
-                self.logger.info("No more results to process. Exiting.", **get_logging_context())
+                self.logger.info("No more results to process. Exiting.", **self.connection.log_values)
                 return log_entries
             elif next_link:
                 self.logger.info(
                     "Over 500 results are available for this query, but only a limited number will be returned. Please use a more specific query to get all results.",
-                    **get_logging_context(),
+                    **self.connection.log_values,
                 )
                 callback_url = next_link.get("href")
 
             counter -= 1
             if counter <= 0:
-                self.logger.error("Timeout exceeded while waiting for logs.", **get_logging_context())
+                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.log_values)
                 raise PluginException(
                     cause="Time out exceeded",
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info("No valid log entries were fetched within the timeout period.", **get_logging_context())
+        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.log_values)
         return {}
 
     def maybe_get_log_entries(
@@ -187,8 +187,8 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if not statistical:
             params["per_page"] = 500
 
-        self.logger.info(f"Getting logs from: {endpoint}", **get_logging_context())
-        self.logger.info(f"Using parameters: {params}", **get_logging_context())
+        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.log_values)
+        self.logger.info(f"Using parameters: {params}", **self.connection.log_values)
         response = self.connection.session.get(endpoint, params=params)
         try:
             response.raise_for_status()
@@ -203,7 +203,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
 
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
-            self.logger.info(f"Getting statistical from: {stats_endpoint}", **get_logging_context())
+            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.log_values)
             stats_response = self.connection.session.get(stats_endpoint, params=params)
             try:
                 stats_response.raise_for_status()
@@ -222,7 +222,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             potential_results = results_object.get("events")
 
         if potential_results:
-            self.logger.info("Got results immediately, returning.", **get_logging_context())
+            self.logger.info("Got results immediately, returning.", **self.connection.log_values)
             if results_object.get("links", [{}])[0].get("rel") == "Next":
                 self.logger.info(
                     "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
@@ -40,7 +40,7 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -48,7 +48,7 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.SUCCESS: True, Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
@@ -40,7 +40,7 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -48,7 +48,7 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.SUCCESS: True, Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
@@ -54,7 +54,7 @@ class CloseInvestigationsInBulk(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource", "{}"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the expected format.",
                 assistance="Contact support for help. See log for more details:",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
@@ -54,7 +54,7 @@ class CloseInvestigationsInBulk(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource", "{}"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the expected format.",
                 assistance="Contact support for help. See log for more details:",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
@@ -47,7 +47,7 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -55,7 +55,7 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
@@ -47,7 +47,7 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -55,7 +55,7 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
@@ -19,6 +19,6 @@ class DeleteAttachment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Deleting the {attachment_rrn} attachment...", **self.connection.log_values)
+        self.logger.info(f"Deleting the {attachment_rrn} attachment...", **self.connection.cloud_log_values)
         request.delete_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
@@ -19,6 +19,6 @@ class DeleteAttachment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Deleting the {attachment_rrn} attachment...", **get_logging_context())
+        self.logger.info(f"Deleting the {attachment_rrn} attachment...", **self.connection.log_values)
         request.delete_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
@@ -19,6 +19,6 @@ class DeleteComment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         comment_rrn = params.get(Input.COMMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Deleting the {comment_rrn} comment...", **get_logging_context())
+        self.logger.info(f"Deleting the {comment_rrn} comment...", **self.connection.log_values)
         request.delete_comment(Comments.delete_comment(self.connection.url, comment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
@@ -19,6 +19,6 @@ class DeleteComment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         comment_rrn = params.get(Input.COMMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Deleting the {comment_rrn} comment...", **self.connection.log_values)
+        self.logger.info(f"Deleting the {comment_rrn} comment...", **self.connection.cloud_log_values)
         request.delete_comment(Comments.delete_comment(self.connection.url, comment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
@@ -19,6 +19,6 @@ class DownloadAttachment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Downloading the {attachment_rrn} attachment...", **self.connection.log_values)
+        self.logger.info(f"Downloading the {attachment_rrn} attachment...", **self.connection.cloud_log_values)
         content = request.download_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.ATTACHMENT_CONTENT: content, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
@@ -19,6 +19,6 @@ class DownloadAttachment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Downloading the {attachment_rrn} attachment...", **get_logging_context())
+        self.logger.info(f"Downloading the {attachment_rrn} attachment...", **self.connection.log_values)
         content = request.download_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.ATTACHMENT_CONTENT: content, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
@@ -33,7 +33,7 @@ class GetASavedQuery(insightconnect_plugin_runtime.Action):
             result = json.loads(response["resource"])
             saved_query = insightconnect_plugin_runtime.helper.clean(result.get("saved_query"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
@@ -33,7 +33,7 @@ class GetASavedQuery(insightconnect_plugin_runtime.Action):
             result = json.loads(response["resource"])
             saved_query = insightconnect_plugin_runtime.helper.clean(result.get("saved_query"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
@@ -24,6 +24,6 @@ class GetAccountInformation(insightconnect_plugin_runtime.Action):
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         endpoint = Accounts.get_account(self.connection.url, account_rrn)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the account information for {account_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the account information for {account_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(endpoint, "get")
         return {Output.ACCOUNT: response}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
@@ -24,6 +24,6 @@ class GetAccountInformation(insightconnect_plugin_runtime.Action):
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         endpoint = Accounts.get_account(self.connection.url, account_rrn)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the account information for {account_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the account information for {account_rrn}...", **self.connection.log_values)
         response = request.make_request(endpoint, "get")
         return {Output.ACCOUNT: response}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
@@ -21,7 +21,7 @@ class GetAlertActors(insightconnect_plugin_runtime.Action):
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
-        self.logger.info(f"Getting the alert actors for {alert_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the alert actors for {alert_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(
             Alerts.get_alert_actor(self.connection.url, alert_rrn), method="get", params=params
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
@@ -21,7 +21,7 @@ class GetAlertActors(insightconnect_plugin_runtime.Action):
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
-        self.logger.info(f"Getting the alert actors for {alert_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the alert actors for {alert_rrn}...", **self.connection.log_values)
         response = request.make_request(
             Alerts.get_alert_actor(self.connection.url, alert_rrn), method="get", params=params
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
@@ -22,7 +22,7 @@ class GetAlertEvidence(insightconnect_plugin_runtime.Action):
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
-        self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(
             Alerts.get_alert_evidence(self.connection.url, alert_rrn), method="get", params=params
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
@@ -22,7 +22,7 @@ class GetAlertEvidence(insightconnect_plugin_runtime.Action):
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
-        self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **self.connection.log_values)
         response = request.make_request(
             Alerts.get_alert_evidence(self.connection.url, alert_rrn), method="get", params=params
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
@@ -20,6 +20,6 @@ class GetAlertInformation(insightconnect_plugin_runtime.Action):
         alert_rrn = params.get(Input.ALERT_RRN)
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the alert information for {alert_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the alert information for {alert_rrn}...", **self.connection.log_values)
         response = request.make_request(Alerts.get_alert_information(self.connection.url, alert_rrn), "get")
         return {Output.ALERT: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
@@ -20,6 +20,6 @@ class GetAlertInformation(insightconnect_plugin_runtime.Action):
         alert_rrn = params.get(Input.ALERT_RRN)
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the alert information for {alert_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the alert information for {alert_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(Alerts.get_alert_information(self.connection.url, alert_rrn), "get")
         return {Output.ALERT: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
@@ -24,7 +24,7 @@ class GetAllSavedQueries(insightconnect_plugin_runtime.Action):
             result = json.loads(response["resource"])
             saved_queries = insightconnect_plugin_runtime.helper.clean(result.get("saved_queries"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
@@ -24,7 +24,7 @@ class GetAllSavedQueries(insightconnect_plugin_runtime.Action):
             result = json.loads(response["resource"])
             saved_queries = insightconnect_plugin_runtime.helper.clean(result.get("saved_queries"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
@@ -20,6 +20,6 @@ class GetAssetInformation(insightconnect_plugin_runtime.Action):
         asset_rrn = params.get(Input.ASSET_RRN)
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the asset information for {asset_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the asset information for {asset_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(Assets.get_asset_information(self.connection.url, asset_rrn), "get")
         return {Output.ASSET: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
@@ -20,6 +20,6 @@ class GetAssetInformation(insightconnect_plugin_runtime.Action):
         asset_rrn = params.get(Input.ASSET_RRN)
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the asset information for {asset_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the asset information for {asset_rrn}...", **self.connection.log_values)
         response = request.make_request(Assets.get_asset_information(self.connection.url, asset_rrn), "get")
         return {Output.ASSET: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
@@ -19,7 +19,7 @@ class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **self.connection.cloud_log_values)
         response = request.get_attachment_information(
             Attachments.get_attachment_information(self.connection.url, attachment_rrn)
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
@@ -19,7 +19,7 @@ class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **self.connection.log_values)
         response = request.get_attachment_information(
             Attachments.get_attachment_information(self.connection.url, attachment_rrn)
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
@@ -30,7 +30,7 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -38,7 +38,7 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
@@ -30,7 +30,7 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -38,7 +38,7 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
@@ -20,6 +20,6 @@ class GetUserInformation(insightconnect_plugin_runtime.Action):
         user_rrn = params.get(Input.USER_RRN)
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the user information for {user_rrn}...", **self.connection.log_values)
+        self.logger.info(f"Getting the user information for {user_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(Users.get_user_information(self.connection.url, user_rrn), "get")
         return {Output.USER: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
@@ -20,6 +20,6 @@ class GetUserInformation(insightconnect_plugin_runtime.Action):
         user_rrn = params.get(Input.USER_RRN)
         self.connection.session.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info(f"Getting the user information for {user_rrn}...", **get_logging_context())
+        self.logger.info(f"Getting the user information for {user_rrn}...", **self.connection.log_values)
         response = request.make_request(Users.get_user_information(self.connection.url, user_rrn), "get")
         return {Output.USER: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
@@ -34,7 +34,7 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
@@ -34,7 +34,7 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
@@ -26,7 +26,7 @@ class ReplaceIndicators(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
@@ -26,7 +26,7 @@ class ReplaceIndicators(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
@@ -35,7 +35,7 @@ class SearchAccounts(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
@@ -35,7 +35,7 @@ class SearchAccounts(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
@@ -75,7 +75,7 @@ class SearchAlerts(insightconnect_plugin_runtime.Action):
             )
             self.logger.info(
                 f"No user supplied time, defaulting to start time of 6 months ago: {start_time}",
-                **self.connection.log_values,
+                **self.connection.cloud_log_values,
             )
 
         search = clean(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
@@ -75,7 +75,7 @@ class SearchAlerts(insightconnect_plugin_runtime.Action):
             )
             self.logger.info(
                 f"No user supplied time, defaulting to start time of 6 months ago: {start_time}",
-                **get_logging_context(),
+                **self.connection.log_values,
             )
 
         search = clean(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
@@ -60,7 +60,7 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -70,7 +70,7 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
             metadata = result.get("metadata", {})
             return {Output.INVESTIGATIONS: investigations, Output.METADATA: metadata}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
@@ -60,7 +60,7 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -70,7 +70,7 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
             metadata = result.get("metadata", {})
             return {Output.INVESTIGATIONS: investigations, Output.METADATA: metadata}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
@@ -32,7 +32,7 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -40,7 +40,7 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
@@ -32,7 +32,7 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -40,7 +40,7 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
@@ -38,7 +38,7 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -46,7 +46,7 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
@@ -38,7 +38,7 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -46,7 +46,7 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
@@ -48,7 +48,7 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -56,7 +56,7 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **get_logging_context())
+            self.logger.error(result, **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
@@ -48,7 +48,7 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -56,7 +56,7 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.log_values)
+            self.logger.error(result, **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
@@ -25,7 +25,7 @@ class UploadAttachment(insightconnect_plugin_runtime.Action):
         if not mime_type:
             mime_type = "text/plain"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info("Uploading an attachment...", **get_logging_context())
+        self.logger.info("Uploading an attachment...", **self.connection.log_values)
         response = request.upload_attachment(
             Attachments.attachments(self.connection.url), files={"filedata": (filename, file_content, mime_type)}
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
@@ -25,7 +25,7 @@ class UploadAttachment(insightconnect_plugin_runtime.Action):
         if not mime_type:
             mime_type = "text/plain"
         request = ResourceHelper(self.connection.session, self.logger)
-        self.logger.info("Uploading an attachment...", **self.connection.log_values)
+        self.logger.info("Uploading an attachment...", **self.connection.cloud_log_values)
         response = request.upload_attachment(
             Attachments.attachments(self.connection.url), files={"filedata": (filename, file_content, mime_type)}
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -37,7 +37,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         except AttributeError:
             self.session.headers["User-Agent"] = "test-version"
         self.logger.info(f"Connect: Connecting...", **self.log_values)
-        self.logger.info(f"Request ID: {self.log_values.get('RR-Correlation-Id')}", **self.log_values)
+        self.logger.info(f"Request ID: {self.log_values.get('R7-Correlation-Id')}", **self.log_values)
 
     def test(self):
         response = self.session.get(f"{self.url}validate")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
@@ -26,7 +26,7 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
         # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         input_frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Alerts: trigger started", **self.connection.log_values)
+        self.logger.info("Get Alerts: trigger started", **self.connection.cloud_log_values)
 
         # Set initial set for storing initial alert_rrn values
         initial_alerts = set()
@@ -103,5 +103,5 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_alert(self, alert: dict):
-        self.logger.info(f"Alert found: {alert.get('rrn')}", **self.connection.log_values)
+        self.logger.info(f"Alert found: {alert.get('rrn')}", **self.connection.cloud_log_values)
         self.send({Output.ALERT: clean(alert)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
@@ -26,7 +26,7 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
         # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         input_frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Alerts: trigger started", **get_logging_context())
+        self.logger.info("Get Alerts: trigger started", **self.connection.log_values)
 
         # Set initial set for storing initial alert_rrn values
         initial_alerts = set()
@@ -103,5 +103,5 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_alert(self, alert: dict):
-        self.logger.info(f"Alert found: {alert.get('rrn')}", **get_logging_context())
+        self.logger.info(f"Alert found: {alert.get('rrn')}", **self.connection.log_values)
         self.send({Output.ALERT: clean(alert)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -27,7 +27,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
         search = params.get(Input.SEARCH)
         frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Investigations: trigger started", **get_logging_context())
+        self.logger.info("Get Investigations: trigger started", **self.connection.log_values)
 
         # Set initial set for storing initial alert_rrn values
         initial_investigations = set()
@@ -79,7 +79,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             response = request.resource_request(endpoint, "post", payload=data)
             return self.parse_json_response(response)
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **get_logging_context())
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -94,5 +94,5 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_investigation(self, investigation: dict):
-        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **get_logging_context())
+        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **self.connection.log_values)
         self.send({Output.INVESTIGATION: clean(investigation)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -27,7 +27,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
         search = params.get(Input.SEARCH)
         frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Investigations: trigger started", **self.connection.log_values)
+        self.logger.info("Get Investigations: trigger started", **self.connection.cloud_log_values)
 
         # Set initial set for storing initial alert_rrn values
         initial_investigations = set()
@@ -79,7 +79,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             response = request.resource_request(endpoint, "post", payload=data)
             return self.parse_json_response(response)
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.log_values)
+            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -94,5 +94,5 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_investigation(self, investigation: dict):
-        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **self.connection.log_values)
+        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **self.connection.cloud_log_values)
         self.send({Output.INVESTIGATION: clean(investigation)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -103,7 +103,7 @@ class ResourceHelper(object):
         """
         try:
             self.logger.info(
-                f"Making request to {endpoint} with request ID: {self.session.get('R7-Correlation-Id', 'N/A')}",
+                f"Making request to {endpoint} with request ID: {self.session.headers.get('R7-Correlation-Id', 'N/A')}",
             )
             request_method = getattr(self.session, method.lower())
             if not params:
@@ -155,7 +155,7 @@ class ResourceHelper(object):
     ):  # noqa: MC0001
         try:
             self.logger.info(
-                f"Making request to {path} with request ID: {self.session.get('R7-Correlation-Id', 'N/A')}",
+                f"Making request to {path} with request ID: {self.session.headers.get('R7-Correlation-Id', 'N/A')}",
             )
             response = self.session.request(
                 method=method.upper(),

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -151,6 +151,10 @@ class ResourceHelper(object):
         self, path: str, method: str = "GET", params: dict = None, json_data: dict = None, files: dict = None
     ):  # noqa: MC0001
         try:
+            self.logger.info(
+                f"Making request to {path} with request ID: {self.log_values.get('R7-Correlation-Id')}",
+                **self.log_values
+            )
             response = self.session.request(
                 method=method.upper(),
                 url=path,

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -102,6 +102,9 @@ class ResourceHelper(object):
         :return: Dict containing the JSON response body
         """
         try:
+            self.logger.info(
+                f"Making request to {endpoint} with request ID: {self.session.get('R7-Correlation-Id', 'N/A')}",
+            )
             request_method = getattr(self.session, method.lower())
             if not params:
                 params = {}
@@ -152,8 +155,7 @@ class ResourceHelper(object):
     ):  # noqa: MC0001
         try:
             self.logger.info(
-                f"Making request to {path} with request ID: {self.log_values.get('R7-Correlation-Id')}",
-                **self.log_values
+                f"Making request to {path} with request ID: {self.session.get('R7-Correlation-Id', 'N/A')}",
             )
             response = self.session.request(
                 method=method.upper(),

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
@@ -1,12 +1,15 @@
 import os
+import uuid
 from flask import request
 from insightconnect_plugin_runtime.helper import clean_dict
 
 
 def get_logging_context():
     log_values = {}
+    backup_uuid = str(uuid.uuid4())
+    # For cloud get our request ID from upstream services other build a new one
     if os.environ.get("PLUGIN_RUNTIME_ENVIRONMENT", "") == "cloud":
-        log_values["R7-Correlation-Id"] = request.headers.get("X-REQUEST-ID")
-        return clean_dict(log_values)
+        log_values["R7-Correlation-Id"] = request.headers.get("X-REQUEST-ID", backup_uuid)
     else:
-        return log_values
+        log_values["R7-Correlation-Id"] = backup_uuid
+    return log_values

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
@@ -1,15 +1,12 @@
 import os
-import uuid
 from flask import request
 from insightconnect_plugin_runtime.helper import clean_dict
 
 
 def get_logging_context():
     log_values = {}
-    backup_uuid = str(uuid.uuid4())
-    # For cloud get our request ID from upstream services other build a new one
+    # For cloud get our request ID from upstream services
     if os.environ.get("PLUGIN_RUNTIME_ENVIRONMENT", "") == "cloud":
-        log_values["R7-Correlation-Id"] = request.headers.get("X-REQUEST-ID", backup_uuid)
-    else:
-        log_values["R7-Correlation-Id"] = backup_uuid
-    return log_values
+        log_values["R7-Correlation-Id"] = request.headers.get("X-REQUEST-ID")
+
+    return clean_dict(log_values)


### PR DESCRIPTION
Pass a request ID and log this when running not on cloud, but when running on cloud use the request from our incoming requests.

Changes:
- an empty dict for cloud log vaues that gets ignored on an orch
- this gets passed as structure logging when running in cloud mode
- orch actions will also pass the same request ID

Testing:
```
# Cloud:
{"message": "Connect: Connecting...", "R7-Correlation-Id": "id-from-cloud", "request_path": "/actions/get_investigation", "request_id": "id-from-cloud", "level": "info", "timestamp": "2025-06-13 17:09.15"}
{"message": "Request ID: id-from-cloud", "R7-Correlation-Id": "id-from-cloud", "request_path": "/actions/get_investigation", "request_id": "id-from-cloud", "level": "info", "timestamp": "2025-06-13 17:09.15"}
{"message": "rapid7/Rapid7 InsightIDR:11.0.7. Step name: get_investigation", "request_path": "/actions/get_investigation", "request_id": "id-from-cloud", "level": "info", "timestamp": "2025-06-13 17:09.15"}
{"message": "Making request to <redacted> with request ID: id-from-cloud", "request_path": "/actions/get_investigation", "request_id": "id-from-cloud", "level": "info", "timestamp": "2025-06-13 17:09.15"}
```

```
# Local
Connect: Connecting...
Request ID: 9268385c-5643-4f28-8ee0-e730ded4af97
rapid7/Rapid7 InsightIDR:11.0.7. Step name: get_investigation
Making request to <redacted> with request ID: 9268385c-5643-4f28-8ee0-e730ded4af97

rapid7/Rapid7 InsightIDR:11.0.7. Step name: get_investigation
Making request to <redacted> with request ID: 9268385c-5643-4f28-8ee0-e730ded4af97
```