### PR TITLE
[SI-29846] [SOAR-19570] Stop session persisting across actions

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "bf1cb16b503f9577aa8f826e33c346a5",
-	"manifest": "1a98df420ee86528911e90aaaa67b268",
-	"setup": "246592467dc76dee95f213a2dade0e52",
+	"spec": "f76a8b4d2d40e15663b4b8b0912497d2",
+	"manifest": "abd8b86d00d9673ce145246f39e24e20",
+	"setup": "9cc860ee727a51894317f61818805610",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "11.0.7"
+Version = "11.0.8"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3428,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 11.0.8 - Remove use of session from the connection object to prevent session timeouts.
 * 11.0.7 - Adding request id to the plugin for traceability
 * 11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.6
 * 11.0.5 - Added new disposition of the alert

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
@@ -32,7 +32,7 @@ class AddIndicatorsToAThreat(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/add_indicators_to_a_threat/action.py
@@ -11,7 +11,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Threats
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 
 
@@ -25,8 +24,8 @@ class AddIndicatorsToAThreat(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         endpoint = Threats.add_indicators_to_a_threat(self.connection.url, params.pop(Input.KEY))
 
         response = request.resource_request(endpoint, "post", params={"format": "json"}, payload=params)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -128,7 +128,8 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.cloud_log_values
+                        "Results were not ready. Sleeping 1 second and trying again.",
+                        **self.connection.cloud_log_values,
                     )
                     self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
                     response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
@@ -137,10 +138,13 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}", **self.connection.cloud_log_values
+                                f"Updated Progress: {results_object.get('progress')}",
+                                **self.connection.cloud_log_values,
                             )
                     except Exception as e:
-                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values)
+                        self.logger.error(
+                            f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values
+                        )
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -175,7 +179,9 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values)
+        self.logger.info(
+            "No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values
+        )
         return {}
 
     def maybe_get_log_entries(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -49,9 +49,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
             )
 
         if log_id and log_name:
-            self.logger.info(
-                "Values were provided for both log ID and log name, the value for log id will be used"
-            )
+            self.logger.info("Values were provided for both log ID and log name, the value for log id will be used")
 
         if not log_id:
             log_id = self.get_log_id(log_name)
@@ -92,7 +90,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
             if entry in query:
                 return True
 
-    def get_results_from_callback(self, callback_url: str, timeout: int, statistical: bool) -> [object]:  # noqa: C901
+    def get_results_from_callback(self, callback_url: str, timeout: int, statistical: bool) -> [object]:  # noqa: MC0001
         """
         Get log entries from a callback URL.
 
@@ -135,13 +133,9 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
-                            self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}"
-                            )
+                            self.logger.info(f"Updated Progress: {results_object.get('progress')}")
                     except Exception as e:
-                        self.logger.error(
-                            f"Failed to get logs during progress check: {e}"
-                        )
+                        self.logger.error(f"Failed to get logs during progress check: {e}")
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -175,9 +169,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info(
-            "No valid log entries were fetched within the timeout period."
-        )
+        self.logger.info("No valid log entries were fetched within the timeout period.")
         return {}
 
     def maybe_get_log_entries(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -50,8 +50,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
 
         if log_id and log_name:
             self.logger.info(
-                "Values were provided for both log ID and log name, the value for log id will be used",
-                **self.connection.cloud_log_values,
+                "Values were provided for both log ID and log name, the value for log id will be used"
             )
 
         if not log_id:
@@ -69,7 +68,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                 self.connection, insightconnect_plugin_runtime.helper.clean(log_entries)
             )
 
-        self.logger.info("Sending results to orchestrator.", **self.connection.cloud_log_values)
+        self.logger.info("Sending results to orchestrator.")
 
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
@@ -102,18 +101,18 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         :param statistical: bool - Whether to fetch statistical results or event logs.
         :return: list of log entries or statistical data.
         """
-        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.cloud_log_values)
+        self.logger.info(f"Trying to get results from callback URL: {callback_url}")
         counter = timeout
 
         while callback_url and counter > 0:
             response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
-            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
+            self.logger.info(f"IDR Response Status Code: {response.status_code}")
 
             try:
                 # IDR seems to return both `raise_for_status` and `status_code` - value is in `status_code` / `raise_for_status` just returns `None`
                 response.raise_for_status()
             except Exception as error:
-                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.cloud_log_values)
+                self.logger.error(f"Failed to get logs from InsightIDR: {error}")
                 raise PluginException(
                     cause="Failed to get logs from InsightIDR",
                     assistance=f"Could not get logs from: {callback_url}",
@@ -123,27 +122,25 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
             results_object = response.json()
 
             if "progress" in results_object:
-                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.cloud_log_values)
+                self.logger.info(f"Progress: {results_object.get('progress')}")
                 while "progress" in results_object and counter > 0:
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
                         "Results were not ready. Sleeping 1 second and trying again.",
-                        **self.connection.cloud_log_values,
                     )
-                    self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
+                    self.logger.info(f"Time left: {counter} seconds")
                     response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}",
-                                **self.connection.cloud_log_values,
+                                f"Updated Progress: {results_object.get('progress')}"
                             )
                     except Exception as e:
                         self.logger.error(
-                            f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values
+                            f"Failed to get logs during progress check: {e}"
                         )
                         raise PluginException(
                             cause="Failed to get logs during progress check",
@@ -161,26 +158,25 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
             next_link = next((link for link in results_object.get("links", []) if link.get("rel") == "Next"), None)
 
             if "progress" not in results_object:
-                self.logger.info("No more results to process. Exiting.", **self.connection.cloud_log_values)
+                self.logger.info("No more results to process. Exiting.")
                 return log_entries
 
             elif next_link:
                 self.logger.info(
                     "Over 500 results are available for this query, but only a limited number will be returned. Please use a more specific query to get all results.",
-                    **self.connection.cloud_log_values,
                 )
                 callback_url = next_link.get("href")
 
             counter -= 1
             if counter <= 0:
-                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.cloud_log_values)
+                self.logger.error("Timeout exceeded while waiting for logs.")
                 raise PluginException(
                     cause="Time out exceeded",
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
         self.logger.info(
-            "No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values
+            "No valid log entries were fetched within the timeout period."
         )
         return {}
 
@@ -209,8 +205,8 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         if not statistical:
             params["per_page"] = 500
 
-        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.cloud_log_values)
-        self.logger.info(f"Using parameters: {params}", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting logs from: {endpoint}")
+        self.logger.info(f"Using parameters: {params}")
         response = send_session_request(req_url=endpoint, req_headers=self.connection.headers, req_params=params)
         try:
             response.raise_for_status()
@@ -225,7 +221,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
 
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
-            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
+            self.logger.info(f"Getting statistical from: {stats_endpoint}")
             stats_response = send_session_request(req_url=stats_endpoint, req_headers=self.connection.headers)
             try:
                 stats_response.raise_for_status()

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log/action.py
@@ -6,7 +6,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 import time
 from komand_rapid7_insightidr.util.parse_dates import parse_dates
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
+from komand_rapid7_insightidr.util.util import send_session_request
 from requests import HTTPError
 from typing import Tuple
 
@@ -106,7 +106,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         counter = timeout
 
         while callback_url and counter > 0:
-            response = self.connection.session.get(callback_url)
+            response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
             self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
 
             try:
@@ -131,7 +131,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
                         "Results were not ready. Sleeping 1 second and trying again.", **self.connection.cloud_log_values
                     )
                     self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
-                    response = self.connection.session.get(callback_url)
+                    response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
@@ -205,7 +205,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
 
         self.logger.info(f"Getting logs from: {endpoint}", **self.connection.cloud_log_values)
         self.logger.info(f"Using parameters: {params}", **self.connection.cloud_log_values)
-        response = self.connection.session.get(endpoint, params=params)
+        response = send_session_request(req_url=endpoint, req_headers=self.connection.headers, req_params=params)
         try:
             response.raise_for_status()
         except Exception:
@@ -220,7 +220,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
             self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
-            stats_response = self.connection.session.get(stats_endpoint, params=params)
+            stats_response = send_session_request(req_url=stats_endpoint, req_headers=self.connection.headers)
             try:
                 stats_response.raise_for_status()
             except HTTPError as error:
@@ -258,7 +258,7 @@ class AdvancedQueryOnLog(insightconnect_plugin_runtime.Action):
         endpoint = f"{self.connection.url}log_search/management/logs"
 
         self.logger.info(f"Getting log entries from: {endpoint}")
-        response = self.connection.session.get(endpoint)
+        response = send_session_request(req_url=endpoint, req_headers=self.connection.headers)
         try:
             response.raise_for_status()
         except Exception:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -54,7 +54,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 self.connection, insightconnect_plugin_runtime.helper.clean(log_entries)
             )
 
-        self.logger.info("Sending results to orchestrator.", **self.connection.cloud_log_values)
+        self.logger.info("Sending results to orchestrator.")
 
         if not statistical:
             return {Output.RESULTS_EVENTS: log_entries, Output.COUNT: len(log_entries)}
@@ -87,18 +87,18 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         :param statistical: bool - Whether to fetch statistical results or event logs.
         :return: list of log entries or statistical data.
         """
-        self.logger.info(f"Trying to get results from callback URL: {callback_url}", **self.connection.cloud_log_values)
+        self.logger.info(f"Trying to get results from callback URL: {callback_url}")
         counter = timeout
 
         while callback_url and counter > 0:
             response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
-            self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
+            self.logger.info(f"IDR Response Status Code: {response.status_code}")
 
             try:
                 # IDR seems to return both `raise_for_status` and `status_code` - value is in `status_code` / `raise_for_status` just returns `None`
                 response.raise_for_status()
             except Exception as error:
-                self.logger.error(f"Failed to get logs from InsightIDR: {error}", **self.connection.cloud_log_values)
+                self.logger.error(f"Failed to get logs from InsightIDR: {error}")
                 raise PluginException(
                     cause="Failed to get logs from InsightIDR",
                     assistance=f"Could not get logs from: {callback_url}",
@@ -108,27 +108,25 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             results_object = response.json()
 
             if "progress" in results_object:
-                self.logger.info(f"Progress: {results_object.get('progress')}", **self.connection.cloud_log_values)
+                self.logger.info(f"Progress: {results_object.get('progress')}")
                 while "progress" in results_object and counter > 0:
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again.",
-                        **self.connection.cloud_log_values,
+                        "Results were not ready. Sleeping 1 second and trying again."
                     )
-                    self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
+                    self.logger.info(f"Time left: {counter} seconds")
                     response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}",
-                                **self.connection.cloud_log_values,
+                                f"Updated Progress: {results_object.get('progress')}"
                             )
                     except Exception as e:
                         self.logger.error(
-                            f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values
+                            f"Failed to get logs during progress check: {e}"
                         )
                         raise PluginException(
                             cause="Failed to get logs during progress check",
@@ -146,26 +144,24 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             next_link = next((link for link in results_object.get("links", []) if link.get("rel") == "Next"), None)
 
             if "progress" not in results_object:
-                self.logger.info("No more results to process. Exiting.", **self.connection.cloud_log_values)
+                self.logger.info("No more results to process. Exiting.")
                 return log_entries
             elif next_link:
                 self.logger.info(
-                    "Over 500 results are available for this query, but only a limited number will be returned. Please use a more specific query to get all results.",
-                    **self.connection.cloud_log_values,
+                    "Over 500 results are available for this query, but only a limited number will be returned. Please use a more specific query to get all results."
                 )
                 callback_url = next_link.get("href")
 
             counter -= 1
             if counter <= 0:
-                self.logger.error("Timeout exceeded while waiting for logs.", **self.connection.cloud_log_values)
+                self.logger.error("Timeout exceeded while waiting for logs.")
                 raise PluginException(
                     cause="Time out exceeded",
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
         self.logger.info(
-            "No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values
-        )
+            "No valid log entries were fetched within the timeout period.")
         return {}
 
     def maybe_get_log_entries(
@@ -193,8 +189,8 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if not statistical:
             params["per_page"] = 500
 
-        self.logger.info(f"Getting logs from: {endpoint}", **self.connection.cloud_log_values)
-        self.logger.info(f"Using parameters: {params}", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting logs from: {endpoint}")
+        self.logger.info(f"Using parameters: {params}")
         response = send_session_request(req_url=endpoint, req_params=params, req_headers=self.connection.headers)
         try:
             response.raise_for_status()
@@ -209,7 +205,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
 
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
-            self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
+            self.logger.info(f"Getting statistical from: {stats_endpoint}")
             stats_response = send_session_request(
                 req_url=stats_endpoint, req_params=params, req_headers=self.connection.headers
             )
@@ -230,7 +226,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             potential_results = results_object.get("events")
 
         if potential_results:
-            self.logger.info("Got results immediately, returning.", **self.connection.cloud_log_values)
+            self.logger.info("Got results immediately, returning.")
             if results_object.get("links", [{}])[0].get("rel") == "Next":
                 self.logger.info(
                     "Over 500 results are available for this query, but only 500 will be returned, please use a more specific query to get all results"

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -78,7 +78,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
             if entry in query:
                 return True
 
-    def get_results_from_callback(self, callback_url: str, timeout: int, statistical: bool) -> [object]:  # noqa: C901
+    def get_results_from_callback(self, callback_url: str, timeout: int, statistical: bool) -> [object]:  # noqa: MC0001
         """
         Get log entries from a callback URL.
 
@@ -112,22 +112,16 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                 while "progress" in results_object and counter > 0:
                     time.sleep(1)
                     counter -= 1
-                    self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again."
-                    )
+                    self.logger.info("Results were not ready. Sleeping 1 second and trying again.")
                     self.logger.info(f"Time left: {counter} seconds")
                     response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
                         if "progress" in results_object:
-                            self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}"
-                            )
+                            self.logger.info(f"Updated Progress: {results_object.get('progress')}")
                     except Exception as e:
-                        self.logger.error(
-                            f"Failed to get logs during progress check: {e}"
-                        )
+                        self.logger.error(f"Failed to get logs during progress check: {e}")
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -160,8 +154,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info(
-            "No valid log entries were fetched within the timeout period.")
+        self.logger.info("No valid log entries were fetched within the timeout period.")
         return {}
 
     def maybe_get_log_entries(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -6,7 +6,7 @@ import time
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightidr.util.parse_dates import parse_dates
-from komand_rapid7_insightidr.util.util import get_logging_context
+from komand_rapid7_insightidr.util.util import send_session_request
 from requests import HTTPError
 from typing import Tuple
 
@@ -91,7 +91,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         counter = timeout
 
         while callback_url and counter > 0:
-            response = self.connection.session.get(callback_url)
+            response = send_session_request(req_url=callback_url,req_headers=self.connection.headers)
             self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
 
             try:
@@ -116,7 +116,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                         "Results were not ready. Sleeping 1 second and trying again.", **self.connection.cloud_log_values
                     )
                     self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
-                    response = self.connection.session.get(callback_url)
+                    response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
                     try:
                         response.raise_for_status()
                         results_object = response.json()
@@ -189,7 +189,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
 
         self.logger.info(f"Getting logs from: {endpoint}", **self.connection.cloud_log_values)
         self.logger.info(f"Using parameters: {params}", **self.connection.cloud_log_values)
-        response = self.connection.session.get(endpoint, params=params)
+        response = send_session_request(req_url=endpoint, req_params=params, req_headers=self.connection.headers)
         try:
             response.raise_for_status()
         except Exception:
@@ -204,7 +204,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
             self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
-            stats_response = self.connection.session.get(stats_endpoint, params=params)
+            stats_response = send_session_request(req_url=stats_endpoint, req_params=params, req_headers=self.connection.headers)
             try:
                 stats_response.raise_for_status()
             except HTTPError as error:
@@ -242,7 +242,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         endpoint = f"{self.connection.url}log_search/management/logsets"
 
         self.logger.info(f"Getting log entries from: {endpoint}")
-        response = self.connection.session.get(endpoint)
+        response = send_session_request(req_url=endpoint, req_headers=self.connection.headers)
         try:
             response.raise_for_status()
         except Exception:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/advanced_query_on_log_set/action.py
@@ -91,7 +91,7 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         counter = timeout
 
         while callback_url and counter > 0:
-            response = send_session_request(req_url=callback_url,req_headers=self.connection.headers)
+            response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
             self.logger.info(f"IDR Response Status Code: {response.status_code}", **self.connection.cloud_log_values)
 
             try:
@@ -113,7 +113,8 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     time.sleep(1)
                     counter -= 1
                     self.logger.info(
-                        "Results were not ready. Sleeping 1 second and trying again.", **self.connection.cloud_log_values
+                        "Results were not ready. Sleeping 1 second and trying again.",
+                        **self.connection.cloud_log_values,
                     )
                     self.logger.info(f"Time left: {counter} seconds", **self.connection.cloud_log_values)
                     response = send_session_request(req_url=callback_url, req_headers=self.connection.headers)
@@ -122,10 +123,13 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                         results_object = response.json()
                         if "progress" in results_object:
                             self.logger.info(
-                                f"Updated Progress: {results_object.get('progress')}", **self.connection.cloud_log_values
+                                f"Updated Progress: {results_object.get('progress')}",
+                                **self.connection.cloud_log_values,
                             )
                     except Exception as e:
-                        self.logger.error(f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values)
+                        self.logger.error(
+                            f"Failed to get logs during progress check: {e}", **self.connection.cloud_log_values
+                        )
                         raise PluginException(
                             cause="Failed to get logs during progress check",
                             assistance=f"Could not get logs from: {callback_url}",
@@ -159,7 +163,9 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
                     assistance="Time out for the query results was exceeded. Try simplifying your query or extending the timeout period.",
                 )
 
-        self.logger.info("No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values)
+        self.logger.info(
+            "No valid log entries were fetched within the timeout period.", **self.connection.cloud_log_values
+        )
         return {}
 
     def maybe_get_log_entries(
@@ -204,7 +210,9 @@ class AdvancedQueryOnLogSet(insightconnect_plugin_runtime.Action):
         if statistical:
             stats_endpoint = f"{self.connection.url}log_search/query/{results_object.get('id', '')}"
             self.logger.info(f"Getting statistical from: {stats_endpoint}", **self.connection.cloud_log_values)
-            stats_response = send_session_request(req_url=stats_endpoint, req_params=params, req_headers=self.connection.headers)
+            stats_response = send_session_request(
+                req_url=stats_endpoint, req_params=params, req_headers=self.connection.headers
+            )
             try:
                 stats_response.raise_for_status()
             except HTTPError as error:

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
@@ -39,7 +39,7 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -47,7 +47,7 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.SUCCESS: True, Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/action.py
@@ -13,7 +13,6 @@ from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
@@ -31,8 +30,8 @@ class AssignUserToInvestigation(insightconnect_plugin_runtime.Action):
 
         payload = {"user_email_address": user_email}
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.set_user_for_investigation(self.connection.url, investigation_id)
         response = request.resource_request(endpoint, "put", payload=payload)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
@@ -5,7 +5,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 from datetime import datetime
 from datetime import timedelta
@@ -21,8 +20,8 @@ class CloseInvestigationsInBulk(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         endpoint = Investigations.close_investigations_in_bulk(self.connection.url)
 
         source = self._get_with_default(params, Input.SOURCE, "MANUAL")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/close_investigations_in_bulk/action.py
@@ -53,7 +53,7 @@ class CloseInvestigationsInBulk(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource", "{}"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the expected format.",
                 assistance="Contact support for help. See log for more details:",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_comment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_comment/action.py
@@ -17,7 +17,7 @@ class CreateComment(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         attachments = params.get(Input.ATTACHMENTS)
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         if attachments:
             for attachment in attachments:
                 request.get_attachment_information(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
@@ -4,7 +4,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 # Custom imports below
 import json
@@ -38,8 +37,8 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         if email:
             data.update({"assignee": {Input.EMAIL: email}})
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.create_investigation(self.connection.url)
         response = request.resource_request(endpoint, "post", payload=data)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/action.py
@@ -46,7 +46,7 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -54,7 +54,7 @@ class CreateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_threat/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_threat/action.py
@@ -19,8 +19,8 @@ class CreateThreat(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         endpoint = Threats.create_threat(self.connection.url)
 
         indicators = params.get(Input.INDICATORS)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
@@ -18,6 +18,6 @@ class DeleteAttachment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Deleting the {attachment_rrn} attachment...", **self.connection.cloud_log_values)
+        self.logger.info(f"Deleting the {attachment_rrn} attachment...", **request.logging_context)
         request.delete_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_attachment/action.py
@@ -4,7 +4,6 @@ from .schema import DeleteAttachmentInput, DeleteAttachmentOutput, Input, Output
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Attachments
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class DeleteAttachment(insightconnect_plugin_runtime.Action):
@@ -18,7 +17,7 @@ class DeleteAttachment(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Deleting the {attachment_rrn} attachment...", **self.connection.cloud_log_values)
         request.delete_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
@@ -18,6 +18,6 @@ class DeleteComment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         comment_rrn = params.get(Input.COMMENT_RRN)
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Deleting the {comment_rrn} comment...", **self.connection.cloud_log_values)
+        self.logger.info(f"Deleting the {comment_rrn} comment...", **request.logging_context)
         request.delete_comment(Comments.delete_comment(self.connection.url, comment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/delete_comment/action.py
@@ -4,7 +4,6 @@ from .schema import DeleteCommentInput, DeleteCommentOutput, Input, Output, Comp
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Comments
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class DeleteComment(insightconnect_plugin_runtime.Action):
@@ -18,7 +17,7 @@ class DeleteComment(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         comment_rrn = params.get(Input.COMMENT_RRN)
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Deleting the {comment_rrn} comment...", **self.connection.cloud_log_values)
         request.delete_comment(Comments.delete_comment(self.connection.url, comment_rrn))
         return {Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
@@ -4,7 +4,6 @@ from .schema import DownloadAttachmentInput, DownloadAttachmentOutput, Input, Ou
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Attachments
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class DownloadAttachment(insightconnect_plugin_runtime.Action):
@@ -18,7 +17,7 @@ class DownloadAttachment(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Downloading the {attachment_rrn} attachment...", **self.connection.cloud_log_values)
         content = request.download_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.ATTACHMENT_CONTENT: content, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/download_attachment/action.py
@@ -18,6 +18,6 @@ class DownloadAttachment(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Downloading the {attachment_rrn} attachment...", **self.connection.cloud_log_values)
+        self.logger.info(f"Downloading the {attachment_rrn} attachment...", **request.logging_context)
         content = request.download_attachment(Attachments.attachment(self.connection.url, attachment_rrn))
         return {Output.ATTACHMENT_CONTENT: content, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_log/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_log/action.py
@@ -15,8 +15,8 @@ class GetALog(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         response = request.resource_request(Logs.get_a_log(self.connection.url, params.get(Input.ID)), "get")
         try:
             result = json.loads(response["resource"])

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
@@ -32,7 +32,7 @@ class GetASavedQuery(insightconnect_plugin_runtime.Action):
             result = json.loads(response["resource"])
             saved_query = insightconnect_plugin_runtime.helper.clean(result.get("saved_query"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_a_saved_query/action.py
@@ -3,7 +3,6 @@ import insightconnect_plugin_runtime
 from .schema import GetASavedQueryInput, GetASavedQueryOutput, Input, Output, Component
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from komand_rapid7_insightidr.util.endpoints import Queries
-from komand_rapid7_insightidr.util.util import get_logging_context
 from insightconnect_plugin_runtime.exceptions import PluginException
 from validators import uuid
 import json
@@ -26,8 +25,8 @@ class GetASavedQuery(insightconnect_plugin_runtime.Action):
                 assistance="Please enter a valid UUID value in the Query ID field.",
                 data=f"Query ID: {query_id}",
             )
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         response = request.resource_request(Queries.get_query_by_id(self.connection.region, query_id), "get")
         try:
             result = json.loads(response["resource"])

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
@@ -6,7 +6,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Accounts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 
 
@@ -21,9 +20,9 @@ class GetAccountInformation(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         account_rrn = params.get(Input.ACCOUNT_RRN)
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
+        self.connection.headers["Accept-version"] = "strong-force-preview"
         endpoint = Accounts.get_account(self.connection.url, account_rrn)
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Getting the account information for {account_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(endpoint, "get")
         return {Output.ACCOUNT: response}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_account_information/action.py
@@ -23,6 +23,6 @@ class GetAccountInformation(insightconnect_plugin_runtime.Action):
         self.connection.headers["Accept-version"] = "strong-force-preview"
         endpoint = Accounts.get_account(self.connection.url, account_rrn)
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Getting the account information for {account_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting the account information for {account_rrn}...", **request.logging_context)
         response = request.make_request(endpoint, "get")
         return {Output.ACCOUNT: response}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
@@ -4,7 +4,6 @@ from .schema import GetAlertActorsInput, GetAlertActorsOutput, Input, Output, Co
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Alerts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class GetAlertActors(insightconnect_plugin_runtime.Action):
@@ -18,8 +17,8 @@ class GetAlertActors(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         alert_rrn = params.get(Input.ALERT_RRN)
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
         self.logger.info(f"Getting the alert actors for {alert_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_actors/action.py
@@ -20,7 +20,7 @@ class GetAlertActors(insightconnect_plugin_runtime.Action):
         self.connection.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.headers, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
-        self.logger.info(f"Getting the alert actors for {alert_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting the alert actors for {alert_rrn}...", **request.logging_context)
         response = request.make_request(
             Alerts.get_alert_actor(self.connection.url, alert_rrn), method="get", params=params
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
@@ -4,7 +4,6 @@ from .schema import GetAlertEvidenceInput, GetAlertEvidenceOutput, Input, Output
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Alerts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 
 
@@ -19,8 +18,8 @@ class GetAlertEvidence(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         alert_rrn = params.get(Input.ALERT_RRN)
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
         self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_evidence/action.py
@@ -21,7 +21,7 @@ class GetAlertEvidence(insightconnect_plugin_runtime.Action):
         self.connection.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.headers, self.logger)
         params = {"size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
-        self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting the alert evidence for {alert_rrn}...", **request.logging_context)
         response = request.make_request(
             Alerts.get_alert_evidence(self.connection.url, alert_rrn), method="get", params=params
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
@@ -19,6 +19,6 @@ class GetAlertInformation(insightconnect_plugin_runtime.Action):
         alert_rrn = params.get(Input.ALERT_RRN)
         self.connection.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Getting the alert information for {alert_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting the alert information for {alert_rrn}...", **request.logging_context)
         response = request.make_request(Alerts.get_alert_information(self.connection.url, alert_rrn), "get")
         return {Output.ALERT: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/action.py
@@ -4,7 +4,6 @@ from .schema import GetAlertInformationInput, GetAlertInformationOutput, Input, 
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Alerts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class GetAlertInformation(insightconnect_plugin_runtime.Action):
@@ -18,8 +17,8 @@ class GetAlertInformation(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         alert_rrn = params.get(Input.ALERT_RRN)
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Getting the alert information for {alert_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(Alerts.get_alert_information(self.connection.url, alert_rrn), "get")
         return {Output.ALERT: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_logs/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_logs/action.py
@@ -15,8 +15,8 @@ class GetAllLogs(insightconnect_plugin_runtime.Action):
         )
 
     def run(self):
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         response = request.resource_request(Logs.get_all_logs(self.connection.url), "get")
         try:
             result = json.loads(response["resource"])

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
@@ -23,7 +23,7 @@ class GetAllSavedQueries(insightconnect_plugin_runtime.Action):
             result = json.loads(response["resource"])
             saved_queries = insightconnect_plugin_runtime.helper.clean(result.get("saved_queries"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_all_saved_queries/action.py
@@ -2,7 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import GetAllSavedQueriesInput, GetAllSavedQueriesOutput, Input, Output, Component
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from komand_rapid7_insightidr.util.endpoints import Queries
-from komand_rapid7_insightidr.util.util import get_logging_context
 from insightconnect_plugin_runtime.exceptions import PluginException
 import json
 
@@ -17,8 +16,8 @@ class GetAllSavedQueries(insightconnect_plugin_runtime.Action):
         )
 
     def run(self):
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         response = request.resource_request(Queries.get_all_queries(self.connection.region), "get")
         try:
             result = json.loads(response["resource"])

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
@@ -19,6 +19,6 @@ class GetAssetInformation(insightconnect_plugin_runtime.Action):
         asset_rrn = params.get(Input.ASSET_RRN)
         self.connection.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Getting the asset information for {asset_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting the asset information for {asset_rrn}...", **request.logging_context)
         response = request.make_request(Assets.get_asset_information(self.connection.url, asset_rrn), "get")
         return {Output.ASSET: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_asset_information/action.py
@@ -4,7 +4,6 @@ from .schema import GetAssetInformationInput, GetAssetInformationOutput, Input, 
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Assets
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class GetAssetInformation(insightconnect_plugin_runtime.Action):
@@ -18,8 +17,8 @@ class GetAssetInformation(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         asset_rrn = params.get(Input.ASSET_RRN)
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Getting the asset information for {asset_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(Assets.get_asset_information(self.connection.url, asset_rrn), "get")
         return {Output.ASSET: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
@@ -18,7 +18,9 @@ class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(
+            f"Getting the attachment information for {attachment_rrn}...", **self.connection.cloud_log_values
+        )
         response = request.get_attachment_information(
             Attachments.get_attachment_information(self.connection.url, attachment_rrn)
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
@@ -19,7 +19,7 @@ class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(
-            f"Getting the attachment information for {attachment_rrn}...", **self.connection.cloud_log_values
+            f"Getting the attachment information for {attachment_rrn}...", **request.logging_context
         )
         response = request.get_attachment_information(
             Attachments.get_attachment_information(self.connection.url, attachment_rrn)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
@@ -4,7 +4,6 @@ from .schema import GetAttachmentInformationInput, GetAttachmentInformationOutpu
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Attachments
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
@@ -18,7 +17,7 @@ class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **self.connection.cloud_log_values)
         response = request.get_attachment_information(
             Attachments.get_attachment_information(self.connection.url, attachment_rrn)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_attachment_information/action.py
@@ -18,9 +18,7 @@ class GetAttachmentInformation(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         attachment_rrn = params.get(Input.ATTACHMENT_RRN)
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(
-            f"Getting the attachment information for {attachment_rrn}...", **request.logging_context
-        )
+        self.logger.info(f"Getting the attachment information for {attachment_rrn}...", **request.logging_context)
         response = request.get_attachment_information(
             Attachments.get_attachment_information(self.connection.url, attachment_rrn)
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
@@ -29,7 +29,7 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -37,7 +37,7 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/action.py
@@ -4,7 +4,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 # Custom imports below
 import json
@@ -21,8 +20,8 @@ class GetInvestigation(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         identifier = params.get(Input.ID)
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.update_or_get_investigation(self.connection.url, identifier)
         response = request.resource_request(endpoint, "get")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
@@ -19,6 +19,6 @@ class GetUserInformation(insightconnect_plugin_runtime.Action):
         user_rrn = params.get(Input.USER_RRN)
         self.connection.headers["Accept-version"] = "strong-force-preview"
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info(f"Getting the user information for {user_rrn}...", **self.connection.cloud_log_values)
+        self.logger.info(f"Getting the user information for {user_rrn}...", **request.logging_context)
         response = request.make_request(Users.get_user_information(self.connection.url, user_rrn), "get")
         return {Output.USER: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_user_information/action.py
@@ -4,7 +4,6 @@ from .schema import GetUserInformationInput, GetUserInformationOutput, Input, Ou
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Users
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class GetUserInformation(insightconnect_plugin_runtime.Action):
@@ -18,8 +17,8 @@ class GetUserInformation(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         user_rrn = params.get(Input.USER_RRN)
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Getting the user information for {user_rrn}...", **self.connection.cloud_log_values)
         response = request.make_request(Users.get_user_information(self.connection.url, user_rrn), "get")
         return {Output.USER: response, Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
@@ -34,7 +34,7 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_alerts_for_investigation/action.py
@@ -26,8 +26,8 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
         index = params.get(Input.INDEX)
 
         parameters = {"size": size, "index": index}
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.list_alerts_for_investigation(self.connection.url, identifier)
         response = request.resource_request(endpoint, "get", params=parameters)
@@ -51,7 +51,8 @@ class ListAlertsForInvestigation(insightconnect_plugin_runtime.Action):
                 assistance="Contact support for help. See log for more details",
             )
 
-    def _get_rule_rrn(self, result: Dict[str, Any]) -> None:
+    @staticmethod
+    def _get_rule_rrn(result: Dict[str, Any]) -> None:
         """
         Retrieve rule rrn from all records,
         due to inconsistent API from insightIDR

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_attachments/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_attachments/action.py
@@ -16,7 +16,7 @@ class ListAttachments(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Listing the attachments for {params.get(Input.TARGET)}...")
         response = request.list_attachments(Attachments.attachments(self.connection.url), params)
         return {Output.ATTACHMENTS: response.get("data", []), Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_comments/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_comments/action.py
@@ -16,7 +16,7 @@ class ListComments(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info(f"Listing the comments for {params.get(Input.TARGET)}...")
         response = request.list_comments(Comments.comments(self.connection.url), params)
         return {Output.COMMENTS: response.get("data", []), Output.SUCCESS: True}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_investigations/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_investigations/action.py
@@ -43,7 +43,7 @@ class ListInvestigations(insightconnect_plugin_runtime.Action):
             rest_params["end_time"] = end_time_parsed.astimezone(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
         rest_params = clean(rest_params)
 
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.list_investigations(self.connection.url)
         response = request.make_request(endpoint, "GET", params=rest_params)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/query/action.py
@@ -23,8 +23,8 @@ class Query(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         most_recent_first = params.get(Input.MOST_RECENT_FIRST)
         time_now = int(time.time())
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
         from_var = time_now - THREE_MONTHS_SECONDS
         if most_recent_first and from_var < TWENTY_FOURTH_NOVEMBER:
             from_var = TWENTY_FOURTH_NOVEMBER

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
@@ -5,7 +5,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Threats
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 
 
@@ -19,9 +18,9 @@ class ReplaceIndicators(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         endpoint = Threats.replace_indicators(self.connection.url, params.pop(Input.KEY))
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
+        self.connection.headers["Accept-version"] = "investigations-preview"
         response = request.resource_request(endpoint, "post", params={"format": "json"}, payload=params)
         try:
             result = json.loads(response.get("resource"))

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/replace_indicators/action.py
@@ -25,7 +25,7 @@ class ReplaceIndicators(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
@@ -6,7 +6,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Accounts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 
 
@@ -27,8 +26,8 @@ class SearchAccounts(insightconnect_plugin_runtime.Action):
             "sort": params.get(Input.SORT, []),
         }
 
-        self.connection.session.headers["Accept-version"] = "strong-force-preview "
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview "
+        request = ResourceHelper(self.connection.headers, self.logger)
         endpoint = Accounts.search_accounts(self.connection.url)
         response = request.resource_request(endpoint, "post", payload=data, params=parameters)
 

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_accounts/action.py
@@ -34,7 +34,7 @@ class SearchAccounts(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
@@ -6,7 +6,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Alerts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 from dateutil.relativedelta import relativedelta
 import datetime
 import json
@@ -100,8 +99,8 @@ class SearchAlerts(insightconnect_plugin_runtime.Action):
             {"rrns_only": params.get(Input.RRNS_ONLY), "size": params.get(Input.SIZE), "index": params.get(Input.INDEX)}
         )
 
-        self.connection.session.headers["Accept-version"] = "strong-force-preview "
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview "
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Alerts.get_alert_serach(self.connection.url)
         response = request.resource_request(endpoint, "post", payload=data, params=parameters)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
@@ -73,8 +73,7 @@ class SearchAlerts(insightconnect_plugin_runtime.Action):
                 .strftime("%Y-%m-%dT%H:%M:%SZ")
             )
             self.logger.info(
-                f"No user supplied time, defaulting to start time of 6 months ago: {start_time}",
-                **self.connection.cloud_log_values,
+                f"No user supplied time, defaulting to start time of 6 months ago: {start_time}"
             )
 
         search = clean(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/action.py
@@ -20,7 +20,7 @@ class SearchAlerts(insightconnect_plugin_runtime.Action):
             output=SearchAlertsOutput(),
         )
 
-    def run(self, params={}):  # noqa MC0001
+    def run(self, params={}):  # noqa: MC0001
         input_start_time = params.get(Input.START_TIME)
         input_end_time = params.get(Input.END_TIME)
 
@@ -72,9 +72,7 @@ class SearchAlerts(insightconnect_plugin_runtime.Action):
                 .astimezone(datetime.timezone.utc)
                 .strftime("%Y-%m-%dT%H:%M:%SZ")
             )
-            self.logger.info(
-                f"No user supplied time, defaulting to start time of 6 months ago: {start_time}"
-            )
+            self.logger.info(f"No user supplied time, defaulting to start time of 6 months ago: {start_time}")
 
         search = clean(
             {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
@@ -6,7 +6,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 import datetime
 
@@ -51,8 +50,8 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
 
         parameters = clean({Input.SIZE: size, Input.INDEX: index})
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.search_investigation(self.connection.url)
         response = request.resource_request(endpoint, "post", payload=data, params=parameters)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/action.py
@@ -59,7 +59,7 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -69,7 +69,7 @@ class SearchInvestigations(insightconnect_plugin_runtime.Action):
             metadata = result.get("metadata", {})
             return {Output.INVESTIGATIONS: investigations, Output.METADATA: metadata}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_disposition_of_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_disposition_of_investigation/action.py
@@ -22,8 +22,8 @@ class SetDispositionOfInvestigation(insightconnect_plugin_runtime.Action):
         identifier = params.get(Input.ID)
         disposition = params.get(Input.DISPOSITION)
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.set_the_disposition_of_an_investigation(self.connection.url, identifier, disposition)
         response = request.resource_request(endpoint, "put")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
@@ -31,7 +31,7 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -39,7 +39,7 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/action.py
@@ -4,7 +4,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 # Custom imports below
 import json
@@ -23,8 +22,8 @@ class SetPriorityOfInvestigation(insightconnect_plugin_runtime.Action):
         identifier = params.get(Input.ID)
         priority = params.get(Input.PRIORITY)
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.set_the_priority_of_an_investigation(self.connection.url, identifier, priority)
         response = request.resource_request(endpoint, "put")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
@@ -12,7 +12,6 @@ from insightconnect_plugin_runtime.helper import clean
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 
 
@@ -29,8 +28,8 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         idr_id = params.get(Input.ID)
         status = params.get(Input.STATUS)
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.set_the_status_of_an_investigation(self.connection.url, idr_id, status)
         response = request.resource_request(endpoint, "put")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/action.py
@@ -37,7 +37,7 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response["resource"])
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -45,7 +45,7 @@ class SetStatusOfInvestigationAction(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_alert/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_alert/action.py
@@ -42,8 +42,8 @@ class UpdateAlert(insightconnect_plugin_runtime.Action):
         data = {k: v for k, v in data.items() if v and (isinstance(v, dict) and v["value"] or not isinstance(v, dict))}
 
         # Set the API version header and create a request helper instance
-        self.connection.session.headers["Accept-version"] = "strong-force-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "strong-force-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         # Construct the endpoint URL
         endpoint = Alerts.get_alert_information(self.connection.url, alert_rrn)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
@@ -47,7 +47,7 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             result = json.loads(response.get("resource"))
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -55,7 +55,7 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         try:
             return {Output.INVESTIGATION: clean(result)}
         except KeyError:
-            self.logger.error(result, **self.connection.cloud_log_values)
+            self.logger.error(result, **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/action.py
@@ -4,7 +4,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 # Custom imports below
 import json
@@ -39,8 +38,8 @@ class UpdateInvestigation(insightconnect_plugin_runtime.Action):
         if email:
             data.update({"assignee": {Input.EMAIL: email}})
 
-        self.connection.session.headers["Accept-version"] = "investigations-preview"
-        request = ResourceHelper(self.connection.session, self.logger)
+        self.connection.headers["Accept-version"] = "investigations-preview"
+        request = ResourceHelper(self.connection.headers, self.logger)
 
         endpoint = Investigations.update_or_get_investigation(self.connection.url, identifier)
         response = request.resource_request(endpoint, "patch", payload=data)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
@@ -4,7 +4,6 @@ from .schema import UploadAttachmentInput, UploadAttachmentOutput, Input, Output
 # Custom imports below
 from komand_rapid7_insightidr.util.endpoints import Attachments
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
-from komand_rapid7_insightidr.util.util import get_logging_context
 import base64
 import mimetypes
 
@@ -24,7 +23,7 @@ class UploadAttachment(insightconnect_plugin_runtime.Action):
         mime_type = mimetypes.guess_type(filename)[0]
         if not mime_type:
             mime_type = "text/plain"
-        request = ResourceHelper(self.connection.session, self.logger)
+        request = ResourceHelper(self.connection.headers, self.logger)
         self.logger.info("Uploading an attachment...", **self.connection.cloud_log_values)
         response = request.upload_attachment(
             Attachments.attachments(self.connection.url), files={"filedata": (filename, file_content, mime_type)}

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/upload_attachment/action.py
@@ -24,7 +24,7 @@ class UploadAttachment(insightconnect_plugin_runtime.Action):
         if not mime_type:
             mime_type = "text/plain"
         request = ResourceHelper(self.connection.headers, self.logger)
-        self.logger.info("Uploading an attachment...", **self.connection.cloud_log_values)
+        self.logger.info("Uploading an attachment...", **request.logging_context)
         response = request.upload_attachment(
             Attachments.attachments(self.connection.url), files={"filedata": (filename, file_content, mime_type)}
         )

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -1,30 +1,21 @@
-import uuid
-
 import insightconnect_plugin_runtime
 from .schema import ConnectionSchema, Input
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException
 
 # Custom imports below
 import requests
-from typing import Optional
 from komand_rapid7_insightidr.util.endpoints import Investigations
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class Connection(insightconnect_plugin_runtime.Connection):
     def __init__(self):
         super(self.__class__, self).__init__(input=ConnectionSchema())
         self.url = None
-        self.session: Optional[requests.Session] = None
-        self.cloud_log_values = {}
+        self.headers = {}
+        self.cloud_log_values = {}   # todo- this should be removed or populated in request helper properly
 
     def connect(self, params={}):
         api_key = params.get(Input.API_KEY).get("secretKey")
-        cloud_request_id = get_logging_context()
-        request_uuid = str(uuid.uuid4())
-        if cloud_req_id := cloud_request_id.get("R7-Correlation-Id"):
-            request_uuid = cloud_req_id
-            self.cloud_log_values = cloud_request_id
 
         self.region = params.get(Input.REGION)
         self.url = Investigations.connection_api_url(self.region)
@@ -32,20 +23,16 @@ class Connection(insightconnect_plugin_runtime.Connection):
         if not self.url.endswith("/"):
             self.url = f"{self.url}/"
 
-        self.session = requests.session()
-        self.session.headers["X-Api-Key"] = api_key
-        self.session.headers["Accept-version"] = "investigations-preview"
+        self.headers = {
+            "X-Api-Key": api_key,
+            "Accept-version": "investigations-preview",
+            "User-Agent": "test-version" if not hasattr(self, "meta.version") else self.meta.version
+        }
 
-        self.session.headers["R7-Correlation-Id"] = request_uuid
-        try:
-            self.session.headers["User-Agent"] = f"r7:insightconnect-insightidr-plugin/{self.meta.version}"
-        except AttributeError:
-            self.session.headers["User-Agent"] = "test-version"
-        self.logger.info(f"Connect: Connecting...", **self.cloud_log_values)
-        self.logger.info(f"Request ID: {request_uuid}", **self.cloud_log_values)
+        self.logger.info(f"Connect: Connecting...")
 
     def test(self):
-        response = self.session.get(f"{self.url}validate")
+        response = requests.get(f"{self.url}validate", headers=self.headers)
         if response.status_code == 401:
             raise ConnectionTestException(preset=ConnectionTestException.Preset.UNAUTHORIZED)
         if response.status_code in range(500, 599):
@@ -53,7 +40,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         if response.status_code == 200:
             return response.json()
         else:
-            self.logger.error(response.text, **self.connection.cloud_log_values)
+            self.logger.error(response.text)
             raise ConnectionTestException(
                 cause=f"An unknown error occurred." f" InsightIDR responded with a {response.status_code} code.",
                 assistance="See log for more details. If the problem persists, please contact support.",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -31,10 +31,10 @@ class Connection(insightconnect_plugin_runtime.Connection):
             "User-Agent": f"r7:insightconnect-insightidr-plugin/{user_agent_version}",
         }
 
-        self.logger.info(f"Connect: Connecting...")
+        self.logger.info("Connect: Connecting...")
 
     def test(self):
-        response = requests.get(f"{self.url}validate", headers=self.headers)
+        response = requests.get(f"{self.url}validate", headers=self.headers, timeout=60)
         if response.status_code == 401:
             raise ConnectionTestException(preset=ConnectionTestException.Preset.UNAUTHORIZED)
         if response.status_code in range(500, 599):

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -12,7 +12,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         super(self.__class__, self).__init__(input=ConnectionSchema())
         self.url = None
         self.headers = {}
-        self.cloud_log_values = {}  # todo- this should be removed or populated in request helper properly
+        self.region = ""
 
     def connect(self, params={}):
         api_key = params.get(Input.API_KEY).get("secretKey")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -23,10 +23,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
         if not self.url.endswith("/"):
             self.url = f"{self.url}/"
 
+        user_agent_version = "test-version" if not hasattr(self, "meta.version") else self.meta.version
+
         self.headers = {
             "X-Api-Key": api_key,
             "Accept-version": "investigations-preview",
-            "User-Agent": "test-version" if not hasattr(self, "meta.version") else self.meta.version,
+            "User-Agent": f"r7:insightconnect-insightidr-plugin/{user_agent_version}",
         }
 
         self.logger.info(f"Connect: Connecting...")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/connection/connection.py
@@ -12,7 +12,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         super(self.__class__, self).__init__(input=ConnectionSchema())
         self.url = None
         self.headers = {}
-        self.cloud_log_values = {}   # todo- this should be removed or populated in request helper properly
+        self.cloud_log_values = {}  # todo- this should be removed or populated in request helper properly
 
     def connect(self, params={}):
         api_key = params.get(Input.API_KEY).get("secretKey")
@@ -26,7 +26,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
         self.headers = {
             "X-Api-Key": api_key,
             "Accept-version": "investigations-preview",
-            "User-Agent": "test-version" if not hasattr(self, "meta.version") else self.meta.version
+            "User-Agent": "test-version" if not hasattr(self, "meta.version") else self.meta.version,
         }
 
         self.logger.info(f"Connect: Connecting...")

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
@@ -25,7 +25,7 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
         # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         input_frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Alerts: trigger started", **self.connection.cloud_log_values)
+        self.logger.info("Get Alerts: trigger started", **request.logging_context)
 
         # Set initial set for storing initial alert_rrn values
         initial_alerts = set()
@@ -102,5 +102,5 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_alert(self, alert: dict):
-        self.logger.info(f"Alert found: {alert.get('rrn')}", **self.connection.cloud_log_values)
+        self.logger.info(f"Alert found: {alert.get('rrn')}", **request.logging_context)
         self.send({Output.ALERT: clean(alert)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
@@ -10,7 +10,6 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightidr.util.endpoints import Alerts
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from komand_rapid7_insightidr.util.constants import TOTAL_SIZE
-from komand_rapid7_insightidr.util.util import get_logging_context
 
 
 class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
@@ -84,8 +83,8 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
 
     def make_resource_request(self, data):
         try:
-            self.connection.session.headers["Accept-version"] = "strong-force-preview"
-            request = ResourceHelper(self.connection.session, self.logger)
+            self.connection.headers["Accept-version"] = "strong-force-preview"
+            request = ResourceHelper(self.connection.headers, self.logger)
             endpoint = Alerts.get_alert_serach(self.connection.url)
             response = request.resource_request(endpoint, "post", payload=data)
             return self.parse_json_response(response)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/trigger.py
@@ -25,7 +25,7 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
         # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         input_frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Alerts: trigger started", **request.logging_context)
+        self.logger.info("Get Alerts: trigger started")
 
         # Set initial set for storing initial alert_rrn values
         initial_alerts = set()
@@ -102,5 +102,5 @@ class GetNewAlerts(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_alert(self, alert: dict):
-        self.logger.info(f"Alert found: {alert.get('rrn')}", **request.logging_context)
+        self.logger.info(f"Alert found: {alert.get('rrn')}")
         self.send({Output.ALERT: clean(alert)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -8,7 +8,6 @@ from insightconnect_plugin_runtime.helper import clean
 from komand_rapid7_insightidr.util.endpoints import Investigations
 from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
 from komand_rapid7_insightidr.util.constants import TOTAL_SIZE
-from komand_rapid7_insightidr.util.util import get_logging_context
 import json
 import datetime
 
@@ -73,8 +72,8 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
 
     def make_resource_request(self, data):
         try:
-            self.connection.session.headers["Accept-version"] = "investigations-preview"
-            request = ResourceHelper(self.connection.session, self.logger)
+            self.connection.headers["Accept-version"] = "investigations-preview"
+            request = ResourceHelper(self.connection.headers, self.logger)
             endpoint = Investigations.search_investigation(self.connection.url)
             response = request.resource_request(endpoint, "post", payload=data)
             return self.parse_json_response(response)

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -26,7 +26,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
         search = params.get(Input.SEARCH)
         frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Investigations: trigger started", **request.logging_context)
+        self.logger.info("Get Investigations: trigger started")
 
         # Set initial set for storing initial alert_rrn values
         initial_investigations = set()
@@ -78,7 +78,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             response = request.resource_request(endpoint, "post", payload=data)
             return self.parse_json_response(response)
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
+            self.logger.error(f"InsightIDR response: {response}")
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -93,5 +93,5 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_investigation(self, investigation: dict):
-        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **request.logging_context)
+        self.logger.info(f"Investigation found: {investigation.get('rrn')}")
         self.send({Output.INVESTIGATION: clean(investigation)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -26,7 +26,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
         search = params.get(Input.SEARCH)
         frequency = params.get(Input.FREQUENCY, 15)
         # END INPUT BINDING - DO NOT REMOVE
-        self.logger.info("Get Investigations: trigger started", **self.connection.cloud_log_values)
+        self.logger.info("Get Investigations: trigger started", **request.logging_context)
 
         # Set initial set for storing initial alert_rrn values
         initial_investigations = set()
@@ -78,7 +78,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             response = request.resource_request(endpoint, "post", payload=data)
             return self.parse_json_response(response)
         except json.decoder.JSONDecodeError:
-            self.logger.error(f"InsightIDR response: {response}", **self.connection.cloud_log_values)
+            self.logger.error(f"InsightIDR response: {response}", **request.logging_context)
             raise PluginException(
                 cause="The response from InsightIDR was not in the correct format.",
                 assistance="Contact support for help. See log for more details",
@@ -93,5 +93,5 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             )
 
     def send_investigation(self, investigation: dict):
-        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **self.connection.cloud_log_values)
+        self.logger.info(f"Investigation found: {investigation.get('rrn')}", **request.logging_context)
         self.send({Output.INVESTIGATION: clean(investigation)})

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -161,9 +161,9 @@ class ResourceHelper(object):
         if response.status_code >= 500:
             raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
 
-    def make_request(
+    def make_request(  # noqa: MC0001
         self, path: str, method: str = "GET", params: dict = None, json_data: dict = None, files: dict = None
-    ):  # noqa: MC0001
+    ):
         try:
             self.logger.info(
                 f"Making request to {path} with request ID: {self.headers.get('R7-Correlation-Id', 'N/A')}",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -92,7 +92,7 @@ class ResourceHelper(object):
         """
 
         self.logger = logger
-        self.headers = connection_headers   # keep the API key and other headers set from the connection level
+        self.headers = connection_headers  # keep the API key and other headers set from the connection level
 
         # extract the request ID from the request context
         self.logging_context = get_logging_context()
@@ -114,10 +114,7 @@ class ResourceHelper(object):
                 f"Making request to {endpoint} with request ID: {self.headers.get('R7-Correlation-Id', 'N/A')}",
             )
             _request = requests.Request(
-                method=method.upper(),
-                headers=self.headers,
-                url=endpoint,
-                params=params if params else {}
+                method=method.upper(), headers=self.headers, url=endpoint, params=params if params else {}
             )
             if payload:
                 _request.json = payload

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -2,6 +2,7 @@ import asyncio
 import base64
 import json
 import re
+import uuid
 from typing import Any, Dict, List
 
 import aiohttp
@@ -82,15 +83,22 @@ class ResourceHelper(object):
         000: "Unknown Status Code",
     }
 
-    def __init__(self, session, logger):
+    def __init__(self, connection_headers, logger):
         """
         Creates a new instance of ResourceHelper
         :param session: Session object available to Komand actions/triggers, usually self.connection.session
         :param logger: Logger object available to Komand actions/triggers, usually self.logger
         :return: ResourceHelper object
         """
+
         self.logger = logger
-        self.session = session
+        self.headers = connection_headers   # keep the API key and other headers set from the connection level
+
+        # extract the request ID from the request context
+        self.logging_context = get_logging_context()
+
+        # add the request ID to the headers or make a new one if we're running on an orchestrator
+        self.headers["R7-Correlation-Id"] = self.logging_context.get("R7-Correlation-Id", str(uuid.uuid4()))
 
     def resource_request(self, endpoint: str, method: str = "get", params: dict = None, payload: dict = None) -> dict:
         """
@@ -103,15 +111,21 @@ class ResourceHelper(object):
         """
         try:
             self.logger.info(
-                f"Making request to {endpoint} with request ID: {self.session.headers.get('R7-Correlation-Id', 'N/A')}",
+                f"Making request to {endpoint} with request ID: {self.headers.get('R7-Correlation-Id', 'N/A')}",
             )
-            request_method = getattr(self.session, method.lower())
-            if not params:
-                params = {}
-            if not payload:
-                response = request_method(url=endpoint, params=params, verify=False)
-            else:
-                response = request_method(url=endpoint, params=params, json=payload, verify=False)
+            _request = requests.Request(
+                method=method.upper(),
+                headers=self.headers,
+                url=endpoint,
+                params=params if params else {}
+            )
+            if payload:
+                _request.json = payload
+
+            with requests.Session() as session:
+                prepared_request = session.prepare_request(request=_request)
+                response = session.send(prepared_request)
+
         except requests.RequestException as error:
             self.logger.error(error)
             raise
@@ -155,15 +169,20 @@ class ResourceHelper(object):
     ):  # noqa: MC0001
         try:
             self.logger.info(
-                f"Making request to {path} with request ID: {self.session.headers.get('R7-Correlation-Id', 'N/A')}",
+                f"Making request to {path} with request ID: {self.headers.get('R7-Correlation-Id', 'N/A')}",
             )
-            response = self.session.request(
+            _request = requests.Request(
                 method=method.upper(),
+                headers=self.headers,
                 url=path,
                 json=json_data,
                 params=params,
                 files=files,
             )
+
+            with requests.Session() as session:
+                prepared_request = session.prepare_request(request=_request)
+                response = session.send(prepared_request)
             if response.status_code == 400:
                 raise PluginException(preset=PluginException.Preset.BAD_REQUEST, data=response.text)
             if response.status_code in [401, 403]:
@@ -193,36 +212,36 @@ class ResourceHelper(object):
             raise PluginException(preset=PluginException.Preset.UNKNOWN, data=error)
 
     def create_comment(self, endpoint: str, json_data: dict):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint, method="POST", json_data=json_data)
 
     def delete_comment(self, endpoint: str):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint, method="DELETE")
 
     def list_comments(self, endpoint: str, parameters: dict):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint, params=parameters)
 
     def list_attachments(self, endpoint: str, parameters: dict):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint, params=parameters)
 
     def delete_attachment(self, endpoint: str):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint, method="DELETE")
 
     def download_attachment(self, endpoint: str):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         content = self.make_request(path=endpoint)
         return str(base64.b64encode(content), "utf-8")
 
     def upload_attachment(self, endpoint: str, files: dict):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint, method="POST", files=files)
 
     def get_attachment_information(self, endpoint: str):
-        self.session.headers["Accept-version"] = "comments-preview"
+        self.headers["Accept-version"] = "comments-preview"
         return self.make_request(path=endpoint)
 
     @staticmethod
@@ -269,7 +288,7 @@ class ResourceHelper(object):
             for label in log_entry.get("labels", []):
                 label_ids.add(label.get("id"))
 
-        async with _get_async_session(connection.session.headers) as async_session:
+        async with _get_async_session(connection.headers) as async_session:
             tasks: [asyncio.Future] = []
             for label_id in label_ids:
                 tasks.append(

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
@@ -16,7 +16,8 @@ def send_session_request(req_url, req_headers, req_params=None):
     if req_params is None:
         req_params = {}
     with requests.Session() as session:
-        prepared_request = session.prepare_request(request=requests.Request(
-            method="GET", headers=req_headers, url=req_url, params=req_params))
+        prepared_request = session.prepare_request(
+            request=requests.Request(method="GET", headers=req_headers, url=req_url, params=req_params)
+        )
         response = session.send(prepared_request)
     return response

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/util.py
@@ -1,3 +1,4 @@
+import requests
 import os
 from flask import request
 from insightconnect_plugin_runtime.helper import clean_dict
@@ -8,5 +9,14 @@ def get_logging_context():
     # For cloud get our request ID from upstream services
     if os.environ.get("PLUGIN_RUNTIME_ENVIRONMENT", "") == "cloud":
         log_values["R7-Correlation-Id"] = request.headers.get("X-REQUEST-ID")
-
     return clean_dict(log_values)
+
+
+def send_session_request(req_url, req_headers, req_params=None):
+    if req_params is None:
+        req_params = {}
+    with requests.Session() as session:
+        prepared_request = session.prepare_request(request=requests.Request(
+            method="GET", headers=req_headers, url=req_url, params=req_params))
+        response = session.send(prepared_request)
+    return response

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 11.0.7
+version: 11.0.8
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2025-06-11."]
 vendor: rapid7
@@ -35,6 +35,7 @@ sdk:
   version: 6.3.6
   user: nobody
 version_history:
+  - "11.0.8 - Remove use of session from the connection object to prevent session timeouts."
   - "11.0.7 - Adding request id to the plugin for traceability"
   - "11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.6"
   - "11.0.5 - Added new disposition of the alert"

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="11.0.7",
+    version="11.0.8",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",

--- a/plugins/rapid7_insightidr/unit_test/mock.py
+++ b/plugins/rapid7_insightidr/unit_test/mock.py
@@ -28,19 +28,23 @@ STUB_USER_EMAIL = "user@example.com"
 
 # Define and return mock API responses based on request type and endpoint
 def mock_get_request(*args, **_kwarg):
-    return mock_request_selection(_kwarg.get("url"), method=REQUEST_GET)
+    url = args[0].url
+    return mock_request_selection(url, method=REQUEST_GET)
 
 
 def mock_post_request(*args, **_kwarg):
-    return mock_request_selection(_kwarg.get("url"), method=REQUEST_POST)
+    url = args[0].url
+    return mock_request_selection(url, method=REQUEST_POST)
 
 
 def mock_patch_request(*args, **_kwarg):
-    return mock_request_selection(_kwarg.get("url"), method=REQUEST_PATCH)
+    url = args[0].url
+    return mock_request_selection(url, method=REQUEST_PATCH)
 
 
 def mock_put_request(*args, **_kwarg):
-    return mock_request_selection(_kwarg.get("url"), method=REQUEST_PUT)
+    url = args[0].url
+    return mock_request_selection(url, method=REQUEST_PUT)
 
 
 class MockResponse:
@@ -120,6 +124,7 @@ def mock_request_put(url: str) -> MockResponse:
 
 
 def mock_request_selection(url, method="get"):
+    url = url.split("?")[0]
     # Check reqeust type and endpoint. Return appropriate file name to be loaded and response code
     if method == REQUEST_POST:
         return mock_request_post(url)

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_set_unit.py
@@ -16,7 +16,7 @@ from unittest.mock import patch
 from jsonschema import validate
 
 
-@patch("requests.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 @patch("aiohttp.ClientSession.get", side_effect=Util.mocked_async_requests)
 class TestAdvancedQueryOnLogSet(TestCase):
     @classmethod

--- a/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
+++ b/plugins/rapid7_insightidr/unit_test/test_advanced_query_on_log_unit.py
@@ -17,7 +17,7 @@ from jsonschema import validate
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 
-@patch("requests.Session.get", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 @patch("aiohttp.ClientSession.get", side_effect=Util.mocked_async_requests)
 class TestAdvancedQueryOnLog(TestCase):
     @classmethod

--- a/plugins/rapid7_insightidr/unit_test/test_assign_user_to_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_assign_user_to_investigation.py
@@ -36,7 +36,7 @@ class TestAssignUserToInvestigation(TestCase):
         self.action = Util.default_connector(AssignUserToInvestigation())
         self.connection = self.action.connection
 
-    @patch("requests.Session.put", side_effect=mock_put_request)
+    @patch("requests.Session.send", side_effect=mock_put_request)
     def test_assign_user_to_investigation(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.USER_EMAIL_ADDRESS: STUB_USER_EMAIL}
         validate(test_input, AssignUserToInvestigationInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_close_investigations_in_bulk.py
+++ b/plugins/rapid7_insightidr/unit_test/test_close_investigations_in_bulk.py
@@ -18,7 +18,7 @@ from util import Util
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestCloseInvestigationsInBulk(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_create_comment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_create_comment.py
@@ -13,7 +13,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestCreateComment(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_create_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_create_investigation.py
@@ -36,7 +36,7 @@ class TestCreateInvestigation(TestCase):
         self.action = Util.default_connector(CreateInvestigation())
         self.connection = self.action.connection
 
-    @patch("requests.Session.post", side_effect=mock_post_request)
+    @patch("requests.Session.send", side_effect=mock_post_request)
     def test_create_investigation(self, _mock_req):
         test_input = {Input.TITLE: "Example Title", Input.EMAIL: STUB_USER_EMAIL}
         validate(test_input, CreateInvestigationInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_create_threat.py
+++ b/plugins/rapid7_insightidr/unit_test/test_create_threat.py
@@ -18,7 +18,7 @@ from util import Util
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestCreateThreat(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_delete_attachment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_delete_attachment.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestDeleteAttachment(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_delete_comment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_delete_comment.py
@@ -13,7 +13,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestDeleteComment(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_download_attachment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_download_attachment.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestDownloadAttachment(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_a_log.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_a_log.py
@@ -18,7 +18,7 @@ from util import Util
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetALog(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_a_saved_query.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_a_saved_query.py
@@ -33,7 +33,7 @@ class TestGetASavedQuery(TestCase):
         self.action = Util.default_connector(GetASavedQuery())
         self.connection = self.action.connection
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_get_a_saved_query(self, _mock_req):
         test_input = {Input.QUERY_ID: self.params.get("query_id")}
         validate(test_input, GetASavedQueryInput.schema)
@@ -60,7 +60,7 @@ class TestGetASavedQuery(TestCase):
         cause = "Query ID field did not contain a valid UUID."
         self.assertEqual(exception.exception.cause, cause)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_get_a_saved_query_not_found(self, _mock_req):
         test_input = {Input.QUERY_ID: self.params.get("not_found_query_id")}
         validate(test_input, GetASavedQueryInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_get_account_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_account_information.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetAccountInformation(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_alert_actors.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_alert_actors.py
@@ -23,13 +23,13 @@ class TestGetAlertActors(TestCase):
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetAlertActors())
 
-    # @parameterized.expand(Util.load_parameters("get_alert_actors_minimum").get("parameters"))
-    # def test_get_alert_actors_minimum(self, mock_request: MagicMock, alert_rrn: str, expected: dict) -> None:
-    #     test_input = {Input.ALERT_RRN: alert_rrn}
-    #     validate(test_input, GetAlertActorsInput.schema)
-    #     actual = self.action.run(test_input)
-    #     self.assertEqual(actual, expected)
-    #     validate(actual, GetAlertActorsOutput.schema)
+    @parameterized.expand(Util.load_parameters("get_alert_actors_minimum").get("parameters"))
+    def test_get_alert_actors_minimum(self, mock_request: MagicMock, alert_rrn: str, expected: dict) -> None:
+        test_input = {Input.ALERT_RRN: alert_rrn}
+        validate(test_input, GetAlertActorsInput.schema)
+        actual = self.action.run(test_input)
+        self.assertEqual(actual, expected)
+        validate(actual, GetAlertActorsOutput.schema)
 
     @parameterized.expand(Util.load_parameters("get_alert_actors").get("parameters"))
     def test_get_alert_actors(
@@ -41,11 +41,11 @@ class TestGetAlertActors(TestCase):
         self.assertEqual(actual, expected)
         validate(actual, GetAlertActorsOutput.schema)
 
-    # @parameterized.expand(Util.load_parameters("get_alert_actors_not_found").get("parameters"))
-    # def test_get_alert_actors_bad(self, mock_request: MagicMock, alert_rrn: str, cause: str, assistance: str) -> None:
-    #     test_input = {Input.ALERT_RRN: alert_rrn}
-    #     validate(test_input, GetAlertActorsInput.schema)
-    #     with self.assertRaises(PluginException) as error:
-    #         self.action.run(test_input)
-    #     self.assertEqual(error.exception.cause, cause)
-    #     self.assertEqual(error.exception.assistance, assistance)
+    @parameterized.expand(Util.load_parameters("get_alert_actors_not_found").get("parameters"))
+    def test_get_alert_actors_bad(self, mock_request: MagicMock, alert_rrn: str, cause: str, assistance: str) -> None:
+        test_input = {Input.ALERT_RRN: alert_rrn}
+        validate(test_input, GetAlertActorsInput.schema)
+        with self.assertRaises(PluginException) as error:
+            self.action.run(test_input)
+        self.assertEqual(error.exception.cause, cause)
+        self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_get_alert_actors.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_alert_actors.py
@@ -17,19 +17,19 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetAlertActors(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(GetAlertActors())
 
-    @parameterized.expand(Util.load_parameters("get_alert_actors_minimum").get("parameters"))
-    def test_get_alert_actors_minimum(self, mock_request: MagicMock, alert_rrn: str, expected: dict) -> None:
-        test_input = {Input.ALERT_RRN: alert_rrn}
-        validate(test_input, GetAlertActorsInput.schema)
-        actual = self.action.run(test_input)
-        self.assertEqual(actual, expected)
-        validate(actual, GetAlertActorsOutput.schema)
+    # @parameterized.expand(Util.load_parameters("get_alert_actors_minimum").get("parameters"))
+    # def test_get_alert_actors_minimum(self, mock_request: MagicMock, alert_rrn: str, expected: dict) -> None:
+    #     test_input = {Input.ALERT_RRN: alert_rrn}
+    #     validate(test_input, GetAlertActorsInput.schema)
+    #     actual = self.action.run(test_input)
+    #     self.assertEqual(actual, expected)
+    #     validate(actual, GetAlertActorsOutput.schema)
 
     @parameterized.expand(Util.load_parameters("get_alert_actors").get("parameters"))
     def test_get_alert_actors(
@@ -41,11 +41,11 @@ class TestGetAlertActors(TestCase):
         self.assertEqual(actual, expected)
         validate(actual, GetAlertActorsOutput.schema)
 
-    @parameterized.expand(Util.load_parameters("get_alert_actors_not_found").get("parameters"))
-    def test_get_alert_actors_bad(self, mock_request: MagicMock, alert_rrn: str, cause: str, assistance: str) -> None:
-        test_input = {Input.ALERT_RRN: alert_rrn}
-        validate(test_input, GetAlertActorsInput.schema)
-        with self.assertRaises(PluginException) as error:
-            self.action.run(test_input)
-        self.assertEqual(error.exception.cause, cause)
-        self.assertEqual(error.exception.assistance, assistance)
+    # @parameterized.expand(Util.load_parameters("get_alert_actors_not_found").get("parameters"))
+    # def test_get_alert_actors_bad(self, mock_request: MagicMock, alert_rrn: str, cause: str, assistance: str) -> None:
+    #     test_input = {Input.ALERT_RRN: alert_rrn}
+    #     validate(test_input, GetAlertActorsInput.schema)
+    #     with self.assertRaises(PluginException) as error:
+    #         self.action.run(test_input)
+    #     self.assertEqual(error.exception.cause, cause)
+    #     self.assertEqual(error.exception.assistance, assistance)

--- a/plugins/rapid7_insightidr/unit_test/test_get_alert_evidence.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_alert_evidence.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetAlertEvidences(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_alert_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_alert_information.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetAlertInformation(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_all_saved_queries.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_all_saved_queries.py
@@ -29,7 +29,7 @@ class TestGetAllSavedQueries(TestCase):
         self.action = Util.default_connector(GetAllSavedQueries())
         self.connection = self.action.connection
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_get_all_saved_queries(self, _mock_req):
         actual = self.action.run()
         expected = {

--- a/plugins/rapid7_insightidr/unit_test/test_get_asset_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_asset_information.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetAssetInformation(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_attachment_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_attachment_information.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetAttachmentInformation(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_get_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_investigation.py
@@ -36,7 +36,7 @@ class TestCreateInvestigation(TestCase):
         self.action = Util.default_connector(GetInvestigation())
         self.connection = self.action.connection
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_get_investigation(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER}
         validate(test_input, GetInvestigationInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_get_user_information.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_user_information.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestGetUserInformation(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_list_alerts_for_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_alerts_for_investigation.py
@@ -52,7 +52,7 @@ class TestCreateInvestigation(TestCase):
             "metadata": {"index": 0, "size": 1, "total_data": 1, "total_pages": 1},
         }
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_list_alerts_for_investigation(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.SIZE: 1, Input.INDEX: 0}
         validate(test_input, ListAlertsForInvestigationInput.schema)
@@ -60,7 +60,7 @@ class TestCreateInvestigation(TestCase):
         self.assertEqual(actual, self.expected_result)
         validate(actual, ListAlertsForInvestigationOutput.schema)
 
-    @patch("requests.Session.get", side_effect=mock_request_for_different_rrn_object)
+    @patch("requests.Session.send", side_effect=mock_request_for_different_rrn_object)
     def test_list_alerts_for_investigation_when_different_rrn_type(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.SIZE: 1, Input.INDEX: 0}
         validate(test_input, ListAlertsForInvestigationInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_list_attachments.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_attachments.py
@@ -13,7 +13,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestListAttachments(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_list_comments.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_comments.py
@@ -13,7 +13,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestListComments(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_list_investigations.py
+++ b/plugins/rapid7_insightidr/unit_test/test_list_investigations.py
@@ -21,7 +21,7 @@ from util import Util
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestListInvestigations(TestCase):
     @classmethod
     def setUpClass(self) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_query.py
+++ b/plugins/rapid7_insightidr/unit_test/test_query.py
@@ -35,7 +35,7 @@ class TestQuery(TestCase):
         self.action = Util.default_connector(Query())
         self.connection = self.action.connection
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_query(self, _mock_req):
         test_input = {
             Input.ID: self.params.get("id"),
@@ -73,7 +73,7 @@ class TestQuery(TestCase):
         self.assertEqual(actual, expected)
         validate(actual, QueryOutput.schema)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_query_true(self, _mock_req):
         test_input = {
             Input.ID: self.params.get("id"),
@@ -110,7 +110,7 @@ class TestQuery(TestCase):
         self.assertEqual(actual, expected)
         validate(actual, QueryOutput.schema)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     @patch("time.time", return_value=1682954418)
     def test_query_true_future(self, _mock_req, mock_time):
         test_input = {
@@ -148,7 +148,7 @@ class TestQuery(TestCase):
         self.assertEqual(actual, expected)
         validate(actual, QueryOutput.schema)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_query_202(self, _mock_req):
         test_input = {
             Input.ID: self.params.get("id_202"),
@@ -185,7 +185,7 @@ class TestQuery(TestCase):
         self.assertEqual(actual, expected)
         validate(actual, QueryOutput.schema)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_query_202_error(self, _mock_req):
         test_input = {
             Input.ID: self.params.get("id_202_error"),
@@ -197,7 +197,7 @@ class TestQuery(TestCase):
         cause = "The response from InsightIDR was not in the correct format."
         self.assertEqual(exception.exception.cause, cause)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_query_not_found(self, _mock_req):
         test_input = {
             Input.ID: self.params.get("not_found_id"),
@@ -209,7 +209,7 @@ class TestQuery(TestCase):
         cause = "InsightIDR returned a status code of 404: Not Found"
         self.assertEqual(exception.exception.cause, cause)
 
-    @patch("requests.Session.get", side_effect=mock_get_request)
+    @patch("requests.Session.send", side_effect=mock_get_request)
     def test_query_key_error(self, _mock_req):
         test_input = {
             Input.ID: self.params.get("id_key_error"),

--- a/plugins/rapid7_insightidr/unit_test/test_replace_indicators.py
+++ b/plugins/rapid7_insightidr/unit_test/test_replace_indicators.py
@@ -18,7 +18,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.post", side_effect=mock_post_request)
+@patch("requests.Session.send", side_effect=mock_post_request)
 class TestReplaceIndicators(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_search_accounts.py
+++ b/plugins/rapid7_insightidr/unit_test/test_search_accounts.py
@@ -13,7 +13,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestSearchAccounts(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_search_alerts.py
+++ b/plugins/rapid7_insightidr/unit_test/test_search_alerts.py
@@ -17,7 +17,7 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestSearchAlerts(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/test_search_investigations.py
+++ b/plugins/rapid7_insightidr/unit_test/test_search_investigations.py
@@ -36,7 +36,7 @@ class TestSearchInvestigation(TestCase):
         self.action = Util.default_connector(SearchInvestigations())
         self.connection = self.action.connection
 
-    @patch("requests.Session.post", side_effect=mock_post_request)
+    @patch("requests.Session.send", side_effect=mock_post_request)
     def test_search_investigations(self, _mock_req):
         test_input = {
             Input.INDEX: 0,

--- a/plugins/rapid7_insightidr/unit_test/test_set_disposition_of_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_set_disposition_of_investigation.py
@@ -36,7 +36,7 @@ class TestSetDispositionOfInvestigation(TestCase):
         self.action = Util.default_connector(SetDispositionOfInvestigation())
         self.connection = self.action.connection
 
-    @patch("requests.Session.put", side_effect=mock_put_request)
+    @patch("requests.Session.send", side_effect=mock_put_request)
     def test_set_disposition_of_investigation(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.DISPOSITION: STUB_DISPOSITION}
         validate(test_input, SetDispositionOfInvestigationInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_set_priority_of_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_set_priority_of_investigation.py
@@ -36,7 +36,7 @@ class TestSetPriorityOfInvestigation(TestCase):
         self.action = Util.default_connector(SetPriorityOfInvestigation())
         self.connection = self.action.connection
 
-    @patch("requests.Session.put", side_effect=mock_put_request)
+    @patch("requests.Session.send", side_effect=mock_put_request)
     def test_set_priority_of_investigation(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.PRIORITY: STUB_PRIORITY}
         validate(test_input, SetPriorityOfInvestigationInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_set_status_of_investigation_action.py
+++ b/plugins/rapid7_insightidr/unit_test/test_set_status_of_investigation_action.py
@@ -36,7 +36,7 @@ class TestSetStatusOfInvestigationAction(TestCase):
         self.action = Util.default_connector(SetStatusOfInvestigationAction())
         self.connection = self.action.connection
 
-    @patch("requests.Session.put", side_effect=mock_put_request)
+    @patch("requests.Session.send", side_effect=mock_put_request)
     def test_set_status_of_investigation(self, _mock_req):
         test_input = {Input.ID: STUB_INVESTIGATION_IDENTIFIER, Input.STATUS: STUB_STATUS}
         validate(test_input, SetStatusOfInvestigationActionInput.schema)

--- a/plugins/rapid7_insightidr/unit_test/test_update_investigation.py
+++ b/plugins/rapid7_insightidr/unit_test/test_update_investigation.py
@@ -36,7 +36,7 @@ class TestCreateInvestigation(TestCase):
         self.action = Util.default_connector(UpdateInvestigation())
         self.connection = self.action.connection
 
-    @patch("requests.Session.patch", side_effect=mock_patch_request)
+    @patch("requests.Session.send", side_effect=mock_patch_request)
     def test_update_investigations(self, _mock_req):
         test_input = {
             Input.TITLE: "Example Title",

--- a/plugins/rapid7_insightidr/unit_test/test_upload_attachment.py
+++ b/plugins/rapid7_insightidr/unit_test/test_upload_attachment.py
@@ -16,7 +16,7 @@ from parameterized import parameterized
 from jsonschema import validate
 
 
-@patch("requests.Session.request", side_effect=Util.mocked_requests)
+@patch("requests.Session.send", side_effect=Util.mocked_requests)
 class TestUploadAttachment(TestCase):
     @classmethod
     def setUpClass(cls) -> None:

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -135,6 +135,7 @@ class Util:
                         os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{self.filename}.json.resp")
                     )
                 )
+
         # TODO: this should be addressed and mocked properly within the test and not needing the conversion below
         # Re-build a fake args list of the urls based on the `ResourceHelper` calls this either pos 0 or pos 1
         # New logic to remove sessions remaining open passes a prepared request object and needs converted for mocking
@@ -153,8 +154,8 @@ class Util:
 
         # Some tests are testing `filenames` so we need to allow for this on the body param
         content_type = kwargs.get("headers", {}).get("Content-Type", "")
-        if kwargs.get('body') and "multipart/form-data" not in content_type:
-            kwargs["json"] = json.loads(kwargs.get('body'))
+        if kwargs.get("body") and "multipart/form-data" not in content_type:
+            kwargs["json"] = json.loads(kwargs.get("body"))
 
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:1234567890",
@@ -366,15 +367,15 @@ class Util:
             return MockResponse("log_id8", 200)
 
         if args[1] == "https://us.api.insight.rapid7.com/idr/at/alerts/ops/search":
-            if kwargs.get("params", {}).get("rrns_only") == 'True':
+            if kwargs.get("params", {}).get("rrns_only") == "True":
                 return MockResponse("test_search_alerts_rrns_true", 200)
             else:
                 return MockResponse("test_search_alerts_rrns_false", 200)
 
         if args[1] == "https://us.api.insight.rapid7.com/idr/v1/accounts/_search":
-            if kwargs.get("params", {}).get("size") == '1':
+            if kwargs.get("params", {}).get("size") == "1":
                 return MockResponse("test_search_accounts_1", 200)
-            elif kwargs.get("params", {}).get("size") == '2':
+            elif kwargs.get("params", {}).get("size") == "2":
                 return MockResponse("test_search_accounts_2", 200)
         if args[1] == "https://us.api.insight.rapid7.com/log_search/management/logs/test_id":
             return MockResponse("get_a_log", 200)

--- a/plugins/rapid7_insightidr/unit_test/util.py
+++ b/plugins/rapid7_insightidr/unit_test/util.py
@@ -10,6 +10,8 @@ from komand_rapid7_insightidr.connection import Connection
 from komand_rapid7_insightidr.connection.schema import Input
 from requests.models import HTTPError
 
+from urllib.parse import urlparse, parse_qs
+
 
 class Meta:
     version = "0.0.0"
@@ -113,6 +115,11 @@ class Util:
                         os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{self.filename}.json.resp")
                     )
 
+            def _get_params(self, url):
+                parsed_url = urlparse(url)
+                params = parse_qs(parsed_url.query)
+                return {k: v[0] for k, v in params.items()} if params else {}
+
             def raise_for_status(self):
                 if self.status_code == 404:
                     raise HTTPError("Not found", response=self)
@@ -128,29 +135,49 @@ class Util:
                         os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{self.filename}.json.resp")
                     )
                 )
+        # TODO: this should be addressed and mocked properly within the test and not needing the conversion below
+        # Re-build a fake args list of the urls based on the `ResourceHelper` calls this either pos 0 or pos 1
+        # New logic to remove sessions remaining open passes a prepared request object and needs converted for mocking
+
+        # First grab the request URL and kwargs from the prepared request
+        req_url, kwargs = args[0].url.split("?")[0], args[0].__dict__
+
+        # Rebuild this full URL to just the connection URL + endpoint
+        parsed_url = urlparse(args[0].path_url)
+        args = [req_url, req_url]
+        kwargs["url"] = req_url
+
+        # Now convert the params of the query back into a dict for comparison below
+        params = parse_qs(parsed_url.query)
+        kwargs["params"] = {k: v[0] for k, v in params.items()} if params else {}
+
+        # Some tests are testing `filenames` so we need to allow for this on the body param
+        content_type = kwargs.get("headers", {}).get("Content-Type", "")
+        if kwargs.get('body') and "multipart/form-data" not in content_type:
+            kwargs["json"] = json.loads(kwargs.get('body'))
 
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:1234567890",
-            "index": 0,
-            "size": 0,
+            "index": "0",
+            "size": "0",
         }:
             return MockResponse("invalid_size", 400)
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:1234567890",
-            "index": 0,
-            "size": 1,
+            "index": "0",
+            "size": "1",
         }:
             return MockResponse("list_comments", 200)
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:1234567899",
-            "index": 0,
-            "size": 1,
+            "index": "0",
+            "size": "1",
         }:
             return MockResponse("list_attachments", 200)
         if kwargs.get("params") == {
             "target": "rrn:investigation:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:investigation:9876543210",
-            "index": 0,
-            "size": 1,
+            "index": "0",
+            "size": "1",
         }:
             return MockResponse("list_empty", 200)
         if (
@@ -235,9 +262,9 @@ class Util:
             == "https://us.api.insight.rapid7.com/idr/v1/attachments/rrn:collaboration:us:44d88612-fea8-a8f3-6de8-2e1278abb02f:attachment:not_found"
         ):
             return MockResponse("not_found", 404)
-        if kwargs.get("files") == {"filedata": ("test.txt", b"test", "text/plain")}:
+        if 'filename="test.txt"' in str(kwargs.get("body", "")):
             return MockResponse("upload_attachment", 200)
-        if kwargs.get("files") == {"filedata": ("test", b"test", "text/plain")}:
+        if 'filename="test"' in str(kwargs.get("body", "")):
             return MockResponse("upload_attachment_without_file_extension", 200)
 
         if (
@@ -339,15 +366,15 @@ class Util:
             return MockResponse("log_id8", 200)
 
         if args[1] == "https://us.api.insight.rapid7.com/idr/at/alerts/ops/search":
-            if kwargs.get("params", {}).get("rrns_only") == True:
+            if kwargs.get("params", {}).get("rrns_only") == 'True':
                 return MockResponse("test_search_alerts_rrns_true", 200)
             else:
                 return MockResponse("test_search_alerts_rrns_false", 200)
 
         if args[1] == "https://us.api.insight.rapid7.com/idr/v1/accounts/_search":
-            if kwargs.get("params", {}).get("size") == 1:
+            if kwargs.get("params", {}).get("size") == '1':
                 return MockResponse("test_search_accounts_1", 200)
-            elif kwargs.get("params", {}).get("size") == 2:
+            elif kwargs.get("params", {}).get("size") == '2':
                 return MockResponse("test_search_accounts_2", 200)
         if args[1] == "https://us.api.insight.rapid7.com/log_search/management/logs/test_id":
             return MockResponse("get_a_log", 200)


### PR DESCRIPTION
Ticket: 
- [SI-29846](https://rapid7.atlassian.net/browse/SI-29846)
- [SOAR-19570](https://rapid7.atlassian.net/browse/SOAR-19570)

Background:
- Previously we created the session as part of the connection when then persisted across multiple action calls. Doing this meant that even on triggering the action again with a new request ID in the header it was not updated and we would send the wrong value to IDR but yet contain the new request ID in the log (see below). 
- As a result of holding the same session and not closing this we would eventually see that the session was being forced closed and the action in progress would fail. 

Same ID being held:
```
# First call created the connection object and the session:
{"message": "Connect: Connecting...", "R7-Correlation-Id": "fake-request-id-for-testing", "request_path": "/actions/get_a_log", "request_id": "fake-request-id-for-testing", "level": "info", "timestamp": "2025-06-17 08:06.38"}
{"message": "Request ID: fake-request-id-for-testing", "R7-Correlation-Id": "fake-request-id-for-testing", "request_path": "/actions/get_a_log", "request_id": "fake-request-id-for-testing", "level": "info", "timestamp": "2025-06-17 08:06.38"}


# Calling the action for the first time
{"message": "rapid7/Rapid7 InsightIDR:11.0.7. Step name: get_a_log", "request_path": "/actions/get_a_log", "request_id": "fake-request-id-for-testing", "level": "info", "timestamp": "2025-06-17 08:06.38"}
{"message": "Making request to https://us.api.insight.rapid7.com/log_search/management/logs/<redacted> with request ID: fake-request-id-for-testing", "request_path": "/actions/get_a_log", "request_id": "fake-request-id-for-testing", "level": "info", "timestamp": "2025-06-17 08:06.38"}
/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'us.api.insight.rapid7.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(....)


# Second request request ID hasn't updated but the structured log has pulled new ID:
{"message": "rapid7/Rapid7 InsightIDR:11.0.7. Step name: get_a_log", "request_path": "/actions/get_a_log", "request_id": "fake-request-id-for-testing-updated", "level": "info", "timestamp": "2025-06-17 08:06.54"}
{"message": "Making request to https://us.api.insight.rapid7.com/log_search/management/logs/<redacted> with request ID: fake-request-id-for-testing", "request_path": "/actions/get_a_log", "request_id": "fake-request-id-for-testing-updated", "level": "info", "timestamp": "2025-06-17 08:06.54"}
/usr/local/lib/python3.11/site-packages/urllib3/connectionpool.py:1097: InsecureRequestWarning: Unverified HTTPS request is being made to host 'us.api.insight.rapid7.com'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#tls-warnings
  warnings.warn(...)
```

Changes:
- Move the session to be created as part of the ResourceHelper that gets used in each action - taking our connection headers and adding the request ID from the cloud request or building a new UUID if running on orchestrator.
- A small helper for two actions that didn't follow this convention of the ResourceHelper to keep code changes as small as possible.
- Still include our request ID in the logs were possible.
- Unit tests are very roughly updated to now take our new prepared req object to format into the expected format for the tests to be mocked. 

Testing:
- [X] unit tests updated and all passing
- [X] integration tests passing
- [X] local test results below
- [X] testing on staging - evidence attached to qualified jira.

Local logs getting new ID as expected:
```
{"message": "Connect: Connecting...", "request_id": "fake-request-id-for-testing-updated", "request_path": "/actions/get_a_log", "level": "info", "timestamp": "2025-06-17 08:36.03"}

{"message": "rapid7/Rapid7 InsightIDR:11.0.8. Step name: get_a_log", "request_id": "fake-request-id-for-testing-updated", "request_path": "/actions/get_a_log", "level": "info", "timestamp": "2025-06-17 08:36.03"}
{"message": "Making request to https://us.api.insight.rapid7.com/log_search/management/logs/<redacted> with request ID: fake-request-id-for-testing-updated", "request_id": "fake-request-id-for-testing-updated", "request_path": "/actions/get_a_log", "level": "info", "timestamp": "2025-06-17 08:36.03"}

# new request logging and using the new ID
{"message": "rapid7/Rapid7 InsightIDR:11.0.8. Step name: get_a_log", "request_id": "fake-request-id-for-testing-removed", "request_path": "/actions/get_a_log", "level": "info", "timestamp": "2025-06-17 08:36.27"}
{"message": "Making request to https://us.api.insight.rapid7.com/log_search/management/logs/<redacted> with request ID: fake-request-id-for-testing-removed", "request_id": "fake-request-id-for-testing-removed", "request_path": "/actions/get_a_log", "level": "info", "timestamp": "2025-06-17 08:36.27"}
```

[SI-29846]: https://rapid7.atlassian.net/browse/SI-29846?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[SOAR-19570]: https://rapid7.atlassian.net/browse/SOAR-19570?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ