### PR TITLE
[SOAR-19518] Rapid7 InsightIDR - Additional disposition values

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "f76a8b4d2d40e15663b4b8b0912497d2",
-	"manifest": "abd8b86d00d9673ce145246f39e24e20",
-	"setup": "9cc860ee727a51894317f61818805610",
+	"spec": "bf3e857db56a04a3446b31bc14cc748d",
+	"manifest": "81997beb0163d1cc2d97d9ea60561e1b",
+	"setup": "aa9c0d288ee80345f90e0930e2ffa6db",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",
@@ -17,7 +17,7 @@
 		},
 		{
 			"identifier": "assign_user_to_investigation/schema.py",
-			"hash": "700bb47caf955f639dc2f4c5b28f307c"
+			"hash": "bcd6d61e54385a0d6bcedbaccbb0080c"
 		},
 		{
 			"identifier": "close_investigations_in_bulk/schema.py",
@@ -29,7 +29,7 @@
 		},
 		{
 			"identifier": "create_investigation/schema.py",
-			"hash": "ed4ab7d62bc66454d976ab7dda67b189"
+			"hash": "d68a161838209167ada525f4befcefad"
 		},
 		{
 			"identifier": "create_threat/schema.py",
@@ -69,7 +69,7 @@
 		},
 		{
 			"identifier": "get_alert_information/schema.py",
-			"hash": "b638bc385299b7c8cdbd03b4bb65515c"
+			"hash": "d30fdba1ac822a028931a4878abfa230"
 		},
 		{
 			"identifier": "get_all_logs/schema.py",
@@ -89,7 +89,7 @@
 		},
 		{
 			"identifier": "get_investigation/schema.py",
-			"hash": "7fbd36bf2a553608068baefb6f63b815"
+			"hash": "cb5d41bfdde6e660057b11d93b28f7bd"
 		},
 		{
 			"identifier": "get_user_information/schema.py",
@@ -109,7 +109,7 @@
 		},
 		{
 			"identifier": "list_investigations/schema.py",
-			"hash": "fa6fd9ae1f255bd94e062aba7aad8f36"
+			"hash": "51011328b05eae2b86808dfb9b389d5f"
 		},
 		{
 			"identifier": "query/schema.py",
@@ -125,31 +125,31 @@
 		},
 		{
 			"identifier": "search_alerts/schema.py",
-			"hash": "32ac097f9bbbfee2346b46eac3c6c8be"
+			"hash": "c485ab5dc32d329b8029cb814f59c824"
 		},
 		{
 			"identifier": "search_investigations/schema.py",
-			"hash": "ec8d3ff990fdb431b585e9bacb5cbf1a"
+			"hash": "c07f94ccec11851f17e67f1e01d6c68a"
 		},
 		{
 			"identifier": "set_disposition_of_investigation/schema.py",
-			"hash": "c7363e1f8c0b2fc54f5451a4e96bfea5"
+			"hash": "7bd007dd3420652c97ffbe2681c0fe08"
 		},
 		{
 			"identifier": "set_priority_of_investigation/schema.py",
-			"hash": "4a0640b4ac0377d794c97c8d28a2742a"
+			"hash": "9a4e3462a7820a8f1ea5cb5b58b0d320"
 		},
 		{
 			"identifier": "set_status_of_investigation_action/schema.py",
-			"hash": "ccc3ad900d84c0d57722bb16ef263c11"
+			"hash": "1f6b204e5077956c0ab661f90ed30c52"
 		},
 		{
 			"identifier": "update_alert/schema.py",
-			"hash": "b85d84292fbe3569542806a6bb9388d4"
+			"hash": "525e7b7f6fbe9a3ce3d5db4239e29710"
 		},
 		{
 			"identifier": "update_investigation/schema.py",
-			"hash": "5ce61e5a3e3debe39ab11c2b8f9664f3"
+			"hash": "225c52f604b553f51863dd7d062abe3c"
 		},
 		{
 			"identifier": "upload_attachment/schema.py",
@@ -161,11 +161,11 @@
 		},
 		{
 			"identifier": "get_new_alerts/schema.py",
-			"hash": "7c7f3d33a7271231f88ecac04aa93300"
+			"hash": "4a76553d3b80261225b6147a8aeed6a0"
 		},
 		{
 			"identifier": "get_new_investigations/schema.py",
-			"hash": "9268b3d3b7af345a2b441c9e097be10f"
+			"hash": "fd2a272c0a486b1be614926fd6196efd"
 		}
 	]
 }

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "bf3e857db56a04a3446b31bc14cc748d",
-	"manifest": "81997beb0163d1cc2d97d9ea60561e1b",
-	"setup": "aa9c0d288ee80345f90e0930e2ffa6db",
+	"spec": "020c4c8d73e953c3c846cfdf332b1bd2",
+	"manifest": "ac713b96089215717986aaee8e3f12ca",
+	"setup": "4db5f0771846b34e31217b01b9507735",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "11.0.9"
+Version = "12.0.0"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "11.0.8"
+Version = "11.0.9"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -743,7 +743,7 @@ This action is used to allows to create investigation manually
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|disposition|string|None|False|Investigation's disposition|["", "UNDECIDED", "BENIGN", "MALICIOUS", "NOT_APPLICABLE"]|BENIGN|None|None|
+|disposition|string|None|False|Investigation's disposition|["", "BENIGN", "FALSE_POSITIVE", "MALICIOUS", "NOT_APPLICABLE", "SECURITY_TEST", "UNDECIDED", "UNKNOWN"]|BENIGN|None|None|
 |email|string|None|False|A user's email address for investigation to be assigned|None|user@example.com|None|None|
 |priority|string|None|False|Investigation's priority|["", "LOW", "MEDIUM", "HIGH", "CRITICAL"]|LOW|None|None|
 |status|string|None|False|Investigation's status|["", "OPEN", "CLOSED"]|OPEN|None|None|
@@ -2416,7 +2416,7 @@ This action is used to allows to change the disposition of the investigation wit
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|disposition|string|None|True|Investigation's disposition|["BENIGN", "MALICIOUS", "NOT_APPLICABLE"]|BENIGN|None|None|
+|disposition|string|None|True|Investigation's disposition|["", "BENIGN", "FALSE_POSITIVE", "MALICIOUS", "NOT_APPLICABLE", "SECURITY_TEST", "UNDECIDED", "UNKNOWN"]|BENIGN|None|None|
 |id|string|None|True|The ID or RRN of the investigation to change the disposition of|None|rrn:investigation:example:11111111-1111-1111-1111-111111111111:investigation:11111111|None|None|
   
 Example input:
@@ -2569,7 +2569,7 @@ This action is used to updates information for a single alert
 |alert_rrn|string|None|True|The unique identifier of the alert|None|rrn:alerts:us1:12345678-abcd-cdef-1234-12345abc:alert:1:12345678-abcd-cdef-1234-12345abg|None|None|
 |assignee_id|string|None|False|The new user to assign to the alert|None|8205375a-1234-4652-8098-870d656bc693|None|None|
 |comment|string|None|False|The reason for updating the alert, which is captured in the alert audit log for tracking purposes|None|Updated alert priority by automation through InsightConnect|None|None|
-|disposition|string|None|False|The alert disposition|["", "UNMAPPED", "UNDECIDED", "MALICIOUS", "BENIGN", "UNKNOWN", "NOT_APPLICABLE", "SECURITY_TEST", "FALSE_POSITIVE"]|MALICIOUS|None|None|
+|disposition|string|None|False|The alert disposition|["", "BENIGN", "FALSE_POSITIVE", "MALICIOUS", "NOT_APPLICABLE", "SECURITY_TEST", "UNDECIDED", "UNKNOWN"]|MALICIOUS|None|None|
 |investigation_rrn|string|None|False|The RRN of the investigation to add the alert to|None|rrn:investigation:us:12345678-abcd-cdef-1234-12345abc:investigation:ABCDEFGHI|None|None|
 |priority|string|None|False|The alert priority|["", "UNMAPPED", "INFO", "LOW", "MEDIUM", "HIGH", "CRITICAL"]|INFO|None|None|
 |status|string|None|False|The alert status|["", "UNMAPPED", "OPEN", "INVESTIGATING", "WAITING", "CLOSED"]|OPEN|None|None|
@@ -2688,7 +2688,7 @@ This action is used to allows to update existing investigation by ID or RRN
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
-|disposition|string|None|False|Investigation's disposition|["", "BENIGN", "MALICIOUS", "NOT_APPLICABLE"]|BENIGN|None|None|
+|disposition|string|None|False|Investigation's disposition|["", "BENIGN", "FALSE_POSITIVE", "MALICIOUS", "NOT_APPLICABLE", "SECURITY_TEST", "UNDECIDED", "UNKNOWN"]|BENIGN|None|None|
 |email|string|None|False|A user's email address for investigation to be assigned|None|user@example.com|None|None|
 |id|string|None|True|The identifier of investigation to be update (ID or RRN)|None|rrn:investigation:example:11111111-1111-1111-1111-111111111111:investigation:11111111|None|None|
 |priority|string|None|False|Investigation's priority|["", "UNSPECIFIED", "LOW", "MEDIUM", "HIGH", "CRITICAL"]|LOW|None|None|
@@ -3006,7 +3006,7 @@ Example output:
 | :--- | :--- | :--- | :--- | :--- | :--- |
 |Assignee|assignee|None|False|The user assigned to this investigation, if any|None|
 |Created Time|string|None|False|The time the investigation was created as an ISO formatted timestamp|None|
-|Disposition|string|None|False|The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED|None|
+|Disposition|string|None|False|The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`|None|
 |First Alert Time|string|None|False|The create time of the first alert belonging to this investigation|None|
 |Last Accessed|string|None|False|The time investigation was last viewed or modified|None|
 |Latest Alert Time|string|None|False|The create time of the most recent alert belonging to this investigation|None|
@@ -3428,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 11.0.9 - Additional `disposition` values added for `Create Investigation`, `Update Investigation` and `Set Disposition of Investigation`
 * 11.0.8 - Remove use of session from the connection object to prevent session timeouts.
 * 11.0.7 - Adding request id to the plugin for traceability
 * 11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.6

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3428,7 +3428,7 @@ Example output:
 
 # Version History
 
-* 11.0.9 - Additional `disposition` values added for `Create Investigation`, `Update Investigation` and `Set Disposition of Investigation`
+* 12.0.0 - Additional `disposition` values added for `Create Investigation`, `Update Investigation` and `Set Disposition of Investigation`
 * 11.0.8 - Remove use of session from the connection object to prevent session timeouts.
 * 11.0.7 - Adding request id to the plugin for traceability
 * 11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.6

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/assign_user_to_investigation/schema.py
@@ -94,7 +94,7 @@ class AssignUserToInvestigationOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/create_investigation/schema.py
@@ -32,10 +32,13 @@ class CreateInvestigationInput(insightconnect_plugin_runtime.Input):
       "description": "Investigation's disposition",
       "enum": [
         "",
-        "UNDECIDED",
         "BENIGN",
+        "FALSE_POSITIVE",
         "MALICIOUS",
-        "NOT_APPLICABLE"
+        "NOT_APPLICABLE",
+        "SECURITY_TEST",
+        "UNDECIDED",
+        "UNKNOWN"
       ],
       "order": 4
     },
@@ -125,7 +128,7 @@ class CreateInvestigationOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_alert_information/schema.py
@@ -223,7 +223,6 @@ class GetAlertInformationOutput(insightconnect_plugin_runtime.Output):
           "title": "Disposition",
           "description": "The disposition of the alert.",
           "enum": [
-            "UNMAPPED",
             "UNDECIDED",
             "MALICIOUS",
             "BENIGN",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/get_investigation/schema.py
@@ -78,7 +78,7 @@ class GetInvestigationOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_investigations/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/list_investigations/schema.py
@@ -176,7 +176,7 @@ class ListInvestigationsOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_alerts/schema.py
@@ -481,7 +481,6 @@ class SearchAlertsOutput(insightconnect_plugin_runtime.Output):
           "title": "Disposition",
           "description": "The disposition of the alert.",
           "enum": [
-            "UNMAPPED",
             "UNDECIDED",
             "MALICIOUS",
             "BENIGN",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/search_investigations/schema.py
@@ -137,7 +137,7 @@ class SearchInvestigationsOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_disposition_of_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_disposition_of_investigation/schema.py
@@ -28,9 +28,14 @@ class SetDispositionOfInvestigationInput(insightconnect_plugin_runtime.Input):
       "title": "Disposition",
       "description": "Investigation's disposition",
       "enum": [
+        "",
         "BENIGN",
+        "FALSE_POSITIVE",
         "MALICIOUS",
-        "NOT_APPLICABLE"
+        "NOT_APPLICABLE",
+        "SECURITY_TEST",
+        "UNDECIDED",
+        "UNKNOWN"
       ],
       "order": 2
     },
@@ -91,7 +96,7 @@ class SetDispositionOfInvestigationOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_priority_of_investigation/schema.py
@@ -93,7 +93,7 @@ class SetPriorityOfInvestigationOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/set_status_of_investigation_action/schema.py
@@ -91,7 +91,7 @@ class SetStatusOfInvestigationActionOutput(insightconnect_plugin_runtime.Output)
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_alert/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_alert/schema.py
@@ -52,14 +52,13 @@ class UpdateAlertInput(insightconnect_plugin_runtime.Input):
       "description": "The alert disposition",
       "enum": [
         "",
-        "UNMAPPED",
-        "UNDECIDED",
-        "MALICIOUS",
         "BENIGN",
-        "UNKNOWN",
+        "FALSE_POSITIVE",
+        "MALICIOUS",
         "NOT_APPLICABLE",
         "SECURITY_TEST",
-        "FALSE_POSITIVE"
+        "UNDECIDED",
+        "UNKNOWN"
       ],
       "order": 3
     },
@@ -281,7 +280,6 @@ class UpdateAlertOutput(insightconnect_plugin_runtime.Output):
           "title": "Disposition",
           "description": "The disposition of the alert.",
           "enum": [
-            "UNMAPPED",
             "UNDECIDED",
             "MALICIOUS",
             "BENIGN",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/actions/update_investigation/schema.py
@@ -34,8 +34,12 @@ class UpdateInvestigationInput(insightconnect_plugin_runtime.Input):
       "enum": [
         "",
         "BENIGN",
+        "FALSE_POSITIVE",
         "MALICIOUS",
-        "NOT_APPLICABLE"
+        "NOT_APPLICABLE",
+        "SECURITY_TEST",
+        "UNDECIDED",
+        "UNKNOWN"
       ],
       "order": 5
     },
@@ -133,7 +137,7 @@ class UpdateInvestigationOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_alerts/schema.py
@@ -366,7 +366,6 @@ class GetNewAlertsOutput(insightconnect_plugin_runtime.Output):
           "title": "Disposition",
           "description": "The disposition of the alert.",
           "enum": [
-            "UNMAPPED",
             "UNDECIDED",
             "MALICIOUS",
             "BENIGN",

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/schema.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/schema.py
@@ -86,7 +86,7 @@ class GetNewInvestigationsOutput(insightconnect_plugin_runtime.Output):
         "disposition": {
           "type": "string",
           "title": "Disposition",
-          "description": "The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED",
+          "description": "The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`",
           "order": 3
         },
         "first_alert_time": {

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 11.0.8
+version: 11.0.9
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2025-06-11."]
 vendor: rapid7
@@ -35,6 +35,7 @@ sdk:
   version: 6.3.6
   user: nobody
 version_history:
+  - "11.0.9 - Additional `disposition` values added for `Create Investigation`, `Update Investigation` and `Set Disposition of Investigation`"
   - "11.0.8 - Remove use of session from the connection object to prevent session timeouts."
   - "11.0.7 - Adding request id to the plugin for traceability"
   - "11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.6"
@@ -191,7 +192,7 @@ types:
       required: false
     disposition:
       title: Disposition
-      description: The disposition of this investigation, where possible values are BENIGN, MALICIOUS, NOT_APPLICABLE, and UNSPECIFIED
+      description: The disposition of this investigation, where possible values are `BENIGN`, `MALICIOUS`, `NOT_APPLICABLE`, `UNKNOWN`, `UNDECIDED`, `SECURITY_TEST`,`FALSE_POSITIVE`
       type: string
       required: false
     first_alert_time:
@@ -957,7 +958,6 @@ types:
       type: string
       required: false
       enum:
-        - UNMAPPED
         - UNDECIDED
         - MALICIOUS
         - BENIGN
@@ -1581,10 +1581,13 @@ actions:
         type: string
         enum:
           - ""
-          - UNDECIDED
           - BENIGN
+          - FALSE_POSITIVE
           - MALICIOUS
           - NOT_APPLICABLE
+          - SECURITY_TEST
+          - UNDECIDED
+          - UNKNOWN
         required: false
         example: BENIGN
       email:
@@ -1702,8 +1705,12 @@ actions:
         enum:
           - ""
           - BENIGN
+          - FALSE_POSITIVE
           - MALICIOUS
           - NOT_APPLICABLE
+          - SECURITY_TEST
+          - UNDECIDED
+          - UNKNOWN
         required: false
         example: BENIGN
       email:
@@ -1780,9 +1787,14 @@ actions:
         description: Investigation's disposition
         type: string
         enum:
+          - ""
           - BENIGN
+          - FALSE_POSITIVE
           - MALICIOUS
           - NOT_APPLICABLE
+          - SECURITY_TEST
+          - UNDECIDED
+          - UNKNOWN
         required: true
         example: BENIGN
     output:
@@ -2833,14 +2845,13 @@ actions:
         type: string
         enum:
           - ""
-          - UNMAPPED
-          - UNDECIDED
-          - MALICIOUS
           - BENIGN
-          - UNKNOWN
+          - FALSE_POSITIVE
+          - MALICIOUS
           - NOT_APPLICABLE
           - SECURITY_TEST
-          - FALSE_POSITIVE
+          - UNDECIDED
+          - UNKNOWN
         required: false
         example: MALICIOUS
       priority:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 11.0.9
+version: 12.0.0
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2025-06-11."]
 vendor: rapid7
@@ -35,7 +35,7 @@ sdk:
   version: 6.3.6
   user: nobody
 version_history:
-  - "11.0.9 - Additional `disposition` values added for `Create Investigation`, `Update Investigation` and `Set Disposition of Investigation`"
+  - "12.0.0 - Additional `disposition` values added for `Create Investigation`, `Update Investigation` and `Set Disposition of Investigation`"
   - "11.0.8 - Remove use of session from the connection object to prevent session timeouts."
   - "11.0.7 - Adding request id to the plugin for traceability"
   - "11.0.6 - Updated `disposition` values for `create_investigation` and `update_alert` action | SDK bump to 6.3.6"

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="11.0.8",
+    version="11.0.9",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="11.0.9",
+    version="12.0.0",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

IDR have since updated the possible disposition values when creating/updating an investigation. A field or two will now return 400 if it is not removed as IDR no longer support is as a disposition field (`UNMAPPED`) and additional fields have been added. 

- Link to IDR code to specify the possible fields: https://github.com/rapid7/razor-properties/blob/master/CPS/globals/globals.yml#L1282


Describe the proposed changes:

  - Adding additional `disposition` values


### Testing

Tested each new disposition value and it creates/updates with the new value. 