### PR TITLE
[SOAR-19634] Carbon Black Cloud - Fix set time on dedupe

### DIFF
--- a/plugins/carbon_black_cloud/.CHECKSUM
+++ b/plugins/carbon_black_cloud/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "eece3ffdbb8da6c0dccc86d37f06ed33",
-	"manifest": "cc2a88b4ad712b952386d290642c4403",
-	"setup": "c1864a4876d430e4e319f2c12e3b357b",
+	"spec": "98839f446c3f5addcf7e11435ab64931",
+	"manifest": "82b6280c23aaf48710e2eb941d6518f2",
+	"setup": "5c28dcf2e1d0b3be1ccf20b128fce67a",
 	"schemas": [
 		{
 			"identifier": "get_agent_details/schema.py",

--- a/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
+++ b/plugins/carbon_black_cloud/bin/icon_carbon_black_cloud
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "VMware Carbon Black Cloud"
 Vendor = "rapid7"
-Version = "2.2.10"
+Version = "2.2.11"
 Description = "The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin"
 
 

--- a/plugins/carbon_black_cloud/help.md
+++ b/plugins/carbon_black_cloud/help.md
@@ -440,6 +440,7 @@ Example output:
 
 # Version History
 
+* 2.2.11 - 'Monitor Alerts': Fix bug related to search window reset for deduplicated alerts
 * 2.2.10 - Add support for high volume event support at cutoff time and date | Update SDK to 6.3.6
 * 2.2.9 - Fix error handing for when we don't get results served correctly from observations API
 * 2.2.8 - Fix error handling for HTTP Not Found status code responses from Carbon Black Cloud | Update SDK to 6.2.0

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
@@ -193,7 +193,7 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
             "time_range": {"start": start_time, "end": end_time},
         }
         url = f"{self.connection.base_url}/{endpoint}"
-        self.logger.info("Triggering observation search", time_start=start_time, time_end=end_time, start=index)
+        self.logger.info("Triggering observation search")
         observation_job_id = self.connection.request_api(url, search_params, debug=debug).get("job_id")
 
         state[OBSERVATION_QUERY_END_TIME] = end_time

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
@@ -127,17 +127,13 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
 
             self.logger.info(
                 "HTTP error from Carbon Black",
-                error=http_error.cause,
-                status_code=http_error.status_code,
-                returning_code=status_code,
-                state=state,
             )
 
             return alerts_and_observations, state, has_more_pages, status_code, error
 
         except Exception as error:
             self.logger.error(
-                f"Hit an unexpected error during task execution. State={state}, Error={error}", exc_info=True
+                f"Hit an unexpected error during task execution. State={state}, Error={error}"
             )
             return alerts_and_observations, state, False, 500, error
 

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
@@ -127,13 +127,17 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
 
             self.logger.info(
                 "HTTP error from Carbon Black",
+                error=http_error.cause,
+                status_code=http_error.status_code,
+                returning_code=status_code,
+                state=state,
             )
 
             return alerts_and_observations, state, has_more_pages, status_code, error
 
         except Exception as error:
             self.logger.error(
-                f"Hit an unexpected error during task execution. State={state}, Error={error}"
+                f"Hit an unexpected error during task execution. State={state}, Error={error}", exc_info=True
             )
             return alerts_and_observations, state, False, 500, error
 
@@ -189,7 +193,7 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
             "time_range": {"start": start_time, "end": end_time},
         }
         url = f"{self.connection.base_url}/{endpoint}"
-        self.logger.info("Triggering observation search")
+        self.logger.info("Triggering observation search", time_start=start_time, time_end=end_time, start=index)
         observation_job_id = self.connection.request_api(url, search_params, debug=debug).get("job_id")
 
         state[OBSERVATION_QUERY_END_TIME] = end_time

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
@@ -172,7 +172,7 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
                 alerts_has_more_pages = True
 
             alerts, state = self._dedupe_and_get_last_time(alerts, state, start_alert_time, observations=False)
-        else:
+        if not alerts:
             self.logger.info("No alerts retrieved for time period searched...")
             state[LAST_ALERT_TIME] = end_alert_time
         self.logger.info(f"{LAST_ALERT_TIME} set to: {state[LAST_ALERT_TIME]}, has_more_pages={alerts_has_more_pages}")

--- a/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
+++ b/plugins/carbon_black_cloud/icon_carbon_black_cloud/tasks/monitor_alerts/task.py
@@ -172,7 +172,7 @@ class MonitorAlerts(insightconnect_plugin_runtime.Task):
                 alerts_has_more_pages = True
 
             alerts, state = self._dedupe_and_get_last_time(alerts, state, start_alert_time, observations=False)
-        if not alerts:
+        else:
             self.logger.info("No alerts retrieved for time period searched...")
             state[LAST_ALERT_TIME] = end_alert_time
         self.logger.info(f"{LAST_ALERT_TIME} set to: {state[LAST_ALERT_TIME]}, has_more_pages={alerts_has_more_pages}")

--- a/plugins/carbon_black_cloud/plugin.spec.yaml
+++ b/plugins/carbon_black_cloud/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: carbon_black_cloud
 title: VMware Carbon Black Cloud
 description: The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin
-version: 2.2.10
+version: 2.2.11
 vendor: rapid7
 support: rapid7
 cloud_ready: true
@@ -18,6 +18,7 @@ requirements:
   - API Credentials
   - Base URL
 version_history:
+  - "2.2.11 - 'Monitor Alerts': Fix bug related to search window reset for deduplicated alerts"
   - "2.2.10 - Add support for high volume event support at cutoff time and date | Update SDK to 6.3.6"
   - "2.2.9 - Fix error handing for when we don't get results served correctly from observations API"
   - "2.2.8 - Fix error handling for HTTP Not Found status code responses from Carbon Black Cloud | Update SDK to 6.2.0"

--- a/plugins/carbon_black_cloud/setup.py
+++ b/plugins/carbon_black_cloud/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="carbon_black_cloud-rapid7-plugin",
-    version="2.2.10",
+    version="2.2.11",
     description="The [VMware Carbon Black Cloud](https://www.carbonblack.com/products/vmware-carbon-black-cloud/) is a cloud-native endpoint protection platform (EPP) that combines the intelligent system hardening and behavioral prevention needed to keep emerging threats at bay, using a single lightweight agent and an easy-to-use console. Manage and contain threats on your Carbon Black endpoints using this plugin",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## Proposed Changes

### Description

Describe the proposed changes:

  - Update start time to end time if no logs after dedupe

## PR Requirements

Developers, verify you have completed the following items by checking them off:

### Testing

#### Unit Tests

Review our documentation on [generating](https://docs.rapid7.com/insightconnect/unit-test-generation) and [writing](https://docs.rapid7.com/insightconnect/unit-test-primer) plugin unit tests

- [ ] Unit tests written for any new or updated code

#### In-Product Tests

If you are an InsightConnect customer or have access to an InsightConnect instance, the following in-product tests should be done:

- [ ] Screenshot of job output with the plugin changes
- [ ] Screenshot of the changed connection, actions, or triggers input within the InsightConnect workflow builder

### Style

Review the [style guide](https://docs.rapid7.com/insightconnect/style-guide/)

- [ ] For dependencies, pin [OS package](https://docs.rapid7.com/insightconnect/style-guide/#dockerfile) and [Python package](https://docs.rapid7.com/insightconnect/style-guide/#requirements.txt) versions
- [ ] For security, set least privileged account with ``USER nobody`` in the ``Dockerfile`` when possible
- [ ] For size, use the [slim SDK images](https://docs.rapid7.com/insightconnect/sdk-guide/#sdk-guide) when possible: ``rapid7/insightconnect-python-3-38-slim-plugin:{sdk-version-num}`` and ``rapid7/insightconnect-python-3-38-plugin:{sdk-version-num}``
- [ ] For error handling, use of [PluginException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations/#plugin-exceptions) and [ConnectionTestException](https://docs.rapid7.com/insightconnect/error-handling-in-integrations#connection-exceptions)
- [ ] For logging, use [self.logger](https://docs.rapid7.com/insightconnect/sdk-guide/#logging)
- [ ] For docs, use [changelog style](https://docs.rapid7.com/insightconnect/style-guide/#changelog)
- [ ] For docs, validate markdown with ``insight-plugin validate`` which calls ``icon_validate`` to lint ``help.md``

### Functional Checklist
- [ ] Work fully completed
- [ ] Functional
  - [ ] Any new actions/triggers include JSON [test files](https://docs.rapid7.com/insightconnect/style-guide/#tests) in the `tests/` directory created with `insight-plugin samples`
  - [ ] Tests should all pass unless it's a negative test. Negative tests have a naming convention of `tests/$action_bad.json`
  - [ ] Unsuccessful tests should fail by raising an exception causing the plugin to die and an object should be returned on successful test
  - [ ] Add functioning test results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -T tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run -T all --debug --jq` (use PR format at end)
  - [ ] Add functioning run results to PR, sanitize any output if necessary
    * Single action/trigger `insight-plugin run -R tests/example.json --debug --jq`
    * All actions/triggers shortcut `insight-plugin run --debug --jq` (use PR format at end)

### Assessment

You must validate your work to reviewers:

1. Run `insight-plugin validate` and make sure everything passes
2. Run the assessment tool: `insight-plugin run -A`. For single action validation: `insight-plugin run tests/{file}.json -A`
3. Copy (`insight-plugin ... | pbcopy`) and paste the output in **a new post** on this PR
4. Add required screenshots from the In-Product Tests section
