### PR TITLE
[SOAR-19462] Anomali - Minor Refinements after staging test

### DIFF
--- a/plugins/anomali_threatstream/.CHECKSUM
+++ b/plugins/anomali_threatstream/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "8e7975dc61f8c54edd9e8ff75577b54e",
+	"spec": "4f75801fa474db29456abea03678cd7c",
 	"manifest": "5a978e55740c1c5aae9987a12c39b29f",
 	"setup": "c49eecdac5557c8bcd51655a32a1d0ee",
 	"schemas": [
@@ -13,7 +13,7 @@
 		},
 		{
 			"identifier": "import_observable/schema.py",
-			"hash": "201b675c043d8023bd75ccce342538b5"
+			"hash": "b0cdc1eaea5deab80271daaef3d1c5bd"
 		},
 		{
 			"identifier": "lookup_hash/schema.py",

--- a/plugins/anomali_threatstream/Dockerfile
+++ b/plugins/anomali_threatstream/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.3.6 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.3.7 AS builder
 
 WORKDIR /python/src
 
@@ -11,7 +11,7 @@ ADD . /python/src
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.3.6
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.3.7
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/anomali_threatstream/help.md
+++ b/plugins/anomali_threatstream/help.md
@@ -179,8 +179,8 @@ This action is used to import observable(s) into Anomali ThreatStream with appro
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |file|file|None|True|File of data to be imported into Anomali ThreatStream|None|setup.exe|None|None|
-|observable_settings|observable_settings|None|False|Settings needed for importing an observable that needs approval. If `threat_type` is used alongside other mapping fields, it will overwrite them|None|{'classification': 'public', 'confidence': 100, 'threat_type': 'brute'}|None|None|
-|tlp|string|None|False|Protocol to indicate how sensitive information should be shared|["red", "amber", "green", "clear", "amber+strict"]|red|None|None|
+|observable_settings|observable_settings|None|False|Settings needed for importing an observable that needs approval|None|{'classification': 'public', 'confidence': 100, 'threat_type': 'brute'}|None|None|
+|tlp|string|None|False|Protocol to indicate how sensitive information should be shared|["red", "amber", "green", "clear", "amber+strict", ""]|red|None|None|
   
 Example input:
 
@@ -535,16 +535,16 @@ Example output:
 |Name|Type|Default|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- | :--- |
 |Classification|string|private|True|Classification of the observable|None|
-|Confidence|integer|None|None|Confidence value assigned to the observable. Confidence score can range from 0-100, in increasing order of confidence|None|
+|Confidence|integer|None|True|Confidence value assigned to the observable. Confidence score can range from 0-100, in increasing order of confidence|None|
 |Domain Mapping|string|None|False|Indicator type to assign if a specific type is not associated with an observable|None|
 |Email Mapping|string|None|False|Indicator type to assign if a specific type is not associated with an observable|None|
-|Expiration Time Stamp|date|None|None|Time stamp of when intelligence will expire on ThreatStream|None|
+|Expiration Time Stamp|date|None|None|Time stamp of when intelligence will expire on ThreatStream. If no date is provided, `Expiration Time Stamp` it will set to 90 days from the current date|None|
 |IP Mapping|string|None|False|Indicator type to assign if a specific type is not associated with an observable|None|
 |MD5 Mapping|string|None|False|Indicator type to assign if a specific type is not associated with an observable|None|
 |Notes|[]string|None|None|Additional details for the observable. This information is displayed in the Tags column of the ThreatStream UI e.g ['note1', 'note2', 'note3']|None|
 |Severity|string||None|Severity you want to assign to the observable when it is imported|None|
 |Source Confidence Weight|integer|None|None|Specifies the ratio between the amount of the source confidence of each observable and the ThreatStream confidence|None|
-|Threat Type|string|None|False|Type of threat associated with the imported observables|None|
+|Threat Type|string|None|False|Type of threat associated with the imported observables. If used alongside other mapping fields, it will overwrite them|None|
 |Trusted Circles|[]integer|None|None|ID of the trusted circle to which this threat data should be imported. If you want to import the threat data to multiple trusted circles, enter the list of comma-separated IDs e.g [1,2,3]|None|
 |URL Mapping|string|None|False|Indicator type to assign if a specific type is not associated with an observable|None|
   
@@ -599,7 +599,7 @@ Example output:
 
 # Version History
 
-* 4.0.0 - Updated actions to V2 API (V1 deprecated for various actions) | SDK Bump to 6.3.6 | Additional output fields added for `Get Sandbox Report`
+* 4.0.0 - Updated actions to V2 API (V1 deprecated for various actions) | SDK Bump to 6.3.7 | Additional output fields added for `Get Sandbox Report`
 * 3.1.2 - Update SDK to newest version
 * 3.1.1 - Mask API key from URLs in log output
 * 3.1.0 - Add new actions Submit File, Submit URL and Get Sandbox Report

--- a/plugins/anomali_threatstream/komand_anomali_threatstream/actions/import_observable/action.py
+++ b/plugins/anomali_threatstream/komand_anomali_threatstream/actions/import_observable/action.py
@@ -32,8 +32,22 @@ class ImportObservable(insightconnect_plugin_runtime.Action):
         data = {}
         observable_settings = params.get(Input.OBSERVABLE_SETTINGS, {})
         # Format observable settings
-        if observable_settings.get("expiration_ts", "").startswith("0001-01-01"):
+
+        # If no timestamp is sent, Anomali will default it to 90 days
+        if (
+            observable_settings.get("expiration_ts", "").startswith("0001-01-01")
+            or observable_settings.get("expiration_ts") == ""
+        ):
             del observable_settings["expiration_ts"]
+
+        if observable_settings.get("confidence"):
+            if not 0 <= observable_settings.get("confidence") <= 100:
+                raise PluginException(
+                    cause="Confidence score is either above the maximum limit or below the minimum limit.",
+                    assistance="Please ensure the confidence score is between 0 and 100.",
+                    data=f"Confidence score: {observable_settings.get('confidence')} is either above or below the limit.",
+                )
+
         for key, value in observable_settings.items():
             if key in ("notes", "trustedcircles"):
                 value = ",".join(str(val) for val in value)

--- a/plugins/anomali_threatstream/komand_anomali_threatstream/actions/import_observable/schema.py
+++ b/plugins/anomali_threatstream/komand_anomali_threatstream/actions/import_observable/schema.py
@@ -33,7 +33,7 @@ class ImportObservableInput(insightconnect_plugin_runtime.Input):
     "observable_settings": {
       "$ref": "#/definitions/observable_settings",
       "title": "Observable Settings",
-      "description": "Settings needed for importing an observable that needs approval. If `threat_type` is used alongside other mapping fields, it will overwrite them",
+      "description": "Settings needed for importing an observable that needs approval",
       "order": 2
     },
     "tlp": {
@@ -45,7 +45,8 @@ class ImportObservableInput(insightconnect_plugin_runtime.Input):
         "amber",
         "green",
         "clear",
-        "amber+strict"
+        "amber+strict",
+        ""
       ],
       "order": 3
     }
@@ -119,7 +120,7 @@ class ImportObservableInput(insightconnect_plugin_runtime.Input):
           "format": "date-time",
           "displayType": "date",
           "title": "Expiration Time Stamp",
-          "description": "Time stamp of when intelligence will expire on ThreatStream",
+          "description": "Time stamp of when intelligence will expire on ThreatStream. If no date is provided, `Expiration Time Stamp` it will set to 90 days from the current date",
           "order": 5
         },
         "notes": {
@@ -173,12 +174,13 @@ class ImportObservableInput(insightconnect_plugin_runtime.Input):
         "threat_type": {
           "type": "string",
           "title": "Threat Type",
-          "description": "Type of threat associated with the imported observables",
+          "description": "Type of threat associated with the imported observables. If used alongside other mapping fields, it will overwrite them",
           "order": 13
         }
       },
       "required": [
-        "classification"
+        "classification",
+        "confidence"
       ]
     }
   }

--- a/plugins/anomali_threatstream/plugin.spec.yaml
+++ b/plugins/anomali_threatstream/plugin.spec.yaml
@@ -11,7 +11,7 @@ support: community
 supported_versions: ["Anomali API API 19-06-2025"]
 sdk:
   type: slim
-  version: 6.3.6
+  version: 6.3.7
   user: nobody
 status: []
 resources:
@@ -40,7 +40,7 @@ hub_tags:
   keywords: [anomali, threatstream]
   features: []
 version_history:
-  - 4.0.0 - Updated actions to V2 API (V1 deprecated for various actions) | SDK Bump to 6.3.6 | Additional output fields added for `Get Sandbox Report`
+  - 4.0.0 - Updated actions to V2 API (V1 deprecated for various actions) | SDK Bump to 6.3.7 | Additional output fields added for `Get Sandbox Report`
   - 3.1.2 - Update SDK to newest version
   - 3.1.1 - Mask API key from URLs in log output
   - 3.1.0 - Add new actions Submit File, Submit URL and Get Sandbox Report
@@ -163,6 +163,7 @@ types:
       description: Confidence value assigned to the observable. Confidence score can
         range from 0-100, in increasing order of confidence
       type: integer
+      required: true
     source_confidence_weight:
       title: Source Confidence Weight
       description: Specifies the ratio between the amount of the source confidence
@@ -178,7 +179,7 @@ types:
       - medium
       - high
       - very-high
-      - ''
+      - ""
     classification:
       title: Classification
       description: Classification of the observable
@@ -190,7 +191,7 @@ types:
       required: true
     expiration_ts:
       title: Expiration Time Stamp
-      description: Time stamp of when intelligence will expire on ThreatStream
+      description: Time stamp of when intelligence will expire on ThreatStream. If no date is provided, `Expiration Time Stamp` it will set to 90 days from the current date
       type: date
     notes:
       title: Notes
@@ -235,7 +236,7 @@ types:
       type: '[]integer'
     threat_type:
       title: Threat Type
-      description: Type of threat associated with the imported observables
+      description: Type of threat associated with the imported observables. If used alongside other mapping fields, it will overwrite them
       type: string
       required: false
   import_observable_response:
@@ -450,7 +451,7 @@ actions:
         required: true
       observable_settings:
         title: Observable Settings
-        description: Settings needed for importing an observable that needs approval. If `threat_type` is used alongside other mapping fields, it will overwrite them
+        description: Settings needed for importing an observable that needs approval
         type: observable_settings
         example: {"classification": "public", "confidence": 100, "threat_type": "brute"}
         required: false
@@ -464,6 +465,7 @@ actions:
           - green
           - clear
           - amber+strict
+          - ""
         example: red
         required: false
     output:


### PR DESCRIPTION
## Proposed Changes

### Description

SDK Bump to 6.3.7

After testing on staging I spotted a few bugs:
- If no date value provided action will fail as "" is not of type date. This will set it to None and exclude it from the body. Anomali will then default it to 90 days on their end
- Various enum values did not have an option to select null (in the case they selected a value and changed their mind)
- Validation added to ensure confidence is between 0-100

Original PR: #3469 

