### PR TITLE
[FIX] DynamoDB Fixing title spacing for 'Get Item'

### DIFF
--- a/plugins/dynamodb/.CHECKSUM
+++ b/plugins/dynamodb/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "2c629c2bfb1fcb86adbf9ecf3a1045ba",
+	"spec": "8f88474e8b2a00e723ab5edf9b04fe15",
 	"manifest": "963d1178571c518c8d6b80f8250232f4",
 	"setup": "2086b8232e9dccaa238ebe1e8e738e1c",
 	"schemas": [

--- a/plugins/dynamodb/help.md
+++ b/plugins/dynamodb/help.md
@@ -44,7 +44,7 @@ Example input:
 ### Actions
 
 
-#### GetItem
+#### Get Item
 
 This action is used to return a set of attributes for the item with the given primary key
 

--- a/plugins/dynamodb/plugin.spec.yaml
+++ b/plugins/dynamodb/plugin.spec.yaml
@@ -139,7 +139,7 @@ connection:
     default: us-east-1
 actions:
   get_item:
-    title: GetItem
+    title: Get Item
     description: Return a set of attributes for the item with the given primary key
     input:
       table_name:


### PR DESCRIPTION
## Proposed Changes

### Description


On staging I noticed there is no spacing between the 'Get Item' action. This will add a space to make it easier to read:
![image](https://github.com/user-attachments/assets/f77c874f-8471-44bc-a503-ce63039fb42a)


 