### PR TITLE
[NO-TICKET] InsightConnect - Bumping snyk version to 3.11

### DIFF
--- a/.snyk
+++ b/.snyk
@@ -2,3 +2,5 @@ version: v1.25.0
 ignore: {}
 patch: {}
 exclude: {}
+language-settings:
+  python: "3.11"


### PR DESCRIPTION
## Proposed Changes

### Description

Various snyk vulnerabilities have come in which are patchable in `3.11` but not in `3.9`. In addition to this, our repo uses `3.11` so it's best to align this with snyk. This will update the python version snyk uses for this repo to be `3.11`

Describe the proposed changes:

  - Update Snyk version to `3.11`

