### PR TITLE
Duo Admin v5.0.7 Release

### DIFF
--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e912cc2a379eff7d99c31097d7f689c6",
-	"manifest": "b07f5fef9ea0cab0c9eabbf2ce9d1383",
-	"setup": "ba714b9df1523930df59041f2aad08c5",
+	"spec": "eeea0408e6946972d10d2a0e6c4f4d76",
+	"manifest": "3a3b1c7cd60b0005fe74a63fbcc056a2",
+	"setup": "0573ce5a1d3dea1c7837bb11f18e5cf1",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "eeea0408e6946972d10d2a0e6c4f4d76",
-	"manifest": "3a3b1c7cd60b0005fe74a63fbcc056a2",
-	"setup": "0573ce5a1d3dea1c7837bb11f18e5cf1",
+	"spec": "5f2deefdccede3f994b30645e3920378",
+	"manifest": "af9869d18645ddf7d9eadf9f39404bcf",
+	"setup": "57f1d1cb6bf1378f210d9604ea20c651",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/duo_admin/.CHECKSUM
+++ b/plugins/duo_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "eeea0408e6946972d10d2a0e6c4f4d76",
-	"manifest": "3a3b1c7cd60b0005fe74a63fbcc056a2",
-	"setup": "0573ce5a1d3dea1c7837bb11f18e5cf1",
+	"spec": "e912cc2a379eff7d99c31097d7f689c6",
+	"manifest": "b07f5fef9ea0cab0c9eabbf2ce9d1383",
+	"setup": "ba714b9df1523930df59041f2aad08c5",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",

--- a/plugins/duo_admin/Dockerfile
+++ b/plugins/duo_admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.3 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.8 AS builder
 
 WORKDIR /python/src
 
@@ -11,7 +11,7 @@ ADD . /python/src
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.8
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/duo_admin/Dockerfile
+++ b/plugins/duo_admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.8 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.3 AS builder
 
 WORKDIR /python/src
 
@@ -11,7 +11,7 @@ ADD . /python/src
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.8
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.3
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/duo_admin/bin/komand_duo_admin
+++ b/plugins/duo_admin/bin/komand_duo_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Duo Admin API"
 Vendor = "rapid7"
-Version = "5.0.5"
+Version = "5.0.6"
 Description = "[Duo](https://duo.com/)'s Trusted Access platform verifies the identity of your users with two-factor authentication and security health of their devices before they connect to the apps they use. Using the Duo plugin for InsightConnect will allow Duo user management within automation workflows"
 
 

--- a/plugins/duo_admin/bin/komand_duo_admin
+++ b/plugins/duo_admin/bin/komand_duo_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Duo Admin API"
 Vendor = "rapid7"
-Version = "5.0.6"
+Version = "5.0.5"
 Description = "[Duo](https://duo.com/)'s Trusted Access platform verifies the identity of your users with two-factor authentication and security health of their devices before they connect to the apps they use. Using the Duo plugin for InsightConnect will allow Duo user management within automation workflows"
 
 

--- a/plugins/duo_admin/bin/komand_duo_admin
+++ b/plugins/duo_admin/bin/komand_duo_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Duo Admin API"
 Vendor = "rapid7"
-Version = "5.0.6"
+Version = "5.0.7"
 Description = "[Duo](https://duo.com/)'s Trusted Access platform verifies the identity of your users with two-factor authentication and security health of their devices before they connect to the apps they use. Using the Duo plugin for InsightConnect will allow Duo user management within automation workflows"
 
 

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -950,7 +950,6 @@ Example output:
 
 # Version History
 
-* 5.0.6 - Update SDK to the latest version (6.3.8) | Update Task `Monitor Logs` for Task delay logging
 * 5.0.5 - Updated SDK to the latest version (6.3.3)
 * 5.0.4 - Updated SDK to the latest version (6.2.5)
 * 5.0.3 - Bump the SDK to version 6.2.3 | Update Task `monitor_logs` to delay retry if a rate limit error is returned from Duo Admin

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -950,6 +950,7 @@ Example output:
 
 # Version History
 
+* 5.0.6 - Update SDK to the latest version (6.3.8) | Update Task `Monitor Logs` for Task delay logging
 * 5.0.5 - Updated SDK to the latest version (6.3.3)
 * 5.0.4 - Updated SDK to the latest version (6.2.5)
 * 5.0.3 - Bump the SDK to version 6.2.3 | Update Task `monitor_logs` to delay retry if a rate limit error is returned from Duo Admin

--- a/plugins/duo_admin/help.md
+++ b/plugins/duo_admin/help.md
@@ -950,6 +950,7 @@ Example output:
 
 # Version History
 
+* 5.0.7 - Update Task `Monitor Logs` timestamp handling
 * 5.0.6 - Update SDK to the latest version (6.3.8) | Update Task `Monitor Logs` for Task delay logging
 * 5.0.5 - Updated SDK to the latest version (6.3.3)
 * 5.0.4 - Updated SDK to the latest version (6.2.5)

--- a/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
+++ b/plugins/duo_admin/komand_duo_admin/tasks/monitor_logs/task.py
@@ -500,16 +500,12 @@ class MonitorLogs(insightconnect_plugin_runtime.Task):
             if format_ == "milliseconds":
                 # Convert to milliseconds if the timestamp is in seconds
                 if epoch_timestamp < 1e10:
-                    self.logger.log(
-                        self.log_level, f"Converting epoch timestamp {epoch_timestamp} from seconds to milliseconds."
-                    )
+                    self.logger.info(f"Converting epoch timestamp {epoch_timestamp} from seconds to milliseconds.")
                     return epoch_timestamp * 1000
             elif format_ == "seconds":
                 # Convert to milliseconds if the timestamp is in seconds
                 if epoch_timestamp >= 1e10:
-                    self.logger.log(
-                        self.log_level, f"Converting epoch timestamp {epoch_timestamp} from milliseconds to seconds."
-                    )
+                    self.logger.info(f"Converting epoch timestamp {epoch_timestamp} from milliseconds to seconds.")
                     return epoch_timestamp // 1000
 
         # If the format is not recognized, just return the epoch timestamp as is

--- a/plugins/duo_admin/komand_duo_admin/util/helpers.py
+++ b/plugins/duo_admin/komand_duo_admin/util/helpers.py
@@ -21,13 +21,3 @@ def convert_fields_to_string(provided_logs: list) -> list:
                     access_device[field] = str(obtained_field)
             log["accessDevice"] = access_device
     return provided_logs
-
-
-def convert_string_to_bool(string: str):
-    if isinstance(string, str):
-        string = string.strip().lower()
-        if string == "true":
-            return True
-        elif string == "false":
-            return False
-    return string

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -11,7 +11,7 @@ status: []
 supported_versions: [Duo Admin API 2024-09-17]
 sdk:
   type: full
-  version: 6.3.3
+  version: 6.3.8
   user: nobody
 description: "[Duo](https://duo.com/)'s Trusted Access platform verifies the identity\
   \ of your users with two-factor authentication and security health of their devices\
@@ -31,7 +31,7 @@ key_features:
 requirements:
 - Two secret keys - `integration key` and `secret key`
 - '`API hostname`'
-version: 5.0.5
+version: 5.0.6
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/duo_admin
@@ -54,6 +54,7 @@ troubleshooting:
   - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained
   by passing a username to the Get User Status action.
 version_history:
+- 5.0.6 - Update SDK to the latest version (6.3.8) | Update Task `Monitor Logs` for Task delay logging
 - 5.0.5 - Updated SDK to the latest version (6.3.3)
 - 5.0.4 - Updated SDK to the latest version (6.2.5)
 - 5.0.3 - Bump the SDK to version 6.2.3 | Update Task `monitor_logs` to delay retry

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -11,7 +11,7 @@ status: []
 supported_versions: [Duo Admin API 2024-09-17]
 sdk:
   type: full
-  version: 6.3.8
+  version: 6.3.3
   user: nobody
 description: "[Duo](https://duo.com/)'s Trusted Access platform verifies the identity\
   \ of your users with two-factor authentication and security health of their devices\
@@ -31,7 +31,7 @@ key_features:
 requirements:
 - Two secret keys - `integration key` and `secret key`
 - '`API hostname`'
-version: 5.0.6
+version: 5.0.5
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/duo_admin
@@ -54,7 +54,6 @@ troubleshooting:
   - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained
   by passing a username to the Get User Status action.
 version_history:
-- 5.0.6 - Update SDK to the latest version (6.3.8) | Update Task `Monitor Logs` for Task delay logging
 - 5.0.5 - Updated SDK to the latest version (6.3.3)
 - 5.0.4 - Updated SDK to the latest version (6.2.5)
 - 5.0.3 - Bump the SDK to version 6.2.3 | Update Task `monitor_logs` to delay retry

--- a/plugins/duo_admin/plugin.spec.yaml
+++ b/plugins/duo_admin/plugin.spec.yaml
@@ -31,7 +31,7 @@ key_features:
 requirements:
 - Two secret keys - `integration key` and `secret key`
 - '`API hostname`'
-version: 5.0.6
+version: 5.0.7
 connection_version: 4
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/duo_admin
@@ -54,6 +54,7 @@ troubleshooting:
   - instead it's a unique identifier e.g. DU9I6T0F7R2S1J4XZHHA. A User ID can be obtained
   by passing a username to the Get User Status action.
 version_history:
+- 5.0.7 - Update Task `Monitor Logs` timestamp handling
 - 5.0.6 - Update SDK to the latest version (6.3.8) | Update Task `Monitor Logs` for Task delay logging
 - 5.0.5 - Updated SDK to the latest version (6.3.3)
 - 5.0.4 - Updated SDK to the latest version (6.2.5)

--- a/plugins/duo_admin/setup.py
+++ b/plugins/duo_admin/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="duo_admin-rapid7-plugin",
-    version="5.0.6",
+    version="5.0.5",
     description="[Duo](https://duo.com/)'s Trusted Access platform verifies the identity of your users with two-factor authentication and security health of their devices before they connect to the apps they use. Using the Duo plugin for InsightConnect will allow Duo user management within automation workflows",
     author="rapid7",
     author_email="",

--- a/plugins/duo_admin/setup.py
+++ b/plugins/duo_admin/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="duo_admin-rapid7-plugin",
-    version="5.0.5",
+    version="5.0.6",
     description="[Duo](https://duo.com/)'s Trusted Access platform verifies the identity of your users with two-factor authentication and security health of their devices before they connect to the apps they use. Using the Duo plugin for InsightConnect will allow Duo user management within automation workflows",
     author="rapid7",
     author_email="",

--- a/plugins/duo_admin/setup.py
+++ b/plugins/duo_admin/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="duo_admin-rapid7-plugin",
-    version="5.0.6",
+    version="5.0.7",
     description="[Duo](https://duo.com/)'s Trusted Access platform verifies the identity of your users with two-factor authentication and security health of their devices before they connect to the apps they use. Using the Duo plugin for InsightConnect will allow Duo user management within automation workflows",
     author="rapid7",
     author_email="",

--- a/plugins/duo_admin/unit_test/test_monitor_logs.py
+++ b/plugins/duo_admin/unit_test/test_monitor_logs.py
@@ -102,9 +102,9 @@ class TestMonitorLogs(TestCase):
         config,
     ):
         actual, actual_state, has_more_pages, status_code, _ = self.task.run(state=current_state, custom_config=config)
-        self.assertEqual(expected.get("logs"), actual)
-        self.assertEqual(expected.get("state"), actual_state)
-        self.assertEqual(expected.get("status_code"), status_code)
+        self.assertEqual(actual, expected.get("logs"))
+        self.assertEqual(actual_state, expected.get("state"))
+        self.assertEqual(status_code, expected.get("status_code"))
 
     def test_monitor_logs_with_rate_limit_whole_flow(
         self, mock_request, mock_request_instance, mock_get_headers, mock_get_time


### PR DESCRIPTION
This release rolls back 5.0.7 release to remove the corrupted state values bug being tracked under: https://rapid7.atlassian.net/browse/SOAR-19900

Noticed as part of a low alert triggering that task failures in us-west-2 but was impacted spread across all regions. 

PR changes:
- Revert the changes applied in 5.0.6 that added the lagging decorator and bumping the time forward causing the corrupted timestamp value when no data is returned. 
- The reason behind bumping the time forward was to prevent the alerts of the integration being 'stuck' if no data was returned within the lagging period. 
- A new conversion method added to the start of the integration run to revert corrupted data values in the state and let the task resume as expected. 

Testing:
- Locally testing on the the task execution with a corrupted state
- Rollover of an in on staging of a bad state value, gets normalised and execution as expected: `6adc320d-9b55-4ad7-80cf-d1c5c6bbea5f`
- New integration setup and no errors observed: `13a57617-f6c1-4e87-8e59-f4e8a002287b`

Roll out plan:
1. Push out to all regions and confirm a few select integrations rollover and pull data as expected.
2. Promote to all integrations.