### PR TITLE
[SOAR-19978] InsightVM - Tag Assets (Convert 'Tag Source' input to correct case)

### DIFF
--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e69ca6b63f234dcdf3610255ef004851",
-	"manifest": "a453a4461d9bb3f033d6df20d6b51919",
-	"setup": "339a1123ce498082c330ed2d4e63bfaa",
+	"spec": "3d9931496c2cc61d03ace6f0c41bc131",
+	"manifest": "610650a75f0cbf3529548f57a5a653d6",
+	"setup": "6310a78894925f0ba3ff220d76286e2d",
 	"schemas": [
 		{
 			"identifier": "add_scan_engine_pool_engine/schema.py",
@@ -289,7 +289,7 @@
 		},
 		{
 			"identifier": "tag_assets/schema.py",
-			"hash": "e73002cc518dfae0d91132f9dd78930b"
+			"hash": "381af5b4ec33fa40da1623a81a2cfb27"
 		},
 		{
 			"identifier": "tag_site/schema.py",

--- a/plugins/rapid7_insightvm/Dockerfile
+++ b/plugins/rapid7_insightvm/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.4 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.9 AS builder
 
 WORKDIR /python/src
 
@@ -11,7 +11,7 @@ ADD . /python/src
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.4
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.3.9
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
+++ b/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightVM Console"
 Vendor = "rapid7"
-Version = "8.0.12"
+Version = "8.0.13"
 Description = "InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans"
 
 

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -2499,7 +2499,7 @@ Example output:
 
 #### Tag Assets
 
-This action is used to add a tag to multiple assets in bulk
+This action is used to add a tag to multiple assets in bulk. Please note this does not work with 'build-in' tags
 
 ##### Input
 
@@ -2508,8 +2508,8 @@ This action is used to add a tag to multiple assets in bulk
 |asset_ids|[]integer|None|True|Asset IDs to tag|None|[1, 2, 3, 4]|None|None|
 |tag_id|integer|None|True|ID of tag to add to assets|None|12345|None|None|
 |tag_name|string|None|True|Name of tag to add to assets|None|Very High|None|None|
-|tag_source|string|None|True|Source of tag to add to assets|None|built-in|None|None|
-|tag_type|string|None|True|Type of tag to add to assets|None|criticality|None|None|
+|tag_source|string|None|True|Source of tag to add to assets|None|VM|None|None|
+|tag_type|string|None|True|Type of tag to add to assets|None|owner|None|None|
   
 Example input:
 
@@ -2523,8 +2523,8 @@ Example input:
   ],
   "tag_id": 12345,
   "tag_name": "Very High",
-  "tag_source": "built-in",
-  "tag_type": "criticality"
+  "tag_source": "VM",
+  "tag_type": "owner"
 }
 ```
 
@@ -4012,6 +4012,7 @@ Example output:
 
 # Version History
 
+* 8.0.13 - Updated 'Tag Assets' action to parse certain 'Tag Source' inputs correctly | Updated SDK to latest version (6.3.9) | Resolved Snyk Vulnerability
 * 8.0.12 - Resolved Snyk Vulnerabilities | Updated SDK to latest version (6.3.4)
 * 8.0.11 - Updated the cache storage path and replaced the external function with internal implementation | Updated SDK to the latest version (6.2.6)
 * 8.0.10 - Updated SDK to the latest version (6.2.5)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/tag_assets/action.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/tag_assets/action.py
@@ -20,6 +20,9 @@ class TagAssets(insightconnect_plugin_runtime.Action):
         tag_type = params.get(Input.TAG_TYPE)
         tag_source = params.get(Input.TAG_SOURCE)
 
+        # Allows output from 'Get Tag' to be used (as action requires uppercase and V3 returns lower). Issue with V3 API
+        tag_source = tag_source.upper() if tag_source.lower() != "built-in" else tag_source
+
         tag = {
             "attributes": [{"tag_attribute_name": "SOURCE", "tag_attribute_value": tag_source}],
             "tag_name": tag_name,

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/tag_assets/schema.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/tag_assets/schema.py
@@ -4,7 +4,7 @@ import json
 
 
 class Component:
-    DESCRIPTION = "Add a tag to multiple assets in bulk"
+    DESCRIPTION = "Add a tag to multiple assets in bulk. Please note this does not work with 'build-in' tags"
 
 
 class Input:

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -6,7 +6,7 @@ title: Rapid7 InsightVM Console
 description: InsightVM is a powerful vulnerability management tool which finds, prioritizes,
   and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations,
   scan results and start scans
-version: 8.0.12
+version: 8.0.13
 connection_version: 8
 supported_versions: [Rapid7 InsightVM API v3 2022-05-25]
 fedramp_ready: true
@@ -15,7 +15,7 @@ support: rapid7
 status: []
 sdk:
   type: full
-  version: 6.3.4
+  version: 6.3.9
   user: root
   custom_cmd:
     - RUN apk add --no-cache --virtual .build-deps make gcc libc-dev libffi-dev openssl-dev libxml2-dev libxslt-dev
@@ -30,6 +30,7 @@ links:
 references:
 - '[InsightVM API 3](https://help.rapid7.com/insightvm/en-us/api/index.html)'
 version_history:
+- 8.0.13 - Updated 'Tag Assets' action to parse certain 'Tag Source' inputs correctly | Updated SDK to latest version (6.3.9) | Resolved Snyk Vulnerability
 - 8.0.12 - Resolved Snyk Vulnerabilities | Updated SDK to latest version (6.3.4)
 - 8.0.11 - Updated the cache storage path and replaced the external function with internal implementation | Updated SDK to the latest version (6.2.6)
 - 8.0.10 - Updated SDK to the latest version (6.2.5)
@@ -2743,7 +2744,7 @@ actions:
         example: []
   tag_assets:
     title: Tag Assets
-    description: Add a tag to multiple assets in bulk
+    description: Add a tag to multiple assets in bulk. Please note this does not work with 'build-in' tags
     input:
       asset_ids:
         title: Asset IDs
@@ -2767,13 +2768,13 @@ actions:
         title: Tag Type
         description: Type of tag to add to assets
         type: string
-        example: criticality
+        example: owner
         required: true
       tag_source:
         title: Tag Source
         description: Source of tag to add to assets
         type: string
-        example: built-in
+        example: VM
         required: true
     output:
       success:

--- a/plugins/rapid7_insightvm/requirements.txt
+++ b/plugins/rapid7_insightvm/requirements.txt
@@ -1,7 +1,7 @@
 # List third-party dependencies here, separated by newlines.
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-aiohttp==3.11.10
+aiohttp==3.12.14
 defusedxml==0.7.1
 datetime==5.5
 python-dateutil==2.9.0

--- a/plugins/rapid7_insightvm/setup.py
+++ b/plugins/rapid7_insightvm/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightvm-rapid7-plugin",
-    version="8.0.12",
+    version="8.0.13",
     description="InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
### Description

[Support case](https://rapid7.atlassian.net/browse/SI-30609) opened regarding the output from `Get Tag` not working for `Tag Assets`. There is an issue with the V3 API where it does not return the data correctly from UI (tag source not returned in correct case, and tag type not always correct). This is causing workflows (which use output from `Get Tag` in input for `Tag Assets`) to fail as the `Tag Assets` action requires the source to be in uppercase. I raised a [ticket](https://rapid7.atlassian.net/browse/NEX-60026) with IVM about this but we can't afford to wait til it's fixed on their end.

Realistically this could be resolved if IVM fixed their Get Tag API to return it with that the UI shows but not sure on when that can be picked up so adding this change in now.

Description also updated as I found we don't support build-in tags. I am not sure why but this API is V2 which is very old. It is not supported in V3 so we need to made do. An IDEA ticket was made to support this for V3.

Describe the proposed changes:

  - Updated Tag Assets to convert Tag Source inputs to uppercase (as API requires it to always be uppercase)
  - SDK Bump to 6.3.9
  - Resolved Snyk bumping `aiohttp` 


### Testing

Prior to update 'custom' would not work as API requires it to be 'CUSTOM'. This is due to Get Tag not returning it in correct case. After changing it to convert source to upper it works:

Prior:
<img width="2068" height="572" alt="image" src="https://github.com/user-attachments/assets/f954755d-613c-4353-9063-6d5903ac53d2" />


After:
<img width="1772" height="586" alt="image" src="https://github.com/user-attachments/assets/cb31af04-493c-407a-956f-553273c1ea6f" />
