### PR TITLE
[SOAR-20017] Rapid7 InsightVM - Snyk Vulnerability

### DIFF
--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "3d9931496c2cc61d03ace6f0c41bc131",
+	"spec": "f778aa808d8c9d80030ccd6e8d6fa753",
 	"manifest": "610650a75f0cbf3529548f57a5a653d6",
 	"setup": "6310a78894925f0ba3ff220d76286e2d",
 	"schemas": [

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -4012,7 +4012,7 @@ Example output:
 
 # Version History
 
-* 8.0.13 - Updated 'Tag Assets' action to parse certain 'Tag Source' inputs correctly | Updated SDK to latest version (6.3.9) | Resolved Snyk Vulnerability
+* 8.0.13 - Resolved Snyk Vulnerability | Updated SDK to latest version (6.3.9)
 * 8.0.12 - Resolved Snyk Vulnerabilities | Updated SDK to latest version (6.3.4)
 * 8.0.11 - Updated the cache storage path and replaced the external function with internal implementation | Updated SDK to the latest version (6.2.6)
 * 8.0.10 - Updated SDK to the latest version (6.2.5)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/tag_assets/action.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/tag_assets/action.py
@@ -20,9 +20,6 @@ class TagAssets(insightconnect_plugin_runtime.Action):
         tag_type = params.get(Input.TAG_TYPE)
         tag_source = params.get(Input.TAG_SOURCE)
 
-        # Allows output from 'Get Tag' to be used (as action requires uppercase and V3 returns lower). Issue with V3 API
-        tag_source = tag_source.upper() if tag_source.lower() != "built-in" else tag_source
-
         tag = {
             "attributes": [{"tag_attribute_name": "SOURCE", "tag_attribute_value": tag_source}],
             "tag_name": tag_name,

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -30,7 +30,7 @@ links:
 references:
 - '[InsightVM API 3](https://help.rapid7.com/insightvm/en-us/api/index.html)'
 version_history:
-- 8.0.13 - Updated 'Tag Assets' action to parse certain 'Tag Source' inputs correctly | Updated SDK to latest version (6.3.9) | Resolved Snyk Vulnerability
+- 8.0.13 - Resolved Snyk Vulnerability | Updated SDK to latest version (6.3.9)
 - 8.0.12 - Resolved Snyk Vulnerabilities | Updated SDK to latest version (6.3.4)
 - 8.0.11 - Updated the cache storage path and replaced the external function with internal implementation | Updated SDK to the latest version (6.2.6)
 - 8.0.10 - Updated SDK to the latest version (6.2.5)


### PR DESCRIPTION
## Proposed Changes

### Description

Resolving high Snyk vulnerability: https://app.snyk.io/org/soar-insightconnect-new/project/ca817260-aa88-429e-aabe-517065276b1b

I was going to make an update to IVM a few weeks ago in regards to an SI but it closed out as it is not a plugin issue. This PR will remove them changes. 

Describe the proposed changes:

  - Revert changes in #3530
  - SDK bump to 6.3.9
  - Bumping `aiohttp` (snyk)

