### PR TITLE
[SOAR-20185] Hybrid analysis connection URL

### DIFF
--- a/plugins/hybrid_analysis/.CHECKSUM
+++ b/plugins/hybrid_analysis/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "31b5b616b794fa713b29d1b311918068",
-	"manifest": "b3e26a0051638fe019a954d8b2be8fd8",
-	"setup": "5a60b5ee743dbe0e6f4b500b2b8e1a39",
+	"spec": "12cfce1430981ea6cb132dbc8a0c4d9c",
+	"manifest": "97ec75223b7055933fbfe41739a5fd3c",
+	"setup": "fa0d720755c7da65062b5677c4c38abc",
 	"schemas": [
 		{
 			"identifier": "lookup_hash/schema.py",
@@ -21,7 +21,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "f774afc9cb9dbbd2388835475135053f"
+			"hash": "e471716fe802483de30caeb89f38e641"
 		}
 	]
 }

--- a/plugins/hybrid_analysis/bin/icon_hybrid_analysis
+++ b/plugins/hybrid_analysis/bin/icon_hybrid_analysis
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Hybrid Analysis"
 Vendor = "rapid7"
-Version = "4.0.0"
+Version = "4.0.1"
 Description = "[Hybrid Analysis](https://www.hybrid-analysis.com/) is a free malware analysis service powered by Payload Security that detects and analyzes unknown threats using a unique Hybrid Analysis technology. This plugin provides the ability to lookup file hashes to determine whether or not they are malicious"
 
 

--- a/plugins/hybrid_analysis/help.md
+++ b/plugins/hybrid_analysis/help.md
@@ -24,14 +24,14 @@ The connection configuration accepts the following parameters:
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |api_key|credential_secret_key|None|True|API key|None|9de5069c5afe602b2ea0a04b66beb2c0|None|None|
-|url|string|https://www.hybrid-analysis.com|True|Hybrid Analysis API server URL|None|https://www.hybrid-analysis.com|None|None|
+|url|string|hybrid-analysis.com|True|Hybrid Analysis API server URL|None|hybrid-analysis.com|None|None|
 
 Example input:
 
 ```
 {
   "api_key": "9de5069c5afe602b2ea0a04b66beb2c0",
-  "url": "https://www.hybrid-analysis.com"
+  "url": "hybrid-analysis.com"
 }
 ```
 
@@ -124,8 +124,8 @@ Example input:
 |Name|Type|Required|Description|Example|
 | :--- | :--- | :--- | :--- | :--- |
 |count|integer|True|Number of results returned|1|
-|result|[]result|False|List of results|None|
-|search_terms|[]search_term|True|List of key value pairs. Where the key is the parameter specified and its value|None|
+|result|[]result|False|List of results|[ { "analysis_start_time": "2021-09-02 18:58:23", "av_detect": "0", "environment_description": "Windows 7 64 bit", "environment_id": 120, "job_id": "61311eca7a48ee7a9e3041d7", "sha256": "82b43762a5bc9c0ab7b5d1f96dc47b34700924b598070a7ccb30c92eb5ee1599", "size": 18944, "submit_name": "ew_usbccgpfilter.sys", "type_short": "64-bit service", "verdict": "whitelisted" } ]|
+|search_terms|[]search_term|True|List of key value pairs. Where the key is the parameter specified and its value|[ { "id": "filename", "value": "setup.exe" }, { "id": "verdict", "value": "1" } ]|
   
 Example output:
 
@@ -184,7 +184,7 @@ Example input:
 |error|string|False|An error that occurred during the analysis|File \"testing.com.txt\" was detected as \"unknown\", this format is not supported on WINDOWS|
 |error_origin|string|False|Error origin|CLIENT|
 |error_type|string|False|Type of error that occurred|FILE_TYPE_BAD_ERROR|
-|related_reports|[]related_reports|False|Related reports which contained analysis information on linked data|None|
+|related_reports|[]related_reports|False|Related reports which contained analysis information on linked data|[ { "job_id": "61dc148b0cad612f7371d2d3", "environment_id": 300, "state": "SUCCESS", "sha256": "275a021bbfb6489e54d411499f7db9d1663fc695ec2fe2a2c4538aabf651fd0f" } ]|
 |state|string|True|State in which the analysis is in|ERROR|
   
 Example output:
@@ -196,10 +196,10 @@ Example output:
   "error_type": "FILE_TYPE_BAD_ERROR",
   "related_reports": [
     {
-      "job_id": "61dc148b0cad612f7371d2d3",
       "environment_id": 300,
-      "state": "SUCCESS",
-      "sha256": "275a021bbfb6489e54d411499f7db9d1663fc695ec2fe2a2c4538aabf651fd0f"
+      "job_id": "61dc148b0cad612f7371d2d3",
+      "sha256": "275a021bbfb6489e54d411499f7db9d1663fc695ec2fe2a2c4538aabf651fd0f",
+      "state": "SUCCESS"
     }
   ],
   "state": "ERROR"
@@ -503,6 +503,7 @@ Example output:
 
 # Version History
 
+* 4.0.1 - Adjusted the way the connection URL is passed to improve compatibility
 * 4.0.0 - Adjusted actions to comply with the 2.35.0 API version | SDK bump to 6.3.10
 * 3.0.1 - Bumping requirements.txt | SDK bump to 6.1.4
 * 3.0.0 - Update to support version 2 API | Created new actions which was moved from plugin **vxstream_sandbox** such as: Submit File, Lookup by Hash, Search Database, Retrieve Report

--- a/plugins/hybrid_analysis/icon_hybrid_analysis/connection/schema.py
+++ b/plugins/hybrid_analysis/icon_hybrid_analysis/connection/schema.py
@@ -25,7 +25,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "type": "string",
       "title": "URL",
       "description": "Hybrid Analysis API server URL",
-      "default": "https://www.hybrid-analysis.com",
+      "default": "hybrid-analysis.com",
       "order": 1
     }
   },

--- a/plugins/hybrid_analysis/icon_hybrid_analysis/util/api.py
+++ b/plugins/hybrid_analysis/icon_hybrid_analysis/util/api.py
@@ -67,7 +67,6 @@ class HybridAnalysisAPI:
             elif response.status_code >= 500:
                 raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
             else:
-                self.logger.info(response.text)
                 raise PluginException(
                     cause=response.json().get("message", "Unknown"),
                     assistance=f"validation_errors: {response.json().get('validation_errors')}",

--- a/plugins/hybrid_analysis/icon_hybrid_analysis/util/api.py
+++ b/plugins/hybrid_analysis/icon_hybrid_analysis/util/api.py
@@ -1,11 +1,15 @@
 import json
 import urllib.parse
 from logging import Logger
+from typing import Literal
 
 import requests
 
 from icon_hybrid_analysis.util import constants
 from insightconnect_plugin_runtime.exceptions import PluginException
+
+
+URL_PREFIX_TYPE = Literal[constants.DEFAULT_HTTP_PREFIX, constants.DEFAULT_HTTP_WWW_PREFIX]
 
 
 class HybridAnalysisAPI:
@@ -16,22 +20,37 @@ class HybridAnalysisAPI:
         self.logger = logger
 
     def lookup_by_hash(self, analyzed_hash: str):
-        return self._send_request(method="GET", path="/search/hash", params={"hash": analyzed_hash})
+        return self._send_request(
+            method="GET",
+            path="/search/hash",
+            url_prefix=constants.DEFAULT_HTTP_PREFIX,
+            params={"hash": analyzed_hash},
+        )
 
     def lookup_by_terms(self, data: dict):
-        return self._send_request(method="POST", path="/search/terms", data=data)
+        return self._send_request(
+            method="POST", path="/search/terms", url_prefix=constants.DEFAULT_HTTP_PREFIX, data=data
+        )
 
     def report(self, analyzed_hash: str):
-        return self._send_request(method="GET", path=f"/report/{urllib.parse.quote(analyzed_hash)}/state")
+        return self._send_request(
+            method="GET",
+            path=f"/report/{urllib.parse.quote(analyzed_hash)}/state",
+            url_prefix=constants.DEFAULT_HTTP_WWW_PREFIX,
+        )
 
     def submit(self, files: dict, data: dict):
-        return self._send_request(method="POST", path="/submit/file", files=files, data=data)
+        return self._send_request(
+            method="POST", path="/submit/file", url_prefix=constants.DEFAULT_HTTP_PREFIX, files=files, data=data
+        )
 
-    def _send_request(self, method: str, path: str, data: dict = None, params=None, files: dict = None) -> dict:
+    def _send_request(
+        self, method: str, path: str, url_prefix: URL_PREFIX_TYPE, data: dict = None, params=None, files: dict = None
+    ) -> dict:
         try:
             response = requests.request(
                 method.upper(),
-                f"{self.base_url}{path}",
+                f"{url_prefix}{self.base_url}{path}",
                 data=data,
                 params=params,
                 files=files,
@@ -48,6 +67,7 @@ class HybridAnalysisAPI:
             elif response.status_code >= 500:
                 raise PluginException(preset=PluginException.Preset.SERVER_ERROR, data=response.text)
             else:
+                self.logger.info(response.text)
                 raise PluginException(
                     cause=response.json().get("message", "Unknown"),
                     assistance=f"validation_errors: {response.json().get('validation_errors')}",

--- a/plugins/hybrid_analysis/icon_hybrid_analysis/util/constants.py
+++ b/plugins/hybrid_analysis/icon_hybrid_analysis/util/constants.py
@@ -1,2 +1,4 @@
 DEFAULT_URL = "https://www.hybrid-analysis.com"
 DEFAULT_USER_AGENT = "Falcon Sandbox"
+DEFAULT_HTTP_PREFIX = "https://"
+DEFAULT_HTTP_WWW_PREFIX = "https://www."

--- a/plugins/hybrid_analysis/plugin.spec.yaml
+++ b/plugins/hybrid_analysis/plugin.spec.yaml
@@ -10,7 +10,7 @@ description: "[Hybrid Analysis](https://www.hybrid-analysis.com/)\
   \ is a free malware analysis service powered by Payload Security\
   \ that detects and analyzes unknown threats using a unique Hybrid Analysis technology.\
   \ This plugin provides the ability to lookup file hashes to determine whether or not they are malicious"
-version: 4.0.0
+version: 4.0.1
 connection_version: 3
 supported_versions:
   - Hybrid Analysis API v2
@@ -36,6 +36,7 @@ key_features:
 requirements:
   - "A HybridAnalysis API key and token"
 version_history:
+  - "4.0.1 - Adjusted the way the connection URL is passed to improve compatibility"
   - "4.0.0 - Adjusted actions to comply with the 2.35.0 API version | SDK bump to 6.3.10"
   - "3.0.1 - Bumping requirements.txt | SDK bump to 6.1.4"
   - "3.0.0 - Update to support version 2 API | Created new actions which was moved from plugin **vxstream_sandbox** such as: Submit File, Lookup by Hash, Search Database, Retrieve Report"
@@ -718,8 +719,8 @@ connection:
     type: string
     description: Hybrid Analysis API server URL
     required: true
-    example: https://www.hybrid-analysis.com
-    default: https://www.hybrid-analysis.com
+    example: hybrid-analysis.com
+    default: hybrid-analysis.com
   api_key:
     title: API Key
     type: credential_secret_key
@@ -828,6 +829,7 @@ actions:
         description: List of key value pairs. Where the key is the parameter specified and its value
         type: '[]search_term'
         required: true
+        example: '[ { "id": "filename", "value": "setup.exe" }, { "id": "verdict", "value": "1" } ]'
       count:
         title: Count
         description: Number of results returned
@@ -839,6 +841,7 @@ actions:
         description: List of results
         type: '[]result'
         required: false
+        example: '[ { "analysis_start_time": "2021-09-02 18:58:23", "av_detect": "0", "environment_description": "Windows 7 64 bit", "environment_id": 120, "job_id": "61311eca7a48ee7a9e3041d7", "sha256": "82b43762a5bc9c0ab7b5d1f96dc47b34700924b598070a7ccb30c92eb5ee1599", "size": 18944, "submit_name": "ew_usbccgpfilter.sys", "type_short": "64-bit service", "verdict": "whitelisted" } ]'
   submit:
     title: Submit File
     description: Submit file for analysis
@@ -969,3 +972,4 @@ actions:
         type: '[]related_reports'
         description: Related reports which contained analysis information on linked data
         required: false
+        example: '[ { "job_id": "61dc148b0cad612f7371d2d3", "environment_id": 300, "state": "SUCCESS", "sha256": "275a021bbfb6489e54d411499f7db9d1663fc695ec2fe2a2c4538aabf651fd0f" } ]'

--- a/plugins/hybrid_analysis/setup.py
+++ b/plugins/hybrid_analysis/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="hybrid_analysis-rapid7-plugin",
-    version="4.0.0",
+    version="4.0.1",
     description="[Hybrid Analysis](https://www.hybrid-analysis.com/) is a free malware analysis service powered by Payload Security that detects and analyzes unknown threats using a unique Hybrid Analysis technology. This plugin provides the ability to lookup file hashes to determine whether or not they are malicious",
     author="rapid7",
     author_email="",

--- a/plugins/hybrid_analysis/unit_test/util.py
+++ b/plugins/hybrid_analysis/unit_test/util.py
@@ -13,7 +13,7 @@ class Util:
         default_connection = Connection()
         default_connection.logger = logging.getLogger("connection logger")
         params = {
-            Input.URL: "https://www.hybrid-analysis.com",
+            Input.URL: "hybrid-analysis.com",
             Input.API_KEY: {"secretKey": "9de5069c5afe602b2ea0a04b66beb2c0"},
         }
         default_connection.connect(params)
@@ -37,11 +37,11 @@ class Util:
                 return Util.load_json(f"payloads/{self.filename}.json.resp")
 
         if (
-            args[1] == "https://www.hybrid-analysis.com/api/v2/search/hash"
+            args[1] == "https://hybrid-analysis.com/api/v2/search/hash"
             and kwargs.get("params").get("hash") == "4c740b7f0bdc728daf9fca05241e85d921a54a6e17ae47ed1577a2b30792cf5c"
         ):
             return MockResponse("action_lookup_hash", 200)
-        elif args[1] == "https://www.hybrid-analysis.com/api/v2/search/hash" and (
+        elif args[1] == "https://hybrid-analysis.com/api/v2/search/hash" and (
             kwargs.get("params").get("hash") == "275a021bbfb6489e54d471899f7db9d1663fc695ec2fe2a2c4538aabf651fd0f"
             or kwargs.get("params").get("hash") == "44d88612fea8a8f36de82e1278abb02f"
         ):
@@ -51,9 +51,9 @@ class Util:
             == "https://www.hybrid-analysis.com/api/v2/report/30f800f97aeaa8d62bdf3a6fb2b0681179a360c12e127f07038f8521461e5050/state"
         ):
             return MockResponse("action_report", 200)
-        elif args[1] == "https://www.hybrid-analysis.com/api/v2/submit/file":
+        elif args[1] == "https://hybrid-analysis.com/api/v2/submit/file":
             return MockResponse("action_submit", 200)
-        elif args[1] == "https://www.hybrid-analysis.com/api/v2/search/terms":
+        elif args[1] == "https://hybrid-analysis.com/api/v2/search/terms":
             request_data = kwargs.get("data")
             if request_data.get(Input_terms.FILENAME) == "test" and request_data.get(Input_terms.VERDICT) == 1:
                 return MockResponse("action_lookup_terms_filename", 200)


### PR DESCRIPTION
https://rapid7.atlassian.net/browse/SOAR-20185

For the following actions, now we use the specified URLs: 
- Lookup by Hash – https://www.hybrid-analysis.com 
- Search Database – https://hybrid-analysis.com 
- Submit File – https://hybrid-analysis.com 
- Retrieve Report – https://www.hybrid-analysis.com 

It seems that two separate connections, with and without “www,” are needed for the plugin to function correctly.