### PR TITLE
SI-33125: fix token expiry, add trigger checkpointing, add filters to…

### DIFF
--- a/plugins/azure_sentinel/icon_azure_sentinel/actions/list_incidents/action.py
+++ b/plugins/azure_sentinel/icon_azure_sentinel/actions/list_incidents/action.py
@@ -1,7 +1,9 @@
+import datetime
+
 import insightconnect_plugin_runtime
 
 from .schema import Component, Input, ListIncidentsInput, ListIncidentsOutput, Output
-from icon_azure_sentinel.util.tools import map_output_for_list
+from icon_azure_sentinel.util.tools import map_output_for_list, generate_query_params
 
 
 class ListIncidents(insightconnect_plugin_runtime.Action):
@@ -17,10 +19,29 @@ class ListIncidents(insightconnect_plugin_runtime.Action):
         subscription_id = params.get(Input.SUBSCRIPTIONID)
         resource_group_name = params.get(Input.RESOURCEGROUPNAME)
         workspace_name = params.get(Input.WORKSPACENAME)
+
+        # OData sorting/paging filters
         filters = {
             Input.ORDERBY: params.get(Input.ORDERBY),
             Input.TOP: params.get(Input.TOP),
         }
+
+        # Build OData $filter for status and time range (same logic as trigger)
+        status = params.get("status", "All") or "All"
+        created_from = params.get("created_from")
+        created_to = params.get("created_to")
+
+        created_time = None
+        if created_from:
+            try:
+                created_time = datetime.datetime.fromisoformat(created_from.replace("Z", "")).replace(tzinfo=None)
+            except (ValueError, TypeError):
+                self.logger.warning(f"Invalid created_from value: {created_from}, ignoring filter")
+
+        query_params = generate_query_params(status, created_time)
+        if query_params:
+            filters["filter"] = query_params.get("filter", "")
+
         incidents, _ = self.connection.api_client.list_incident(
             resource_group_name, workspace_name, filters, subscription_id
         )

--- a/plugins/azure_sentinel/icon_azure_sentinel/triggers/get_new_incidents/trigger.py
+++ b/plugins/azure_sentinel/icon_azure_sentinel/triggers/get_new_incidents/trigger.py
@@ -8,6 +8,8 @@ import insightconnect_plugin_runtime
 from icon_azure_sentinel.util.tools import generate_query_params
 from .schema import Component, GetNewIncidentsInput, GetNewIncidentsOutput, Input, Output
 
+STATE_LAST_INCIDENT_TIME = "last_incident_time"
+
 
 class GetNewIncidents(insightconnect_plugin_runtime.Trigger):
     def __init__(self):
@@ -17,6 +19,33 @@ class GetNewIncidents(insightconnect_plugin_runtime.Trigger):
             input=GetNewIncidentsInput(),
             output=GetNewIncidentsOutput(),
         )
+
+    def _get_last_incident_time(self, interval: int) -> datetime.datetime:
+        """Retrieve the last processed incident time from persistent state, or fall back to now - interval."""
+        saved_time = self.state.get(STATE_LAST_INCIDENT_TIME)
+        if saved_time:
+            try:
+                return datetime.datetime.fromisoformat(saved_time)
+            except (ValueError, TypeError):
+                self.logger.warning(f"Invalid saved state for {STATE_LAST_INCIDENT_TIME}, falling back to default")
+        return datetime.datetime.now() - datetime.timedelta(seconds=interval)
+
+    def _update_last_incident_time(self, incidents: list):
+        """Update persistent state with the latest incident's createdTimeUtc."""
+        latest_time = None
+        for incident in incidents:
+            props = incident.get("properties", {})
+            created_str = props.get("createdTimeUtc")
+            if created_str:
+                try:
+                    created = datetime.datetime.fromisoformat(created_str.replace("Z", ""))
+                    if latest_time is None or created > latest_time:
+                        latest_time = created
+                except (ValueError, TypeError):
+                    continue
+        if latest_time:
+            self.state[STATE_LAST_INCIDENT_TIME] = latest_time.isoformat()
+            self.logger.info(f"Updated checkpoint to {latest_time.isoformat()}")
 
     def run(self, params={}):
         subscription_id = params.get(Input.SUBSCRIPTIONID)
@@ -32,15 +61,18 @@ class GetNewIncidents(insightconnect_plugin_runtime.Trigger):
         )
 
         assigned_to = params.get(Input.ASSIGNED_TO)
-        request_elapsed_time = datetime.timedelta(seconds=interval)
+
         while True:
-            time_ago = datetime.datetime.now() - (request_elapsed_time + datetime.timedelta(seconds=interval))
-            filters = generate_query_params(status, time_ago, last_update_time, assigned_to)
-            incidents, request_elapsed_time = self.connection.api_client.list_incident(
+            checkpoint_time = self._get_last_incident_time(interval)
+            self.logger.info(f"Polling incidents from checkpoint: {checkpoint_time.isoformat()}")
+
+            filters = generate_query_params(status, checkpoint_time, last_update_time, assigned_to)
+            incidents, _ = self.connection.api_client.list_incident(
                 resource_group_name, workspace_name, filters, subscription_id
             )
             if incidents:
                 self.send({Output.INCIDENTS: incidents})
+                self._update_last_incident_time(incidents)
             else:
                 self.logger.info("No new incidents have been found!")
             self.logger.info(f"Sleeping for {interval} seconds...\n")

--- a/plugins/azure_sentinel/icon_azure_sentinel/util/api.py
+++ b/plugins/azure_sentinel/icon_azure_sentinel/util/api.py
@@ -1,5 +1,6 @@
 import json
 import sys
+import time as time_module
 from typing import Any, Dict, List, Tuple, Optional, Union
 import urllib.parse
 
@@ -10,33 +11,33 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from .endpoints import Endpoint
 from .tools import request_execution_time
 
+# Token refresh buffer in seconds — refresh 5 minutes before expiry
+TOKEN_EXPIRY_BUFFER = 300
+
 
 class AzureClient:
     def __init__(self, logger: Any, tenant_id: str, client_id: str, client_secret: str):
         self.O365_AUTH_ENDPOINT = "https://login.microsoftonline.com/{}/oauth2/token"
         self.SCOPE = "https://management.azure.com"
         self._auth_token = ""  # nosec
+        self._token_expiry = 0  # epoch timestamp when token expires
         self.tenant_id = tenant_id
         self.client_id = client_id
         self.client_secret = client_secret
         self.logger = logger
 
-    @property
-    def auth_token(self):
-        tenant_id = self.tenant_id
-        client_id = self.client_id
-        client_secret = self.client_secret
-
+    def _refresh_token(self):
+        """Fetch a new OAuth token from Azure AD."""
         self.logger.info("Updating auth token...")
 
         data = {
             "grant_type": "client_credentials",
-            "client_id": client_id,
+            "client_id": self.client_id,
             "resource": self.SCOPE,
-            "client_secret": client_secret,
+            "client_secret": self.client_secret,
         }
 
-        formatted_endpoint = self.O365_AUTH_ENDPOINT.format(tenant_id)
+        formatted_endpoint = self.O365_AUTH_ENDPOINT.format(self.tenant_id)
         self.logger.info("Getting token from: " + formatted_endpoint)
 
         request = requests.request("POST", formatted_endpoint, data=data)
@@ -51,16 +52,32 @@ class AzureClient:
                 "Azure administrator.",
                 data=request.text,
             )
-        token = request.json().get("access_token")
-        self._auth_token = token
+        token_response = request.json()
+        self._auth_token = token_response.get("access_token")
+        # Azure tokens include expires_in (seconds). Default to 3600 if missing.
+        expires_in = int(token_response.get("expires_in", 3600))
+        self._token_expiry = time_module.time() + expires_in
         self.logger.info(f"Authentication Token: ****************{self._auth_token[-5:]}")
-        return token
+        self.logger.info(f"Token expires in {expires_in} seconds")
+
+    @property
+    def auth_token(self):
+        """Return a valid token, refreshing if expired or about to expire."""
+        if not self._auth_token or time_module.time() >= (self._token_expiry - TOKEN_EXPIRY_BUFFER):
+            self._refresh_token()
+        return self._auth_token
 
 
 class AzureSentinelClient(AzureClient):
     def __init__(self, logger: Any, tenant_id: str, client_id: str, client_secret: str):
         super(AzureSentinelClient, self).__init__(logger, tenant_id, client_id, client_secret)  # noqa
-        self.headers = {"Content-Type": "application/json", "Authorization": f"Bearer {self.auth_token}"}
+        # Fetch initial token to validate credentials at connection time
+        self._refresh_token()
+
+    @property
+    def headers(self):
+        """Generate headers dynamically so the token is always fresh."""
+        return {"Content-Type": "application/json", "Authorization": f"Bearer {self.auth_token}"}
 
     def _call_api(
         self, method: str, url: str, headers: dict, payload: Optional[dict] = None, params: Optional[dict] = None

--- a/plugins/azure_sentinel/plugin.spec.yaml
+++ b/plugins/azure_sentinel/plugin.spec.yaml
@@ -8,7 +8,7 @@ support: community
 supported_versions: [2021-04-01]
 status: []
 description: Microsoft Azure Sentinel is a cloud-native SIEM that provides intelligent security analytics for your entire enterprise, powered by AI
-version: 2.1.0
+version: 2.2.0
 resources:
   source_url: https://github.com/rapid7/insightconnect-plugins/tree/master/plugins/azure_sentinel
   license_url: https://github.com/rapid7/insightconnect-plugins/blob/master/LICENSE
@@ -1400,6 +1400,24 @@ actions:
         required: false
         type: integer
         example: 1867
+      status:
+        title: Status
+        description: Filter incidents by status. Use 'All' or leave empty to return all statuses
+        required: false
+        type: string
+        default: All
+        enum:
+          - All
+          - Active
+          - Closed
+          - New
+        example: New
+      created_from:
+        title: Created From
+        description: Filter incidents created after this ISO 8601 datetime
+        required: false
+        type: date
+        example: "2024-01-01T00:00:00Z"
     output:
       incidents:
         title: Incidents


### PR DESCRIPTION
Fixes three issues found during escalation SI-33125 where the Azure Sentinel trigger stops picking up incidents after running for a while.

What changed:

api.py — Auth token was set once in __init__ and never refreshed. After ~60 min it expires and all API calls start failing with 401. Now self.headers is a property that checks token TTL and refreshes proactively before expiry.

trigger.py — Polling window was calculated as now - interval on every tick with no state persistence. If the container restarts or lags, incidents in the gap are lost. Now uses self.state to checkpoint the last processed incident timestamp across restarts.

action.py + plugin.spec.yaml — List Incidents action had no support for status or time filters, making the Timer + List Incidents workaround useless. Added optional status and created_from params using the same generate_query_params logic the trigger uses.

Bumped version to 2.2.0.