### PR TITLE
Update get_list_request_notes

### DIFF
--- a/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_list_request/action.py
+++ b/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_list_request/action.py
@@ -2,7 +2,7 @@ import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.helper import clean
 
 from icon_manage_engine_service_desk.util.constants import Response, ResponseStatus
-from icon_manage_engine_service_desk.util.helpers import transform_request
+from icon_manage_engine_service_desk.util.helpers import transform_request, safe_get
 from .schema import GetListRequestInput, GetListRequestOutput, Input, Output, Component
 
 # Custom imports below
@@ -27,11 +27,11 @@ class GetListRequest(insightconnect_plugin_runtime.Action):
             sort_field=params.get(Input.SORT_FIELD),
         )
 
-        requests = [transform_request(request) for request in clean(response_json.get(Response.REQUESTS))]
+        requests = [transform_request(request) for request in response_json.get(Response.REQUESTS) or []]
 
         return clean(
             {
                 Output.REQUESTS: requests,
-                Output.STATUS: response_json.get(Response.RESPONSE_STATUS, [{}])[0].get(ResponseStatus.STATUS),
+                Output.STATUS: safe_get(response_json, Response.RESPONSE_STATUS, 0, ResponseStatus.STATUS),
             }
         )

--- a/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_list_request_notes/action.py
+++ b/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_list_request_notes/action.py
@@ -2,7 +2,7 @@ import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.helper import clean
 
 from icon_manage_engine_service_desk.util.constants import Response, Note, ResponseStatus, Time, User
-from icon_manage_engine_service_desk.util.helpers import remove_other_keys
+from icon_manage_engine_service_desk.util.helpers import remove_other_keys, safe_get
 from .schema import GetListRequestNotesInput, GetListRequestNotesOutput, Input, Output, Component
 
 # Custom imports below
@@ -25,16 +25,14 @@ class GetListRequestNotes(insightconnect_plugin_runtime.Action):
             clean_note = remove_other_keys(note, Note().get_all_attributes())
             clean_note[Note.LAST_UPDATED_BY] = remove_other_keys(note.get(Note.LAST_UPDATED_BY), [User.NAME, User.ID])
             clean_note[Note.ADDED_BY] = remove_other_keys(note.get(Note.ADDED_BY), [User.NAME, User.ID])
-            clean_note[Note.LAST_UPDATED_TIME] = (clean_note.get(Note.LAST_UPDATED_TIME) or {}).get(Time.DISPLAY_VALUE)
-            clean_note[Note.ADDED_TIME] = (clean_note.get(Note.ADDED_TIME) or {}).get(Time.DISPLAY_VALUE)
+            clean_note[Note.LAST_UPDATED_TIME] = safe_get(note, Note.LAST_UPDATED_TIME, Time.DISPLAY_VALUE)
+            clean_note[Note.ADDED_TIME] = safe_get(note, Note.ADDED_TIME, Time.DISPLAY_VALUE)
             updated_notes.append(clean_note)
         return clean(
             {
                 Output.REQUEST_ID: str(request_id),
                 Output.NOTES: updated_notes,
-                Output.STATUS: response_json.get(Response.RESPONSE_STATUS, [{}])[0].get(ResponseStatus.STATUS),
-                Output.STATUS_CODE: response_json.get(Response.RESPONSE_STATUS, [{}])[0].get(
-                    ResponseStatus.STATUS_CODE
-                ),
+                Output.STATUS: safe_get(response_json, Response.RESPONSE_STATUS, 0, ResponseStatus.STATUS),
+                Output.STATUS_CODE: safe_get(response_json, Response.RESPONSE_STATUS, 0, ResponseStatus.STATUS_CODE),
             }
         )

--- a/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_list_request_notes/action.py
+++ b/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_list_request_notes/action.py
@@ -25,8 +25,8 @@ class GetListRequestNotes(insightconnect_plugin_runtime.Action):
             clean_note = remove_other_keys(note, Note().get_all_attributes())
             clean_note[Note.LAST_UPDATED_BY] = remove_other_keys(note.get(Note.LAST_UPDATED_BY), [User.NAME, User.ID])
             clean_note[Note.ADDED_BY] = remove_other_keys(note.get(Note.ADDED_BY), [User.NAME, User.ID])
-            clean_note[Note.LAST_UPDATED_TIME] = clean_note.get(Note.LAST_UPDATED_TIME, {}).get(Time.DISPLAY_VALUE)
-            clean_note[Note.ADDED_TIME] = clean_note.get(Note.ADDED_TIME, {}).get(Time.DISPLAY_VALUE)
+            clean_note[Note.LAST_UPDATED_TIME] = (clean_note.get(Note.LAST_UPDATED_TIME) or {}).get(Time.DISPLAY_VALUE)
+            clean_note[Note.ADDED_TIME] = (clean_note.get(Note.ADDED_TIME) or {}).get(Time.DISPLAY_VALUE)
             updated_notes.append(clean_note)
         return clean(
             {

--- a/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_request/action.py
+++ b/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_request/action.py
@@ -2,7 +2,7 @@ import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.helper import clean
 
 from icon_manage_engine_service_desk.util.constants import Response, ResponseStatus
-from icon_manage_engine_service_desk.util.helpers import transform_request
+from icon_manage_engine_service_desk.util.helpers import transform_request, safe_get
 from .schema import GetRequestInput, GetRequestOutput, Input, Output, Component
 
 # Custom imports below
@@ -21,6 +21,6 @@ class GetRequest(insightconnect_plugin_runtime.Action):
         return clean(
             {
                 Output.REQUEST: request,
-                Output.STATUS: response_json.get(Response.RESPONSE_STATUS, {}).get(ResponseStatus.STATUS),
+                Output.STATUS: safe_get(response_json, Response.RESPONSE_STATUS, ResponseStatus.STATUS),
             }
         )

--- a/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_resolution/action.py
+++ b/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/actions/get_resolution/action.py
@@ -4,6 +4,7 @@ import insightconnect_plugin_runtime
 from insightconnect_plugin_runtime.helper import clean
 
 from icon_manage_engine_service_desk.util.constants import Response, ResponseStatus, Resolution
+from icon_manage_engine_service_desk.util.helpers import safe_get
 from .schema import GetResolutionInput, GetResolutionOutput, Input, Output, Component
 
 
@@ -23,8 +24,8 @@ class GetResolution(insightconnect_plugin_runtime.Action):
         return clean(
             {
                 Output.REQUEST_ID: str(request_id),
-                Output.CONTENT: response_json.get(Response.RESOLUTION, {}).get(Resolution.CONTENT),
-                Output.STATUS: response_json.get(Response.RESPONSE_STATUS, {}).get(ResponseStatus.STATUS),
-                Output.STATUS_CODE: response_json.get(Response.RESPONSE_STATUS, {}).get(ResponseStatus.STATUS_CODE),
+                Output.CONTENT: safe_get(response_json, Response.RESOLUTION, Resolution.CONTENT),
+                Output.STATUS: safe_get(response_json, Response.RESPONSE_STATUS, ResponseStatus.STATUS),
+                Output.STATUS_CODE: safe_get(response_json, Response.RESPONSE_STATUS, ResponseStatus.STATUS_CODE),
             }
         )

--- a/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/util/helpers.py
+++ b/plugins/manage_engine_service_desk/icon_manage_engine_service_desk/util/helpers.py
@@ -48,6 +48,26 @@ def remove_other_keys(input_dict: dict, keys_to_keep: list) -> dict:
     return {key: input_dict.get(key) for key in keys_to_keep}
 
 
+def safe_get(data, *keys, default=None):
+    """Safely traverse nested dicts/lists that may contain None values.
+
+    Examples:
+        safe_get(response, "request", "id") -> response["request"]["id"] or default
+        safe_get(response, "response_status", "status") -> handles None at any level
+        safe_get(response, "created_time", "display_value") -> handles null timestamps
+    """
+    for key in keys:
+        if isinstance(data, dict):
+            data = data.get(key)
+        elif isinstance(data, list) and isinstance(key, int) and key < len(data):
+            data = data[key]
+        else:
+            return default
+        if data is None:
+            return default
+    return data
+
+
 def normalize_note_response(response: dict) -> dict:
     """Normalize Cloud API 'request_note' key to 'note' so actions can use a consistent key."""
     if "request_note" in response and "note" not in response:
@@ -66,6 +86,6 @@ def transform_request(request: dict) -> dict:
 
     request[Request.PRIORITY] = remove_other_keys(request.get(Request.PRIORITY) or {}, [Priority.NAME, Priority.ID])
     request[Request.STATUS] = remove_other_keys(request.get(Request.STATUS) or {}, [Status.NAME, Status.ID])
-    request[Request.CREATED_TIME] = (request.get(Request.CREATED_TIME) or {}).get(Time.DISPLAY_VALUE)
-    request[Request.DUE_BY_TIME] = (request.get(Request.DUE_BY_TIME) or {}).get(Time.DISPLAY_VALUE)
+    request[Request.CREATED_TIME] = safe_get(request, Request.CREATED_TIME, Time.DISPLAY_VALUE)
+    request[Request.DUE_BY_TIME] = safe_get(request, Request.DUE_BY_TIME, Time.DISPLAY_VALUE)
     return remove_other_keys(request, Request().get_all_attributes())


### PR DESCRIPTION
## 🎫 Ticket
<!-- Link to the related Jira ticket (if applicable, typically for features and bug fixes) -->
<!-- If no ticket exists, you can remove this section or write "N/A" -->
<!-- Ticket: [<insert ticket title>](<insert ticket link>) -->

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [x] Bug fix
- [ ] Other

## 🧠 Background & Motivation
<!-- Why is this change needed? What problem or context led to this PR? -->
<!-- Provide a short explanation of the motivation and the problem being solved. -->
<!-- Examples: 
- "Users reported X error when doing Y"
- "New feature X was requested"
-->
When the API returns "last_updated_time": null, .get(key, {}) returns None (key exists with null value), then .get(Time.DISPLAY_VALUE) fails.

## ✨ What Changed
<!-- What was done? Summarize the key changes in this PR. -->
<!-- Describe the core implementation and high-level impact. -->
<!-- Examples:
- "Added new action 'X' to plugin Y"
- "Refactored X to improve performance"
-->
Refactored actions using safe_get:

transform_request — timestamp fields (created_time, due_by_time)
get_list_request_notes — note timestamps + response_status list access
get_list_request — response_status list access + null-safe requests list (or [])
get_resolution — nullable resolution object + response_status
get_request — response_status
This eliminates the entire class of 'NoneType' object has no attribute 'get' errors across all actions that read nested API response data.

## 🧪 Testing
<!-- Describe how you verified the changes work as intended -->
<!-- Include details of your testing process, such as:
- Unit tests
- Manual testing steps
- Any relevant screenshots or logs
-->
All 14 actions tested against live instances for both Cloud and On-Prem connection types. Unit tests: 66 passed.

### Cloud (connection_type: "Cloud")

| # | Action | Input | Output |
|---|--------|-------|--------|
| 1 | **add_request** | subject: "Test", requester: {"name": "Heather Graham"} | request_id: "280040000000449001", status: "success" |
| 2 | **get_request** | request_id: "280040000000449001" | request with subject "Test", requester "Heather Graham", status "Open" |
| 3 | **edit_request** | request_id: "280040000000449001", subject: "Updated Test Subject" | request_id: "280040000000449001", status: "success" |
| 4 | **assign_request** | request_id: "280040000000449001", technician: {"name": "Eric"} | request_id: "280040000000449001", status: "success" |
| 5 | **pickup_request** | request_id: "280040000000449001" | request_id: "280040000000449001", status: "success" |
| 6 | **add_request_note** | request_id: "280040000000449001", description: "This is a note" | request_note_id: "280040000000451001", status: "success" |
| 7 | **edit_request_note** | request_id: "280040000000449001", request_note_id: "280040000000451001" | status: "success" |
| 8 | **get_list_request_notes** | request_id: "280040000000449001" | 1 note returned, status: "success" |
| 9 | **delete_request_note** | request_id: "280040000000449001", request_note_id: "280040000000451001" | status: "success" |
| 10 | **add_resolution** | request_id: "280040000000449001", content: "Gave user a mouse" | status: "success" |
| 11 | **get_resolution** | request_id: "280040000000449001" | content: "Gave user a mouse", status: "success" |
| 12 | **get_list_request** | page_size: 10, sort_order: "desc" | 10 requests returned, status: "success" |
| 13 | **close_request** | request_id: "280040000000449001" | status: "success" |
| 14 | **delete_request** | request_id: "280040000000449001" | status: "success" |

### On-Prem (connection_type: "On-Prem")

| # | Action | Input | Output |
|---|--------|-------|--------|
| 1 | **add_request** | subject: "Test", requester: {"name": "Heather Graham"} | request_id: "4", status: "success" |
| 2 | **get_request** | request_id: "4" | request with subject "Test", requester "Heather Graham", status "Open" |
| 3 | **edit_request** | request_id: "4", subject: "Updated Test Subject" | request_id: "4", status: "success" |
| 4 | **assign_request** | request_id: "4", technician: {"name": "Eric Wilson"} | request_id: "4", status: "success" |
| 5 | **pickup_request** | request_id: "4" | request_id: "4", status: "success" |
| 6 | **add_request_note** | request_id: "4", description: "This is a note" | request_note_id: "301", status: "success" |
| 7 | **edit_request_note** | request_id: "4", request_note_id: "301" | status: "success" |
| 8 | **get_list_request_notes** | request_id: "4" | 1 note returned, status: "success" |
| 9 | **delete_request_note** | request_id: "4", request_note_id: "301" | status: "success" |
| 10 | **add_resolution** | request_id: "4", content: "Gave user a mouse" | status: "success" |
| 11 | **get_resolution** | request_id: "4" | content: "Gave user a mouse", status: "success" |
| 12 | **get_list_request** | page_size: 10, sort_order: "desc" | 3 requests returned, status: "success" |
| 13 | **close_request** | request_id: "4" | status: "success" |
| 14 | **delete_request** | request_id: "4" | status: "success" |

### Notes
- Zoho OAuth token endpoint rate-limits after ~8 rapid sequential requests (requires ~2 min cooldown). Retry logic with exponential backoff handles this in production where actions are spaced out.
- All IDs returned as strings — verified no precision loss on Cloud IDs (e.g., "280040000000449001" preserved correctly).
