### PR TITLE
Microsoft teams app only auth

### DIFF
--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "eb298c59e91eabdd58c9bdf49a67d8e0",
-	"manifest": "a61ac8c6cfb124e972ffc2cafecdeaa3",
-	"setup": "ed8d0fee50b11ca0d227555e46831c6c",
+	"spec": "e799ccb478fc801dbb2659cedd254fe7",
+	"manifest": "1a2dc7e814ace4c7fccb8b8c9e1eed51",
+	"setup": "4faaaed8301154a2f0927e17639cd58a",
 	"schemas": [
 		{
 			"identifier": "add_channel_to_team/schema.py",
@@ -41,7 +41,7 @@
 		},
 		{
 			"identifier": "get_message_in_chat/schema.py",
-			"hash": "7084e6609fae0c1da35859d3507cf0e2"
+			"hash": "1d97efe4bafcf8c5ff60695bf64cdfea"
 		},
 		{
 			"identifier": "get_reply_list/schema.py",
@@ -77,7 +77,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "266a4729e25b24d5b4d60d18d18500fb"
+			"hash": "2d8a2335c429afdc302db51d27c0ab2d"
 		},
 		{
 			"identifier": "new_message_received/schema.py",

--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "e799ccb478fc801dbb2659cedd254fe7",
+	"spec": "172b81e6039491d8e6bf88b1581925cb",
 	"manifest": "1a2dc7e814ace4c7fccb8b8c9e1eed51",
 	"setup": "4faaaed8301154a2f0927e17639cd58a",
 	"schemas": [

--- a/plugins/microsoft_teams/bin/icon_microsoft_teams
+++ b/plugins/microsoft_teams/bin/icon_microsoft_teams
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Teams"
 Vendor = "rapid7"
-Version = "7.0.6"
+Version = "8.0.0"
 Description = "[Microsoft Teams](https://products.office.com/en-us/microsoft-teams/group-chat-software) is a unified communications platform. The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users. This plugin uses the [Microsoft Teams API](https://docs.microsoft.com/en-us/graph/api/resources/teams-api-overview?view=graph-rest-1.0) to interact with Microsoft Teams"
 
 

--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -1206,7 +1206,8 @@ Example output:
 
 # Version History
 
-* 8.0.0 - Major refactor to eliminate user account requirement | Switched to client_credentials (app-only) OAuth2 flow | Added Bot Framework for sending messages | Migrated all endpoints from /beta to /v1.0 | Removed username_password from connection | Removed username input from get_message_in_chat (now uses app permissions) | Updated SDK to 6.5.1
+* 8.0.0 - Major refactor to eliminate user account requirement | Switched to client_credentials (app-only) OAuth2 flow | Added Bot Framework for sending messages | Migrated all endpoints from /beta to /v1.0 | Removed username_password from connection | Removed username input from get_message_in_chat (now uses app permissions)
+* 7.0.6 - Updated SDK to the latest version (6.5.1)
 * 7.0.5 - Updated SDK to the latest version (6.4.3)
 * 7.0.4 - Updated SDK to the latest version (6.4.2)
 * 7.0.3 - Updated SDK to the latest version (6.3.10)

--- a/plugins/microsoft_teams/help.md
+++ b/plugins/microsoft_teams/help.md
@@ -5,15 +5,18 @@
 # Key Features
 
 * Communication Management for all microsoft products
+* App-only authentication (no user account required)
+* Bot Framework integration for sending messages
 
 # Requirements
 
-* Username and Password
-* Secret Key, similar to API Key
+* Azure App Registration with Application ID and Secret
+* Microsoft Graph application permissions with admin consent
+* Azure Bot registration (for sending messages)
 
 # Supported Product Versions
 
-* Microsoft Graph API v1.0 2024-09-13
+* Microsoft Graph API v1.0 2025-05-18
 
 # Documentation
 
@@ -27,7 +30,6 @@ The connection configuration accepts the following parameters:
 |application_secret|credential_secret_key|None|True|Application secret|None|aMeCAEYdOLlK+qRcD9AjdyxLkCaqZH1UPm7adjJQ5Og=|None|None|
 |directory_id|string|None|True|Directory (tenant) ID|None|9e538ff5-dcb2-46a9-9a28-f93b8250deb0|None|None|
 |endpoint|string|None|True|The type of endpoint to connect to: normal service, GCC (government), GCC High (government), DoD (military)|["Normal", "GCC", "GCC High", "DoD"]|Normal|None|None|
-|username_password|credential_username_password|None|True|Username and password|None|{ "username": "user", "password": "mypassword" }|None|None|
 
 Example input:
 
@@ -36,11 +38,7 @@ Example input:
   "application_id": "63a0cad6-ac64-435c-a221-5d37c97b763e",
   "application_secret": "aMeCAEYdOLlK+qRcD9AjdyxLkCaqZH1UPm7adjJQ5Og=",
   "directory_id": "9e538ff5-dcb2-46a9-9a28-f93b8250deb0",
-  "endpoint": "Normal",
-  "username_password": {
-    "password": "mypassword",
-    "username": "user"
-  }
+  "endpoint": "Normal"
 }
 ```
 
@@ -448,15 +446,13 @@ This action is used to retrieve a single message or a message reply in a chat
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
 |chat_id|string|None|True|The ID of chat|None|11:examplechat.name|None|None|
 |message_id|string|None|True|The ID of message|None|1234567890|None|None|
-|username|string|None|True|The ID of user or his email|None|user@example.com|None|None|
   
 Example input:
 
 ```
 {
   "chat_id": "11:examplechat.name",
-  "message_id": 1234567890,
-  "username": "user@example.com"
+  "message_id": 1234567890
 }
 ```
 
@@ -1210,7 +1206,7 @@ Example output:
 
 # Version History
 
-* 7.0.6 - Updated SDK to the latest version (6.5.1)
+* 8.0.0 - Major refactor to eliminate user account requirement | Switched to client_credentials (app-only) OAuth2 flow | Added Bot Framework for sending messages | Migrated all endpoints from /beta to /v1.0 | Removed username_password from connection | Removed username input from get_message_in_chat (now uses app permissions) | Updated SDK to 6.5.1
 * 7.0.5 - Updated SDK to the latest version (6.4.3)
 * 7.0.4 - Updated SDK to the latest version (6.4.2)
 * 7.0.3 - Updated SDK to the latest version (6.3.10)

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_channel_to_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_channel_to_team/action.py
@@ -1,9 +1,6 @@
 import insightconnect_plugin_runtime
 from .schema import AddChannelToTeamInput, AddChannelToTeamOutput, Input, Output, Component
 
-# Custom imports below
-from icon_microsoft_teams.util.teams_utils import get_teams_from_microsoft, create_channel
-
 
 class AddChannelToTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -20,9 +17,9 @@ class AddChannelToTeam(insightconnect_plugin_runtime.Action):
         channel_description = params.get(Input.CHANNEL_DESCRIPTION)
         channel_type = params.get(Input.CHANNEL_TYPE)
 
-        teams = get_teams_from_microsoft(self.logger, self.connection, team_name)
+        teams = self.connection.client.get_teams(team_name)
         team_id = teams[0].get("id")
 
-        success = create_channel(self.logger, self.connection, team_id, channel_name, channel_description, channel_type)
+        success = self.connection.client.create_channel(team_id, channel_name, channel_description, channel_type)
 
         return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_channel_to_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_channel_to_team/action.py
@@ -1,6 +1,9 @@
 import insightconnect_plugin_runtime
 from .schema import AddChannelToTeamInput, AddChannelToTeamOutput, Input, Output, Component
 
+# Custom imports below
+from insightconnect_plugin_runtime.exceptions import PluginException
+
 
 class AddChannelToTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -18,6 +21,11 @@ class AddChannelToTeam(insightconnect_plugin_runtime.Action):
         channel_type = params.get(Input.CHANNEL_TYPE)
 
         teams = self.connection.client.get_teams(team_name)
+        if not teams:
+            raise PluginException(
+                cause="Team not found.",
+                assistance=f"Please verify '{team_name}' is a valid team name.",
+            )
         team_id = teams[0].get("id")
 
         success = self.connection.client.create_channel(team_id, channel_name, channel_description, channel_type)

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_group_owner/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_group_owner/action.py
@@ -2,11 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import AddGroupOwnerInput, AddGroupOwnerOutput, Input, Output, Component
 
 # Custom imports below
-from icon_microsoft_teams.util.azure_ad_utils import (
-    get_user_info,
-    get_group_id_from_name,
-    add_user_to_owners,
-)
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 
@@ -20,17 +15,16 @@ class AddGroupOwner(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        user_id = get_user_info(self.logger, self.connection, params.get(Input.MEMBER_LOGIN))
-        if not user_id or not user_id.get("id"):
+        user = self.connection.client.get_user_info(params.get(Input.MEMBER_LOGIN))
+        user_id = user.get("id")
+
+        if not user_id:
             raise PluginException(
                 cause="The specified user does not exist.",
                 assistance="Please check that member login is correct.",
             )
-        return {
-            Output.SUCCESS: add_user_to_owners(
-                self.logger,
-                self.connection,
-                get_group_id_from_name(self.logger, self.connection, params.get(Input.GROUP_NAME)),
-                user_id.get("id"),
-            )
-        }
+
+        group_id = self.connection.client.get_group_id_from_name(params.get(Input.GROUP_NAME))
+        success = self.connection.client.add_group_owner(group_id, user_id)
+
+        return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_channel/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_channel/action.py
@@ -2,12 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import AddMemberToChannelInput, AddMemberToChannelOutput, Input, Output, Component
 
 # Custom imports below
-from icon_microsoft_teams.util.teams_utils import get_channels_from_microsoft
-from icon_microsoft_teams.util.azure_ad_utils import (
-    get_user_info,
-    get_group_id_from_name,
-    add_user_to_channel,
-)
 from insightconnect_plugin_runtime.exceptions import PluginException
 
 
@@ -21,27 +15,38 @@ class AddMemberToChannel(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        group_id = get_group_id_from_name(self.logger, self.connection, params.get(Input.GROUP_NAME))
-        channels = get_channels_from_microsoft(self.logger, self.connection, group_id, params.get(Input.CHANNEL_NAME))
-        user_id = get_user_info(self.logger, self.connection, params.get(Input.MEMBER_LOGIN))
+        group_name = params.get(Input.GROUP_NAME)
+        channel_name = params.get(Input.CHANNEL_NAME)
+        member_login = params.get(Input.MEMBER_LOGIN)
         role = params.get(Input.ROLE, "Member").lower()
+
+        group_id = self.connection.client.get_group_id_from_name(group_name)
+        channels = self.connection.client.get_channels(group_id, channel_name)
+
         try:
             channel_id = channels[0].get("id")
-            user_id = user_id.get("id")
-            if not channel_id:
-                raise PluginException(
-                    cause="The specified channel does not exist.",
-                    assistance="Please check that channel name is correct.",
-                )
-            if not user_id:
-                raise PluginException(
-                    cause="The specified user does not exist.",
-                    assistance="Please check that member login is correct.",
-                )
-        except IndexError as e:
+        except (IndexError, TypeError) as error:
             raise PluginException(
                 cause="The specified channel does not exist.",
-                assistance="If the issue persists please contact support.",
-                data=e,
+                assistance="Please check that channel name is correct.",
+                data=str(error),
+            ) from error
+
+        if not channel_id:
+            raise PluginException(
+                cause="The specified channel does not exist.",
+                assistance="Please check that channel name is correct.",
             )
-        return {Output.SUCCESS: add_user_to_channel(self.logger, self.connection, group_id, channel_id, user_id, role)}
+
+        user = self.connection.client.get_user_info(member_login)
+        user_id = user.get("id")
+
+        if not user_id:
+            raise PluginException(
+                cause="The specified user does not exist.",
+                assistance="Please check that member login is correct.",
+            )
+
+        success = self.connection.client.add_member_to_channel(group_id, channel_id, user_id, role)
+
+        return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/add_member_to_team/action.py
@@ -1,10 +1,6 @@
 import insightconnect_plugin_runtime
 from .schema import AddMemberToTeamInput, AddMemberToTeamOutput, Input, Output, Component
 
-# Custom imports below
-from icon_microsoft_teams.util.azure_ad_utils import get_user_info, add_user_to_group
-from icon_microsoft_teams.util.teams_utils import get_teams_from_microsoft
-
 
 class AddMemberToTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -19,15 +15,12 @@ class AddMemberToTeam(insightconnect_plugin_runtime.Action):
         user_login = params.get(Input.MEMBER_LOGIN)
         team_name = params.get(Input.TEAM_NAME)
 
-        # Get User ID
-        user_result = get_user_info(self.logger, self.connection, user_login)
-        user_id = user_result.get("id")
+        user = self.connection.client.get_user_info(user_login)
+        user_id = user.get("id")
 
-        # Get Group ID
-        teams_result = get_teams_from_microsoft(self.logger, self.connection, team_name)
-        group_id = teams_result[0].get("id")
+        teams = self.connection.client.get_teams(team_name)
+        group_id = teams[0].get("id")
 
-        # Add user to Group
-        success = add_user_to_group(self.logger, self.connection, group_id, user_id)
+        success = self.connection.client.add_member_to_group(group_id, user_id)
 
         return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/create_teams_chat/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/create_teams_chat/action.py
@@ -3,7 +3,6 @@ from .schema import CreateTeamsChatInput, CreateTeamsChatOutput, Input, Output, 
 
 # Custom imports below
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
-from icon_microsoft_teams.util.teams_utils import create_chat
 
 
 class CreateTeamsChat(insightconnect_plugin_runtime.Action):
@@ -19,6 +18,6 @@ class CreateTeamsChat(insightconnect_plugin_runtime.Action):
         members = params.get(Input.MEMBERS)
         topic = params.get(Input.TOPIC)
 
-        group_result = create_chat(self.connection, members, topic)
+        group_result = self.connection.client.create_chat(members, topic)
 
         return {Output.CHAT: remove_null_and_clean(group_result)}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/create_teams_enabled_group/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/create_teams_enabled_group/action.py
@@ -8,7 +8,6 @@ from .schema import (
 )
 
 # Custom imports below
-from icon_microsoft_teams.util.azure_ad_utils import create_group, enable_teams_for_group
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 
 
@@ -29,19 +28,16 @@ class CreateTeamsEnabledGroup(insightconnect_plugin_runtime.Action):
         owners = params.get(Input.OWNERS)
         members = params.get(Input.MEMBERS)
 
-        group_result = create_group(
-            self.logger,
-            self.connection,
-            group_name,
-            group_description,
-            mail_nickname,
-            mail_enabled,
-            owners,
-            members,
+        group_result = self.connection.client.create_group(
+            group_name=group_name,
+            group_description=group_description,
+            group_nickname=mail_nickname,
+            mail_enabled=mail_enabled,
+            owners=owners,
+            members=members,
         )
 
         group_id = group_result.get("id")
-
-        enable_teams_for_group(self.logger, self.connection, group_id)
+        self.connection.client.enable_teams_for_group(group_id)
 
         return {Output.GROUP: remove_null_and_clean(group_result)}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/delete_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/delete_team/action.py
@@ -1,9 +1,6 @@
 import insightconnect_plugin_runtime
 from .schema import DeleteTeamInput, DeleteTeamOutput, Input, Output, Component
 
-# Custom imports below
-from icon_microsoft_teams.util.azure_ad_utils import delete_group
-
 
 class DeleteTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -16,5 +13,8 @@ class DeleteTeam(insightconnect_plugin_runtime.Action):
 
     def run(self, params={}):
         team_name = params.get(Input.TEAM_NAME)
-        success = delete_group(self.logger, self.connection, team_name)
+
+        group_id = self.connection.client.get_group_id_from_name(team_name)
+        success = self.connection.client.delete_group(group_id)
+
         return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_channels_for_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_channels_for_team/action.py
@@ -3,6 +3,7 @@ from .schema import GetChannelsForTeamInput, GetChannelsForTeamOutput, Input, Ou
 
 # Custom imports below
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 
 class GetChannelsForTeam(insightconnect_plugin_runtime.Action):
@@ -19,6 +20,11 @@ class GetChannelsForTeam(insightconnect_plugin_runtime.Action):
         channel_name = params.get(Input.CHANNEL_NAME)
 
         teams = self.connection.client.get_teams(team_name)
+        if not teams:
+            raise PluginException(
+                cause="Team not found.",
+                assistance=f"Please verify '{team_name}' is a valid team name.",
+            )
         team_id = teams[0].get("id")
 
         channels = self.connection.client.get_channels(team_id, channel_name)

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_channels_for_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_channels_for_team/action.py
@@ -2,10 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import GetChannelsForTeamInput, GetChannelsForTeamOutput, Input, Output, Component
 
 # Custom imports below
-from icon_microsoft_teams.util.teams_utils import (
-    get_teams_from_microsoft,
-    get_channels_from_microsoft,
-)
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 
 
@@ -22,12 +18,11 @@ class GetChannelsForTeam(insightconnect_plugin_runtime.Action):
         team_name = params.get(Input.TEAM_NAME)
         channel_name = params.get(Input.CHANNEL_NAME)
 
-        team_array = get_teams_from_microsoft(self.logger, self.connection, team_name)
-        team = team_array[0]
+        teams = self.connection.client.get_teams(team_name)
+        team_id = teams[0].get("id")
 
-        team_id = team.get("id")
+        channels = self.connection.client.get_channels(team_id, channel_name)
 
-        channels = get_channels_from_microsoft(self.logger, self.connection, team_id, channel_name)
         clean_channels = []
         for channel in channels:
             clean_channels.append(remove_null_and_clean(channel))

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_message_in_channel/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_message_in_channel/action.py
@@ -1,6 +1,4 @@
 import insightconnect_plugin_runtime
-
-from icon_microsoft_teams.util.teams_utils import get_message_from_channel
 from .schema import GetMessageInChannelInput, GetMessageInChannelOutput, Input, Output, Component
 
 
@@ -19,5 +17,6 @@ class GetMessageInChannel(insightconnect_plugin_runtime.Action):
         message_id = params.get(Input.MESSAGE_ID, "")
         reply_id = params.get(Input.REPLY_ID, "")
 
-        message = get_message_from_channel(self.connection, team_id, channel_id, message_id, reply_id)
+        message = self.connection.client.get_channel_message(team_id, channel_id, message_id, reply_id)
+
         return {Output.MESSAGE: message}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_message_in_chat/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_message_in_chat/action.py
@@ -1,6 +1,5 @@
 import insightconnect_plugin_runtime
 from .schema import GetMessageInChatInput, GetMessageInChatOutput, Input, Output, Component
-from icon_microsoft_teams.util.teams_utils import get_message_from_chat
 
 
 class GetMessageInChat(insightconnect_plugin_runtime.Action):
@@ -13,9 +12,9 @@ class GetMessageInChat(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        username = params.get(Input.USERNAME, "")
         chat_id = params.get(Input.CHAT_ID, "")
         message_id = params.get(Input.MESSAGE_ID, "")
 
-        message = get_message_from_chat(self.connection, username, chat_id, message_id)
+        message = self.connection.client.get_chat_message(chat_id, message_id)
+
         return {Output.MESSAGE: message}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_message_in_chat/schema.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_message_in_chat/schema.py
@@ -10,7 +10,6 @@ class Component:
 class Input:
     CHAT_ID = "chat_id"
     MESSAGE_ID = "message_id"
-    USERNAME = "username"
 
 
 class Output:
@@ -27,25 +26,18 @@ class GetMessageInChatInput(insightconnect_plugin_runtime.Input):
       "type": "string",
       "title": "Chat ID",
       "description": "The ID of chat",
-      "order": 2
+      "order": 1
     },
     "message_id": {
       "type": "string",
       "title": "Message ID",
       "description": "The ID of message",
-      "order": 3
-    },
-    "username": {
-      "type": "string",
-      "title": "Username",
-      "description": "The ID of user or his email",
-      "order": 1
+      "order": 2
     }
   },
   "required": [
     "chat_id",
-    "message_id",
-    "username"
+    "message_id"
   ],
   "definitions": {}
 }

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_reply_list/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_reply_list/action.py
@@ -1,9 +1,8 @@
 import insightconnect_plugin_runtime
-from insightconnect_plugin_runtime.exceptions import PluginException
-
 from .schema import GetReplyListInput, GetReplyListOutput, Input, Output, Component
 
-from icon_microsoft_teams.util.teams_utils import get_teams_from_microsoft, get_channels_from_microsoft, get_reply_list
+# Custom imports below
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 
 class GetReplyList(insightconnect_plugin_runtime.Action):
@@ -16,24 +15,26 @@ class GetReplyList(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        team = params.get(Input.TEAM_NAME)
-        channel = params.get(Input.CHANNEL_NAME)
+        team_name = params.get(Input.TEAM_NAME)
+        channel_name = params.get(Input.CHANNEL_NAME)
         message_id = params.get(Input.MESSAGE_ID)
 
-        team_id, channel_id = "", ""
-        teams = get_teams_from_microsoft(self.logger, self.connection, team)
-        if teams and isinstance(teams, list):
-            team_id = teams[0].get("id")
-            channels = get_channels_from_microsoft(self.logger, self.connection, team_id, channel)
-            if channels and isinstance(channels, list):
-                channel_id = channels[0].get("id")
-
-        if not team_id and not channel_id:
+        teams = self.connection.client.get_teams(team_name)
+        if not teams:
             raise PluginException(
-                cause="No team ID with channel ID was provided.",
-                assistance="Please provide the team and channel details(name or"
-                " GUID) to send the message to a specific channel.",
+                cause="Team not found.",
+                assistance="Please verify the team name is correct.",
             )
 
-        messages = get_reply_list(self.connection, team_id, channel_id, message_id)
+        team_id = teams[0].get("id")
+        channels = self.connection.client.get_channels(team_id, channel_name)
+        if not channels:
+            raise PluginException(
+                cause="Channel not found.",
+                assistance="Please verify the channel name is correct.",
+            )
+
+        channel_id = channels[0].get("id")
+        messages = self.connection.client.get_message_replies(team_id, channel_id, message_id)
+
         return {Output.MESSAGES: messages}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/get_teams/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/get_teams/action.py
@@ -3,7 +3,6 @@ from .schema import GetTeamsInput, GetTeamsOutput, Input, Output, Component
 
 # Custom imports below
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
-from icon_microsoft_teams.util.teams_utils import get_teams_from_microsoft
 
 
 class GetTeams(insightconnect_plugin_runtime.Action):
@@ -18,8 +17,7 @@ class GetTeams(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         team_name = params.get(Input.TEAM_NAME, "")
 
-        # The end of this filters for only MS Team enabled Teams
-        teams = get_teams_from_microsoft(self.logger, self.connection, team_name, False)
+        teams = self.connection.client.get_teams(team_name, explicit=False)
 
         clean_teams = []
         for team in teams:

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/list_messages_in_chat/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/list_messages_in_chat/action.py
@@ -1,8 +1,5 @@
 import insightconnect_plugin_runtime
 from .schema import ListMessagesInChatInput, ListMessagesInChatOutput, Input, Output, Component
-from icon_microsoft_teams.util.teams_utils import list_messages_from_chat
-
-# Custom imports below
 
 
 class ListMessagesInChat(insightconnect_plugin_runtime.Action):
@@ -17,6 +14,6 @@ class ListMessagesInChat(insightconnect_plugin_runtime.Action):
     def run(self, params={}):
         chat_id = params.get(Input.CHAT_ID, "")
 
-        messages = list_messages_from_chat(self.connection, chat_id)
+        messages = self.connection.client.list_chat_messages(chat_id)
 
         return {Output.MESSAGES: messages}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/remove_channel_from_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/remove_channel_from_team/action.py
@@ -7,6 +7,9 @@ from .schema import (
     Component,
 )
 
+# Custom imports below
+from insightconnect_plugin_runtime.exceptions import PluginException
+
 
 class RemoveChannelFromTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -22,8 +25,19 @@ class RemoveChannelFromTeam(insightconnect_plugin_runtime.Action):
         channel_name = params.get(Input.CHANNEL_NAME)
 
         teams = self.connection.client.get_teams(team_name)
+        if not teams:
+            raise PluginException(
+                cause="Team not found.",
+                assistance=f"Please verify '{team_name}' is a valid team name.",
+            )
         team_id = teams[0].get("id")
+
         channels = self.connection.client.get_channels(team_id, channel_name)
+        if not channels:
+            raise PluginException(
+                cause="Channel not found.",
+                assistance=f"Please verify '{channel_name}' is a valid channel name.",
+            )
         channel_id = channels[0].get("id")
 
         success = self.connection.client.delete_channel(team_id, channel_id)

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/remove_channel_from_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/remove_channel_from_team/action.py
@@ -7,13 +7,6 @@ from .schema import (
     Component,
 )
 
-# Custom imports below
-from icon_microsoft_teams.util.teams_utils import (
-    get_teams_from_microsoft,
-    get_channels_from_microsoft,
-    delete_channel,
-)
-
 
 class RemoveChannelFromTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -28,11 +21,11 @@ class RemoveChannelFromTeam(insightconnect_plugin_runtime.Action):
         team_name = params.get(Input.TEAM_NAME)
         channel_name = params.get(Input.CHANNEL_NAME)
 
-        teams = get_teams_from_microsoft(self.logger, self.connection, team_name)
+        teams = self.connection.client.get_teams(team_name)
         team_id = teams[0].get("id")
-        channels = get_channels_from_microsoft(self.logger, self.connection, team_id, channel_name)
+        channels = self.connection.client.get_channels(team_id, channel_name)
         channel_id = channels[0].get("id")
 
-        success = delete_channel(self.logger, self.connection, team_id, channel_id)
+        success = self.connection.client.delete_channel(team_id, channel_id)
 
         return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/remove_member_from_team/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/remove_member_from_team/action.py
@@ -1,10 +1,6 @@
 import insightconnect_plugin_runtime
 from .schema import RemoveMemberFromTeamInput, RemoveMemberFromTeamOutput, Input, Output, Component
 
-# Custom imports below
-from icon_microsoft_teams.util.azure_ad_utils import get_user_info, remove_user_from_group
-from icon_microsoft_teams.util.teams_utils import get_teams_from_microsoft
-
 
 class RemoveMemberFromTeam(insightconnect_plugin_runtime.Action):
     def __init__(self):
@@ -19,15 +15,12 @@ class RemoveMemberFromTeam(insightconnect_plugin_runtime.Action):
         user_login = params.get(Input.MEMBER_LOGIN)
         team_name = params.get(Input.TEAM_NAME)
 
-        # Get User ID
-        user_result = get_user_info(self.logger, self.connection, user_login)
-        user_id = user_result.get("id")
+        user = self.connection.client.get_user_info(user_login)
+        user_id = user.get("id")
 
-        # Get Group ID
-        teams_result = get_teams_from_microsoft(self.logger, self.connection, team_name)
-        group_id = teams_result[0].get("id")
+        teams = self.connection.client.get_teams(team_name)
+        group_id = teams[0].get("id")
 
-        # Remove user to Group
-        success = remove_user_from_group(self.logger, self.connection, group_id, user_id)
+        success = self.connection.client.remove_member_from_group(group_id, user_id)
 
         return {Output.SUCCESS: success}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/send_html_message/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/send_html_message/action.py
@@ -4,6 +4,7 @@ from .schema import SendHtmlMessageInput, SendHtmlMessageOutput, Input, Output, 
 # Custom imports below
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from icon_microsoft_teams.util.words_utils import add_words_values_to_message
+from insightconnect_plugin_runtime.exceptions import PluginException
 
 
 class SendHtmlMessage(insightconnect_plugin_runtime.Action):
@@ -22,8 +23,19 @@ class SendHtmlMessage(insightconnect_plugin_runtime.Action):
         thread_id = params.get(Input.THREAD_ID)
 
         teams = self.connection.client.get_teams(team_name)
+        if not teams:
+            raise PluginException(
+                cause="Team not found.",
+                assistance=f"Please verify '{team_name}' is a valid team name.",
+            )
         team_id = teams[0].get("id")
+
         channels = self.connection.client.get_channels(team_id, channel_name)
+        if not channels:
+            raise PluginException(
+                cause="Channel not found.",
+                assistance=f"Please verify '{channel_name}' is a valid channel name.",
+            )
         channel_id = channels[0].get("id")
 
         result = self.connection.bot.send_channel_message(

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/send_html_message/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/send_html_message/action.py
@@ -2,11 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import SendHtmlMessageInput, SendHtmlMessageOutput, Input, Output, Component
 
 # Custom imports below
-from icon_microsoft_teams.util.teams_utils import (
-    get_teams_from_microsoft,
-    get_channels_from_microsoft,
-    send_html_message,
-)
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from icon_microsoft_teams.util.words_utils import add_words_values_to_message
 
@@ -21,22 +16,29 @@ class SendHtmlMessage(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        message = params.get(Input.MESSAGE_CONTENT)
+        message_content = params.get(Input.MESSAGE_CONTENT)
+        team_name = params.get(Input.TEAM_NAME)
+        channel_name = params.get(Input.CHANNEL_NAME)
+        thread_id = params.get(Input.THREAD_ID)
 
-        teams = get_teams_from_microsoft(self.logger, self.connection, params.get(Input.TEAM_NAME))
+        teams = self.connection.client.get_teams(team_name)
         team_id = teams[0].get("id")
-        channels = get_channels_from_microsoft(self.logger, self.connection, team_id, params.get(Input.CHANNEL_NAME))
+        channels = self.connection.client.get_channels(team_id, channel_name)
+        channel_id = channels[0].get("id")
 
-        message = send_html_message(
-            self.logger,
-            self.connection,
-            message,
-            team_id,
-            channels[0].get("id"),
-            thread_id=params.get(Input.THREAD_ID, None),
+        result = self.connection.bot.send_channel_message(
+            team_id=team_id,
+            channel_id=channel_id,
+            message=message_content,
+            content_type="html",
+            thread_id=thread_id,
         )
 
-        message = remove_null_and_clean(message)
-        message = add_words_values_to_message(message)
+        output_message = {
+            "body": {"contentType": "html", "content": message_content},
+            "id": result.get("id", ""),
+        }
+        output_message = remove_null_and_clean(output_message)
+        output_message = add_words_values_to_message(output_message)
 
-        return {Output.MESSAGE: message}
+        return {Output.MESSAGE: output_message}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/send_message/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/send_message/action.py
@@ -2,11 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import SendMessageInput, SendMessageOutput, Input, Output, Component
 
 # Custom imports below
-from icon_microsoft_teams.util.teams_utils import (
-    get_teams_from_microsoft,
-    get_channels_from_microsoft,
-    send_message,
-)
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from icon_microsoft_teams.util.words_utils import add_words_values_to_message
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -22,40 +17,47 @@ class SendMessage(insightconnect_plugin_runtime.Action):
         )
 
     def run(self, params={}):
-        message = params.get(Input.MESSAGE)
-        team = params.get(Input.TEAM_NAME)
-        channel = params.get(Input.CHANNEL_NAME)
+        message_content = params.get(Input.MESSAGE)
+        team_name = params.get(Input.TEAM_NAME)
+        channel_name = params.get(Input.CHANNEL_NAME)
         chat_id = params.get(Input.CHAT_ID)
+        thread_id = params.get(Input.THREAD_ID)
 
         team_id = ""
         channel_id = ""
 
-        if team and channel:
-            teams = get_teams_from_microsoft(self.logger, self.connection, team)
+        if team_name and channel_name:
+            teams = self.connection.client.get_teams(team_name)
             if teams and isinstance(teams, list):
                 team_id = teams[0].get("id")
-                channels = get_channels_from_microsoft(self.logger, self.connection, team_id, channel)
+                channels = self.connection.client.get_channels(team_id, channel_name)
                 if channels and isinstance(channels, list):
                     channel_id = channels[0].get("id")
 
         if not chat_id and not team_id and not channel_id:
             raise PluginException(
                 cause="No chat ID or team ID with channel ID was provided.",
-                assistance="Please provide the chat ID to send the chat message or the team and channel details(name or"
-                " GUID) to send the message to a specific channel.",
+                assistance="Please provide the chat ID to send the chat message or the team and channel details "
+                "(name or GUID) to send the message to a specific channel.",
             )
 
-        message = send_message(
-            self.logger,
-            self.connection,
-            message,
-            team_id,
-            channel_id,
-            thread_id=params.get(Input.THREAD_ID, None),
-            chat_id=chat_id,
-        )
+        if chat_id:
+            result = self.connection.bot.send_chat_message(chat_id, message_content)
+        else:
+            result = self.connection.bot.send_channel_message(
+                team_id=team_id,
+                channel_id=channel_id,
+                message=message_content,
+                content_type="text",
+                thread_id=thread_id,
+            )
 
-        message = remove_null_and_clean(message)
-        message = add_words_values_to_message(message)
+        # Build a message-like output from the bot response
+        output_message = {
+            "body": {"contentType": "text", "content": message_content},
+            "id": result.get("id", ""),
+        }
+        output_message = remove_null_and_clean(output_message)
+        output_message = add_words_values_to_message(output_message)
 
-        return {Output.MESSAGE: message}
+        return {Output.MESSAGE: output_message}

--- a/plugins/microsoft_teams/icon_microsoft_teams/actions/send_message_by_guid/action.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/actions/send_message_by_guid/action.py
@@ -2,7 +2,6 @@ import insightconnect_plugin_runtime
 from .schema import SendMessageByGuidInput, SendMessageByGuidOutput, Input, Output, Component
 
 # Custom imports below
-from icon_microsoft_teams.util.teams_utils import send_html_message, send_message
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from icon_microsoft_teams.util.words_utils import add_words_values_to_message
 
@@ -22,12 +21,20 @@ class SendMessageByGuid(insightconnect_plugin_runtime.Action):
         is_html = params.get(Input.IS_HTML)
         message_content = params.get(Input.MESSAGE)
 
-        if is_html:
-            message = send_html_message(self.logger, self.connection, message_content, team_guid, channel_guid)
-        else:
-            message = send_message(self.logger, self.connection, message_content, team_guid, channel_guid)
+        content_type = "html" if is_html else "text"
 
-        clean_message = remove_null_and_clean(message)
-        clean_message = add_words_values_to_message(clean_message)
+        result = self.connection.bot.send_channel_message(
+            team_id=team_guid,
+            channel_id=channel_guid,
+            message=message_content,
+            content_type=content_type,
+        )
 
-        return {Output.MESSAGE: clean_message}
+        output_message = {
+            "body": {"contentType": content_type, "content": message_content},
+            "id": result.get("id", ""),
+        }
+        output_message = remove_null_and_clean(output_message)
+        output_message = add_words_values_to_message(output_message)
+
+        return {Output.MESSAGE: output_message}

--- a/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
@@ -50,20 +50,12 @@ class Connection(insightconnect_plugin_runtime.Connection):
     def test(self):
         try:
             self.client.test()
-        except PluginException as error:
-            raise ConnectionTestException(
-                cause="Graph API connection test failed.",
-                assistance="Please verify your Application ID, Directory ID, and Application Secret. "
-                "Ensure the app registration has Microsoft Graph application permissions with admin consent.",
-            ) from error
-
-        try:
             self.bot.test()
         except PluginException as error:
             raise ConnectionTestException(
-                cause="Bot Service connection test failed.",
-                assistance="Please verify your Application ID and Application Secret are correct for the Bot Service. "
-                "Ensure the bot app registration has the Bot Framework API permissions.",
+                cause=error.cause,
+                assistance=error.assistance,
+                data=error.data,
             ) from error
 
         return {"success": True}

--- a/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
@@ -49,22 +49,21 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
     def test(self):
         try:
-            self.client.authenticate()
+            self.client.test()
         except PluginException as error:
             raise ConnectionTestException(
-                cause="Unable to get authentication token.",
+                cause="Graph API connection test failed.",
                 assistance="Please verify your Application ID, Directory ID, and Application Secret. "
                 "Ensure the app registration has Microsoft Graph application permissions with admin consent.",
             ) from error
 
-        # Verify we can actually call the Graph API
         try:
-            self.client._make_request("GET", "/v1.0/organization")  # pylint: disable=protected-access
+            self.bot.test()
         except PluginException as error:
             raise ConnectionTestException(
-                cause="Authentication succeeded but API call failed.",
-                assistance="The token was obtained but could not access Microsoft Graph. "
-                "Verify the app has Organization.Read.All or similar permissions.",
+                cause="Bot Service connection test failed.",
+                assistance="Please verify your Application ID and Application Secret are correct for the Bot Service. "
+                "Ensure the bot app registration has the Bot Framework API permissions.",
             ) from error
 
         return {"success": True}

--- a/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
@@ -3,126 +3,53 @@ from .schema import ConnectionSchema, Input
 
 # Custom imports below
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException, PluginException
-import requests
-import time
 
-from icon_microsoft_teams.util.constants import TIMEOUT, RESOURCE_URL, AUTH_URL, GRAPH_SCOPE_DEFAULT
+from icon_microsoft_teams.util.constants import RESOURCE_URL
 from icon_microsoft_teams.util.graph_api_client import GraphApiClient
 from icon_microsoft_teams.util.bot_service import BotService
 
 
 class Connection(insightconnect_plugin_runtime.Connection):
     def __init__(self):
-        super(self.__class__, self).__init__(input=ConnectionSchema())
+        super().__init__(input=ConnectionSchema())
         self.client = None
         self.bot = None
-        self.app_id = None
-        self.tenant_id = None
-        self.app_secret = None
-        self.api_token = None
         self.resource_endpoint = None
 
-    def connect(self, params):
-        self.app_id = params.get(Input.APPLICATION_ID, "").strip()
-        self.tenant_id = params.get(Input.DIRECTORY_ID, "").strip()
-        self.endpoint = params.get(Input.ENDPOINT, "Normal")
-        self.app_secret = params.get(Input.APPLICATION_SECRET, {}).get("secretKey", "").strip()
+    def connect(self, params):  # pylint: disable=signature-differs
+        app_id = params.get(Input.APPLICATION_ID, "").strip()
+        tenant_id = params.get(Input.DIRECTORY_ID, "").strip()
+        endpoint = params.get(Input.ENDPOINT, "Normal")
+        app_secret = params.get(Input.APPLICATION_SECRET, {}).get("secretKey", "").strip()
 
-        self.resource_endpoint = RESOURCE_URL.get(self.endpoint)
+        self.resource_endpoint = RESOURCE_URL.get(endpoint)
 
-        # Auth tokens expire after 1 hour. Track when we last authenticated.
-        self.time_ago = 0
-        self.time_now = time.time()
-
-        # Authenticate using client_credentials (app-only)
-        self._get_app_token()
-
-        # Initialize the Graph API client
+        # Initialize the Graph API client (handles its own authentication)
         self.client = GraphApiClient(
+            app_id=app_id,
+            app_secret=app_secret,
+            tenant_id=tenant_id,
             base_url=self.resource_endpoint,
+            endpoint=endpoint,
             logger=self.logger,
-            get_headers_func=self.get_headers,
         )
 
-        # Initialize the Bot Framework service for sending messages
+        # Initialize the Bot Framework service (handles its own authentication)
         self.bot = BotService(
-            app_id=self.app_id,
-            app_secret=self.app_secret,
-            tenant_id=self.tenant_id,
+            app_id=app_id,
+            app_secret=app_secret,
+            tenant_id=tenant_id,
+            endpoint=endpoint,
             logger=self.logger,
         )
-
-    def _get_app_token(self):
-        """Authenticate using OAuth2 client_credentials flow (app-only, no user account)."""
-        self.logger.info("Authenticating with client_credentials flow...")
-        token_url = f"{AUTH_URL.get(self.endpoint)}/{self.tenant_id}/oauth2/v2.0/token"
-
-        body = {
-            "grant_type": "client_credentials",
-            "client_id": self.app_id,
-            "client_secret": self.app_secret,
-            "scope": GRAPH_SCOPE_DEFAULT,
-        }
-
-        self.logger.info(f"Getting token from: {token_url}")
-
-        try:
-            result = requests.post(token_url, data=body, timeout=TIMEOUT)
-        except requests.exceptions.Timeout as error:
-            raise PluginException(
-                cause="Authentication request timed out",
-                assistance="Please verify network connectivity and try again.",
-                data=str(error),
-            ) from error
-        except requests.exceptions.ConnectionError as error:
-            raise PluginException(
-                cause="Unable to connect to authentication endpoint",
-                assistance=f"Could not connect to {token_url}. Please verify network connectivity.",
-                data=str(error),
-            ) from error
-
-        if result.status_code != 200:
-            raise PluginException(
-                cause="Authentication to Microsoft Graph failed.",
-                assistance="Please verify your Application ID, Directory ID, and Application Secret are correct. "
-                "Ensure the app registration has the required Microsoft Graph application permissions "
-                "with admin consent granted.",
-                data=result.text,
-            )
-
-        try:
-            result_json = result.json()
-            self.api_token = result_json.get("access_token")
-        except (ValueError, KeyError) as error:
-            raise PluginException(
-                cause="Failed to parse authentication response",
-                assistance="Unexpected response from the token endpoint.",
-                data=str(error),
-            ) from error
-
-        self.time_ago = time.time()
-        self.logger.info(f"Authentication successful, token is: ******************{self.api_token[-5:]}")
-
-    def check_and_refresh_api_token(self, force_refresh=False):
-        """Refresh the token if it's expired (tokens last ~1 hour)."""
-        self.time_now = time.time()
-        if (self.time_now - self.time_ago) > 3500 or force_refresh:
-            self.logger.info("Refreshing auth token...")
-            self._get_app_token()
-        else:
-            self.logger.info("Token is valid, not refreshing.")
 
     def get_headers(self, force_refresh=False) -> dict:
-        """Get authorization headers, refreshing the token if needed."""
-        self.check_and_refresh_api_token(force_refresh)
-        return {
-            "Authorization": f"Bearer {self.api_token}",
-            "Content-Type": "application/json",
-        }
+        """Get Graph API authorization headers (delegates to client)."""
+        return self.client.get_auth_headers(force_refresh)
 
     def test(self):
         try:
-            self._get_app_token()
+            self.client.authenticate()
         except PluginException as error:
             raise ConnectionTestException(
                 cause="Unable to get authentication token.",
@@ -130,22 +57,10 @@ class Connection(insightconnect_plugin_runtime.Connection):
                 "Ensure the app registration has Microsoft Graph application permissions with admin consent.",
             ) from error
 
-        if not self.api_token:
-            raise ConnectionTestException(
-                cause="No authentication token received.",
-                assistance="Please check your connection settings.",
-            )
-
         # Verify we can actually call the Graph API
         try:
-            headers = self.get_headers()
-            test_result = requests.get(
-                f"{self.resource_endpoint}/v1.0/organization",
-                headers=headers,
-                timeout=TIMEOUT,
-            )
-            test_result.raise_for_status()
-        except Exception as error:
+            self.client._make_request("GET", "/v1.0/organization")  # pylint: disable=protected-access
+        except PluginException as error:
             raise ConnectionTestException(
                 cause="Authentication succeeded but API call failed.",
                 assistance="The token was obtained but could not access Microsoft Graph. "

--- a/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/connection/connection.py
@@ -6,121 +6,150 @@ from insightconnect_plugin_runtime.exceptions import ConnectionTestException, Pl
 import requests
 import time
 
-TIMEOUT = 120
-
-# we do not have an instance to test [gcc, gcc high, dod], but endpoint taken from link below
-# https://learn.microsoft.com/en-us/defender-endpoint/gov#api
-# https://learn.microsoft.com/en-us/graph/deployments
-
-RESOURCE_URL = {
-    "Normal": "https://graph.microsoft.com",
-    "GCC": "https://graph.microsoft.com",
-    "GCC High": "https://graph.microsoft.us",
-    "DoD": "https://graph.microsoft.us",
-}
-
-AUTH_URL = {
-    "Normal": "https://login.microsoftonline.com",
-    "GCC": "https://login.microsoftonline.com",
-    "GCC High": "https://login.microsoftonline.us",
-    "DoD": "https://login.microsoftonline.us",
-}
+from icon_microsoft_teams.util.constants import TIMEOUT, RESOURCE_URL, AUTH_URL, GRAPH_SCOPE_DEFAULT
+from icon_microsoft_teams.util.graph_api_client import GraphApiClient
+from icon_microsoft_teams.util.bot_service import BotService
 
 
 class Connection(insightconnect_plugin_runtime.Connection):
     def __init__(self):
         super(self.__class__, self).__init__(input=ConnectionSchema())
+        self.client = None
+        self.bot = None
         self.app_id = None
         self.tenant_id = None
         self.app_secret = None
-        self.username = None
-        self.password = None
         self.api_token = None
-        self.refresh_token = None
         self.resource_endpoint = None
 
     def connect(self, params):
-        self.app_id = params.get(Input.APPLICATION_ID)
-        self.tenant_id = params.get(Input.DIRECTORY_ID)
+        self.app_id = params.get(Input.APPLICATION_ID, "").strip()
+        self.tenant_id = params.get(Input.DIRECTORY_ID, "").strip()
         self.endpoint = params.get(Input.ENDPOINT, "Normal")
-        self.app_secret = params.get(Input.APPLICATION_SECRET).get("secretKey")
-        self.username = params.get(Input.USERNAME_PASSWORD).get("username")
-        self.password = params.get(Input.USERNAME_PASSWORD).get("password")
-
-        # Auth tokens expire after 1 hour. Only make that call if we need to
-        self.time_ago = 0  # Jan 1, 1970
-        self.time_now = time.time()  # More than 1 hour since 1978
+        self.app_secret = params.get(Input.APPLICATION_SECRET, {}).get("secretKey", "").strip()
 
         self.resource_endpoint = RESOURCE_URL.get(self.endpoint)
 
-        self.check_and_refresh_api_token()
+        # Auth tokens expire after 1 hour. Track when we last authenticated.
+        self.time_ago = 0
+        self.time_now = time.time()
 
-    def get_token(self):
-        self.logger.info("Updating Auth Token...")
-        token_url = f"{AUTH_URL.get(self.endpoint)}/{self.tenant_id}/oauth2/token"
+        # Authenticate using client_credentials (app-only)
+        self._get_app_token()
+
+        # Initialize the Graph API client
+        self.client = GraphApiClient(
+            base_url=self.resource_endpoint,
+            logger=self.logger,
+            get_headers_func=self.get_headers,
+        )
+
+        # Initialize the Bot Framework service for sending messages
+        self.bot = BotService(
+            app_id=self.app_id,
+            app_secret=self.app_secret,
+            tenant_id=self.tenant_id,
+            logger=self.logger,
+        )
+
+    def _get_app_token(self):
+        """Authenticate using OAuth2 client_credentials flow (app-only, no user account)."""
+        self.logger.info("Authenticating with client_credentials flow...")
+        token_url = f"{AUTH_URL.get(self.endpoint)}/{self.tenant_id}/oauth2/v2.0/token"
 
         body = {
-            "resource": self.resource_endpoint,
-            "grant_type": "password",
+            "grant_type": "client_credentials",
             "client_id": self.app_id,
             "client_secret": self.app_secret,
-            "username": self.username,
-            "password": self.password,
+            "scope": GRAPH_SCOPE_DEFAULT,
         }
 
-        if self.refresh_token:
-            body["refresh_token"] = self.refresh_token
-
         self.logger.info(f"Getting token from: {token_url}")
-        result = requests.post(token_url, data=body, timeout=TIMEOUT)
 
         try:
-            result.raise_for_status()
-        except Exception as e:
+            result = requests.post(token_url, data=body, timeout=TIMEOUT)
+        except requests.exceptions.Timeout as error:
+            raise PluginException(
+                cause="Authentication request timed out",
+                assistance="Please verify network connectivity and try again.",
+                data=str(error),
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise PluginException(
+                cause="Unable to connect to authentication endpoint",
+                assistance=f"Could not connect to {token_url}. Please verify network connectivity.",
+                data=str(error),
+            ) from error
+
+        if result.status_code != 200:
             raise PluginException(
                 cause="Authentication to Microsoft Graph failed.",
-                assistance=f"Some common causes for this error include an invalid username, password, or connection settings."
-                f"Verify you are using the correct domain name for your user, and verify that user has access to "
-                f"the target tenant. Verify you can log into Office365 with the user account as well.\n"
-                f"The result returned was:\n{result.text}",
-                data=e,
-            ) from e
+                assistance="Please verify your Application ID, Directory ID, and Application Secret are correct. "
+                "Ensure the app registration has the required Microsoft Graph application permissions "
+                "with admin consent granted.",
+                data=result.text,
+            )
 
-        result_json = result.json()
-        self.api_token = result_json.get("access_token")
-        self.refresh_token = result_json.get("refresh_token")
+        try:
+            result_json = result.json()
+            self.api_token = result_json.get("access_token")
+        except (ValueError, KeyError) as error:
+            raise PluginException(
+                cause="Failed to parse authentication response",
+                assistance="Unexpected response from the token endpoint.",
+                data=str(error),
+            ) from error
 
-        self.logger.info(f"Authentication was successful, token is: ******************{self.api_token[-5:]}")
-        self.logger.info(f"Detected Permissions: {result_json.get('scope')}")
+        self.time_ago = time.time()
+        self.logger.info(f"Authentication successful, token is: ******************{self.api_token[-5:]}")
 
-    def check_and_refresh_api_token(self, force_refresh_token=False):
+    def check_and_refresh_api_token(self, force_refresh=False):
+        """Refresh the token if it's expired (tokens last ~1 hour)."""
         self.time_now = time.time()
-        self.logger.info(f"Time Now: {self.time_now}")
-        self.logger.info(f"Time Ago: {self.time_ago}")
-        if (self.time_now - self.time_ago) > 3500 or force_refresh_token:  # 1 hour in seconds (minus some buffer time)
-            self.logger.info("Refreshing auth token")
-            self.get_token()
-            self.time_ago = time.time()
+        if (self.time_now - self.time_ago) > 3500 or force_refresh:
+            self.logger.info("Refreshing auth token...")
+            self._get_app_token()
         else:
             self.logger.info("Token is valid, not refreshing.")
 
-    def get_headers(self, forceRefreshToken=False):
-        self.check_and_refresh_api_token(forceRefreshToken)
-        headers = {"Authorization": f"Bearer {self.api_token}", "Content-Type": "application/json"}
-        return headers
+    def get_headers(self, force_refresh=False) -> dict:
+        """Get authorization headers, refreshing the token if needed."""
+        self.check_and_refresh_api_token(force_refresh)
+        return {
+            "Authorization": f"Bearer {self.api_token}",
+            "Content-Type": "application/json",
+        }
 
     def test(self):
         try:
-            self.check_and_refresh_api_token()
+            self._get_app_token()
         except PluginException as error:
             raise ConnectionTestException(
                 cause="Unable to get authentication token.",
-                assistance="Please check your connection settings.",
+                assistance="Please verify your Application ID, Directory ID, and Application Secret. "
+                "Ensure the app registration has Microsoft Graph application permissions with admin consent.",
             ) from error
+
         if not self.api_token:
             raise ConnectionTestException(
-                cause="No authentication token found.",
+                cause="No authentication token received.",
                 assistance="Please check your connection settings.",
             )
-        else:
-            return {"success": True}
+
+        # Verify we can actually call the Graph API
+        try:
+            headers = self.get_headers()
+            test_result = requests.get(
+                f"{self.resource_endpoint}/v1.0/organization",
+                headers=headers,
+                timeout=TIMEOUT,
+            )
+            test_result.raise_for_status()
+        except Exception as error:
+            raise ConnectionTestException(
+                cause="Authentication succeeded but API call failed.",
+                assistance="The token was obtained but could not access Microsoft Graph. "
+                "Verify the app has Organization.Read.All or similar permissions.",
+            ) from error
+
+        return {"success": True}

--- a/plugins/microsoft_teams/icon_microsoft_teams/connection/schema.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/connection/schema.py
@@ -8,7 +8,6 @@ class Input:
     APPLICATION_SECRET = "application_secret"
     DIRECTORY_ID = "directory_id"
     ENDPOINT = "endpoint"
-    USERNAME_PASSWORD = "username_password"
 
 
 class ConnectionSchema(insightconnect_plugin_runtime.Input):
@@ -45,12 +44,6 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
         "GCC High",
         "DoD"
       ],
-      "order": 5
-    },
-    "username_password": {
-      "$ref": "#/definitions/credential_username_password",
-      "title": "Credentials",
-      "description": "Username and password",
       "order": 4
     }
   },
@@ -58,8 +51,7 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
     "application_id",
     "application_secret",
     "directory_id",
-    "endpoint",
-    "username_password"
+    "endpoint"
   ],
   "definitions": {
     "credential_secret_key": {
@@ -79,32 +71,6 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
           "displayType": "password"
         }
       }
-    },
-    "credential_username_password": {
-      "id": "credential_username_password",
-      "title": "Credential: Username and Password",
-      "description": "A username and password combination",
-      "type": "object",
-      "properties": {
-        "username": {
-          "type": "string",
-          "title": "Username",
-          "description": "The username to log in with",
-          "order": 1
-        },
-        "password": {
-          "type": "string",
-          "title": "Password",
-          "description": "The password",
-          "format": "password",
-          "displayType": "password",
-          "order": 2
-        }
-      },
-      "required": [
-        "username",
-        "password"
-      ]
     }
   }
 }

--- a/plugins/microsoft_teams/icon_microsoft_teams/triggers/new_message_received/trigger.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/triggers/new_message_received/trigger.py
@@ -4,10 +4,6 @@ from .schema import NewMessageReceivedInput, NewMessageReceivedOutput, Input, Ou
 
 # Custom imports below
 from insightconnect_plugin_runtime.exceptions import PluginException
-from icon_microsoft_teams.util.teams_utils import (
-    get_teams_from_microsoft,
-    get_channels_from_microsoft,
-)
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from icon_microsoft_teams.util.words_utils import add_words_values_to_message, strip_html
 from typing import Pattern
@@ -16,7 +12,7 @@ import requests
 import maya
 import validators
 
-TIMEOUT = 120
+from icon_microsoft_teams.util.constants import TIMEOUT
 
 
 class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
@@ -49,23 +45,22 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
         except Exception as error:
             raise PluginException(PluginException.Preset.INVALID_JSON) from error
 
-        time.sleep(1)  # Make sure we don't kill the API. It's limited to 3 calls a second
+        time.sleep(1)
 
         while True:  # pylint: disable=too-many-nested-blocks
-            # Get messages
             sorted_messages = self.get_sorted_messages(messages_endpoint)
             most_recent_message_time = maya.parse(sorted_messages[0].get("createdDateTime"))
 
-            if most_recent_message_time > last_time_we_checked:  # We have new messages
+            if most_recent_message_time > last_time_we_checked:
                 self.logger.info("New messages found.")
                 temp_time = most_recent_message_time
 
-                for message in sorted_messages:  # For each new message
+                for message in sorted_messages:
                     message = remove_null_and_clean(message)
                     message = add_words_values_to_message(message)
                     if maya.parse(message.get("createdDateTime")) > last_time_we_checked:
                         self.logger.info("Analyzing message...")
-                        if message_content:  # Do we have a reg ex
+                        if message_content:
                             self.logger.info("Checking message content.")
                             ms_message_content = message.get("body", {}).get("content", "")
                             if message.get("body", {}).get("contentType", "").lower() == "html":
@@ -85,9 +80,10 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
                                 )
                             else:
                                 self.logger.info(
-                                    f"Message did not match regex.\nMessage: {ms_message_content}\nRegex: {message_content}"
+                                    f"Message did not match regex.\n"
+                                    f"Message: {ms_message_content}\nRegex: {message_content}"
                                 )
-                        else:  # we did not have a regex
+                        else:
                             self.logger.info("Returning new message.")
                             self.send(
                                 {
@@ -96,8 +92,6 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
                                 }
                             )
                     else:
-                        # This speeds up execution a ton. The Beta endpoint doesn't limit how many messages are returned.
-                        # Thus, get out of the loop as soon as we see an old message
                         self.logger.info("End of new messages")
                         break
 
@@ -107,12 +101,7 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
             time.sleep(params.get("interval", 10))
 
     def compile_message_content(self, message_content: str) -> Pattern:
-        """
-        This will take a regex string and compile it to verify it's valid
-
-        :param message_content: String
-        :return: Pattern
-        """
+        """Compile and validate a regex pattern."""
         compiled_message_content = None
         if message_content:
             try:
@@ -125,31 +114,22 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
         return compiled_message_content
 
     def get_sorted_messages(self, messages_endpoint: str) -> list:
-        """
-        This gets new messages from the Graph API, sorts them into chronological order and returns that payload
-        as a list of json objects
-
-        :param messages_endpoint: string
-        :return: list (of json messages)
-        """
+        """Get messages from Graph API, sorted in chronological order."""
         headers = self.connection.get_headers()
         messages_result = requests.get(messages_endpoint, headers=headers, timeout=TIMEOUT)
         try:
             messages_result.raise_for_status()
-
-        # The beta API bombs out every once in a while with Auth denied. Try forcing a refersh of our auth token and
-        # retry getting messages before raising an exception.
         except Exception:
             self.logger.info("Get messages failed, refreshing token and trying again.")
-            time.sleep(10)  # sleep for 10 seconds to make sure we're not killing the API
-            headers = self.connection.get_headers(True)  # This will force a refresh of our auth token
+            time.sleep(10)
+            headers = self.connection.get_headers(True)
             messages_result = requests.get(messages_endpoint, headers=headers, timeout=TIMEOUT)
             try:
                 messages_result.raise_for_status()
             except Exception as error:
                 raise PluginException(
-                    cause=f"Could not get messages from Microsoft Graph API."
-                    f"Get messages result code: {messages_result.status_code}",
+                    cause=f"Could not get messages from Microsoft Graph API. "
+                    f"Status code: {messages_result.status_code}",
                     assistance=messages_result.text,
                 ) from error
 
@@ -157,31 +137,18 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
         return sorted_messages
 
     def sort_messages_from_request(self, messages_result: dict) -> list:
-        """
-        Takes a json payload from Graph API, extracts all the messages, then returns them in chronological order
-
-        :param messages_result: dict (json payload from the get messages endpoint)
-        :return: list (json message objects)
-        """
-        messages = messages_result.get("value")
-
-        # reverse for descending order
+        """Sort messages in descending chronological order."""
+        messages = messages_result.get("value", [])
         messages.sort(key=lambda x: maya.parse(x.get("createdDateTime", 0)), reverse=True)
         return messages
 
     def setup_endpoint(self, channel_name: str, team_name: str) -> str:
-        """
-        This takes a team name and channel in that team and generates a get messages endpoint.
-
-        :param channel_name: String
-        :param team_name: String
-        :return: String (URL)
-        """
-        team = get_teams_from_microsoft(self.logger, self.connection, team_name)
-        team_id = team[0].get("id")
-        channel = get_channels_from_microsoft(self.logger, self.connection, team_id, channel_name)
-        channel_id = channel[0].get("id")
-        messages_endpoint = f"{self.connection.resource_endpoint}/beta/teams/{team_id}/channels/{channel_id}/messages"
+        """Build the messages endpoint URL using v1.0 Graph API."""
+        teams = self.connection.client.get_teams(team_name)
+        team_id = teams[0].get("id")
+        channels = self.connection.client.get_channels(team_id, channel_name)
+        channel_id = channels[0].get("id")
+        messages_endpoint = f"{self.connection.resource_endpoint}/v1.0/teams/{team_id}/channels/{channel_id}/messages"
         return messages_endpoint
 
     def get_indicators(self, message: str) -> object:
@@ -193,15 +160,10 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
             for url in urls:
                 if not url.lower().startswith("http") and not url.lower().startswith("https"):
                     url = f"https://{url}"
-                # ensure domain, subdomain, and suffix are lower case
-                # path and query params may be upper case
-                # split subdomain, domain, and suffix from path and query params
                 split_url = url.split("/")
                 split_url = ["/".join(split_url[i : i + 3]) for i in range(0, len(split_url), 3)]
-                # separate query params immediately after suffix
                 separated_query_params = split_url[0].split("?", 1)
                 separated_query_params[0] = separated_query_params[0].lower()
-                # rejoin query params immediately after suffix
                 split_url[0] = "?".join(separated_query_params)
                 url = "/".join(split_url)
                 normalized_urls.append(url)
@@ -233,10 +195,8 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
     def extract_first_word(message: str) -> str:
         message_normalize = re.sub(r"<.*?>", "", message)
         words = message_normalize.split()
-
         if len(words) == 0:
             return ""
-
         return words[0]
 
     @staticmethod
@@ -262,7 +222,6 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
             r"::(?:ffff(?::0{1,4}){0,1}:){0,1}[^\s:]" + ipv4_addr,
             r"(?:" + ipv6_seg + r":){1,4}:[^\s:]" + ipv4_addr,
         )
-
         return re.findall("|".join([f"(?:{g})" for g in ipv6_groups[::-1]]), msg)
 
     @staticmethod
@@ -316,5 +275,4 @@ class NewMessageReceived(insightconnect_plugin_runtime.Trigger):
         normalized_mac_addresses = []
         for mac_address in mac_addresses:
             normalized_mac_addresses.append(mac_address.replace("-", ":"))
-
         return normalized_mac_addresses

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/base_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/base_client.py
@@ -90,19 +90,19 @@ class BaseClient:
             raise PluginException(
                 cause="Authentication request timed out",
                 assistance="Please verify network connectivity and try again.",
-                data=str(error),
+                data=error,
             ) from error
         except requests.exceptions.ConnectionError as error:
             raise PluginException(
                 cause="Unable to connect to authentication endpoint",
                 assistance=f"Could not connect to {token_url}. Please verify network connectivity.",
-                data=str(error),
+                data=error,
             ) from error
         except (ValueError, KeyError) as error:
             raise PluginException(
                 cause="Failed to parse authentication response",
                 assistance="Unexpected response from the token endpoint.",
-                data=str(error),
+                data=error,
             ) from error
 
         self._token_acquired_at = time.time()
@@ -147,14 +147,14 @@ class BaseClient:
                 cause="Request timed out",
                 assistance=f"The request to {url} timed out after {TIMEOUT} seconds. "
                 "Please verify network connectivity and try again.",
-                data=str(error),
+                data=error,
             ) from error
         except requests.exceptions.ConnectionError as error:
             raise PluginException(
                 cause="Unable to connect",
                 assistance=f"Could not connect to {url}. "
                 "Please verify network connectivity and that the endpoint is correct.",
-                data=str(error),
+                data=error,
             ) from error
 
     def _handle_json_response(self, response: requests.Response) -> Union[dict, list, None]:

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/base_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/base_client.py
@@ -1,0 +1,185 @@
+import time
+from typing import Union
+
+import requests
+from logging import Logger
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+from icon_microsoft_teams.util.constants import TIMEOUT, HTTP_ERROR_MAP
+
+
+class BaseClient:
+    """
+    Base API client providing shared authentication and request functionality.
+
+    Subclasses (GraphApiClient, BotService) inherit common patterns:
+    - OAuth2 client_credentials token acquisition and refresh
+    - Centralized HTTP request handling with timeout/connection error handling
+    - HTTP status code to PluginException mapping
+    - Automatic token refresh on expiry
+    """
+
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        app_id: str,
+        app_secret: str,
+        tenant_id: str,
+        auth_url: str,
+        scope: str,
+        logger: Logger,
+    ):
+        """
+        Initialize the base client.
+
+        :param app_id: Azure App Registration client ID
+        :param app_secret: Azure App Registration client secret
+        :param tenant_id: Azure AD tenant ID
+        :param auth_url: Base auth URL (e.g., https://login.microsoftonline.com)
+        :param scope: OAuth2 scope for token request
+        :param logger: Logger instance
+        """
+        self._app_id = app_id
+        self._app_secret = app_secret
+        self._tenant_id = tenant_id
+        self._auth_url = auth_url
+        self._scope = scope
+        self._logger = logger
+        self._session = requests.Session()
+        self._token = None
+        self._token_acquired_at = 0
+
+    def _authenticate(self):
+        """Acquire an OAuth2 access token using client_credentials flow."""
+        token_url = f"{self._auth_url}/{self._tenant_id}/oauth2/v2.0/token"
+
+        body = {
+            "grant_type": "client_credentials",
+            "client_id": self._app_id,
+            "client_secret": self._app_secret,
+            "scope": self._scope,
+        }
+
+        self._logger.info(f"Authenticating via: {token_url}")
+
+        try:
+            response = self._session.post(token_url, data=body, timeout=TIMEOUT)
+        except requests.exceptions.Timeout as error:
+            raise PluginException(
+                cause="Authentication request timed out",
+                assistance="Please verify network connectivity and try again.",
+                data=str(error),
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise PluginException(
+                cause="Unable to connect to authentication endpoint",
+                assistance=f"Could not connect to {token_url}. Please verify network connectivity.",
+                data=str(error),
+            ) from error
+
+        if response.status_code != 200:
+            raise PluginException(
+                cause="Authentication failed",
+                assistance="Please verify your Application ID, Directory ID, and Application Secret are correct. "
+                "Ensure the app registration has the required permissions with admin consent granted.",
+                data=response.text,
+            )
+
+        try:
+            result_json = response.json()
+            self._token = result_json.get("access_token")
+        except (ValueError, KeyError) as error:
+            raise PluginException(
+                cause="Failed to parse authentication response",
+                assistance="Unexpected response from the token endpoint.",
+                data=str(error),
+            ) from error
+
+        self._token_acquired_at = time.time()
+        self._logger.info(f"Authentication successful, token: ******************{self._token[-5:]}")
+
+    def _get_token(self, force_refresh: bool = False) -> str:
+        """Get a valid access token, refreshing if expired (tokens last ~1 hour)."""
+        elapsed = time.time() - self._token_acquired_at
+        if not self._token or elapsed > 3500 or force_refresh:
+            self._authenticate()
+        return self._token
+
+    def authenticate(self):
+        """Public method to trigger authentication. Used by connection test."""
+        self._authenticate()
+
+    def get_auth_headers(self, force_refresh: bool = False) -> dict:
+        """Public method to get authorization headers."""
+        return self._get_auth_headers(force_refresh)
+
+    def _get_auth_headers(self, force_refresh: bool = False) -> dict:
+        """Get authorization headers with a valid bearer token."""
+        token = self._get_token(force_refresh)
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def _call_api(self, method: str, url: str, **kwargs) -> requests.Response:
+        """
+        Make an HTTP request with timeout and connection error handling.
+
+        :param method: HTTP method
+        :param url: Full URL to call
+        :param kwargs: Additional arguments passed to requests
+        :return: Response object
+        """
+        try:
+            return self._session.request(method=method, url=url, timeout=TIMEOUT, **kwargs)
+        except requests.exceptions.Timeout as error:
+            raise PluginException(
+                cause="Request timed out",
+                assistance=f"The request to {url} timed out after {TIMEOUT} seconds. "
+                "Please verify network connectivity and try again.",
+                data=str(error),
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise PluginException(
+                cause="Unable to connect",
+                assistance=f"Could not connect to {url}. "
+                "Please verify network connectivity and that the endpoint is correct.",
+                data=str(error),
+            ) from error
+
+    def _handle_json_response(self, response: requests.Response) -> Union[dict, list, None]:
+        """Parse a JSON response, raising PluginException on error status codes."""
+        if response.status_code == 204:
+            return None
+
+        if response.status_code >= 400:
+            self._raise_for_status(response)
+
+        if not response.content:
+            return None
+
+        try:
+            return response.json()
+        except ValueError as error:
+            raise PluginException(
+                cause="Non-JSON response received",
+                assistance="The server returned a response that could not be parsed as JSON.",
+                data=response.text[:500],
+            ) from error
+
+    def _raise_for_status(self, response: requests.Response):
+        """Map HTTP error codes to PluginExceptions using the shared error map."""
+        status_code = response.status_code
+        error_info = HTTP_ERROR_MAP.get(status_code)
+
+        if error_info:
+            raise PluginException(
+                cause=error_info["cause"],
+                assistance=error_info["assistance"],
+                data=response.text[:1000],
+            )
+
+        raise PluginException(
+            cause=f"Unexpected HTTP error: {status_code}",
+            assistance="An unexpected error occurred. Please contact support if this persists.",
+            data=response.text[:1000],
+        )

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/base_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/base_client.py
@@ -7,6 +7,8 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 
 from icon_microsoft_teams.util.constants import TIMEOUT, HTTP_ERROR_MAP
 
+DEFAULT_TOKEN_LIFETIME = 3500
+
 
 class BaseClient:
     """
@@ -44,9 +46,9 @@ class BaseClient:
         self._auth_url = auth_url
         self._scope = scope
         self._logger = logger
-        self._session = requests.Session()
         self._token = None
         self._token_acquired_at = 0
+        self._token_lifetime = DEFAULT_TOKEN_LIFETIME
 
     def _authenticate(self):
         """Acquire an OAuth2 access token using client_credentials flow."""
@@ -62,7 +64,28 @@ class BaseClient:
         self._logger.info(f"Authenticating via: {token_url}")
 
         try:
-            response = self._session.post(token_url, data=body, timeout=TIMEOUT)
+            response = requests.post(token_url, data=body, timeout=TIMEOUT)
+
+            if response.status_code != 200:
+                raise PluginException(
+                    cause="Authentication failed",
+                    assistance="Please verify your Application ID, Directory ID, and Application Secret are correct. "
+                    "Ensure the app registration has the required permissions with admin consent granted.",
+                    data=response.text,
+                )
+
+            result_json = response.json()
+            self._token = result_json.get("access_token")
+
+            # Use expires_in from token response if available, with a 60-second buffer
+            expires_in = result_json.get("expires_in")
+            if expires_in:
+                self._token_lifetime = int(expires_in) - 60
+            else:
+                self._token_lifetime = DEFAULT_TOKEN_LIFETIME
+
+        except PluginException:
+            raise
         except requests.exceptions.Timeout as error:
             raise PluginException(
                 cause="Authentication request timed out",
@@ -75,18 +98,6 @@ class BaseClient:
                 assistance=f"Could not connect to {token_url}. Please verify network connectivity.",
                 data=str(error),
             ) from error
-
-        if response.status_code != 200:
-            raise PluginException(
-                cause="Authentication failed",
-                assistance="Please verify your Application ID, Directory ID, and Application Secret are correct. "
-                "Ensure the app registration has the required permissions with admin consent granted.",
-                data=response.text,
-            )
-
-        try:
-            result_json = response.json()
-            self._token = result_json.get("access_token")
         except (ValueError, KeyError) as error:
             raise PluginException(
                 cause="Failed to parse authentication response",
@@ -98,9 +109,9 @@ class BaseClient:
         self._logger.info(f"Authentication successful, token: ******************{self._token[-5:]}")
 
     def _get_token(self, force_refresh: bool = False) -> str:
-        """Get a valid access token, refreshing if expired (tokens last ~1 hour)."""
+        """Get a valid access token, refreshing if expired."""
         elapsed = time.time() - self._token_acquired_at
-        if not self._token or elapsed > 3500 or force_refresh:
+        if not self._token or elapsed > self._token_lifetime or force_refresh:
             self._authenticate()
         return self._token
 
@@ -130,7 +141,7 @@ class BaseClient:
         :return: Response object
         """
         try:
-            return self._session.request(method=method, url=url, timeout=TIMEOUT, **kwargs)
+            return requests.request(method=method, url=url, timeout=TIMEOUT, **kwargs)
         except requests.exceptions.Timeout as error:
             raise PluginException(
                 cause="Request timed out",

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
@@ -1,0 +1,233 @@
+import requests
+from logging import Logger
+from insightconnect_plugin_runtime.exceptions import PluginException
+
+from icon_microsoft_teams.util.constants import (
+    TIMEOUT,
+    BOT_FRAMEWORK_SCOPE,
+    BOT_SERVICE_URL,
+)
+
+
+class BotService:
+    """
+    Bot Framework service for sending messages to Microsoft Teams.
+
+    Uses the Bot Framework REST API to send messages as a bot identity,
+    eliminating the need for a user account. The bot must be registered
+    in Azure and installed in the target teams/channels.
+    """
+
+    def __init__(self, app_id: str, app_secret: str, tenant_id: str, logger: Logger):
+        """
+        Initialize the Bot Service.
+
+        :param app_id: The Azure Bot / App Registration client ID
+        :param app_secret: The Azure Bot / App Registration client secret
+        :param tenant_id: The Azure AD tenant ID (used for single-tenant bot auth)
+        :param logger: Logger instance
+        """
+        self._app_id = app_id
+        self._app_secret = app_secret
+        self._tenant_id = tenant_id
+        self._logger = logger
+        self._session = requests.Session()
+        self._token = None
+        self._service_url = BOT_SERVICE_URL
+
+    def _get_bot_token(self) -> str:
+        """Authenticate with the Bot Framework and get an access token."""
+        if self._token:
+            return self._token
+
+        # For single-tenant bots, authenticate against the app's own tenant
+        # For multi-tenant bots, use botframework.com
+        token_url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
+
+        body = {
+            "grant_type": "client_credentials",
+            "client_id": self._app_id,
+            "client_secret": self._app_secret,
+            "scope": BOT_FRAMEWORK_SCOPE,
+        }
+
+        self._logger.info(f"Authenticating with Bot Framework via tenant: {self._tenant_id}")
+
+        try:
+            response = self._session.post(token_url, data=body, timeout=TIMEOUT)
+        except requests.exceptions.Timeout as error:
+            raise PluginException(
+                cause="Bot Framework authentication timed out",
+                assistance="Please verify network connectivity and try again.",
+                data=str(error),
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise PluginException(
+                cause="Unable to connect to Bot Framework token endpoint",
+                assistance="Please verify network connectivity.",
+                data=str(error),
+            ) from error
+
+        if response.status_code != 200:
+            raise PluginException(
+                cause="Bot Framework authentication failed",
+                assistance="Please verify the Application ID and Application Secret are correct, "
+                "and that the app registration is configured as a Bot.",
+                data=response.text,
+            )
+
+        try:
+            result = response.json()
+            self._token = result.get("access_token")
+        except (ValueError, KeyError) as error:
+            raise PluginException(
+                cause="Failed to parse Bot Framework token response",
+                assistance="Unexpected response from the token endpoint.",
+                data=str(error),
+            ) from error
+
+        self._logger.info("Bot Framework authentication successful.")
+        return self._token
+
+    def _get_bot_headers(self) -> dict:
+        """Get headers with Bot Framework bearer token."""
+        token = self._get_bot_token()
+        return {
+            "Authorization": f"Bearer {token}",
+            "Content-Type": "application/json",
+        }
+
+    def invalidate_token(self):
+        """Force token refresh on next request."""
+        self._token = None
+
+    def send_channel_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        team_id: str,
+        channel_id: str,
+        message: str,
+        content_type: str = "text",
+        thread_id: str = None,
+    ) -> dict:
+        """
+        Send a message to a Teams channel via Bot Framework.
+
+        The bot must be installed in the team for this to work.
+
+        :param team_id: The team ID (group ID)
+        :param channel_id: The channel ID
+        :param message: Message content
+        :param content_type: 'text' or 'html'
+        :param thread_id: Optional parent message ID for threaded replies
+        :return: Activity response dict
+        """
+        conversation_id = channel_id
+        if thread_id:
+            conversation_id = f"{channel_id};messageid={thread_id}"
+
+        endpoint = f"{self._service_url}/v3/conversations/{conversation_id}/activities"
+
+        activity = {
+            "type": "message",
+            "text": message if content_type == "text" else None,
+            "textFormat": "plain" if content_type == "text" else "xml",
+            "channelData": {
+                "teamsChannelId": channel_id,
+                "teamsTeamId": team_id,
+            },
+        }
+
+        if content_type == "html":
+            activity["text"] = message
+            activity["textFormat"] = "xml"
+
+        return self._send_activity(endpoint, activity)
+
+    def send_chat_message(self, chat_id: str, message: str, content_type: str = "text") -> dict:
+        """
+        Send a message to a Teams chat via Bot Framework.
+
+        The bot must be a participant in the chat for this to work.
+
+        :param chat_id: The chat ID
+        :param message: Message content
+        :param content_type: 'text' or 'html'
+        :return: Activity response dict
+        """
+        endpoint = f"{self._service_url}/v3/conversations/{chat_id}/activities"
+
+        activity = {
+            "type": "message",
+            "text": message,
+            "textFormat": "plain" if content_type == "text" else "xml",
+        }
+
+        return self._send_activity(endpoint, activity)
+
+    def _send_activity(self, endpoint: str, activity: dict) -> dict:
+        """
+        Send an activity to the Bot Framework.
+
+        Includes a single retry on 401 (token expiry).
+        """
+        headers = self._get_bot_headers()
+
+        self._logger.info(f"Sending bot activity to: {endpoint}")
+
+        response = self._post_activity(endpoint, activity, headers)
+
+        # Single retry on 401 (token expired)
+        if response.status_code == 401:
+            self._logger.info("Bot token expired, refreshing and retrying...")
+            self.invalidate_token()
+            headers = self._get_bot_headers()
+            response = self._post_activity(endpoint, activity, headers)
+
+        return self._handle_activity_response(response)
+
+    def _post_activity(self, endpoint: str, activity: dict, headers: dict) -> requests.Response:
+        """Post an activity to the Bot Framework endpoint with error handling."""
+        try:
+            return self._session.post(endpoint, json=activity, headers=headers, timeout=TIMEOUT)
+        except requests.exceptions.Timeout as error:
+            raise PluginException(
+                cause="Bot message send timed out",
+                assistance="Please verify network connectivity and try again.",
+                data=str(error),
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise PluginException(
+                cause="Unable to connect to Bot Framework service",
+                assistance=f"Could not connect to {self._service_url}. Please verify network connectivity.",
+                data=str(error),
+            ) from error
+
+    def _handle_activity_response(self, response: requests.Response) -> dict:
+        """Handle the response from a Bot Framework activity post."""
+        if response.status_code in (200, 201):
+            try:
+                return response.json()
+            except ValueError:
+                return {"id": "sent"}
+
+        if response.status_code == 403:
+            raise PluginException(
+                cause="Bot is not authorized to send messages to this conversation",
+                assistance="Ensure the bot app is installed in the target team or added to the chat. "
+                "Go to the Teams channel > Manage channel > Apps and add your bot.",
+                data=response.text,
+            )
+
+        if response.status_code == 404:
+            raise PluginException(
+                cause="Conversation not found",
+                assistance="The specified team/channel/chat was not found. "
+                "Verify the IDs are correct and the bot is installed in the target team.",
+                data=response.text,
+            )
+
+        raise PluginException(
+            cause=f"Bot message send failed with status {response.status_code}",
+            assistance="Please verify the bot is properly configured and installed in the target team.",
+            data=response.text[:1000],
+        )

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
@@ -38,6 +38,10 @@ class BotService(BaseClient):
         )
         self._service_url = BOT_SERVICE_URL
 
+    def test(self):
+        """Test Bot Service connectivity by authenticating."""
+        self._authenticate()
+
     def send_channel_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
         team_id: str,

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
@@ -1,15 +1,13 @@
-import requests
 from logging import Logger
+
+import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
 
-from icon_microsoft_teams.util.constants import (
-    TIMEOUT,
-    BOT_FRAMEWORK_SCOPE,
-    BOT_SERVICE_URL,
-)
+from icon_microsoft_teams.util.base_client import BaseClient
+from icon_microsoft_teams.util.constants import BOT_FRAMEWORK_SCOPE, BOT_SERVICE_URL, AUTH_URL
 
 
-class BotService:
+class BotService(BaseClient):
     """
     Bot Framework service for sending messages to Microsoft Teams.
 
@@ -18,88 +16,27 @@ class BotService:
     in Azure and installed in the target teams/channels.
     """
 
-    def __init__(self, app_id: str, app_secret: str, tenant_id: str, logger: Logger):
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, app_id: str, app_secret: str, tenant_id: str, endpoint: str, logger: Logger
+    ):
         """
         Initialize the Bot Service.
 
-        :param app_id: The Azure Bot / App Registration client ID
-        :param app_secret: The Azure Bot / App Registration client secret
-        :param tenant_id: The Azure AD tenant ID (used for single-tenant bot auth)
+        :param app_id: Azure Bot / App Registration client ID
+        :param app_secret: Azure Bot / App Registration client secret
+        :param tenant_id: Azure AD tenant ID (used for single-tenant bot auth)
+        :param endpoint: Endpoint type (Normal, GCC, etc.) for auth URL resolution
         :param logger: Logger instance
         """
-        self._app_id = app_id
-        self._app_secret = app_secret
-        self._tenant_id = tenant_id
-        self._logger = logger
-        self._session = requests.Session()
-        self._token = None
+        super().__init__(
+            app_id=app_id,
+            app_secret=app_secret,
+            tenant_id=tenant_id,
+            auth_url=AUTH_URL.get(endpoint, "https://login.microsoftonline.com"),
+            scope=BOT_FRAMEWORK_SCOPE,
+            logger=logger,
+        )
         self._service_url = BOT_SERVICE_URL
-
-    def _get_bot_token(self) -> str:
-        """Authenticate with the Bot Framework and get an access token."""
-        if self._token:
-            return self._token
-
-        # For single-tenant bots, authenticate against the app's own tenant
-        # For multi-tenant bots, use botframework.com
-        token_url = f"https://login.microsoftonline.com/{self._tenant_id}/oauth2/v2.0/token"
-
-        body = {
-            "grant_type": "client_credentials",
-            "client_id": self._app_id,
-            "client_secret": self._app_secret,
-            "scope": BOT_FRAMEWORK_SCOPE,
-        }
-
-        self._logger.info(f"Authenticating with Bot Framework via tenant: {self._tenant_id}")
-
-        try:
-            response = self._session.post(token_url, data=body, timeout=TIMEOUT)
-        except requests.exceptions.Timeout as error:
-            raise PluginException(
-                cause="Bot Framework authentication timed out",
-                assistance="Please verify network connectivity and try again.",
-                data=str(error),
-            ) from error
-        except requests.exceptions.ConnectionError as error:
-            raise PluginException(
-                cause="Unable to connect to Bot Framework token endpoint",
-                assistance="Please verify network connectivity.",
-                data=str(error),
-            ) from error
-
-        if response.status_code != 200:
-            raise PluginException(
-                cause="Bot Framework authentication failed",
-                assistance="Please verify the Application ID and Application Secret are correct, "
-                "and that the app registration is configured as a Bot.",
-                data=response.text,
-            )
-
-        try:
-            result = response.json()
-            self._token = result.get("access_token")
-        except (ValueError, KeyError) as error:
-            raise PluginException(
-                cause="Failed to parse Bot Framework token response",
-                assistance="Unexpected response from the token endpoint.",
-                data=str(error),
-            ) from error
-
-        self._logger.info("Bot Framework authentication successful.")
-        return self._token
-
-    def _get_bot_headers(self) -> dict:
-        """Get headers with Bot Framework bearer token."""
-        token = self._get_bot_token()
-        return {
-            "Authorization": f"Bearer {token}",
-            "Content-Type": "application/json",
-        }
-
-    def invalidate_token(self):
-        """Force token refresh on next request."""
-        self._token = None
 
     def send_channel_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,
@@ -129,7 +66,7 @@ class BotService:
 
         activity = {
             "type": "message",
-            "text": message if content_type == "text" else None,
+            "text": message,
             "textFormat": "plain" if content_type == "text" else "xml",
             "channelData": {
                 "teamsChannelId": channel_id,
@@ -138,7 +75,6 @@ class BotService:
         }
 
         if content_type == "html":
-            activity["text"] = message
             activity["textFormat"] = "xml"
 
         return self._send_activity(endpoint, activity)
@@ -170,8 +106,7 @@ class BotService:
 
         Includes a single retry on 401 (token expiry).
         """
-        headers = self._get_bot_headers()
-
+        headers = self._get_auth_headers()
         self._logger.info(f"Sending bot activity to: {endpoint}")
 
         response = self._post_activity(endpoint, activity, headers)
@@ -179,28 +114,14 @@ class BotService:
         # Single retry on 401 (token expired)
         if response.status_code == 401:
             self._logger.info("Bot token expired, refreshing and retrying...")
-            self.invalidate_token()
-            headers = self._get_bot_headers()
+            headers = self._get_auth_headers(force_refresh=True)
             response = self._post_activity(endpoint, activity, headers)
 
         return self._handle_activity_response(response)
 
     def _post_activity(self, endpoint: str, activity: dict, headers: dict) -> requests.Response:
-        """Post an activity to the Bot Framework endpoint with error handling."""
-        try:
-            return self._session.post(endpoint, json=activity, headers=headers, timeout=TIMEOUT)
-        except requests.exceptions.Timeout as error:
-            raise PluginException(
-                cause="Bot message send timed out",
-                assistance="Please verify network connectivity and try again.",
-                data=str(error),
-            ) from error
-        except requests.exceptions.ConnectionError as error:
-            raise PluginException(
-                cause="Unable to connect to Bot Framework service",
-                assistance=f"Could not connect to {self._service_url}. Please verify network connectivity.",
-                data=str(error),
-            ) from error
+        """Post an activity to the Bot Framework endpoint."""
+        return self._call_api("POST", endpoint, headers=headers, json=activity)
 
     def _handle_activity_response(self, response: requests.Response) -> dict:
         """Handle the response from a Bot Framework activity post."""

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/bot_service.py
@@ -39,8 +39,22 @@ class BotService(BaseClient):
         self._service_url = BOT_SERVICE_URL
 
     def test(self):
-        """Test Bot Service connectivity by authenticating."""
-        self._authenticate()
+        """
+        Test Bot Service connectivity by authenticating.
+
+        :raises PluginException: If authentication fails
+        """
+        try:
+            self._authenticate()
+        except PluginException:
+            raise
+        except Exception as error:
+            raise PluginException(
+                cause="Bot Service connection test failed.",
+                assistance="Please verify your Application ID and Application Secret are correct for the Bot Service. "
+                "Ensure the bot app registration has the Bot Framework API permissions.",
+                data=error,
+            ) from error
 
     def send_channel_message(  # pylint: disable=too-many-arguments,too-many-positional-arguments
         self,

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/constants.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/constants.py
@@ -1,0 +1,53 @@
+TIMEOUT = 30
+BOT_FRAMEWORK_SCOPE = "https://api.botframework.com/.default"
+BOT_SERVICE_URL = "https://smba.trafficmanager.net/teams"
+
+GRAPH_SCOPE_DEFAULT = "https://graph.microsoft.com/.default"
+
+RESOURCE_URL = {
+    "Normal": "https://graph.microsoft.com",
+    "GCC": "https://graph.microsoft.com",
+    "GCC High": "https://graph.microsoft.us",
+    "DoD": "https://graph.microsoft.us",
+}
+
+AUTH_URL = {
+    "Normal": "https://login.microsoftonline.com",
+    "GCC": "https://login.microsoftonline.com",
+    "GCC High": "https://login.microsoftonline.us",
+    "DoD": "https://login.microsoftonline.us",
+}
+
+DEFAULT_MAX_RESULTS = 50
+
+HTTP_ERROR_MAP = {
+    400: {
+        "cause": "Bad request",
+        "assistance": "The request was malformed or contained invalid parameters. Please verify your inputs.",
+    },
+    401: {
+        "cause": "Unauthorized",
+        "assistance": "Authentication failed. Please verify your application credentials and permissions.",
+    },
+    403: {
+        "cause": "Forbidden",
+        "assistance": "The application does not have sufficient permissions for this operation. "
+        "Verify the app registration has the required Microsoft Graph application permissions granted with admin consent.",
+    },
+    404: {
+        "cause": "Resource not found",
+        "assistance": "The requested resource was not found. Please verify the IDs or names provided are correct.",
+    },
+    429: {
+        "cause": "Rate limit exceeded",
+        "assistance": "Too many requests have been made. Please wait and try again later.",
+    },
+    500: {
+        "cause": "Internal server error",
+        "assistance": "Microsoft Graph encountered an internal error. Please try again later.",
+    },
+    503: {
+        "cause": "Service unavailable",
+        "assistance": "Microsoft Graph is temporarily unavailable. Please try again later.",
+    },
+}

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
@@ -1,109 +1,57 @@
-import requests
+import re
+import urllib.parse
 from logging import Logger
-from typing import Union
 from time import sleep
+from typing import Union
+
 from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 
-from icon_microsoft_teams.util.constants import TIMEOUT, HTTP_ERROR_MAP
+from icon_microsoft_teams.util.base_client import BaseClient
+from icon_microsoft_teams.util.constants import GRAPH_SCOPE_DEFAULT, AUTH_URL
 from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 
-import re
-import urllib.parse
 
-
-class GraphApiClient:
+class GraphApiClient(BaseClient):
     """Microsoft Graph API client using application-only (client_credentials) authentication."""
 
-    def __init__(self, base_url: str, logger: Logger, get_headers_func):
+    def __init__(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self, app_id: str, app_secret: str, tenant_id: str, base_url: str, endpoint: str, logger: Logger
+    ):
         """
         Initialize the Graph API client.
 
-        :param base_url: The Graph API base URL (e.g., https://graph.microsoft.com)
+        :param app_id: Azure App Registration client ID
+        :param app_secret: Azure App Registration client secret
+        :param tenant_id: Azure AD tenant ID
+        :param base_url: Graph API base URL (e.g., https://graph.microsoft.com)
+        :param endpoint: Endpoint type (Normal, GCC, etc.) for auth URL resolution
         :param logger: Logger instance
-        :param get_headers_func: Callable that returns auth headers dict
         """
+        super().__init__(
+            app_id=app_id,
+            app_secret=app_secret,
+            tenant_id=tenant_id,
+            auth_url=AUTH_URL.get(endpoint, "https://login.microsoftonline.com"),
+            scope=GRAPH_SCOPE_DEFAULT,
+            logger=logger,
+        )
         self._base_url = base_url
-        self._logger = logger
-        self._get_headers = get_headers_func
-        self._session = requests.Session()
 
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Union[dict, list]:
         """
-        Central request method with error handling.
+        Make a Graph API request with authentication.
 
-        :param method: HTTP method (GET, POST, PUT, DELETE, PATCH)
+        :param method: HTTP method
         :param endpoint: API endpoint path (e.g., /v1.0/groups)
-        :param kwargs: Additional arguments passed to requests
+        :param kwargs: Additional arguments (json, params, etc.)
         :return: Parsed JSON response
         """
         url = f"{self._base_url}{endpoint}"
-        headers = self._get_headers()
-
+        headers = self._get_auth_headers()
         self._logger.info(f"Making {method} request to: {url}")
-
-        try:
-            response = self._session.request(
-                method=method,
-                url=url,
-                headers=headers,
-                timeout=TIMEOUT,
-                **kwargs,
-            )
-        except requests.exceptions.Timeout as error:
-            raise PluginException(
-                cause="Request timed out",
-                assistance=f"The request to {url} timed out after {TIMEOUT} seconds. "
-                "Please verify network connectivity and try again.",
-                data=str(error),
-            ) from error
-        except requests.exceptions.ConnectionError as error:
-            raise PluginException(
-                cause="Unable to connect",
-                assistance=f"Could not connect to {self._base_url}. "
-                "Please verify network connectivity and that the endpoint is correct.",
-                data=str(error),
-            ) from error
-
-        return self._handle_response(response)
-
-    def _handle_response(self, response: requests.Response) -> Union[dict, list, None]:
-        """Handle the API response, raising appropriate exceptions for error codes."""
-        if response.status_code == 204:
-            return None
-
-        if response.status_code >= 400:
-            self._handle_error_status(response)
-
-        if not response.content:
-            return None
-
-        try:
-            return response.json()
-        except ValueError as error:
-            raise PluginException(
-                cause="Non-JSON response received",
-                assistance="The server returned a response that could not be parsed as JSON.",
-                data=response.text[:500],
-            ) from error
-
-    def _handle_error_status(self, response: requests.Response):
-        """Map HTTP error codes to PluginExceptions."""
-        status_code = response.status_code
-        error_info = HTTP_ERROR_MAP.get(status_code)
-
-        if error_info:
-            raise PluginException(
-                cause=error_info["cause"],
-                assistance=error_info["assistance"],
-                data=response.text[:1000],
-            )
-
-        raise PluginException(
-            cause=f"Unexpected HTTP error: {status_code}",
-            assistance="An unexpected error occurred. Please contact support if this persists.",
-            data=response.text[:1000],
-        )
+        response = self._call_api(method, url, headers=headers, **kwargs)
+        return self._handle_json_response(response)
 
     # ─── Teams / Groups ───────────────────────────────────────────────────────────
 
@@ -138,10 +86,10 @@ class GraphApiClient:
     def _paginate_results(self, items: list, next_link: str) -> list:
         """Follow pagination links and collect all results."""
         while next_link:
-            next_result = self._session.get(next_link, headers=self._get_headers(), timeout=TIMEOUT)
+            response = self._call_api("GET", next_link, headers=self._get_auth_headers())
             try:
-                next_result.raise_for_status()
-                next_json = next_result.json()
+                response.raise_for_status()
+                next_json = response.json()
             except Exception as error:
                 raise PluginException(
                     cause="Attempt to get paginated results failed.",
@@ -227,18 +175,13 @@ class GraphApiClient:
         }
 
         self._logger.info(f"Creating {channel_type} channel: {channel_name}")
-        response = self._session.request(
-            method="POST",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            json=payload,
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("POST", url, headers=self._get_auth_headers(), json=payload)
 
         if response.status_code == 201:
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     def delete_channel(self, team_id: str, channel_id: str) -> bool:
@@ -246,17 +189,13 @@ class GraphApiClient:
         endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}"
 
         self._logger.info(f"Deleting channel: {channel_id}")
-        response = self._session.request(
-            method="DELETE",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("DELETE", url, headers=self._get_auth_headers())
 
         if response.status_code == 204:
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     # ─── Messages (Read) ──────────────────────────────────────────────────────────
@@ -322,18 +261,13 @@ class GraphApiClient:
         payload = {"@odata.id": f"{self._base_url}/v1.0/directoryObjects/{user_id}"}
 
         self._logger.info(f"Adding user {user_id} to group {group_id}")
-        response = self._session.request(
-            method="POST",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            json=payload,
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("POST", url, headers=self._get_auth_headers(), json=payload)
 
         if response.status_code == 204:
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     def remove_member_from_group(self, group_id: str, user_id: str) -> bool:
@@ -341,17 +275,13 @@ class GraphApiClient:
         endpoint = f"/v1.0/groups/{group_id}/members/{user_id}/$ref"
 
         self._logger.info(f"Removing user {user_id} from group {group_id}")
-        response = self._session.request(
-            method="DELETE",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("DELETE", url, headers=self._get_auth_headers())
 
         if response.status_code == 204:
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     def add_group_owner(self, group_id: str, user_id: str) -> bool:
@@ -360,13 +290,8 @@ class GraphApiClient:
         payload = {"@odata.id": f"{self._base_url}/v1.0/directoryObjects/{user_id}"}
 
         self._logger.info(f"Adding user {user_id} as owner of group {group_id}")
-        response = self._session.request(
-            method="POST",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            json=payload,
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("POST", url, headers=self._get_auth_headers(), json=payload)
 
         if response.status_code == 204:
             self._logger.info("User was added as owner successfully.")
@@ -375,7 +300,7 @@ class GraphApiClient:
             self._logger.info("User is already an owner of this group.")
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     def add_member_to_channel(self, team_id: str, channel_id: str, user_id: str, role: str) -> bool:
@@ -388,13 +313,8 @@ class GraphApiClient:
         }
 
         self._logger.info(f"Adding user {user_id} to channel {channel_id}")
-        response = self._session.request(
-            method="POST",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            json=payload,
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("POST", url, headers=self._get_auth_headers(), json=payload)
 
         if response.status_code == 201:
             self._logger.info("User was added to channel successfully.")
@@ -403,7 +323,7 @@ class GraphApiClient:
             self._logger.info("User has already been added to the channel.")
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     def create_group(  # pylint: disable=too-many-arguments,too-many-positional-arguments
@@ -427,20 +347,13 @@ class GraphApiClient:
         }
 
         if owners:
-            owners_payload = self._build_user_references(owners)
-            payload["owners@odata.bind"] = owners_payload
+            payload["owners@odata.bind"] = self._build_user_references(owners)
         if members:
-            members_payload = self._build_user_references(members)
-            payload["members@odata.bind"] = members_payload
+            payload["members@odata.bind"] = self._build_user_references(members)
 
         self._logger.info(f"Creating group: {group_name}")
-        response = self._session.request(
-            method="POST",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            json=payload,
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("POST", url, headers=self._get_auth_headers(), json=payload)
 
         if response.status_code == 201:
             try:
@@ -452,7 +365,7 @@ class GraphApiClient:
                     data=str(error),
                 ) from error
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return {}
 
     def delete_group(self, group_id: str) -> bool:
@@ -460,17 +373,13 @@ class GraphApiClient:
         endpoint = f"/v1.0/groups/{group_id}"
 
         self._logger.info(f"Deleting group: {group_id}")
-        response = self._session.request(
-            method="DELETE",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("DELETE", url, headers=self._get_auth_headers())
 
         if response.status_code == 204:
             return True
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return False
 
     def get_group_id_from_name(self, group_name: str) -> str:
@@ -492,6 +401,7 @@ class GraphApiClient:
     def enable_teams_for_group(self, group_id: str) -> bool:
         """Enable Microsoft Teams for a group."""
         endpoint = f"/v1.0/groups/{group_id}/team"
+        url = f"{self._base_url}{endpoint}"
         payload = {
             "memberSettings": {
                 "allowCreateUpdateChannels": True,
@@ -519,13 +429,7 @@ class GraphApiClient:
         self._logger.info(f"Enabling Teams for group: {group_id}")
 
         for attempt in range(1, 6):
-            response = self._session.request(
-                method="PUT",
-                url=f"{self._base_url}{endpoint}",
-                headers=self._get_headers(),
-                json=payload,
-                timeout=TIMEOUT,
-            )
+            response = self._call_api("PUT", url, headers=self._get_auth_headers(), json=payload)
 
             if response.status_code == 201:
                 self._logger.info("Team was enabled successfully.")
@@ -574,13 +478,8 @@ class GraphApiClient:
         payload["members"] = list_members
 
         self._logger.info(f"Creating chat with {len(list_members)} members")
-        response = self._session.request(
-            method="POST",
-            url=f"{self._base_url}{endpoint}",
-            headers=self._get_headers(),
-            json=payload,
-            timeout=TIMEOUT,
-        )
+        url = f"{self._base_url}{endpoint}"
+        response = self._call_api("POST", url, headers=self._get_auth_headers(), json=payload)
 
         if response.status_code == 201:
             try:
@@ -592,7 +491,7 @@ class GraphApiClient:
                     data=str(error),
                 ) from error
 
-        self._handle_error_status(response)
+        self._raise_for_status(response)
         return {}
 
     # ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
@@ -22,11 +22,22 @@ class GraphApiClient(BaseClient):
         Initialize the Graph API client.
 
         :param app_id: Azure App Registration client ID
+        :type app_id: str
+
         :param app_secret: Azure App Registration client secret
+        :type app_secret: str
+
         :param tenant_id: Azure AD tenant ID
+        :type tenant_id: str
+
         :param base_url: Graph API base URL (e.g., https://graph.microsoft.com)
+        :type base_url: str
+
         :param endpoint: Endpoint type (Normal, GCC, etc.) for auth URL resolution
+        :type endpoint: str
+
         :param logger: Logger instance
+        :type logger: Logger
         """
         super().__init__(
             app_id=app_id,
@@ -38,14 +49,29 @@ class GraphApiClient(BaseClient):
         )
         self._base_url = base_url
 
+    def test(self):
+        """
+        Test Graph API connectivity by authenticating and calling the organization endpoint.
+
+        :raises PluginException: If authentication or API call fails
+        """
+        self._authenticate()
+        self._make_request("GET", "/v1.0/organization")
+
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Union[dict, list]:
         """
         Make a Graph API request with authentication.
 
         :param method: HTTP method
+        :type method: str
+
         :param endpoint: API endpoint path (e.g., /v1.0/groups)
+        :type endpoint: str
+
         :param kwargs: Additional arguments (json, params, etc.)
+
         :return: Parsed JSON response
+        :rtype: Union[dict, list]
         """
         url = f"{self._base_url}{endpoint}"
         headers = self._get_auth_headers()
@@ -497,10 +523,15 @@ class GraphApiClient(BaseClient):
     # ─── Helpers ──────────────────────────────────────────────────────────────────
 
     def _build_user_references(self, user_logins: list) -> list:
-        """Build odata user reference list from user login names."""
-        user_refs = []
-        for user_login in user_logins:
-            user = self.get_user_info(user_login)
-            user_id = user.get("id")
-            user_refs.append(f"{self._base_url}/v1.0/directoryObjects/{user_id}")
-        return user_refs
+        """
+        Build odata user reference list from user login names.
+
+        :param user_logins: List of user principal names
+        :type user_logins: list
+
+        :return: List of odata directory object references
+        :rtype: list
+        """
+        return [
+            f"{self._base_url}/v1.0/directoryObjects/{self.get_user_info(login).get('id')}" for login in user_logins
+        ]

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
@@ -1,0 +1,607 @@
+import requests
+from logging import Logger
+from typing import Union
+from time import sleep
+from insightconnect_plugin_runtime.exceptions import PluginException
+from insightconnect_plugin_runtime.helper import clean
+
+from icon_microsoft_teams.util.constants import TIMEOUT, HTTP_ERROR_MAP
+from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
+
+import re
+import urllib.parse
+
+
+class GraphApiClient:
+    """Microsoft Graph API client using application-only (client_credentials) authentication."""
+
+    def __init__(self, base_url: str, logger: Logger, get_headers_func):
+        """
+        Initialize the Graph API client.
+
+        :param base_url: The Graph API base URL (e.g., https://graph.microsoft.com)
+        :param logger: Logger instance
+        :param get_headers_func: Callable that returns auth headers dict
+        """
+        self._base_url = base_url
+        self._logger = logger
+        self._get_headers = get_headers_func
+        self._session = requests.Session()
+
+    def _make_request(self, method: str, endpoint: str, **kwargs) -> Union[dict, list]:
+        """
+        Central request method with error handling.
+
+        :param method: HTTP method (GET, POST, PUT, DELETE, PATCH)
+        :param endpoint: API endpoint path (e.g., /v1.0/groups)
+        :param kwargs: Additional arguments passed to requests
+        :return: Parsed JSON response
+        """
+        url = f"{self._base_url}{endpoint}"
+        headers = self._get_headers()
+
+        self._logger.info(f"Making {method} request to: {url}")
+
+        try:
+            response = self._session.request(
+                method=method,
+                url=url,
+                headers=headers,
+                timeout=TIMEOUT,
+                **kwargs,
+            )
+        except requests.exceptions.Timeout as error:
+            raise PluginException(
+                cause="Request timed out",
+                assistance=f"The request to {url} timed out after {TIMEOUT} seconds. "
+                "Please verify network connectivity and try again.",
+                data=str(error),
+            ) from error
+        except requests.exceptions.ConnectionError as error:
+            raise PluginException(
+                cause="Unable to connect",
+                assistance=f"Could not connect to {self._base_url}. "
+                "Please verify network connectivity and that the endpoint is correct.",
+                data=str(error),
+            ) from error
+
+        return self._handle_response(response)
+
+    def _handle_response(self, response: requests.Response) -> Union[dict, list, None]:
+        """Handle the API response, raising appropriate exceptions for error codes."""
+        if response.status_code == 204:
+            return None
+
+        if response.status_code >= 400:
+            self._handle_error_status(response)
+
+        if not response.content:
+            return None
+
+        try:
+            return response.json()
+        except ValueError as error:
+            raise PluginException(
+                cause="Non-JSON response received",
+                assistance="The server returned a response that could not be parsed as JSON.",
+                data=response.text[:500],
+            ) from error
+
+    def _handle_error_status(self, response: requests.Response):
+        """Map HTTP error codes to PluginExceptions."""
+        status_code = response.status_code
+        error_info = HTTP_ERROR_MAP.get(status_code)
+
+        if error_info:
+            raise PluginException(
+                cause=error_info["cause"],
+                assistance=error_info["assistance"],
+                data=response.text[:1000],
+            )
+
+        raise PluginException(
+            cause=f"Unexpected HTTP error: {status_code}",
+            assistance="An unexpected error occurred. Please contact support if this persists.",
+            data=response.text[:1000],
+        )
+
+    # ─── Teams / Groups ───────────────────────────────────────────────────────────
+
+    def get_teams(self, team_name: str = None, explicit: bool = True) -> list:
+        """
+        Get teams from Microsoft Graph.
+
+        :param team_name: Optional team name to filter by
+        :param explicit: If True, match exact name; if False, use regex
+        :return: List of team objects
+        """
+        endpoint = self._build_teams_endpoint(team_name, explicit)
+        result = self._make_request("GET", endpoint)
+        teams = result.get("value", [])
+        teams = self._paginate_results(teams, result.get("@odata.nextLink"))
+
+        if team_name:
+            return self._filter_teams_by_name(teams, team_name, explicit)
+
+        return teams
+
+    def _build_teams_endpoint(self, team_name: str, explicit: bool) -> str:
+        """Build the Graph API endpoint for listing teams."""
+        if explicit and team_name:
+            parsed_team_name = urllib.parse.quote(team_name, safe="")
+            return (
+                f"/v1.0/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') "
+                f"and displayName eq '{parsed_team_name}'"
+            )
+        return "/v1.0/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team')"
+
+    def _paginate_results(self, items: list, next_link: str) -> list:
+        """Follow pagination links and collect all results."""
+        while next_link:
+            next_result = self._session.get(next_link, headers=self._get_headers(), timeout=TIMEOUT)
+            try:
+                next_result.raise_for_status()
+                next_json = next_result.json()
+            except Exception as error:
+                raise PluginException(
+                    cause="Attempt to get paginated results failed.",
+                    assistance="Pagination request failed during retrieval.",
+                    data=str(error),
+                ) from error
+            items.extend(next_json.get("value", []))
+            next_link = next_json.get("@odata.nextLink")
+        return items
+
+    def _filter_teams_by_name(self, teams: list, team_name: str, explicit: bool) -> list:
+        """Filter teams list by name (exact or regex match)."""
+        self._logger.info(f"Looking for team: {team_name}")
+
+        compiled_team_name = None
+        if not explicit:
+            try:
+                compiled_team_name = re.compile(team_name)
+            except re.error as error:
+                raise PluginException(
+                    cause=f"Team Name {team_name} was an invalid regular expression.",
+                    assistance=f"Please correct {team_name}",
+                    data=str(error),
+                ) from error
+
+        for team in teams:
+            name = team.get("displayName", "")
+            if explicit and name == team_name:
+                return [team]
+            if not explicit and compiled_team_name.search(name):
+                return [team]
+
+        raise PluginException(
+            cause=f"Team {team_name} was not found.",
+            assistance=f"Please verify {team_name} is a valid team name.",
+        )
+
+    # ─── Channels ─────────────────────────────────────────────────────────────────
+
+    def get_channels(self, team_id: str, channel_name: str = None) -> list:
+        """
+        Get channels for a team.
+
+        :param team_id: The team ID
+        :param channel_name: Optional channel name to filter by (regex match)
+        :return: List of channel objects
+        """
+        compiled_channel_name = None
+        if channel_name:
+            try:
+                compiled_channel_name = re.compile(channel_name)
+            except re.error as error:
+                raise PluginException(
+                    cause=f"Channel Name {channel_name} was an invalid regular expression.",
+                    assistance=f"Please correct {channel_name}",
+                    data=str(error),
+                ) from error
+
+        endpoint = f"/v1.0/teams/{team_id}/channels"
+        result = self._make_request("GET", endpoint)
+        channels = result.get("value", [])
+
+        if channel_name:
+            self._logger.info(f"Looking for channel: {channel_name}")
+            for channel in channels:
+                name = channel.get("displayName", "")
+                if compiled_channel_name.match(name):
+                    return [channel]
+            raise PluginException(
+                cause=f"Channel {channel_name} was not found.",
+                assistance=f"Please verify {channel_name} is a valid channel for the team with id: {team_id}",
+            )
+
+        return channels
+
+    def create_channel(self, team_id: str, channel_name: str, description: str, channel_type: str) -> bool:
+        """Create a channel in a team."""
+        endpoint = f"/v1.0/teams/{team_id}/channels"
+        payload = {
+            "description": description,
+            "displayName": channel_name,
+            "membershipType": channel_type.lower(),
+        }
+
+        self._logger.info(f"Creating {channel_type} channel: {channel_name}")
+        response = self._session.request(
+            method="POST",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            json=payload,
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 201:
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    def delete_channel(self, team_id: str, channel_id: str) -> bool:
+        """Delete a channel from a team."""
+        endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}"
+
+        self._logger.info(f"Deleting channel: {channel_id}")
+        response = self._session.request(
+            method="DELETE",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 204:
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    # ─── Messages (Read) ──────────────────────────────────────────────────────────
+
+    def get_channel_messages(self, team_id: str, channel_id: str) -> list:
+        """Get messages from a channel."""
+        endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}/messages"
+        result = self._make_request("GET", endpoint)
+        return result.get("value", [])
+
+    def get_channel_message(self, team_id: str, channel_id: str, message_id: str, reply_id: str = None) -> dict:
+        """Get a specific message or reply from a channel."""
+        if reply_id:
+            endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies/{reply_id}"
+        else:
+            endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}/messages/{message_id}"
+
+        result = self._make_request("GET", endpoint)
+        return remove_null_and_clean(result)
+
+    def get_chat_message(self, chat_id: str, message_id: str) -> dict:
+        """Get a specific message from a chat."""
+        endpoint = f"/v1.0/chats/{chat_id}/messages/{message_id}"
+        result = self._make_request("GET", endpoint)
+        return remove_null_and_clean(result)
+
+    def list_chat_messages(self, chat_id: str, top: int = 50) -> list:
+        """List messages from a chat."""
+        endpoint = f"/v1.0/chats/{chat_id}/messages?$top={top}&$orderby=createdDateTime desc"
+        result = self._make_request("GET", endpoint)
+        messages = result.get("value", [])
+        return [clean(message) for message in messages]
+
+    def get_message_replies(self, team_id: str, channel_id: str, message_id: str) -> list:
+        """Get all replies to a message in a channel."""
+        endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}/messages/{message_id}/replies"
+        result = self._make_request("GET", endpoint)
+        return clean(result.get("value", []))
+
+    # ─── Users ────────────────────────────────────────────────────────────────────
+
+    def get_user_info(self, user_login: str) -> dict:
+        """Get user information by UPN (email)."""
+        endpoint = f"/v1.0/users?$filter=userPrincipalName eq '{user_login}'"
+
+        self._logger.info(f"Getting user information for: {user_login}")
+        result = self._make_request("GET", endpoint)
+        users = result.get("value", [])
+
+        if not users:
+            raise PluginException(
+                cause=f"User {user_login} was not found.",
+                assistance=f"Please verify {user_login} is a valid user principal name.",
+            )
+
+        return users[0]
+
+    # ─── Group Management ─────────────────────────────────────────────────────────
+
+    def add_member_to_group(self, group_id: str, user_id: str) -> bool:
+        """Add a user as a member to a group."""
+        endpoint = f"/v1.0/groups/{group_id}/members/$ref"
+        payload = {"@odata.id": f"{self._base_url}/v1.0/directoryObjects/{user_id}"}
+
+        self._logger.info(f"Adding user {user_id} to group {group_id}")
+        response = self._session.request(
+            method="POST",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            json=payload,
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 204:
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    def remove_member_from_group(self, group_id: str, user_id: str) -> bool:
+        """Remove a user from a group."""
+        endpoint = f"/v1.0/groups/{group_id}/members/{user_id}/$ref"
+
+        self._logger.info(f"Removing user {user_id} from group {group_id}")
+        response = self._session.request(
+            method="DELETE",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 204:
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    def add_group_owner(self, group_id: str, user_id: str) -> bool:
+        """Add a user as an owner of a group."""
+        endpoint = f"/v1.0/groups/{group_id}/owners/$ref"
+        payload = {"@odata.id": f"{self._base_url}/v1.0/directoryObjects/{user_id}"}
+
+        self._logger.info(f"Adding user {user_id} as owner of group {group_id}")
+        response = self._session.request(
+            method="POST",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            json=payload,
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 204:
+            self._logger.info("User was added as owner successfully.")
+            return True
+        if response.status_code == 400:
+            self._logger.info("User is already an owner of this group.")
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    def add_member_to_channel(self, team_id: str, channel_id: str, user_id: str, role: str) -> bool:
+        """Add a member to a channel."""
+        endpoint = f"/v1.0/teams/{team_id}/channels/{channel_id}/members"
+        payload = {
+            "@odata.type": "#microsoft.graph.aadUserConversationMember",
+            "roles": [role],
+            "user@odata.bind": f"{self._base_url}/v1.0/users('{user_id}')",
+        }
+
+        self._logger.info(f"Adding user {user_id} to channel {channel_id}")
+        response = self._session.request(
+            method="POST",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            json=payload,
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 201:
+            self._logger.info("User was added to channel successfully.")
+            return True
+        if response.status_code == 400:
+            self._logger.info("User has already been added to the channel.")
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    def create_group(  # pylint: disable=too-many-arguments,too-many-positional-arguments
+        self,
+        group_name: str,
+        group_description: str,
+        group_nickname: str,
+        mail_enabled: bool,
+        owners: list = None,
+        members: list = None,
+    ) -> dict:
+        """Create a Microsoft 365 group."""
+        endpoint = "/v1.0/groups"
+        payload = {
+            "description": group_description,
+            "displayName": group_name,
+            "groupTypes": ["Unified"],
+            "mailEnabled": mail_enabled,
+            "mailNickname": group_nickname,
+            "securityEnabled": False,
+        }
+
+        if owners:
+            owners_payload = self._build_user_references(owners)
+            payload["owners@odata.bind"] = owners_payload
+        if members:
+            members_payload = self._build_user_references(members)
+            payload["members@odata.bind"] = members_payload
+
+        self._logger.info(f"Creating group: {group_name}")
+        response = self._session.request(
+            method="POST",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            json=payload,
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 201:
+            try:
+                return response.json()
+            except ValueError as error:
+                raise PluginException(
+                    cause="Non-JSON response received",
+                    assistance="Group was created but the response could not be parsed.",
+                    data=str(error),
+                ) from error
+
+        self._handle_error_status(response)
+        return {}
+
+    def delete_group(self, group_id: str) -> bool:
+        """Delete a group."""
+        endpoint = f"/v1.0/groups/{group_id}"
+
+        self._logger.info(f"Deleting group: {group_id}")
+        response = self._session.request(
+            method="DELETE",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 204:
+            return True
+
+        self._handle_error_status(response)
+        return False
+
+    def get_group_id_from_name(self, group_name: str) -> str:
+        """Get a group ID by its display name."""
+        endpoint = f"/v1.0/groups?$filter=displayName eq '{group_name}'"
+
+        self._logger.info(f"Getting group ID for: {group_name}")
+        result = self._make_request("GET", endpoint)
+        groups = result.get("value", [])
+
+        if not groups:
+            raise PluginException(
+                cause=f"Group {group_name} was not found.",
+                assistance=f"Please verify {group_name} is a valid group name.",
+            )
+
+        return groups[0].get("id")
+
+    def enable_teams_for_group(self, group_id: str) -> bool:
+        """Enable Microsoft Teams for a group."""
+        endpoint = f"/v1.0/groups/{group_id}/team"
+        payload = {
+            "memberSettings": {
+                "allowCreateUpdateChannels": True,
+                "allowDeleteChannels": True,
+                "allowAddRemoveApps": True,
+                "allowCreateUpdateRemoveTabs": True,
+                "allowCreateUpdateRemoveConnectors": True,
+            },
+            "guestSettings": {"allowCreateUpdateChannels": False, "allowDeleteChannels": False},
+            "messagingSettings": {
+                "allowUserEditMessages": True,
+                "allowUserDeleteMessages": True,
+                "allowOwnerDeleteMessages": True,
+                "allowTeamMentions": True,
+                "allowChannelMentions": True,
+            },
+            "funSettings": {
+                "allowGiphy": True,
+                "giphyContentRating": "strict",
+                "allowStickersAndMemes": True,
+                "allowCustomMemes": True,
+            },
+        }
+
+        self._logger.info(f"Enabling Teams for group: {group_id}")
+
+        for attempt in range(1, 6):
+            response = self._session.request(
+                method="PUT",
+                url=f"{self._base_url}{endpoint}",
+                headers=self._get_headers(),
+                json=payload,
+                timeout=TIMEOUT,
+            )
+
+            if response.status_code == 201:
+                self._logger.info("Team was enabled successfully.")
+                return True
+
+            self._logger.info(
+                f"Attempt {attempt} to enable team failed (status: {response.status_code}). "
+                f"Retrying in 10 seconds..."
+            )
+            sleep(10)
+
+        raise PluginException(
+            cause=f"Could not enable Teams for group with ID: {group_id}.",
+            assistance="This may be due to a replication delay in Azure. Please try again later.",
+            data=f"Status Code: {response.status_code}\nResponse:\n{response.text}",
+        )
+
+    # ─── Chats ────────────────────────────────────────────────────────────────────
+
+    def create_chat(self, members: list, topic: str = None) -> dict:
+        """Create a new chat."""
+        endpoint = "/v1.0/chats"
+        payload = {}
+
+        list_members = []
+        for member in members:
+            formatted_member = {
+                "@odata.type": "#microsoft.graph.aadUserConversationMember",
+                "roles": [member.get("role", "owner")],
+                "user@odata.bind": f"{self._base_url}/v1.0/users('{member.get('user_info')}')",
+            }
+            list_members.append(formatted_member)
+
+        if len(list_members) == 2:
+            payload["chatType"] = "oneOnOne"
+        elif len(list_members) > 2:
+            payload["chatType"] = "group"
+            if topic:
+                payload["topic"] = topic
+        else:
+            raise PluginException(
+                cause="Create chat failed.",
+                assistance="At least 2 members are required to create a chat.",
+            )
+
+        payload["members"] = list_members
+
+        self._logger.info(f"Creating chat with {len(list_members)} members")
+        response = self._session.request(
+            method="POST",
+            url=f"{self._base_url}{endpoint}",
+            headers=self._get_headers(),
+            json=payload,
+            timeout=TIMEOUT,
+        )
+
+        if response.status_code == 201:
+            try:
+                return response.json()
+            except ValueError as error:
+                raise PluginException(
+                    cause="Non-JSON response received",
+                    assistance="Chat was created but the response could not be parsed.",
+                    data=str(error),
+                ) from error
+
+        self._handle_error_status(response)
+        return {}
+
+    # ─── Helpers ──────────────────────────────────────────────────────────────────
+
+    def _build_user_references(self, user_logins: list) -> list:
+        """Build odata user reference list from user login names."""
+        user_refs = []
+        for user_login in user_logins:
+            user = self.get_user_info(user_login)
+            user_id = user.get("id")
+            user_refs.append(f"{self._base_url}/v1.0/directoryObjects/{user_id}")
+        return user_refs

--- a/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
+++ b/plugins/microsoft_teams/icon_microsoft_teams/util/graph_api_client.py
@@ -55,8 +55,18 @@ class GraphApiClient(BaseClient):
 
         :raises PluginException: If authentication or API call fails
         """
-        self._authenticate()
-        self._make_request("GET", "/v1.0/organization")
+        try:
+            self._authenticate()
+            self._make_request("GET", "/v1.0/organization")
+        except PluginException:
+            raise
+        except Exception as error:
+            raise PluginException(
+                cause="Graph API connection test failed.",
+                assistance="Please verify your Application ID, Directory ID, and Application Secret. "
+                "Ensure the app registration has Microsoft Graph application permissions with admin consent.",
+                data=error,
+            ) from error
 
     def _make_request(self, method: str, endpoint: str, **kwargs) -> Union[dict, list]:
         """

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -55,7 +55,7 @@ references:
 - '[Adaptive Cards Actions](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/cards/cards-actions#adaptive-cards-actions)'
 - '[Python Regular Expression Library (Re)](https://docs.python.org/3.7/library/re.html)'
 version_history:
-- 8.0.0 - Major refactor to eliminate user account requirement | Switched to client_credentials (app-only) OAuth2 flow | Added Bot Framework for sending messages | Migrated all endpoints from /beta to /v1.0 | Removed username_password from connection | Removed username input from get_message_in_chat (now uses app permissions) | Updated SDK to 6.5.1
+- 8.0.0 - Major refactor to eliminate user account requirement | Switched to client_credentials (app-only) OAuth2 flow | Added Bot Framework for sending messages | Migrated all endpoints from /beta to /v1.0 | Removed username_password from connection | Removed username input from get_message_in_chat (now uses app permissions)
 - 7.0.6 - Updated SDK to the latest version (6.5.1)
 - 7.0.5 - Updated SDK to the latest version (6.4.3)
 - 7.0.4 - Updated SDK to the latest version (6.4.2)

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -11,12 +11,15 @@ description: '[Microsoft Teams](https://products.office.com/en-us/microsoft-team
   to interact with Microsoft Teams'
 key_features:
 - Communication Management for all microsoft products
+- App-only authentication (no user account required)
+- Bot Framework integration for sending messages
 requirements:
-- Username and Password
-- Secret Key, similar to API Key
-version: 7.0.6
-connection_version: 7
-supported_versions: [Microsoft Graph API v1.0 2024-09-13]
+- Azure App Registration with Application ID and Secret
+- Microsoft Graph application permissions with admin consent
+- Azure Bot registration (for sending messages)
+version: 8.0.0
+connection_version: 8
+supported_versions: [Microsoft Graph API v1.0 2025-05-18]
 vendor: rapid7
 support: community
 status: []
@@ -52,6 +55,7 @@ references:
 - '[Adaptive Cards Actions](https://docs.microsoft.com/en-us/microsoftteams/platform/concepts/cards/cards-actions#adaptive-cards-actions)'
 - '[Python Regular Expression Library (Re)](https://docs.python.org/3.7/library/re.html)'
 version_history:
+- 8.0.0 - Major refactor to eliminate user account requirement | Switched to client_credentials (app-only) OAuth2 flow | Added Bot Framework for sending messages | Migrated all endpoints from /beta to /v1.0 | Removed username_password from connection | Removed username input from get_message_in_chat (now uses app permissions) | Updated SDK to 6.5.1
 - 7.0.6 - Updated SDK to the latest version (6.5.1)
 - 7.0.5 - Updated SDK to the latest version (6.4.3)
 - 7.0.4 - Updated SDK to the latest version (6.4.2)
@@ -569,16 +573,9 @@ connection:
     type: credential_secret_key
     required: true
     example: aMeCAEYdOLlK+qRcD9AjdyxLkCaqZH1UPm7adjJQ5Og=
-  username_password:
-    type: credential_username_password
-    title: Credentials
-    description: Username and password
-    required: true
-    example: '{ "username": "user", "password": "mypassword" }'
   endpoint:
     title: Endpoint
-    description: 'The type of endpoint to connect to: normal service, GCC (government),
-      GCC High (government), DoD (military)'
+    description: 'The type of endpoint to connect to: normal service, GCC (government), GCC High (government), DoD (military)'
     type: string
     required: true
     example: Normal
@@ -1137,12 +1134,6 @@ actions:
     title: Get Message in Chat
     description: Retrieve a single message or a message reply in a chat
     input:
-      username:
-        title: Username
-        description: The ID of user or his email
-        type: string
-        required: true
-        example: user@example.com
       chat_id:
         title: Chat ID
         description: The ID of chat

--- a/plugins/microsoft_teams/setup.py
+++ b/plugins/microsoft_teams/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="microsoft_teams-rapid7-plugin",
-    version="7.0.6",
+    version="8.0.0",
     description="[Microsoft Teams](https://products.office.com/en-us/microsoft-teams/group-chat-software) is a unified communications platform. The Microsoft Teams plugin allows you to send and trigger workflows on new messages. The plugin will also allow for teams management with the ability to add and remove teams, channels, and users. This plugin uses the [Microsoft Teams API](https://docs.microsoft.com/en-us/graph/api/resources/teams-api-overview?view=graph-rest-1.0) to interact with Microsoft Teams",
     author="rapid7",
     author_email="",

--- a/plugins/microsoft_teams/unit_test/test_add_channel_to_team.py
+++ b/plugins/microsoft_teams/unit_test/test_add_channel_to_team.py
@@ -3,8 +3,7 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
-from unittest.mock import Mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.add_channel_to_team.action import AddChannelToTeam
 from icon_microsoft_teams.actions.add_channel_to_team.schema import AddChannelToTeamInput, AddChannelToTeamOutput, Input
@@ -13,29 +12,25 @@ from parameterized import parameterized
 
 from util import Util
 
-STUB_TEAM_NAME = "Example Team"
-STUB_CHANNEL_NAME = "ExampleName"
-STUB_CHANNEL_DESCRIPTION = "Example Channel Description"
-
-STUB_EXAMPLE_ACTION_RESPONSE = {"success": True}
-
 
 class TestAddChannelToTeam(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(AddChannelToTeam())
-        self.payload = {
-            Input.TEAM_NAME: STUB_TEAM_NAME,
-            Input.CHANNEL_NAME: STUB_CHANNEL_NAME,
-            Input.CHANNEL_DESCRIPTION: STUB_CHANNEL_DESCRIPTION,
-        }
+        self.action.connection.client.get_teams.return_value = [{"id": "12345", "displayName": "Example Team"}]
+        self.action.connection.client.create_channel.return_value = True
 
     @parameterized.expand([("Standard",), ("Private",)])
-    @mock.patch("requests.get", side_effect=Util.mocked_requests)
-    @mock.patch("requests.post", side_effect=Util.mocked_requests)
-    def test_add_group_owner(self, channel_type: str, mock_requests_post: Mock, mock_requests_get: Mock) -> None:
-        test_input = {**self.payload, "channel_type": channel_type}
+    def test_add_channel_to_team(self, channel_type: str) -> None:
+        test_input = {
+            Input.TEAM_NAME: "Example Team",
+            Input.CHANNEL_NAME: "ExampleName",
+            Input.CHANNEL_DESCRIPTION: "Example Channel Description",
+            Input.CHANNEL_TYPE: channel_type,
+        }
         validate(test_input, AddChannelToTeamInput.schema)
         response = self.action.run(test_input)
-        expected_response = STUB_EXAMPLE_ACTION_RESPONSE
-        self.assertEqual(response, expected_response)
+        self.assertEqual(response, {"success": True})
         validate(response, AddChannelToTeamOutput.schema)
+        self.action.connection.client.create_channel.assert_called_with(
+            "12345", "ExampleName", "Example Channel Description", channel_type
+        )

--- a/plugins/microsoft_teams/unit_test/test_add_group_owner.py
+++ b/plugins/microsoft_teams/unit_test/test_add_group_owner.py
@@ -3,7 +3,7 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.add_group_owner.action import AddGroupOwner
 from icon_microsoft_teams.actions.add_group_owner.schema import AddGroupOwnerInput, AddGroupOwnerOutput, Input
@@ -11,23 +11,20 @@ from jsonschema import validate
 
 from util import Util
 
-STUB_GROUP_NAME = "test"
-STUB_MEMBER_LOGIN = "test"
-
-STUB_EXAMPLE_ACTION_RESPONSE = {"success": True}
-
 
 class TestAddGroupOwner(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(AddGroupOwner())
+        self.action.connection.client.get_user_info.return_value = {"id": "user-123", "displayName": "Test User"}
+        self.action.connection.client.get_group_id_from_name.return_value = "group-456"
+        self.action.connection.client.add_group_owner.return_value = True
 
-        self.payload = {Input.GROUP_NAME: STUB_GROUP_NAME, Input.MEMBER_LOGIN: STUB_MEMBER_LOGIN}
-
-    @mock.patch("requests.get", side_effect=Util.mocked_requests)
-    @mock.patch("requests.post", side_effect=Util.mocked_requests)
-    def test_add_group_owner(self, mock_requests_get, mock_requests_post) -> None:
-        validate(self.payload, AddGroupOwnerInput.schema)
-        response = self.action.run(self.payload)
-        expected_response = STUB_EXAMPLE_ACTION_RESPONSE
-        self.assertEqual(response, expected_response)
+    def test_add_group_owner(self) -> None:
+        test_input = {Input.GROUP_NAME: "test", Input.MEMBER_LOGIN: "test@example.com"}
+        validate(test_input, AddGroupOwnerInput.schema)
+        response = self.action.run(test_input)
+        self.assertEqual(response, {"success": True})
         validate(response, AddGroupOwnerOutput.schema)
+        self.action.connection.client.get_user_info.assert_called_with("test@example.com")
+        self.action.connection.client.get_group_id_from_name.assert_called_with("test")
+        self.action.connection.client.add_group_owner.assert_called_with("group-456", "user-123")

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
@@ -15,7 +15,9 @@ class TestAddMemberToChannel(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(AddMemberToChannel())
         self.action.connection.client.get_group_id_from_name.return_value = "group-123"
-        self.action.connection.client.get_channels.return_value = [{"id": "channel-456", "displayName": "Example Channel"}]
+        self.action.connection.client.get_channels.return_value = [
+            {"id": "channel-456", "displayName": "Example Channel"}
+        ]
         self.action.connection.client.get_user_info.return_value = {"id": "user-789", "displayName": "Test User"}
         self.action.connection.client.add_member_to_channel.return_value = True
 
@@ -31,4 +33,6 @@ class TestAddMemberToChannel(TestCase):
         self.action.connection.client.get_group_id_from_name.assert_called_with("test")
         self.action.connection.client.get_channels.assert_called_with("group-123", "Example Channel")
         self.action.connection.client.get_user_info.assert_called_with("test@example.com")
-        self.action.connection.client.add_member_to_channel.assert_called_with("group-123", "channel-456", "user-789", "owner")
+        self.action.connection.client.add_member_to_channel.assert_called_with(
+            "group-123", "channel-456", "user-789", "owner"
+        )

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_channel.py
@@ -3,35 +3,32 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.add_member_to_channel.action import AddMemberToChannel
 from icon_microsoft_teams.actions.add_member_to_channel.schema import Input
 
 from util import Util
 
-STUB_GROUP_NAME = "test"
-STUB_MEMBER_LOGIN = "test"
-STUB_CHANNEL_NAME = "Example Channel"
-STUB_MEMBER_ROLE = "Owner"
-
-STUB_EXAMPLE_ACTION_RESPONSE = {"success": True}
-
 
 class TestAddMemberToChannel(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(AddMemberToChannel())
+        self.action.connection.client.get_group_id_from_name.return_value = "group-123"
+        self.action.connection.client.get_channels.return_value = [{"id": "channel-456", "displayName": "Example Channel"}]
+        self.action.connection.client.get_user_info.return_value = {"id": "user-789", "displayName": "Test User"}
+        self.action.connection.client.add_member_to_channel.return_value = True
 
-        self.payload = {
-            Input.GROUP_NAME: STUB_GROUP_NAME,
-            Input.MEMBER_LOGIN: STUB_MEMBER_LOGIN,
-            Input.CHANNEL_NAME: STUB_CHANNEL_NAME,
-            Input.ROLE: STUB_MEMBER_ROLE,
+    def test_add_member_to_channel(self) -> None:
+        test_input = {
+            Input.GROUP_NAME: "test",
+            Input.MEMBER_LOGIN: "test@example.com",
+            Input.CHANNEL_NAME: "Example Channel",
+            Input.ROLE: "Owner",
         }
-
-    @mock.patch("requests.get", side_effect=Util.mocked_requests)
-    @mock.patch("requests.post", side_effect=Util.mocked_requests)
-    def test_add_member_to_channel(self, mock_requests_get, mock_requests_post) -> None:
-        response = self.action.run(self.payload)
-        expected_response = STUB_EXAMPLE_ACTION_RESPONSE
-        self.assertEqual(response, expected_response)
+        response = self.action.run(test_input)
+        self.assertEqual(response, {"success": True})
+        self.action.connection.client.get_group_id_from_name.assert_called_with("test")
+        self.action.connection.client.get_channels.assert_called_with("group-123", "Example Channel")
+        self.action.connection.client.get_user_info.assert_called_with("test@example.com")
+        self.action.connection.client.add_member_to_channel.assert_called_with("group-123", "channel-456", "user-789", "owner")

--- a/plugins/microsoft_teams/unit_test/test_add_member_to_team.py
+++ b/plugins/microsoft_teams/unit_test/test_add_member_to_team.py
@@ -1,0 +1,27 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.add_member_to_team import AddMemberToTeam
+from icon_microsoft_teams.actions.add_member_to_team.schema import Input
+
+from util import Util
+
+
+class TestAddMemberToTeam(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(AddMemberToTeam())
+        self.action.connection.client.get_user_info.return_value = {"id": "user-123", "displayName": "Test User"}
+        self.action.connection.client.get_teams.return_value = [{"id": "group-456", "displayName": "Example Team"}]
+        self.action.connection.client.add_member_to_group.return_value = True
+
+    def test_add_member_to_team(self) -> None:
+        test_input = {Input.TEAM_NAME: "Example Team", Input.MEMBER_LOGIN: "user@example.com"}
+        response = self.action.run(test_input)
+        self.assertEqual(response, {"success": True})
+        self.action.connection.client.get_user_info.assert_called_with("user@example.com")
+        self.action.connection.client.get_teams.assert_called_with("Example Team")
+        self.action.connection.client.add_member_to_group.assert_called_with("group-456", "user-123")

--- a/plugins/microsoft_teams/unit_test/test_create_teams_chat.py
+++ b/plugins/microsoft_teams/unit_test/test_create_teams_chat.py
@@ -3,67 +3,57 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
-from unittest.mock import Mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.create_teams_chat import CreateTeamsChat
 from icon_microsoft_teams.actions.create_teams_chat.schema import CreateTeamsChatInput, CreateTeamsChatOutput
 from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
-from parameterized import parameterized
 
 from util import Util
 
 
-@mock.patch("requests.post", side_effect=Util.mocked_requests)
 class TestCreateTeamsChat(TestCase):
-    @classmethod
-    def setUp(cls) -> None:
-        cls.action = Util.default_connector(CreateTeamsChat())
+    def setUp(self) -> None:
+        self.action = Util.default_connector(CreateTeamsChat())
 
-    @parameterized.expand(
-        [
-            [
-                "valid_one_on_one",
-                Util.load_data("input_valid_oneonone_create_teams_chat"),
-                Util.load_data("expected_valid_oneonone_create_teams_chat"),
-            ],
-            [
-                "valid_group",
-                Util.load_data("input_valid_group_create_teams_chat"),
-                Util.load_data("expected_valid_group_create_teams_chat"),
-            ],
-        ]
-    )
-    def test_create_teams_chat_valid(
-        self, _mock_request: Mock, _test_name: str, input_params: dict, expected: dict
-    ) -> None:
-        validate(input_params, CreateTeamsChatInput.schema)
-        actual = self.action.run(input_params)
-        self.assertEqual(actual, expected)
+    def test_create_one_on_one_chat(self) -> None:
+        expected_result = {
+            "chatType": "oneOnOne",
+            "id": "19:abc123@thread.v2",
+            "createdDateTime": "2023-11-09T12:07:43.167Z",
+        }
+        self.action.connection.client.create_chat.return_value = expected_result
+
+        test_input = {
+            "members": [
+                {"user_info": "user1@example.com", "role": "owner"},
+                {"user_info": "user2@example.com", "role": "owner"},
+            ]
+        }
+        validate(test_input, CreateTeamsChatInput.schema)
+        actual = self.action.run(test_input)
+        self.assertEqual(actual["chat"]["chatType"], "oneOnOne")
         validate(actual, CreateTeamsChatOutput.schema)
 
-    @parameterized.expand(
-        [
-            [
-                "less than members",
-                Util.load_data("input_invalid_create_teams_chat"),
-                "Create chat failed.",
-                "Less than 2 valid members were provided",
+    def test_create_group_chat(self) -> None:
+        expected_result = {
+            "chatType": "group",
+            "id": "19:def456@thread.v2",
+            "topic": "Test Topic",
+            "createdDateTime": "2023-11-09T12:07:43.167Z",
+        }
+        self.action.connection.client.create_chat.return_value = expected_result
+
+        test_input = {
+            "members": [
+                {"user_info": "user1@example.com", "role": "owner"},
+                {"user_info": "user2@example.com", "role": "owner"},
+                {"user_info": "user3@example.com", "role": "guest"},
             ],
-            [
-                "server error",
-                Util.load_data("input_invalid_create_teams_chat_server"),
-                "Create chat failed.",
-                "Error message",
-            ],
-        ]
-    )
-    def test_list_messages_in_chat_invalid(
-        self, _mock_request: Mock, _test_name: str, input_params: dict, cause: str, assistance: str
-    ) -> None:
-        validate(input_params, CreateTeamsChatInput.schema)
-        with self.assertRaises(PluginException) as error:
-            self.action.run(input_params)
-        self.assertEqual(error.exception.cause, cause)
-        self.assertEqual(error.exception.assistance, assistance)
+            "topic": "Test Topic",
+        }
+        validate(test_input, CreateTeamsChatInput.schema)
+        actual = self.action.run(test_input)
+        self.assertEqual(actual["chat"]["chatType"], "group")
+        validate(actual, CreateTeamsChatOutput.schema)

--- a/plugins/microsoft_teams/unit_test/test_create_teams_enabled_group.py
+++ b/plugins/microsoft_teams/unit_test/test_create_teams_enabled_group.py
@@ -1,0 +1,39 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.create_teams_enabled_group import CreateTeamsEnabledGroup
+from icon_microsoft_teams.actions.create_teams_enabled_group.schema import Input
+
+from util import Util
+
+
+class TestCreateTeamsEnabledGroup(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(CreateTeamsEnabledGroup())
+        self.action.connection.client.create_group.return_value = {
+            "id": "new-group-id",
+            "displayName": "Test Group",
+            "description": "A test group",
+            "mailNickname": "TestGroup",
+            "mailEnabled": True,
+            "securityEnabled": False,
+        }
+        self.action.connection.client.enable_teams_for_group.return_value = True
+
+    def test_create_teams_enabled_group(self) -> None:
+        test_input = {
+            Input.GROUP_NAME: "Test Group",
+            Input.GROUP_DESCRIPTION: "A test group",
+            Input.MAIL_NICKNAME: "TestGroup",
+            Input.MAIL_ENABLED: True,
+            Input.OWNERS: ["owner@example.com"],
+            Input.MEMBERS: ["member@example.com"],
+        }
+        response = self.action.run(test_input)
+        self.assertEqual(response["group"]["displayName"], "Test Group")
+        self.action.connection.client.create_group.assert_called_once()
+        self.action.connection.client.enable_teams_for_group.assert_called_with("new-group-id")

--- a/plugins/microsoft_teams/unit_test/test_delete_team.py
+++ b/plugins/microsoft_teams/unit_test/test_delete_team.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.delete_team import DeleteTeam
+from icon_microsoft_teams.actions.delete_team.schema import Input
+
+from util import Util
+
+
+class TestDeleteTeam(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(DeleteTeam())
+        self.action.connection.client.get_group_id_from_name.return_value = "group-123"
+        self.action.connection.client.delete_group.return_value = True
+
+    def test_delete_team(self) -> None:
+        test_input = {Input.TEAM_NAME: "Test Team"}
+        response = self.action.run(test_input)
+        self.assertEqual(response, {"success": True})
+        self.action.connection.client.get_group_id_from_name.assert_called_with("Test Team")
+        self.action.connection.client.delete_group.assert_called_with("group-123")

--- a/plugins/microsoft_teams/unit_test/test_get_channels_for_team.py
+++ b/plugins/microsoft_teams/unit_test/test_get_channels_for_team.py
@@ -1,0 +1,29 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.get_channels_for_team import GetChannelsForTeam
+from icon_microsoft_teams.actions.get_channels_for_team.schema import Input
+
+from util import Util
+
+
+class TestGetChannelsForTeam(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(GetChannelsForTeam())
+        self.action.connection.client.get_teams.return_value = [{"id": "team-123", "displayName": "Example Team"}]
+        self.action.connection.client.get_channels.return_value = [
+            {"id": "channel-1", "displayName": "General", "description": "Default channel"},
+            {"id": "channel-2", "displayName": "Alerts", "description": "Alert channel"},
+        ]
+
+    def test_get_channels_for_team(self) -> None:
+        test_input = {Input.TEAM_NAME: "Example Team"}
+        response = self.action.run(test_input)
+        self.assertEqual(len(response["channels"]), 2)
+        self.assertEqual(response["channels"][0]["displayName"], "General")
+        self.action.connection.client.get_teams.assert_called_with("Example Team")
+        self.action.connection.client.get_channels.assert_called_with("team-123", None)

--- a/plugins/microsoft_teams/unit_test/test_get_message_in_channel.py
+++ b/plugins/microsoft_teams/unit_test/test_get_message_in_channel.py
@@ -3,8 +3,7 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
-from unittest.mock import Mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.get_message_in_channel import GetMessageInChannel
 from icon_microsoft_teams.actions.get_message_in_channel.schema import (
@@ -12,7 +11,6 @@ from icon_microsoft_teams.actions.get_message_in_channel.schema import (
     GetMessageInChannelOutput,
     Input,
 )
-from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from jsonschema import validate
 
 from util import Util
@@ -21,17 +19,27 @@ from util import Util
 class TestGetMessageInChannel(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(GetMessageInChannel())
-        self.payload = {
+
+    def test_get_message_in_channel(self) -> None:
+        expected_message = {
+            "id": "1234567890",
+            "messageType": "message",
+            "body": {"contentType": "text", "content": "Hello World"},
+            "from": {"user": {"id": "user-123", "displayName": "Test User"}},
+            "channelIdentity": {"teamId": "example-team-id", "channelId": "11:examplechannel.name"},
+        }
+        self.action.connection.client.get_channel_message.return_value = expected_message
+
+        test_input = {
             Input.TEAM_ID: "example-team-id",
             Input.CHANNEL_ID: "11:examplechannel.name",
             Input.MESSAGE_ID: "1234567890",
             Input.REPLY_ID: "1234567891",
         }
-
-    @mock.patch("requests.get", side_effect=Util.mocked_requests)
-    def test_get_message_in_channel(self, mock: Mock) -> None:
-        validate(self.payload, GetMessageInChannelInput.schema)
-        response = self.action.run(self.payload)
-        expected_response = remove_null_and_clean(Util.load_data("get_message_in_channel"))
-        self.assertEqual(response["message"], expected_response)
+        validate(test_input, GetMessageInChannelInput.schema)
+        response = self.action.run(test_input)
+        self.assertEqual(response["message"], expected_message)
         validate(response, GetMessageInChannelOutput.schema)
+        self.action.connection.client.get_channel_message.assert_called_once_with(
+            "example-team-id", "11:examplechannel.name", "1234567890", "1234567891"
+        )

--- a/plugins/microsoft_teams/unit_test/test_get_message_in_chat.py
+++ b/plugins/microsoft_teams/unit_test/test_get_message_in_chat.py
@@ -3,31 +3,37 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
-from unittest.mock import Mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.get_message_in_chat import GetMessageInChat
-from icon_microsoft_teams.actions.get_message_in_chat.schema import GetMessageInChatInput, GetMessageInChatOutput, Input
-from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
+from icon_microsoft_teams.actions.get_message_in_chat.schema import Input, GetMessageInChatInput, GetMessageInChatOutput
 from jsonschema import validate
 
 from util import Util
 
 
 class TestGetMessageInChat(TestCase):
-    def setUp(self) -> None:
-        self.action = Util.default_connector(GetMessageInChat())
-        self.payload = {
-            Input.USERNAME: "user@example.com",
-            Input.CHAT_ID: "11:examplechat.name",
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(GetMessageInChat())
+
+    def test_get_message_in_chat(self) -> None:
+        expected_message = {
+            "id": "1234567890",
+            "messageType": "message",
+            "body": {"contentType": "text", "content": "Hello World"},
+            "from": {"user": {"id": "user-123", "displayName": "Test User"}},
+        }
+        self.action.connection.client.get_chat_message.return_value = expected_message
+
+        test_input = {
+            Input.CHAT_ID: "19:abc123@thread.v2",
             Input.MESSAGE_ID: "1234567890",
         }
+        validate(test_input, GetMessageInChatInput.schema)
+        actual = self.action.run(test_input)
 
-    @mock.patch("requests.get", side_effect=Util.mocked_requests)
-    def test_get_message_in_chat(self, mock: Mock) -> None:
-        validate(self.payload, GetMessageInChatInput.schema)
-        response = self.action.run(self.payload)
-
-        expected_response = remove_null_and_clean(Util.load_data("get_message_in_chat"))
-        self.assertEqual(response["message"], expected_response)
-        validate(response["message"], GetMessageInChatOutput.schema)
+        self.action.connection.client.get_chat_message.assert_called_once_with("19:abc123@thread.v2", "1234567890")
+        self.assertEqual(actual["message"]["id"], "1234567890")
+        self.assertEqual(actual["message"]["body"]["content"], "Hello World")
+        validate(actual, GetMessageInChatOutput.schema)

--- a/plugins/microsoft_teams/unit_test/test_get_reply_list.py
+++ b/plugins/microsoft_teams/unit_test/test_get_reply_list.py
@@ -3,12 +3,10 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
-from unittest.mock import Mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.get_reply_list import GetReplyList
 from icon_microsoft_teams.actions.get_reply_list.schema import GetReplyListInput, GetReplyListOutput, Input
-from icon_microsoft_teams.util.komand_clean_with_nulls import remove_null_and_clean
 from jsonschema import validate
 
 from util import Util
@@ -17,16 +15,23 @@ from util import Util
 class TestGetReplyList(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(GetReplyList())
-        self.payload = {
+        self.action.connection.client.get_teams.return_value = [{"id": "12345", "displayName": "Example Team"}]
+        self.action.connection.client.get_channels.return_value = [{"id": "56789", "displayName": "Example Channel"}]
+
+    def test_get_reply_list(self) -> None:
+        expected_replies = [
+            {"id": "reply-1", "body": {"content": "First reply", "contentType": "text"}},
+            {"id": "reply-2", "body": {"content": "Second reply", "contentType": "text"}},
+        ]
+        self.action.connection.client.get_message_replies.return_value = expected_replies
+
+        test_input = {
             Input.TEAM_NAME: "Example Team",
             Input.CHANNEL_NAME: "Example Channel",
             Input.MESSAGE_ID: "1234567890",
         }
-
-    @mock.patch("requests.get", side_effect=Util.mocked_requests)
-    def test_get_reply_list(self, mock: Mock) -> None:
-        validate(self.payload, GetReplyListInput.schema)
-        response = self.action.run(self.payload)
-        expected_response = remove_null_and_clean(Util.load_data("get_reply_list"))
-        self.assertEqual(response["messages"], expected_response.get("value"))
+        validate(test_input, GetReplyListInput.schema)
+        response = self.action.run(test_input)
+        self.assertEqual(response["messages"], expected_replies)
         validate(response, GetReplyListOutput.schema)
+        self.action.connection.client.get_message_replies.assert_called_once_with("12345", "56789", "1234567890")

--- a/plugins/microsoft_teams/unit_test/test_get_teams.py
+++ b/plugins/microsoft_teams/unit_test/test_get_teams.py
@@ -1,0 +1,46 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.get_teams import GetTeams
+from icon_microsoft_teams.actions.get_teams.schema import Input, GetTeamsInput, GetTeamsOutput
+from jsonschema import validate
+
+from util import Util
+
+
+class TestGetTeams(TestCase):
+    @classmethod
+    def setUpClass(cls) -> None:
+        cls.action = Util.default_connector(GetTeams())
+
+    def test_get_teams(self) -> None:
+        self.action.connection.client.get_teams.reset_mock()
+        self.action.connection.client.get_teams.return_value = [
+            {"id": "12345", "displayName": "Example Team", "description": "A test team"}
+        ]
+
+        test_input = {Input.TEAM_NAME: "Example"}
+        validate(test_input, GetTeamsInput.schema)
+        actual = self.action.run(test_input)
+
+        self.action.connection.client.get_teams.assert_called_once_with("Example", explicit=False)
+        self.assertEqual(len(actual["teams"]), 1)
+        self.assertEqual(actual["teams"][0]["displayName"], "Example Team")
+        validate(actual, GetTeamsOutput.schema)
+
+    def test_get_all_teams(self) -> None:
+        self.action.connection.client.get_teams.return_value = [
+            {"id": "12345", "displayName": "Team A", "description": "First team"},
+            {"id": "67890", "displayName": "Team B", "description": "Second team"},
+        ]
+
+        test_input = {Input.TEAM_NAME: ""}
+        validate(test_input, GetTeamsInput.schema)
+        actual = self.action.run(test_input)
+
+        self.assertEqual(len(actual["teams"]), 2)
+        validate(actual, GetTeamsOutput.schema)

--- a/plugins/microsoft_teams/unit_test/test_list_messages_in_chat.py
+++ b/plugins/microsoft_teams/unit_test/test_list_messages_in_chat.py
@@ -3,62 +3,29 @@ import sys
 
 sys.path.append(os.path.abspath("../"))
 
-from unittest import TestCase, mock
-from unittest.mock import Mock
+from unittest import TestCase
 
 from icon_microsoft_teams.actions.list_messages_in_chat import ListMessagesInChat
 from icon_microsoft_teams.actions.list_messages_in_chat.schema import ListMessagesInChatInput, ListMessagesInChatOutput
-from insightconnect_plugin_runtime.exceptions import PluginException
 from jsonschema import validate
-from parameterized import parameterized
 
 from util import Util
 
 
-@mock.patch("requests.get", side_effect=Util.mocked_requests)
 class TestListMessagesInChat(TestCase):
-    @classmethod
-    def setUp(cls) -> None:
-        cls.action = Util.default_connector(ListMessagesInChat())
+    def setUp(self) -> None:
+        self.action = Util.default_connector(ListMessagesInChat())
 
-    @parameterized.expand(
-        [
-            [
-                "valid",
-                {"chat_id": "valid_chat_id"},
-                Util.load_data("expected_valid_list_messages_in_chat"),
-            ]
+    def test_list_messages_in_chat_valid(self) -> None:
+        expected_messages = [
+            {"id": "msg-1", "body": {"content": "Hello", "contentType": "text"}},
+            {"id": "msg-2", "body": {"content": "World", "contentType": "text"}},
         ]
-    )
-    def test_list_messages_in_chat_valid(
-        self, _mock_request: Mock, _test_name: str, input_params: dict, expected: dict
-    ) -> None:
-        validate(input_params, ListMessagesInChatInput.schema)
-        actual = self.action.run(input_params)
-        self.assertEqual(actual, expected)
+        self.action.connection.client.list_chat_messages.return_value = expected_messages
+
+        test_input = {"chat_id": "valid_chat_id"}
+        validate(test_input, ListMessagesInChatInput.schema)
+        actual = self.action.run(test_input)
+        self.assertEqual(actual, {"messages": expected_messages})
         validate(actual, ListMessagesInChatOutput.schema)
-
-    @parameterized.expand(
-        [
-            [
-                "bad_request_invalid",
-                {"chat_id": "invalid_chat_id_bad_rquest"},
-                "The server is unable to process the request.",
-                "Verify your plugin input is correct and not malformed and try again. If the issue persists, please contact support.",
-            ],
-            [
-                "invalid_json",
-                {"chat_id": "invalid_chat_id_empty_json"},
-                "Received an unexpected response from the server.",
-                "(non-JSON or no response was received).",
-            ],
-        ]
-    )
-    def test_list_messages_in_chat_invalid(
-        self, _mock_request: Mock, _test_name: str, input_params: dict, cause: str, assistance: str
-    ) -> None:
-        validate(input_params, ListMessagesInChatInput.schema)
-        with self.assertRaises(PluginException) as error:
-            self.action.run(input_params)
-        self.assertEqual(error.exception.cause, cause)
-        self.assertEqual(error.exception.assistance, assistance)
+        self.action.connection.client.list_chat_messages.assert_called_once_with("valid_chat_id")

--- a/plugins/microsoft_teams/unit_test/test_new_message_received.py
+++ b/plugins/microsoft_teams/unit_test/test_new_message_received.py
@@ -12,6 +12,8 @@ from icon_microsoft_teams.triggers.new_message_received import NewMessageReceive
 from insightconnect_plugin_runtime.exceptions import PluginException
 from parameterized import parameterized
 
+from util import MockConnection
+
 GET_INDICATORS_RESPONSE = {
     "domains": [],
     "urls": [],
@@ -24,21 +26,11 @@ GET_INDICATORS_RESPONSE = {
 }
 
 
-# Get a real payload from file
 def read_file_to_string(filename):
     with open(filename) as my_file:
         return my_file.read()
 
 
-class MockConnection:
-    def __init__(self) -> None:
-        self.resource_endpoint = "https://graph.microsoft.com"
-
-    def get_headers(self):
-        return {"header": "value"}
-
-
-# This method will be used by the mock to replace requests.get
 def mocked_requests_get(*args, **kwargs):
     class MockResponse:
         def __init__(self, data, status_code) -> None:
@@ -57,7 +49,6 @@ def mocked_requests_get(*args, **kwargs):
     if args[0] == "http://somefakeendpoint.com":
         return MockResponse(messages_payload, 200)
 
-    print(f"Attempted to get:\n{args[0]}")
     return MockResponse(None, 404)
 
 
@@ -83,7 +74,7 @@ class TestNewMessageReceived(TestCase):
             self.nmr.compile_message_content("[")
 
     @mock.patch("requests.get", side_effect=mocked_requests_get)
-    def test_get_sorted_messages(self, mockGet) -> None:
+    def test_get_sorted_messages(self, mock_get) -> None:
         messages = self.nmr.get_sorted_messages("http://somefakeendpoint.com")
         self.assertIsNotNone(messages)
         self.assertEqual(messages[0].get("body").get("content"), "This should be first")
@@ -110,21 +101,16 @@ class TestNewMessageReceived(TestCase):
         ]
     )
     @mock.patch("requests.get", side_effect=mocked_requests_get)
-    def test_indicators(self, message_number, expected_result, mockGet) -> None:
+    def test_indicators(self, message_number, expected_result, mock_get) -> None:
         messages = self.nmr.get_sorted_messages("http://somefakeendpoint.com")
         indicators = [self.nmr.get_indicators(message.get("body", {}).get("content")) for message in messages]
         self.assertEqual(indicators[message_number], expected_result)
 
     def test_setup_endpoint(self) -> None:
-        # This was a mess to figure out...because I'm importing with from I have to refer to the class it's being
-        #  called from and not the actual function that's being imported
-        with mock.patch(
-            "icon_microsoft_teams.triggers.new_message_received.trigger.get_teams_from_microsoft",
-            return_value=[{"id": "team"}],
-        ):
-            with mock.patch(
-                "icon_microsoft_teams.triggers.new_message_received.trigger.get_channels_from_microsoft",
-                return_value=[{"id": "channel"}],
-            ):
-                endpoint = self.nmr.setup_endpoint("channel", "team")
-        self.assertEqual("https://graph.microsoft.com/beta/teams/team/channels/channel/messages", endpoint)
+        self.nmr.connection.client.get_teams.return_value = [{"id": "team-id"}]
+        self.nmr.connection.client.get_channels.return_value = [{"id": "channel-id"}]
+
+        endpoint = self.nmr.setup_endpoint("channel", "team")
+        self.assertEqual("https://graph.microsoft.com/v1.0/teams/team-id/channels/channel-id/messages", endpoint)
+        self.nmr.connection.client.get_teams.assert_called_with("team")
+        self.nmr.connection.client.get_channels.assert_called_with("team-id", "channel")

--- a/plugins/microsoft_teams/unit_test/test_remove_channel_from_team.py
+++ b/plugins/microsoft_teams/unit_test/test_remove_channel_from_team.py
@@ -1,0 +1,25 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.remove_channel_from_team import RemoveChannelFromTeam
+from icon_microsoft_teams.actions.remove_channel_from_team.schema import Input
+
+from util import Util
+
+
+class TestRemoveChannelFromTeam(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(RemoveChannelFromTeam())
+        self.action.connection.client.get_teams.return_value = [{"id": "team-123", "displayName": "Example Team"}]
+        self.action.connection.client.get_channels.return_value = [{"id": "channel-456", "displayName": "Old Channel"}]
+        self.action.connection.client.delete_channel.return_value = True
+
+    def test_remove_channel_from_team(self) -> None:
+        test_input = {Input.TEAM_NAME: "Example Team", Input.CHANNEL_NAME: "Old Channel"}
+        response = self.action.run(test_input)
+        self.assertEqual(response, {"success": True})
+        self.action.connection.client.delete_channel.assert_called_with("team-123", "channel-456")

--- a/plugins/microsoft_teams/unit_test/test_remove_member_from_team.py
+++ b/plugins/microsoft_teams/unit_test/test_remove_member_from_team.py
@@ -1,0 +1,26 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.remove_member_from_team import RemoveMemberFromTeam
+from icon_microsoft_teams.actions.remove_member_from_team.schema import Input
+
+from util import Util
+
+
+class TestRemoveMemberFromTeam(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(RemoveMemberFromTeam())
+        self.action.connection.client.get_user_info.return_value = {"id": "user-123", "displayName": "Test User"}
+        self.action.connection.client.get_teams.return_value = [{"id": "group-456", "displayName": "Example Team"}]
+        self.action.connection.client.remove_member_from_group.return_value = True
+
+    def test_remove_member_from_team(self) -> None:
+        test_input = {Input.TEAM_NAME: "Example Team", Input.MEMBER_LOGIN: "user@example.com"}
+        response = self.action.run(test_input)
+        self.assertEqual(response, {"success": True})
+        self.action.connection.client.get_user_info.assert_called_with("user@example.com")
+        self.action.connection.client.remove_member_from_group.assert_called_with("group-456", "user-123")

--- a/plugins/microsoft_teams/unit_test/test_send_html_message.py
+++ b/plugins/microsoft_teams/unit_test/test_send_html_message.py
@@ -16,7 +16,9 @@ class TestSendHtmlMessage(TestCase):
     def setUp(self) -> None:
         self.action = Util.default_connector(SendHtmlMessage())
         self.action.connection.client.get_teams.return_value = [{"id": "team-123", "displayName": "Example Team"}]
-        self.action.connection.client.get_channels.return_value = [{"id": "channel-456", "displayName": "Example Channel"}]
+        self.action.connection.client.get_channels.return_value = [
+            {"id": "channel-456", "displayName": "Example Channel"}
+        ]
         self.action.connection.bot.send_channel_message.return_value = {"id": "msg-001"}
 
     def test_send_html_message(self) -> None:

--- a/plugins/microsoft_teams/unit_test/test_send_html_message.py
+++ b/plugins/microsoft_teams/unit_test/test_send_html_message.py
@@ -1,0 +1,38 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.send_html_message import SendHtmlMessage
+from icon_microsoft_teams.actions.send_html_message.schema import Input, SendHtmlMessageOutput
+from jsonschema import validate
+
+from util import Util
+
+
+class TestSendHtmlMessage(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(SendHtmlMessage())
+        self.action.connection.client.get_teams.return_value = [{"id": "team-123", "displayName": "Example Team"}]
+        self.action.connection.client.get_channels.return_value = [{"id": "channel-456", "displayName": "Example Channel"}]
+        self.action.connection.bot.send_channel_message.return_value = {"id": "msg-001"}
+
+    def test_send_html_message(self) -> None:
+        test_input = {
+            Input.TEAM_NAME: "Example Team",
+            Input.CHANNEL_NAME: "Example Channel",
+            Input.MESSAGE_CONTENT: "<b>Hello World</b>",
+        }
+        response = self.action.run(test_input)
+        self.assertEqual(response["message"]["body"]["content"], "<b>Hello World</b>")
+        self.assertEqual(response["message"]["body"]["contentType"], "html")
+        validate(response, SendHtmlMessageOutput.schema)
+        self.action.connection.bot.send_channel_message.assert_called_once_with(
+            team_id="team-123",
+            channel_id="channel-456",
+            message="<b>Hello World</b>",
+            content_type="html",
+            thread_id=None,
+        )

--- a/plugins/microsoft_teams/unit_test/test_send_message.py
+++ b/plugins/microsoft_teams/unit_test/test_send_message.py
@@ -4,7 +4,6 @@ import sys
 sys.path.append(os.path.abspath("../"))
 
 from unittest import TestCase
-from unittest.mock import patch
 
 from icon_microsoft_teams.actions.send_message import SendMessage
 from icon_microsoft_teams.actions.send_message.schema import Input, SendMessageInput, SendMessageOutput
@@ -15,29 +14,70 @@ from parameterized import parameterized
 from util import Util
 
 
-@patch("requests.get", side_effect=Util.mocked_requests)
-@patch("requests.post", side_effect=Util.mocked_requests)
 class TestSendMessage(TestCase):
     @classmethod
     def setUpClass(cls) -> None:
         cls.action = Util.default_connector(SendMessage())
 
-    @parameterized.expand(Util.load_data("send_message_parameters").get("parameters"))
-    def test_send_message(
-        self, mocked_get, mocked_post, name, team, channel, thread_id, chat_id, message, expected
-    ) -> None:
-        test_input = {Input.MESSAGE: message}
-        if team:
-            test_input[Input.TEAM_NAME] = team
-        if channel:
-            test_input[Input.CHANNEL_NAME] = channel
-        if thread_id:
-            test_input[Input.THREAD_ID] = thread_id
-        if chat_id:
-            test_input[Input.CHAT_ID] = chat_id
+    def test_send_message_to_channel(self) -> None:
+        self.action.connection.client.get_teams.return_value = [{"id": "12345", "displayName": "Example Team"}]
+        self.action.connection.client.get_channels.return_value = [{"id": "56789", "displayName": "Example Channel"}]
+        self.action.connection.bot.send_channel_message.return_value = {"id": "msg-001"}
+
+        test_input = {
+            Input.MESSAGE: "Hello World",
+            Input.TEAM_NAME: "Example Team",
+            Input.CHANNEL_NAME: "Example Channel",
+        }
         validate(test_input, SendMessageInput.schema)
         actual = self.action.run(test_input)
-        self.assertEqual(actual, expected)
+
+        self.action.connection.bot.send_channel_message.assert_called_once_with(
+            team_id="12345",
+            channel_id="56789",
+            message="Hello World",
+            content_type="text",
+            thread_id=None,
+        )
+        self.assertEqual(actual["message"]["body"]["content"], "Hello World")
+        self.assertEqual(actual["message"]["id"], "msg-001")
+        validate(actual, SendMessageOutput.schema)
+
+    def test_send_message_to_chat(self) -> None:
+        self.action.connection.bot.send_chat_message.return_value = {"id": "msg-002"}
+
+        test_input = {
+            Input.MESSAGE: "Chat message",
+            Input.CHAT_ID: "19:abc123@thread.v2",
+        }
+        validate(test_input, SendMessageInput.schema)
+        actual = self.action.run(test_input)
+
+        self.action.connection.bot.send_chat_message.assert_called_once_with("19:abc123@thread.v2", "Chat message")
+        self.assertEqual(actual["message"]["body"]["content"], "Chat message")
+        validate(actual, SendMessageOutput.schema)
+
+    def test_send_message_to_thread(self) -> None:
+        self.action.connection.client.get_teams.return_value = [{"id": "12345", "displayName": "Example Team"}]
+        self.action.connection.client.get_channels.return_value = [{"id": "56789", "displayName": "Example Channel"}]
+        self.action.connection.bot.send_channel_message.return_value = {"id": "msg-003"}
+
+        test_input = {
+            Input.MESSAGE: "Thread reply",
+            Input.TEAM_NAME: "Example Team",
+            Input.CHANNEL_NAME: "Example Channel",
+            Input.THREAD_ID: "1636037542013",
+        }
+        validate(test_input, SendMessageInput.schema)
+        actual = self.action.run(test_input)
+
+        self.action.connection.bot.send_channel_message.assert_called_with(
+            team_id="12345",
+            channel_id="56789",
+            message="Thread reply",
+            content_type="text",
+            thread_id="1636037542013",
+        )
         validate(actual, SendMessageOutput.schema)
 
     @parameterized.expand(
@@ -50,8 +90,6 @@ class TestSendMessage(TestCase):
                 None,
                 "test message",
                 "No chat ID or team ID with channel ID was provided.",
-                "Please provide the chat ID to send the chat message or the team and channel details(name or GUID) to "
-                "send the message to a specific channel.",
             ],
             [
                 "without_channel",
@@ -61,8 +99,6 @@ class TestSendMessage(TestCase):
                 None,
                 "test message",
                 "No chat ID or team ID with channel ID was provided.",
-                "Please provide the chat ID to send the chat message or the team and channel details(name or GUID) to "
-                "send the message to a specific channel.",
             ],
             [
                 "without_team",
@@ -72,25 +108,10 @@ class TestSendMessage(TestCase):
                 None,
                 "test message",
                 "No chat ID or team ID with channel ID was provided.",
-                "Please provide the chat ID to send the chat message or the team and channel details(name or GUID) to "
-                "send the message to a specific channel.",
-            ],
-            [
-                "without_channel_and_team",
-                None,
-                None,
-                "1636037542013",
-                None,
-                "test message",
-                "No chat ID or team ID with channel ID was provided.",
-                "Please provide the chat ID to send the chat message or the team and channel details(name or GUID) to "
-                "send the message to a specific channel.",
             ],
         ]
     )
-    def test_send_message_bad(
-        self, mocked_get, mocked_post, name, team, channel, thread_id, chat_id, message, cause, assistance
-    ) -> None:
+    def test_send_message_bad(self, name, team, channel, thread_id, chat_id, message, cause) -> None:
         test_input = {Input.MESSAGE: message}
         if team:
             test_input[Input.TEAM_NAME] = team
@@ -101,7 +122,6 @@ class TestSendMessage(TestCase):
         if chat_id:
             test_input[Input.CHAT_ID] = chat_id
         validate(test_input, SendMessageInput.schema)
-        with self.assertRaises(PluginException) as e:
+        with self.assertRaises(PluginException) as context:
             self.action.run(test_input)
-        self.assertEqual(e.exception.cause, cause)
-        self.assertEqual(e.exception.assistance, assistance)
+        self.assertEqual(context.exception.cause, cause)

--- a/plugins/microsoft_teams/unit_test/test_send_message_by_guid.py
+++ b/plugins/microsoft_teams/unit_test/test_send_message_by_guid.py
@@ -1,0 +1,47 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from unittest import TestCase
+
+from icon_microsoft_teams.actions.send_message_by_guid import SendMessageByGuid
+from icon_microsoft_teams.actions.send_message_by_guid.schema import Input, SendMessageByGuidOutput
+from jsonschema import validate
+
+from util import Util
+
+
+class TestSendMessageByGuid(TestCase):
+    def setUp(self) -> None:
+        self.action = Util.default_connector(SendMessageByGuid())
+        self.action.connection.bot.send_channel_message.return_value = {"id": "msg-001"}
+
+    def test_send_message_by_guid(self) -> None:
+        test_input = {
+            Input.TEAM_GUID: "team-guid-123",
+            Input.CHANNEL_GUID: "channel-guid-456",
+            Input.IS_HTML: False,
+            Input.MESSAGE: "Hello World",
+        }
+        response = self.action.run(test_input)
+        self.assertEqual(response["message"]["body"]["content"], "Hello World")
+        self.assertEqual(response["message"]["body"]["contentType"], "text")
+        validate(response, SendMessageByGuidOutput.schema)
+        self.action.connection.bot.send_channel_message.assert_called_once_with(
+            team_id="team-guid-123",
+            channel_id="channel-guid-456",
+            message="Hello World",
+            content_type="text",
+        )
+
+    def test_send_html_message_by_guid(self) -> None:
+        test_input = {
+            Input.TEAM_GUID: "team-guid-123",
+            Input.CHANNEL_GUID: "channel-guid-456",
+            Input.IS_HTML: True,
+            Input.MESSAGE: "<b>Bold</b>",
+        }
+        response = self.action.run(test_input)
+        self.assertEqual(response["message"]["body"]["contentType"], "html")
+        validate(response, SendMessageByGuidOutput.schema)

--- a/plugins/microsoft_teams/unit_test/util.py
+++ b/plugins/microsoft_teams/unit_test/util.py
@@ -2,19 +2,53 @@ import json
 import logging
 import os
 import sys
-
-import requests
+from unittest.mock import MagicMock
 
 sys.path.append(os.path.abspath("../"))
 
 
+class MockGraphApiClient:
+    """Mock Graph API client for unit tests."""
+
+    def __init__(self):
+        self.get_teams = MagicMock()
+        self.get_channels = MagicMock()
+        self.create_channel = MagicMock()
+        self.delete_channel = MagicMock()
+        self.get_channel_messages = MagicMock()
+        self.get_channel_message = MagicMock()
+        self.get_chat_message = MagicMock()
+        self.list_chat_messages = MagicMock()
+        self.get_message_replies = MagicMock()
+        self.get_user_info = MagicMock()
+        self.add_member_to_group = MagicMock()
+        self.remove_member_from_group = MagicMock()
+        self.add_group_owner = MagicMock()
+        self.add_member_to_channel = MagicMock()
+        self.create_group = MagicMock()
+        self.delete_group = MagicMock()
+        self.get_group_id_from_name = MagicMock()
+        self.enable_teams_for_group = MagicMock()
+        self.create_chat = MagicMock()
+
+
+class MockBotService:
+    """Mock Bot Framework service for unit tests."""
+
+    def __init__(self):
+        self.send_channel_message = MagicMock()
+        self.send_chat_message = MagicMock()
+
+
 class MockConnection:
-    def __init__(self) -> None:
+    def __init__(self):
         self.tenant_id = "1"
         self.resource_endpoint = "https://graph.microsoft.com"
+        self.client = MockGraphApiClient()
+        self.bot = MockBotService()
 
-    def get_headers(self) -> None:
-        return
+    def get_headers(self, force_refresh=False):
+        return {"Authorization": "Bearer mock_token", "Content-Type": "application/json"}
 
 
 class Util:
@@ -38,83 +72,3 @@ class Util:
                 os.path.join(os.path.dirname(os.path.realpath(__file__)), f"payloads/{filename}.json.resp")
             )
         )
-
-    @staticmethod
-    def mocked_requests(*args, **kwargs):
-        class MockResponse:
-            def __init__(self, filename, status_code) -> None:
-                self.filename = filename
-                self.status_code = status_code
-                if self.filename == "not_found":
-                    self.text = 'Response was: {"message": "Not Found"}'
-                elif self.filename == "already_exists":
-                    self.text = 'Response was: {"message": "Already Exists"}'
-                else:
-                    self.text = "Error message"
-
-            def json(self):
-                return Util.load_data(self.filename)
-
-            def raise_for_status(self):
-                if self.filename in [
-                    "response_invalid_group_create_teams_chat",
-                    "response_invalid_list_messages_in_chat_bad_json",
-                ]:
-                    raise ValueError("error")
-                if self.filename in ["response_invalid_list_messages_in_chat"]:
-                    raise requests.HTTPError()
-                else:
-                    return
-
-        if (
-            args[0]
-            == "https://graph.microsoft.com/beta/groups?$filter=resourceProvisioningOptions/Any(x:x eq 'Team') and displayName eq 'Example%20Team'"
-        ):
-            return MockResponse("get_teams", 200)
-        if args[0] == "https://graph.microsoft.com/beta/1/teams/12345/channels":
-            return MockResponse("get_channels", 200)
-        if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels":
-            return MockResponse("add_channel_to_team", 201)
-        if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels/56789/messages":
-            return MockResponse("send_message_channel", 200)
-        if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels/56789/members/":
-            return MockResponse("get_members", 201)
-        if args[0] == "https://graph.microsoft.com/beta/teams/12345/channels/56789/messages/1636037542013/replies":
-            return MockResponse("send_message_thread", 200)
-        if args[0] == "https://graph.microsoft.com/beta/chats/19:10000_20000@unq.gbl.spaces/messages":
-            return MockResponse("send_message_chat", 200)
-        if args[0] == "https://graph.microsoft.com/v1.0/1/users?$filter=userPrincipalName eq 'test'":
-            return MockResponse("get_user_info", 200)
-        if args[0] == "https://graph.microsoft.com/v1.0/1/groups?$filter=displayName eq 'test'":
-            return MockResponse("get_group_id_from_name", 200)
-        if args[0] == "https://graph.microsoft.com/beta/groups/12345/owners/$ref":
-            return MockResponse("no_content", 204)
-        if (
-            args[0]
-            == "https://graph.microsoft.com/beta/1/teams/example-team-id/channels/11:examplechannel.name/messages/1234567890/replies/1234567891"
-        ):
-            return MockResponse("get_message_in_channel", 200)
-        if (
-            args[0]
-            == "https://graph.microsoft.com/beta/1/users/user@example.com/chats/11:examplechat.name/messages/1234567890"
-        ):
-            return MockResponse("get_message_in_chat", 200)
-        if args[0] == "https://graph.microsoft.com/beta/1/teams/12345/channels/56789/messages/1234567890/replies":
-            return MockResponse("get_reply_list", 200)
-        if args[0] == "https://graph.microsoft.com/beta/1/chats/valid_chat_id/messages/":
-            return MockResponse("response_valid_list_messages_in_chat", 200)
-        if args[0] == "https://graph.microsoft.com/beta/1/chats/invalid_chat_id_bad_rquest/messages/":
-            return MockResponse("response_invalid_list_messages_in_chat", 400)
-        if args[0] == "https://graph.microsoft.com/beta/1/chats/invalid_chat_id_empty_json/messages/":
-            return MockResponse("response_invalid_list_messages_in_chat_bad_json", 200)
-
-        if args[0] == "https://graph.microsoft.com/beta/chats/":
-            if kwargs.get("json", {}).get("chatType", "") == "oneOnOne":
-                return MockResponse("response_valid_oneonone_create_teams_chat", 201)
-            elif kwargs.get("json", {}).get("chatType", "") == "group":
-                if "500" in kwargs.get("json", {}).get("members", [])[0].get("user@odata.bind", ""):
-                    return MockResponse("response_invalid_group_create_teams_chat", 500)
-                else:
-                    return MockResponse("response_valid_group_create_teams_chat", 201)
-
-        raise Exception("Not implemented")


### PR DESCRIPTION
## 🎫 Ticket

N/A

## 🧩 Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Other

## 🧠 Background & Motivation

The Microsoft Teams plugin required a dedicated user account with username/password (ROPC OAuth2 flow) to function. This created several operational problems:

- **MFA conflicts** — the service account couldn't use MFA, creating a security exception
- **Licensing costs** — a dedicated Microsoft 365 license was required for the service account
- **Security risk** — storing user credentials and bypassing MFA for automation is a compliance concern
- **Deprecated flow** — Microsoft has been discouraging ROPC and may deprecate it

This PR eliminates the user account entirely by switching to app-only authentication (client_credentials) for Graph API operations and Bot Framework for message sending.

## ✨ What Changed

**Authentication (breaking change):**
- Removed `username_password` from the connection (connection_version bumped to 8)
- Switched from ROPC (`grant_type: password`) to `client_credentials` OAuth2 flow
- Upgraded from legacy `/oauth2/token` (v1) to `/oauth2/v2.0/token` (v2) endpoint
- Uses `scope: https://graph.microsoft.com/.default` instead of `resource` parameter

**Message sending:**
- Added Bot Framework REST API integration for all send actions (`send_message`, `send_message_by_guid`, `send_html_message`)
- Messages now appear as coming from a bot identity rather than a user
- Bot authenticates via the app's own tenant (single-tenant bot support)

**API modernization:**
- Migrated all endpoints from `/beta` to `/v1.0` (GA)
- Removed spurious `{tenant_id}` from Graph API resource paths (tenant is determined by the token)
- Removed `username` input from `get_message_in_chat` action (app permissions use chat_id directly)

**Architecture refactor:**
- New `util/graph_api_client.py` — proper API client class with centralized error handling, pagination, and domain-specific helper methods
- New `util/bot_service.py` — Bot Framework service class with token management and retry logic
- New `util/constants.py` — centralized constants, timeout values, and HTTP error map
- All actions refactored to use `self.connection.client` (Graph) and `self.connection.bot` (messaging)

**Code quality:**
- All prospector issues resolved (mccabe complexity, bandit, pylint)
- SDK updated to 6.5.1
- All unit tests rewritten to mock at client level instead of requests level
- 37 tests passing

## 🧪 Testing

**Unit tests (37 passing):**
- Every action has a dedicated test class mocking the `GraphApiClient` and `BotService`
- Trigger tests verify endpoint construction, message sorting, regex compilation, and indicator extraction
- Tests validate output against generated JSON schemas

**Integration test (`insight-plugin run`):**
- Ran `send_html_message` against a live Microsoft Teams environment
- Verified full flow: Graph API auth → team lookup → channel lookup → Bot Framework auth → message delivered

**Validation:**
- `insight-plugin validate` passes all validators
- `prospector` returns 0 issues on all new util modules