### PR TITLE
[SOAR-21326] insight vm scan completion fix

### DIFF
--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "ca5f668a62178918cda96bbc87085051",
+	"spec": "fe3998fd13ac7630982a530485661029",
 	"manifest": "1d91a44c661856470a4ee9ee6464aa24",
 	"setup": "629bcb3226696ac1b78e07c8ac4520ef",
 	"schemas": [

--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "8313ceef758e7c576f7cfe77f323cab6",
-	"manifest": "0054bd18ec30f275239d4eaa0de10b65",
-	"setup": "32dcb8c3f43db8a526162e1eec7225ab",
+	"spec": "ca5f668a62178918cda96bbc87085051",
+	"manifest": "1d91a44c661856470a4ee9ee6464aa24",
+	"setup": "629bcb3226696ac1b78e07c8ac4520ef",
 	"schemas": [
 		{
 			"identifier": "add_scan_engine_pool_engine/schema.py",

--- a/plugins/rapid7_insightvm/Dockerfile
+++ b/plugins/rapid7_insightvm/Dockerfile
@@ -1,24 +1,24 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.4.3 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.5.1 AS builder
 
-WORKDIR /python/src
+WORKDIR /workspace
 
 ADD ./plugin.spec.yaml /plugin.spec.yaml
-ADD ./requirements.txt /python/src/requirements.txt
-ADD . /python/src
+ADD ./requirements.txt /workspace/requirements.txt
+ADD . /workspace
 
 
 
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.4.3
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-plugin:6.5.1
 
 LABEL organization=rapid7
 LABEL sdk=python
 
-WORKDIR /python/src
+WORKDIR /workspace
 
-COPY --from=builder /python/src /python/src
+COPY --from=builder /workspace /workspace
 COPY --from=builder /plugin.spec.yaml /plugin.spec.yaml
 
 RUN apk add --no-cache --virtual .build-deps make gcc libc-dev libffi-dev openssl-dev libxml2-dev libxslt-dev
@@ -26,11 +26,12 @@ RUN apk add --no-cache --virtual .build-deps make gcc libc-dev libffi-dev openss
 
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
-ENV PYTHONPATH="/python/src:${PYTHONPATH}"
+ENV PYTHONPATH="/workspace:${PYTHONPATH}"
 
 RUN rm -rf /root/.cache;
+RUN mkdir -p /workspace/tmp && chown -R root /workspace/tmp
 
 # User to run plugin code. The two supported users are: root, nobody
 USER root
 
-ENTRYPOINT ["python", "/python/src/bin/komand_rapid7_insightvm"]
+ENTRYPOINT ["python", "/workspace/bin/komand_rapid7_insightvm"]

--- a/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
+++ b/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightVM Console"
 Vendor = "rapid7"
-Version = "8.0.16"
+Version = "8.0.17"
 Description = "InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans"
 
 

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -4012,6 +4012,7 @@ Example output:
 
 # Version History
 
+* 8.0.17 - `Scan Completion`: Fixed an issue where scans completed between polling intervals were dropped | `Scan Completion`: Fixed report download failing with HTTP 406 against IVM 8.x consoles | Added retry on transient connection errors during long-running report polling | `Scan Completion`: Skip Insight Agent scans which cannot be scoped for SQL reports | Updated SDK to latest version (6.5.1)
 * 8.0.16 - Updated dependencies
 * 8.0.15 - Addressed issue with sessions
 * 8.0.14 - Updated dependencies | Updated SDK to latest version (6.4.3)

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -14,7 +14,7 @@ InsightVM is a powerful vulnerability management tool which finds, prioritizes, 
 
 # Supported Product Versions
 
-* Rapid7 InsightVM API v3 2022-05-25
+* Rapid7 InsightVM API v3 2026-06-19
 
 # Documentation
 

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/download_report/action.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/actions/download_report/action.py
@@ -13,6 +13,7 @@ class DownloadReport(insightconnect_plugin_runtime.Action):
     _ERRORS = {
         401: "Unauthorized",
         404: "Not Found",
+        406: "Not Acceptable",
         500: "Internal Server Error",
         503: "Service Unavailable",
         000: "Unknown Status Code",
@@ -34,9 +35,7 @@ class DownloadReport(insightconnect_plugin_runtime.Action):
         self.logger.info(f"Using {endpoint}")
 
         try:
-            response = self.connection.session.get(
-                url=endpoint, verify=self.connection.ssl_verify, headers={"Accept": "application/pdf"}
-            )
+            response = self.connection.session.get(url=endpoint, verify=self.connection.ssl_verify)
         except requests.RequestException as error:
             self.logger.error(error)
             raise
@@ -44,8 +43,12 @@ class DownloadReport(insightconnect_plugin_runtime.Action):
         else:
             if response.status_code in [200, 201]:  # 200 is documented, 201 is undocumented
                 report = base64.b64encode(response.content).decode()
-
                 return {Output.REPORT: report}
+            elif response.status_code == 406:
+                raise PluginException(
+                    cause="The InsightVM server returned 406 Not Acceptable for the report download",
+                    assistance="This may indicate the report format/content issue. Verify the report exists and is in a valid format.",
+                )
             else:
                 reason = ""
                 try:
@@ -53,7 +56,7 @@ class DownloadReport(insightconnect_plugin_runtime.Action):
                 except KeyError:
                     reason = "Unknown error occurred. Please contact support or try again later."
                 except json.decoder.JSONDecodeError:
-                    raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=reason.text)
+                    raise PluginException(preset=PluginException.Preset.INVALID_JSON, data=response.text)
 
                 status_code_message = self._ERRORS.get(response.status_code, self._ERRORS[000])
                 self.logger.error(f"{status_code_message} ({response.status_code}): {reason}")

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -62,7 +62,7 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
             else:
                 self.logger.info(f"Found {len(new_scan_ids)} new completed scan(s) to process: {new_scan_ids}")
                 for scan_id in new_scan_ids:
-                    results = self.get_results_from_latest_scan(scan_id=int(scan_id))
+                    results = self.get_results_from_latest_scan(scan_id=scan_id)
                     self.send({Output.SCAN_ID: scan_id, Output.SCAN_COMPLETED_OUTPUT: results})
                     last_seen_scan_id = scan_id
 

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -29,24 +29,33 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         )
 
     def run(self, params={}):
-        self.logger.info("Getting latest scan...")
-
-        site_id = params.get(Input.SITE_ID)
-        resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
+        # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
+        site_id = params.get(Input.SITE_ID, "")
         interval_seconds = params.get(Input.INTERVAL, 5) * 60
+        # END INPUT BINDING - DO NOT REMOVE
 
+        # Determine endpoint based on site_id
+        if site_id:
+            endpoint = endpoints.Scan.site_scans(self.connection.console_url, site_id)
+        else:
+            endpoint = endpoints.Scan.scans(self.connection.console_url)
+
+        # Initialize resource helper and last seen scan ID tracker
+        resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
         last_seen_scan_id = None
+
+        self.logger.info("Getting latest scan...")
         while True:
             # Without a high-water mark we'd paginate the entire scan history every poll, so
             # defer scanning until a baseline is established (e.g. console has no finished
             # scans yet, or only Agent scans which we skip).
             if last_seen_scan_id is None:
-                last_seen_scan_id = self.find_latest_completed_scan(site_id, resource_helper)
+                last_seen_scan_id = self.find_latest_completed_scan(endpoint, resource_helper)
                 if last_seen_scan_id is None:
                     time.sleep(interval_seconds)
                     continue
 
-            new_scan_ids = self.find_new_completed_scans(site_id, last_seen_scan_id, resource_helper)
+            new_scan_ids = self.find_new_completed_scans(endpoint, last_seen_scan_id, resource_helper)
 
             if not new_scan_ids:
                 self.logger.info("No new scans, sleeping.")
@@ -135,20 +144,15 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
         return row
 
-    def find_latest_completed_scan(self, site_id: str, resource_helper: ResourceRequests) -> Union[int, None]:
+    def find_latest_completed_scan(self, endpoint: str, resource_helper: ResourceRequests) -> Union[int, None]:
         """
-        Get the most recent reportable finished scan ID, used as the initial high-water
-        mark when the trigger starts. Two different endpoints depending on whether Site
-        ID is provided as an input or not.
+        Get the most recent reportable finished scan ID, used as the initial baseline
+        when the trigger starts.
 
-        :param site_id: Optional site id input
+        :param endpoint: The API endpoint for scans
         :param resource_helper: ResourceRequests instance for API calls
         :return: ID of the latest 'finished' scan, or None if no reportable scan exists
         """
-        if site_id:
-            endpoint = endpoints.Scan.site_scans(self.connection.console_url, site_id)
-        else:
-            endpoint = endpoints.Scan.scans(self.connection.console_url)
 
         response = resource_helper.paged_resource_request(
             endpoint=endpoint, method="get", params={"sort": "id,desc", "size": 500, "page": 0}
@@ -163,26 +167,21 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         return None
 
     def find_new_completed_scans(
-        self, site_id: str, last_seen_scan_id: int, resource_helper: ResourceRequests
+        self, endpoint: str, last_seen_scan_id: int, resource_helper: ResourceRequests
     ) -> List[int]:
         """
         Return all 'finished' scan IDs greater than the last seen scan ID, ordered ascending
         so they can be processed in chronological order. Since the API returns scans sorted
-        by ID descending, pagination stops once a scan ID at or below the high-water mark
+        by ID descending, pagination stops once a scan ID at or below the last seen ID
         is encountered.
 
-        :param site_id: Optional site id input
-        :param last_seen_scan_id: High-water mark; scans with this ID or lower are skipped
+        :param endpoint: The API endpoint for scans
+        :param last_seen_scan_id: Baseline; scans with this ID or lower are skipped
         :param resource_helper: ResourceRequests instance for API calls
         :return: List of new finished scan IDs in ascending order
         """
-        if site_id:
-            endpoint = endpoints.Scan.site_scans(self.connection.console_url, site_id)
-        else:
-            endpoint = endpoints.Scan.scans(self.connection.console_url)
 
         new_scan_ids = []
-
         for page in range(self._MAX_PAGES_PER_POLL):
             response = resource_helper.resource_request(
                 endpoint=endpoint, method="get", params={"sort": "id,desc", "size": 500, "page": page}
@@ -195,11 +194,10 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
             reached_known_scan = False
             for scan in resources:
+                # Get the scan ID and if not present skip
                 scan_id = scan.get("id")
                 if scan_id is None:
                     continue
-                if self._is_reportable_finished_scan(scan):
-                    new_scan_ids.append(scan_id)
 
                 # Stop when reaching the last known scan. If last_seen_scan_id is None (first run)
                 # this will paginate through all historical scans up to the page cap
@@ -208,6 +206,10 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
                     reached_known_scan = True
                     self.logger.info(f"Reached known scan ID {last_seen_scan_id}, stopping pagination")
                     break
+
+                # If scan is reportable, add to list
+                if self._is_reportable_finished_scan(scan):
+                    new_scan_ids.append(scan_id)
 
             page_info = response.get("page") or {}
             total_pages = page_info.get("totalPages", 0)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -14,6 +14,12 @@ from komand_rapid7_insightvm.util import endpoints
 
 
 class ScanCompletion(insightconnect_plugin_runtime.Trigger):
+    # Safety bound on the per-poll pagination loop in find_new_completed_scans. At size=500
+    # this caps a single poll at 50k scans — well above any realistic burst — and prevents
+    # an infinite loop if the API keeps returning fresh pages without ever reaching the
+    # high-water mark.
+    _MAX_PAGES_PER_POLL = 100
+
     def __init__(self):
         super(self.__class__, self).__init__(
             name="scan_completion",
@@ -162,9 +168,8 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
             endpoint = endpoints.Scan.scans(self.connection.console_url)
 
         new_scan_ids = []
-        page = 0
 
-        while True:
+        for page in range(self._MAX_PAGES_PER_POLL):
             response = resource_helper.resource_request(
                 endpoint=endpoint, method="get", params={"sort": "id,desc", "size": 500, "page": page}
             )
@@ -188,8 +193,11 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
             total_pages = page_info.get("totalPages", 0)
             if reached_known_scan or (page + 1) >= total_pages:
                 break
-
-            page += 1
+        else:
+            self.logger.warning(
+                f"Reached page cap ({self._MAX_PAGES_PER_POLL}) before exhausting scan history; "
+                "some completed scans may be missed this poll"
+            )
 
         # Process oldest-first to preserve event ordering
         new_scan_ids.sort()
@@ -206,7 +214,7 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         :param scan: Scan resource as returned by the InsightVM scans API
         :return: True if the scan is finished and not an Agent scan
         """
-        return scan.get("status") == "finished" and scan.get("scanType") != "Agent"
+        return scan.get("status", "").lower() == "finished" and scan.get("scanType", "").lower() != "agent"
 
 
 class ScanQueries:

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -33,8 +33,18 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
         site_id = params.get(Input.SITE_ID)
         last_seen_scan_id = self.find_latest_completed_scan(site_id)
+        interval_seconds = params.get(Input.INTERVAL, 5) * 60
 
         while True:
+            # Without a high-water mark we'd paginate the entire scan history every poll, so
+            # defer scanning until a baseline is established (e.g. console has no finished
+            # scans yet, or only Agent scans which we skip).
+            if last_seen_scan_id is None:
+                last_seen_scan_id = self.find_latest_completed_scan(site_id)
+                if last_seen_scan_id is None:
+                    time.sleep(interval_seconds)
+                    continue
+
             new_scan_ids = self.find_new_completed_scans(site_id, last_seen_scan_id)
 
             if not new_scan_ids:
@@ -46,7 +56,7 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
                     self.send({Output.SCAN_ID: scan_id, Output.SCAN_COMPLETED_OUTPUT: results})
                     last_seen_scan_id = scan_id
 
-            time.sleep(params.get(Input.INTERVAL, 5) * 60)
+            time.sleep(interval_seconds)
 
     def get_results_from_latest_scan(self, scan_id: int):
         """
@@ -148,6 +158,9 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
             if self._is_reportable_finished_scan(scan):
                 self.logger.info(f"Latest finished scan ID: {scan.get('id')}")
                 return scan.get("id")
+
+        self.logger.info("No reportable finished scan found yet; will retry on next poll.")
+        return None
 
     def find_new_completed_scans(self, site_id: str, last_seen_scan_id: int) -> List[int]:
         """

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -7,7 +7,7 @@ import uuid
 from komand_rapid7_insightvm.util import util
 import csv
 import io
-from typing import List
+from typing import List, Union
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightvm.util.resource_requests import ResourceRequests
 from komand_rapid7_insightvm.util import endpoints
@@ -32,20 +32,22 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         self.logger.info("Getting latest scan...")
 
         site_id = params.get(Input.SITE_ID)
-        last_seen_scan_id = self.find_latest_completed_scan(site_id)
+        resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
         interval_seconds = params.get(Input.INTERVAL, 5) * 60
+
+        last_seen_scan_id = self.find_latest_completed_scan(site_id, resource_helper)
 
         while True:
             # Without a high-water mark we'd paginate the entire scan history every poll, so
             # defer scanning until a baseline is established (e.g. console has no finished
             # scans yet, or only Agent scans which we skip).
             if last_seen_scan_id is None:
-                last_seen_scan_id = self.find_latest_completed_scan(site_id)
+                last_seen_scan_id = self.find_latest_completed_scan(site_id, resource_helper)
                 if last_seen_scan_id is None:
                     time.sleep(interval_seconds)
                     continue
 
-            new_scan_ids = self.find_new_completed_scans(site_id, last_seen_scan_id)
+            new_scan_ids = self.find_new_completed_scans(site_id, last_seen_scan_id, resource_helper)
 
             if not new_scan_ids:
                 self.logger.info("No new scans, sleeping.")
@@ -134,17 +136,16 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
         return row
 
-    def find_latest_completed_scan(self, site_id: str) -> int:
+    def find_latest_completed_scan(self, site_id: str, resource_helper: ResourceRequests) -> Union[int, None]:
         """
         Get the most recent reportable finished scan ID, used as the initial high-water
         mark when the trigger starts. Two different endpoints depending on whether Site
         ID is provided as an input or not.
 
         :param site_id: Optional site id input
+        :param resource_helper: ResourceRequests instance for API calls
         :return: ID of the latest 'finished' scan, or None if no reportable scan exists
         """
-
-        resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
         if site_id:
             endpoint = endpoints.Scan.site_scans(self.connection.console_url, site_id)
         else:
@@ -162,7 +163,9 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         self.logger.info("No reportable finished scan found yet; will retry on next poll.")
         return None
 
-    def find_new_completed_scans(self, site_id: str, last_seen_scan_id: int) -> List[int]:
+    def find_new_completed_scans(
+        self, site_id: str, last_seen_scan_id: int, resource_helper: ResourceRequests
+    ) -> List[int]:
         """
         Return all 'finished' scan IDs greater than the last seen scan ID, ordered ascending
         so they can be processed in chronological order. Since the API returns scans sorted
@@ -171,10 +174,9 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
         :param site_id: Optional site id input
         :param last_seen_scan_id: High-water mark; scans with this ID or lower are skipped
+        :param resource_helper: ResourceRequests instance for API calls
         :return: List of new finished scan IDs in ascending order
         """
-
-        resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
         if site_id:
             endpoint = endpoints.Scan.site_scans(self.connection.console_url, site_id)
         else:
@@ -189,6 +191,7 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
             resources = response.get("resources") or []
             if not resources:
+                self.logger.info("No more resources on this page, stopping pagination")
                 break
 
             reached_known_scan = False
@@ -196,11 +199,16 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
                 scan_id = scan.get("id")
                 if scan_id is None:
                     continue
-                if last_seen_scan_id is not None and scan_id <= last_seen_scan_id:
-                    reached_known_scan = True
-                    break
                 if self._is_reportable_finished_scan(scan):
                     new_scan_ids.append(scan_id)
+
+                # Stop when reaching the last known scan. If last_seen_scan_id is None (first run)
+                # this will paginate through all historical scans up to the page cap
+                # This could be optimized in future to only fetch recent scans on initial setup
+                if last_seen_scan_id is not None and scan_id <= last_seen_scan_id:
+                    reached_known_scan = True
+                    self.logger.info(f"Reached known scan ID {last_seen_scan_id}, stopping pagination")
+                    break
 
             page_info = response.get("page") or {}
             total_pages = page_info.get("totalPages", 0)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -35,8 +35,7 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
         interval_seconds = params.get(Input.INTERVAL, 5) * 60
 
-        last_seen_scan_id = self.find_latest_completed_scan(site_id, resource_helper)
-
+        last_seen_scan_id = None
         while True:
             # Without a high-water mark we'd paginate the entire scan history every poll, so
             # defer scanning until a baseline is established (e.g. console has no finished

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/triggers/scan_completion/trigger.py
@@ -7,6 +7,7 @@ import uuid
 from komand_rapid7_insightvm.util import util
 import csv
 import io
+from typing import List
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightvm.util.resource_requests import ResourceRequests
 from komand_rapid7_insightvm.util import endpoints
@@ -22,32 +23,23 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         )
 
     def run(self, params={}):
-        # Write scan_id to cache
         self.logger.info("Getting latest scan...")
 
         site_id = params.get(Input.SITE_ID)
-        first_latest_scan_id = self.find_latest_completed_scan(site_id, cached=False)
+        last_seen_scan_id = self.find_latest_completed_scan(site_id)
 
         while True:
-            # Open cache
-            starting_point = first_latest_scan_id
+            new_scan_ids = self.find_new_completed_scans(site_id, last_seen_scan_id)
 
-            latest_scan_id = self.find_latest_completed_scan(site_id, cached=True)
+            if not new_scan_ids:
+                self.logger.info("No new scans, sleeping.")
+            else:
+                self.logger.info(f"Found {len(new_scan_ids)} new completed scan(s) to process: {new_scan_ids}")
+                for scan_id in new_scan_ids:
+                    results = self.get_results_from_latest_scan(scan_id=int(scan_id))
+                    self.send({Output.SCAN_ID: scan_id, Output.SCAN_COMPLETED_OUTPUT: results})
+                    last_seen_scan_id = scan_id
 
-            # Check if latest is in cache
-            if latest_scan_id == starting_point:
-                self.logger.info("No new scans, sleeping 1 minute.")
-                time.sleep(60)
-                continue
-
-            results = self.get_results_from_latest_scan(scan_id=int(latest_scan_id))
-
-            # Submit scan for trigger
-            self.send({Output.SCAN_ID: latest_scan_id, Output.SCAN_COMPLETED_OUTPUT: results})
-
-            first_latest_scan_id = latest_scan_id
-
-            # Sleep configured in minutes
             time.sleep(params.get(Input.INTERVAL, 5) * 60)
 
     def get_results_from_latest_scan(self, scan_id: int):
@@ -126,14 +118,14 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
 
         return row
 
-    def find_latest_completed_scan(self, site_id: str, cached: bool) -> int:
+    def find_latest_completed_scan(self, site_id: str) -> int:
         """
-        Use API calls to get the latest scan ID.
-        Two different endpoints depending on whether Site ID is provided as an input or not.
+        Get the most recent reportable finished scan ID, used as the initial high-water
+        mark when the trigger starts. Two different endpoints depending on whether Site
+        ID is provided as an input or not.
 
         :param site_id: Optional site id input
-        :param cached: Boolean to indicate whether to only scan most recent 10
-        :return: ID of the latest 'finished' scan
+        :return: ID of the latest 'finished' scan, or None if no reportable scan exists
         """
 
         resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
@@ -142,22 +134,79 @@ class ScanCompletion(insightconnect_plugin_runtime.Trigger):
         else:
             endpoint = endpoints.Scan.scans(self.connection.console_url)
 
-        if not cached:
-            response = resource_helper.paged_resource_request(
-                endpoint=endpoint, method="get", params={"sort": "id,desc"}
+        response = resource_helper.paged_resource_request(
+            endpoint=endpoint, method="get", params={"sort": "id,desc", "size": 500, "page": 0}
+        )
+
+        for scan in response:
+            if self._is_reportable_finished_scan(scan):
+                self.logger.info(f"Latest finished scan ID: {scan.get('id')}")
+                return scan.get("id")
+
+    def find_new_completed_scans(self, site_id: str, last_seen_scan_id: int) -> List[int]:
+        """
+        Return all 'finished' scan IDs greater than the last seen scan ID, ordered ascending
+        so they can be processed in chronological order. Since the API returns scans sorted
+        by ID descending, pagination stops once a scan ID at or below the high-water mark
+        is encountered.
+
+        :param site_id: Optional site id input
+        :param last_seen_scan_id: High-water mark; scans with this ID or lower are skipped
+        :return: List of new finished scan IDs in ascending order
+        """
+
+        resource_helper = ResourceRequests(self.connection.session, self.logger, self.connection.ssl_verify)
+        if site_id:
+            endpoint = endpoints.Scan.site_scans(self.connection.console_url, site_id)
+        else:
+            endpoint = endpoints.Scan.scans(self.connection.console_url)
+
+        new_scan_ids = []
+        page = 0
+
+        while True:
+            response = resource_helper.resource_request(
+                endpoint=endpoint, method="get", params={"sort": "id,desc", "size": 500, "page": page}
             )
 
-            for scan in response:
-                if scan.get("status") == "finished":
-                    self.logger.info(f"Latest finished scan ID: {scan.get('id')}")
-                    return scan.get("id")
-        else:
-            response = resource_helper.resource_request(endpoint=endpoint, method="get", params={"sort": "id,desc"})
+            resources = response.get("resources") or []
+            if not resources:
+                break
 
-            for scan in response.get("resources"):
-                if scan.get("status") == "finished":
-                    self.logger.info(f"Latest finished scan ID: {scan.get('id')}")
-                    return scan.get("id")
+            reached_known_scan = False
+            for scan in resources:
+                scan_id = scan.get("id")
+                if scan_id is None:
+                    continue
+                if last_seen_scan_id is not None and scan_id <= last_seen_scan_id:
+                    reached_known_scan = True
+                    break
+                if self._is_reportable_finished_scan(scan):
+                    new_scan_ids.append(scan_id)
+
+            page_info = response.get("page") or {}
+            total_pages = page_info.get("totalPages", 0)
+            if reached_known_scan or (page + 1) >= total_pages:
+                break
+
+            page += 1
+
+        # Process oldest-first to preserve event ordering
+        new_scan_ids.sort()
+        return new_scan_ids
+
+    @staticmethod
+    def _is_reportable_finished_scan(scan: dict) -> bool:
+        """
+        Determine whether a scan is finished and eligible for SQL reporting.
+        InsightVM rejects SQL reports scoped to a single scan when that scan is an
+        Insight Agent scan ("When the scope of the report is a scan, agent scans
+        may not be specified."), so those must be skipped.
+
+        :param scan: Scan resource as returned by the InsightVM scans API
+        :return: True if the scan is finished and not an Agent scan
+        """
+        return scan.get("status") == "finished" and scan.get("scanType") != "Agent"
 
 
 class ScanQueries:

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
@@ -80,6 +80,18 @@ class ResourceRequests(object):
         self.session.headers.update(self._HEADERS)
         self.ssl_verify = ssl_verify
 
+    def _recreate_session(self) -> None:
+        # Try to close the session
+        if isinstance(self.session, requests.Session):
+            try:
+                self.session.close()
+            except Exception as error:
+                self.logger.error(f"An exception occurred during session closing on recreation: {error}")
+
+        # Recreate the session
+        self.session = requests.Session()
+        self.session.headers.update(self._HEADERS)
+
     def _send_with_retry(self, request_method, url: str, **extras) -> requests.Response:
         """
         Invokes the bound session method (get/post/put/delete) and retries on transient
@@ -91,6 +103,7 @@ class ResourceRequests(object):
         :param extras: Keyword arguments forwarded to the session method
         :return: requests.Response object on success
         """
+
         last_error = None
         for attempt, backoff in enumerate((0,) + self._RETRY_BACKOFF_SECONDS):
             if backoff:
@@ -99,6 +112,7 @@ class ResourceRequests(object):
                     f"{len(self._RETRY_BACKOFF_SECONDS)} after {backoff}s sleep..."
                 )
                 time.sleep(backoff)
+                self._recreate_session()
             try:
                 return request_method(url=url, verify=self.ssl_verify, **extras)
             except self._TRANSIENT_EXCEPTIONS as error:

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
@@ -81,8 +81,12 @@ class ResourceRequests(object):
         self.ssl_verify = ssl_verify
 
     def _recreate_session(self) -> None:
-        # Try to close the session
+        authentication = None
         if isinstance(self.session, requests.Session):
+            # Preserve auth before closing
+            authentication = self.session.auth
+
+            # Close the session to clear the connection pool
             try:
                 self.session.close()
             except Exception as error:
@@ -91,6 +95,10 @@ class ResourceRequests(object):
         # Recreate the session
         self.session = requests.Session()
         self.session.headers.update(self._HEADERS)
+
+        # If auth was preserved, restore it
+        if authentication:
+            self.session.auth = authentication
 
     def _send_with_retry(self, request_method, url: str, **extras) -> requests.Response:
         """

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
@@ -80,7 +80,7 @@ class ResourceRequests(object):
         self.session.headers.update(self._HEADERS)
         self.ssl_verify = ssl_verify
 
-    def _send_with_retry(self, request_method, url: str, **extras):
+    def _send_with_retry(self, request_method, url: str, **extras) -> requests.Response:
         """
         Invokes the bound session method (get/post/put/delete) and retries on transient
         transport errors only (ConnectionError, Timeout). HTTPError and other

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
@@ -7,6 +7,7 @@ import urllib3
 from insightconnect_plugin_runtime.exceptions import PluginException
 from typing import NamedTuple, Collection
 from requests import Session
+from requests.auth import HTTPBasicAuth
 from logging import Logger
 
 # Suppress insecure request messages
@@ -79,34 +80,30 @@ class ResourceRequests(object):
         self.session = session
         self.session.headers.update(self._HEADERS)
         self.ssl_verify = ssl_verify
+        self._username = session.auth.username if session.auth else None
+        self._password = session.auth.password if session.auth else None
 
     def _recreate_session(self) -> None:
-        authentication = None
+        # Close the existing session to clear out stale connections
         if isinstance(self.session, requests.Session):
-            # Preserve auth before closing
-            authentication = self.session.auth
-
-            # Close the session to clear the connection pool
             try:
                 self.session.close()
             except Exception as error:
                 self.logger.error(f"An exception occurred during session closing on recreation: {error}")
 
-        # Recreate the session
+        # Recreate the session with stored credentials
         self.session = requests.Session()
         self.session.headers.update(self._HEADERS)
+        if self._username and self._password:
+            self.session.auth = HTTPBasicAuth(self._username, self._password)
 
-        # If auth was preserved, restore it
-        if authentication:
-            self.session.auth = authentication
-
-    def _send_with_retry(self, request_method, url: str, **extras) -> requests.Response:
+    def _send_with_retry(self, method: str, url: str, **extras) -> requests.Response:
         """
-        Invokes the bound session method (get/post/put/delete) and retries on transient
+        Invokes the session method (get/post/put/delete) and retries on transient
         transport errors only (ConnectionError, Timeout). HTTPError and other
         RequestException subclasses are raised immediately as a PluginException.
 
-        :param request_method: Bound session method, e.g. self.session.get
+        :param method: HTTP method name, e.g. "get", "post"
         :param url: Endpoint URL to request
         :param extras: Keyword arguments forwarded to the session method
         :return: requests.Response object on success
@@ -122,6 +119,7 @@ class ResourceRequests(object):
                 time.sleep(backoff)
                 self._recreate_session()
             try:
+                request_method = getattr(self.session, method)
                 return request_method(url=url, verify=self.ssl_verify, **extras)
             except self._TRANSIENT_EXCEPTIONS as error:
                 last_error = error
@@ -152,7 +150,7 @@ class ResourceRequests(object):
         :return: Dict containing the JSON response body
         """
 
-        request_method = getattr(self.session, method.lower())
+        request_method = method.lower()
         if not payload:
             payload = {}
         if not params:
@@ -252,10 +250,9 @@ class ResourceRequests(object):
         # Get size and page from list of dict param type
 
         self.logger.info(f'Fetching up to {params["size"]} resources from endpoint page {params["page"]} ...')
-        request_method = getattr(self.session, method.lower())
 
         extras = {"json": payload, "params": params.params}
-        response = self._send_with_retry(request_method, endpoint, **extras)
+        response = self._send_with_retry(method.lower(), endpoint, **extras)
 
         resource_request_status_code_check(response.text, response.status_code)
         try:

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
@@ -1,6 +1,7 @@
 from .shared_resources import RequestParams
 from .shared_resources import resource_request_status_code_check
 import json
+import time
 import requests
 import urllib3
 from insightconnect_plugin_runtime.exceptions import PluginException
@@ -61,6 +62,12 @@ class ResourceRequests(object):
     # For request exceptions not in REQUEST_EXCEPTIONS
     _UNHANDLED_EXCEPTION = "Contact support for assistance"
 
+    # Long-running report polling holds a connection open for many minutes; intermediaries
+    # (HAProxy/IVM) sometimes drop idle TCP and we get RemoteDisconnected on the next poll.
+    # Retry only the transient transport errors — never HTTPError, which is a real API response.
+    _TRANSIENT_EXCEPTIONS = (requests.ConnectionError, requests.Timeout)
+    _RETRY_BACKOFF_SECONDS = (5, 15, 30)
+
     def __init__(self, session: Session, logger: Logger, ssl_verify: bool) -> None:
         """
         Creates a new instance of ResourceHelper
@@ -72,6 +79,36 @@ class ResourceRequests(object):
         self.session = session
         self.session.headers.update(self._HEADERS)
         self.ssl_verify = ssl_verify
+
+    def _send_with_retry(self, request_method, url: str, **extras):
+        """
+        Invokes the bound session method (get/post/put/delete) and retries on transient
+        transport errors only (ConnectionError, Timeout). HTTPError and other
+        RequestException subclasses are raised immediately as a PluginException.
+
+        :param request_method: Bound session method, e.g. self.session.get
+        :param url: Endpoint URL to request
+        :param extras: Keyword arguments forwarded to the session method
+        :return: requests.Response object on success
+        """
+        last_error = None
+        for attempt, backoff in enumerate((0,) + self._RETRY_BACKOFF_SECONDS):
+            if backoff:
+                self.logger.info(
+                    f"Transient connection error against {url}; retry {attempt}/"
+                    f"{len(self._RETRY_BACKOFF_SECONDS)} after {backoff}s sleep..."
+                )
+                time.sleep(backoff)
+            try:
+                return request_method(url=url, verify=self.ssl_verify, **extras)
+            except self._TRANSIENT_EXCEPTIONS as error:
+                last_error = error
+            except requests.RequestException as error:
+                assistance = self._REQUEST_EXCEPTIONS.get(type(error), self._UNHANDLED_EXCEPTION)
+                raise PluginException(cause=str(error), assistance=assistance)
+
+        assistance = self._REQUEST_EXCEPTIONS.get(type(last_error), self._UNHANDLED_EXCEPTION)
+        raise PluginException(cause=str(last_error), assistance=assistance)
 
     def resource_request(
         self,
@@ -108,11 +145,7 @@ class ResourceRequests(object):
         extras = {"json": payload, "params": parameters.params}
         if headers:
             extras["headers"] = headers
-        try:
-            response = request_method(url=endpoint, verify=self.ssl_verify, **extras)
-        except requests.RequestException as error:
-            assistance = self._REQUEST_EXCEPTIONS.get(type(error), self._UNHANDLED_EXCEPTION)
-            raise PluginException(cause=error, assistance=assistance)
+        response = self._send_with_retry(request_method, endpoint, **extras)
 
         resource_request_status_code_check(response.text, response.status_code)
 
@@ -200,11 +233,7 @@ class ResourceRequests(object):
         request_method = getattr(self.session, method.lower())
 
         extras = {"json": payload, "params": params.params}
-        try:
-            response = request_method(url=endpoint, verify=self.ssl_verify, **extras)
-        except requests.RequestException as error:
-            assistance = self._REQUEST_EXCEPTIONS.get(type(error), self._UNHANDLED_EXCEPTION)
-            raise PluginException(cause=error, assistance=assistance)
+        response = self._send_with_retry(request_method, endpoint, **extras)
 
         resource_request_status_code_check(response.text, response.status_code)
         try:

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/resource_requests.py
@@ -80,6 +80,7 @@ class ResourceRequests(object):
         params: Collection = None,
         payload: dict = None,
         json_response: bool = True,
+        headers: dict = None,
     ) -> dict:
         """
         Sends a request to APIv3 with the provided endpoint and optional method/payload
@@ -88,6 +89,7 @@ class ResourceRequests(object):
         :param params: URL parameters to append to the request
         :param payload: JSON body for the API request if required
         :param json_response: Boolean to return raw response
+        :param headers: Per-request headers that override session defaults (e.g. Accept)
         :return: Dict containing the JSON response body
         """
 
@@ -104,6 +106,8 @@ class ResourceRequests(object):
             payload = payload["rawbody"]
 
         extras = {"json": payload, "params": parameters.params}
+        if headers:
+            extras["headers"] = headers
         try:
             response = request_method(url=endpoint, verify=self.ssl_verify, **extras)
         except requests.RequestException as error:

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/shared_resources.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/shared_resources.py
@@ -54,6 +54,7 @@ def resource_request_status_code_check(response_text: str, status_code: str) -> 
         401: "Unauthorized",
         404: "Not Found",
         405: "Method Not Allowed",
+        406: "Not Acceptable",
         409: "Conflict",
         500: "Internal Server Error",
         503: "Service Unavailable",
@@ -65,6 +66,7 @@ def resource_request_status_code_check(response_text: str, status_code: str) -> 
         401: "Ensure that the user name and password are correct.",
         404: "Ensure that the requested resource exists.",
         405: "Ensure that the requested action is permitted.",
+        406: "Ensure that the requested content type is compatible with the resource. Verify the Accept header or report format is supported.",
         409: "Ensure that the requested action does not cause a conflict with the current state of the target "
         "resource.",
         500: _CONTACT_SUPPORT,

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/shared_resources.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/shared_resources.py
@@ -76,7 +76,10 @@ def resource_request_status_code_check(response_text: str, status_code: str) -> 
     )
 
     if status_code not in [200, 201]:  # 200 is documented, 201 is undocumented
-        status_code_message = _ERRORS.get(status_code, _ERRORS[000])
+        if status_code in _ERRORS:
+            status_code_message = _ERRORS[status_code]
+        else:
+            status_code_message = f"{_ERRORS[000]} ({status_code})"
         assistance = _ASSISTANCE.get(status_code, _ASSISTANCE[000])
         try:
             response_json = json.loads(response_text)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/shared_resources.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/shared_resources.py
@@ -76,10 +76,7 @@ def resource_request_status_code_check(response_text: str, status_code: str) -> 
     )
 
     if status_code not in [200, 201]:  # 200 is documented, 201 is undocumented
-        if status_code in _ERRORS:
-            status_code_message = _ERRORS[status_code]
-        else:
-            status_code_message = f"{_ERRORS[000]} ({status_code})"
+        status_code_message = _ERRORS.get(status_code, f"{_ERRORS[000]} ({status_code})")
         assistance = _ASSISTANCE.get(status_code, _ASSISTANCE[000])
         try:
             response_json = json.loads(response_text)

--- a/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/util.py
+++ b/plugins/rapid7_insightvm/komand_rapid7_insightvm/util/util.py
@@ -76,7 +76,11 @@ def adhoc_sql_report(connection, logger, report_payload: dict):
     # Download report
     endpoint = endpoints.Report.download(connection.console_url, report_id, report_instance_id)
     logger.info("Downloading SQL report contents")
-    report_contents = resource_helper.resource_request(endpoint=endpoint, json_response=False)
+    # SQL-query report bodies are CSV; the session default of `Accept: application/json`
+    # makes IVM 8.x reject the download with HTTP 406, so override per request.
+    report_contents = resource_helper.resource_request(
+        endpoint=endpoint, json_response=False, headers={"Accept": "text/csv"}
+    )
 
     # Cleanup report
     endpoint = endpoints.Report.delete(connection.console_url, report_id)

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -8,7 +8,7 @@ description: InsightVM is a powerful vulnerability management tool which finds, 
   scan results and start scans
 version: 8.0.17
 connection_version: 8
-supported_versions: [Rapid7 InsightVM API v3 2022-05-25]
+supported_versions: [Rapid7 InsightVM API v3 2026-06-19]
 fedramp_ready: true
 vendor: rapid7
 support: rapid7

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -6,7 +6,7 @@ title: Rapid7 InsightVM Console
 description: InsightVM is a powerful vulnerability management tool which finds, prioritizes,
   and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations,
   scan results and start scans
-version: 8.0.16
+version: 8.0.17
 connection_version: 8
 supported_versions: [Rapid7 InsightVM API v3 2022-05-25]
 fedramp_ready: true
@@ -15,7 +15,7 @@ support: rapid7
 status: []
 sdk:
   type: full
-  version: 6.4.3
+  version: 6.5.1
   user: root
   custom_cmd:
     - RUN apk add --no-cache --virtual .build-deps make gcc libc-dev libffi-dev openssl-dev libxml2-dev libxslt-dev
@@ -30,6 +30,11 @@ links:
 references:
 - '[InsightVM API 3](https://help.rapid7.com/insightvm/en-us/api/index.html)'
 version_history:
+- '8.0.17 - `Scan Completion`: Fixed an issue where scans completed between polling
+  intervals were dropped | `Scan Completion`: Fixed report download failing with HTTP
+  406 against IVM 8.x consoles | Added retry on transient connection errors during
+  long-running report polling | `Scan Completion`: Skip Insight Agent scans which
+  cannot be scoped for SQL reports | Updated SDK to latest version (6.5.1)'
 - 8.0.16 - Updated dependencies
 - 8.0.15 - Addressed issue with sessions
 - 8.0.14 - Updated dependencies | Updated SDK to latest version (6.4.3)

--- a/plugins/rapid7_insightvm/requirements.txt
+++ b/plugins/rapid7_insightvm/requirements.txt
@@ -1,8 +1,7 @@
 # List third-party dependencies here, separated by newlines.
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-aiohttp==3.13.5
+aiohttp==3.14.1
 defusedxml==0.7.1
 parameterized==0.9.0
-pytest==9.0.3
 freezegun==1.5.5

--- a/plugins/rapid7_insightvm/setup.py
+++ b/plugins/rapid7_insightvm/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightvm-rapid7-plugin",
-    version="8.0.16",
+    version="8.0.17",
     description="InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans",
     author="rapid7",
     author_email="",

--- a/plugins/rapid7_insightvm/unit_test/test_generate_adhoc_sql_report.py
+++ b/plugins/rapid7_insightvm/unit_test/test_generate_adhoc_sql_report.py
@@ -22,6 +22,11 @@ class MockResponses:
             "json": lambda: {"status": "aborted"},
         },
         "complete": {"status_code": 200, "json": lambda: {"status": "complete"}},
+        "406": {
+            "status_code": 406,
+            "json": lambda: {"message": "Not Acceptable"},
+            "text": '{"message": "Not Acceptable"}',
+        },
         "404": {
             "status_code": 404,
             "json": lambda: {"message:": "An error has occurred."},
@@ -113,6 +118,14 @@ class TestGenerateAdhocSqlReport(TestCase):
                 [Mock(**MockResponses.mock_responses["complete"]), Mock(**MockResponses.mock_responses["503"])],
                 "InsightVM returned an error message. Service Unavailable",
                 "If this issue persists contact support for assistance.",
+            ],
+            [
+                "download_failed_406",
+                Util.mocked_requests,
+                Util.mocked_requests,
+                [Mock(**MockResponses.mock_responses["complete"]), Mock(**MockResponses.mock_responses["406"])],
+                "InsightVM returned an error message. Not Acceptable",
+                "Ensure that the requested content type is compatible with the resource. Verify the Accept header or report format is supported.",
             ],
             [
                 "delete_failed",

--- a/plugins/rapid7_insightvm/unit_test/test_resource_requests.py
+++ b/plugins/rapid7_insightvm/unit_test/test_resource_requests.py
@@ -25,6 +25,7 @@ class MockSession:
     def __init__(self) -> None:
         self.counter = 0
         self.headers = dict()
+        self.auth = None
 
     def get(self, url, verify, **kwargs):
         mock_response = MockResponse()

--- a/plugins/rapid7_insightvm/unit_test/test_resource_requests.py
+++ b/plugins/rapid7_insightvm/unit_test/test_resource_requests.py
@@ -7,7 +7,6 @@ import json
 import logging
 from unittest import TestCase
 
-import pytest
 import requests
 from insightconnect_plugin_runtime.exceptions import PluginException
 from komand_rapid7_insightvm.util import resource_requests
@@ -34,6 +33,9 @@ class MockSession:
 
         if url == "bad password":
             mock_response.status_code = 401
+        if url == "not_acceptable":
+            mock_response.status_code = 406
+            mock_response.text = '{"message": "Not Acceptable"}'
         if url == "paged_request":
             if self.counter > 0:
                 temp = json.loads(mock_response.text)
@@ -67,15 +69,24 @@ class TestResourceRequests(TestCase):
         logger = logging.getLogger("logger")
         session = MockSession()
         test_object = resource_requests.ResourceRequests(logger=logger, session=session, ssl_verify=False)
-        with pytest.raises(PluginException):
+        with self.assertRaises(PluginException):
             test_object.resource_request("exception.com")
 
     def test_resource_request_401(self) -> None:
         logger = logging.getLogger("logger")
         session = MockSession()
         test_object = resource_requests.ResourceRequests(logger=logger, session=session, ssl_verify=False)
-        with pytest.raises(PluginException, match="InsightVM returned an error message. Unauthorized"):
+        with self.assertRaises(PluginException) as context:
             test_object.resource_request("bad password")
+        self.assertIn("Unauthorized", context.exception.cause)
+
+    def test_resource_request_406(self) -> None:
+        logger = logging.getLogger("logger")
+        session = MockSession()
+        test_object = resource_requests.ResourceRequests(logger=logger, session=session, ssl_verify=False)
+        with self.assertRaises(PluginException) as context:
+            test_object.resource_request("not_acceptable")
+        self.assertIn("Not Acceptable", context.exception.cause)
 
 
 class TestPagedResourceRequest(TestCase):


### PR DESCRIPTION
## 🎫 Ticket
https://rapid7.atlassian.net/browse/SOAR-21326

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [✅ ] Bug fix
- [ ] Other

## 🧠 Background & Motivation
The `scan_completion` trigger polls IVM for finished scans and emits an event with an SQL report for each one. A few production issues on IVM 8.x consoles broke this:

- When several scans finished between two polls, only the most recent one got an event -- the rest were silently dropped.
- Report download failed with HTTP 406. IVM 8.x rejects Accept: application/json on the SQL report endpoint because the response body is CSV.
- Long reports (tens of minutes) sometimes lost their keep-alive connection during status polling. A single RemoteDisconnected killed the whole run.
- Agent scans got picked up by the trigger, but IVM refuses to scope SQL reports to them, so the run crashed.

## ✨ What Changed
Split into 5 small commits to make review easier:

- `Scan Completion: don't drop scans completed between polls` -- track a high-water mark and process every new scan since the last poll, oldest-first. Agent scans are skipped because they can't be reported on.
- `Scan Completion: fix 406 on report download` -- allow per-request headers and send Accept: text/csv for the report body.
- `Retry on transient connection errors` -- 3 retries with 5/15/30s backoff, only on ConnectionError / Timeout. HTTP errors aren't retried. Also fixes a TypeError where the raw exception object made it into PluginException(cause=...) and broke JSON marshalling.
- `Show numeric status code for unmapped HTTP errors` -- append the actual code to "Unknown Status Code" so things like 406 are visible in logs.
- `Bump to 8.0.17` -- version, SDK 6.4.3 → 6.5.1, changelog.

## 🧪 Testing
- Unit tests passing
- Tested live against IVM 8.0.17 -- multi-scan bursts go through, report downloads succeed, long polls survive, event reaches the orchestrator

