### PR TITLE
Azure AD Admin 6.0.0 Release

### DIFF
--- a/plugins/azure_ad_admin/.CHECKSUM
+++ b/plugins/azure_ad_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "f7f4cecf95e5c0d169ddc4beb745d768",
-	"manifest": "f297c279803cb808658960d3a40b8075",
-	"setup": "8564b216e970f18f4086cb3228ed723b",
+	"spec": "90b467075296005c76388feae18ebdca",
+	"manifest": "5f232d4175b579a9bec53fe9af2af709",
+	"setup": "4657c80308adbb247d5024efee5e6ed6",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",
@@ -53,7 +53,7 @@
 		},
 		{
 			"identifier": "get_user_info/schema.py",
-			"hash": "fb4351ffb0004c75e9eaaed4c10000d3"
+			"hash": "39160eb3250884c0149accf2f0d53302"
 		},
 		{
 			"identifier": "get_user_memberships/schema.py",
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "list_group_members/schema.py",
-			"hash": "8991acdb3c27a9bd7b7993fd0b7cf427"
+			"hash": "b5cdb559da6ad6284bca9767a32ec88e"
 		},
 		{
 			"identifier": "remove_user_from_group/schema.py",

--- a/plugins/azure_ad_admin/bin/icon_azure_ad_admin
+++ b/plugins/azure_ad_admin/bin/icon_azure_ad_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Entra ID Admin"
 Vendor = "rapid7"
-Version = "5.1.0"
+Version = "6.0.0"
 Description = "Microsoft Entra ID Admin performs administrative tasks in Microsoft Entra ID (formerly Azure AD).It uses the [User](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) endpoint in the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview?view=graph-rest-1.0)"
 
 

--- a/plugins/azure_ad_admin/help.md
+++ b/plugins/azure_ad_admin/help.md
@@ -946,6 +946,13 @@ Example output:
 
 ### Custom Types
   
+**employeeOrgData**
+
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Cost Center|string|None|False|The cost center associated with the user|None|
+|Division|string|None|False|The name of the division in which the user works|None|
+  
 **manager**
 
 |Name|Type|Default|Required|Description|Example|
@@ -967,7 +974,7 @@ Example output:
 |Display Name|string|None|False|Display Name|None|
 |Employee Hire Date|date|None|False|Employee Hire Date|None|
 |Employee ID|string|None|False|Employee ID|None|
-|Employee Org Data|string|None|False|Employee Org Data|None|
+|Employee Org Data|employeeOrgData|None|False|Employee Org Data|None|
 |Employee Type|string|None|False|Employee Type|None|
 |External User State|string|None|False|External User State|None|
 |External User State Change Date Time|string|None|False|External User State Change Date Time|None|
@@ -1160,6 +1167,7 @@ Example output:
 
 # Version History
 
+* 6.0.0 - `Get User Info`: Fixed output validation error when manager has `employeeOrgData` populated with `costCenter` or `division`
 * 5.1.0 - Renamed plugin to Microsoft Entra ID Admin | New action Get User Memberships. | Updated SDK to the latest version (6.5.1)
 * 5.0.1 - `Search Devices`: Fixed issue where devices output was limited | Updated SDK to the latest version (6.4.1)
 * 5.0.0 - Update SDK to the latest version | Update the output type of `risk` for the `risk_detection` trigger to include all fields

--- a/plugins/azure_ad_admin/icon_azure_ad_admin/actions/get_user_info/schema.py
+++ b/plugins/azure_ad_admin/icon_azure_ad_admin/actions/get_user_info/schema.py
@@ -484,7 +484,7 @@ class GetUserInfoOutput(insightconnect_plugin_runtime.Output):
           "order": 51
         },
         "employeeOrgData": {
-          "type": "string",
+          "$ref": "#/definitions/employeeOrgData",
           "title": "Employee Org Data",
           "description": "Employee Org Data",
           "order": 52
@@ -545,6 +545,24 @@ class GetUserInfoOutput(insightconnect_plugin_runtime.Output):
             "type": "object"
           },
           "order": 59
+        }
+      }
+    },
+    "employeeOrgData": {
+      "type": "object",
+      "title": "employeeOrgData",
+      "properties": {
+        "costCenter": {
+          "type": "string",
+          "title": "Cost Center",
+          "description": "The cost center associated with the user",
+          "order": 1
+        },
+        "division": {
+          "type": "string",
+          "title": "Division",
+          "description": "The name of the division in which the user works",
+          "order": 2
         }
       }
     }

--- a/plugins/azure_ad_admin/icon_azure_ad_admin/actions/list_group_members/schema.py
+++ b/plugins/azure_ad_admin/icon_azure_ad_admin/actions/list_group_members/schema.py
@@ -491,7 +491,7 @@ class ListGroupMembersOutput(insightconnect_plugin_runtime.Output):
           "order": 51
         },
         "employeeOrgData": {
-          "type": "string",
+          "$ref": "#/definitions/employeeOrgData",
           "title": "Employee Org Data",
           "description": "Employee Org Data",
           "order": 52
@@ -552,6 +552,24 @@ class ListGroupMembersOutput(insightconnect_plugin_runtime.Output):
             "type": "object"
           },
           "order": 59
+        }
+      }
+    },
+    "employeeOrgData": {
+      "type": "object",
+      "title": "employeeOrgData",
+      "properties": {
+        "costCenter": {
+          "type": "string",
+          "title": "Cost Center",
+          "description": "The cost center associated with the user",
+          "order": 1
+        },
+        "division": {
+          "type": "string",
+          "title": "Division",
+          "description": "The name of the division in which the user works",
+          "order": 2
         }
       }
     }

--- a/plugins/azure_ad_admin/plugin.spec.yaml
+++ b/plugins/azure_ad_admin/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: azure_ad_admin
 title: Microsoft Entra ID Admin
 description: "Microsoft Entra ID Admin performs administrative tasks in Microsoft Entra ID (formerly Azure AD).\n\nIt uses the [User](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) endpoint in the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview?view=graph-rest-1.0)"
-version: 5.1.0
+version: 6.0.0
 connection_version: 4
 vendor: rapid7
 cloud_ready: true
@@ -37,6 +37,7 @@ requirements:
   \n\nTo assign a role, go to `Microsoft Entra ID` -> `Roles and administrators`. Select the desired role, click `Add assignments`, search for your application, and click `Add`."
 troubleshooting: "Trigger `risk_detection` needs Application permission to set as `IdentityRiskEvent.Read.All`"
 version_history:
+  - "6.0.0 - `Get User Info`: Fixed output validation error when manager has `employeeOrgData` populated with `costCenter` or `division`"
   - "5.1.0 - Renamed plugin to Microsoft Entra ID Admin | New action Get User Memberships. | Updated SDK to the latest version (6.5.1)"
   - "5.0.1 - `Search Devices`: Fixed issue where devices output was limited | Updated SDK to the latest version (6.4.1)"
   - "5.0.0 - Update SDK to the latest version | Update the output type of `risk` for the `risk_detection` trigger to include all fields"
@@ -83,6 +84,17 @@ hub_tags:
   keywords: [azure, microsoft, entra id, active directory, administration, cloud_enabled]
   features: []
 types:
+  employeeOrgData:
+    costCenter:
+      title: Cost Center
+      type: string
+      description: The cost center associated with the user
+      required: false
+    division:
+      title: Division
+      type: string
+      description: The name of the division in which the user works
+      required: false
   manager:
     "@odata.context":
       title: "@odata.type"
@@ -341,7 +353,7 @@ types:
       required: false
     employeeOrgData:
       title: Employee Org Data
-      type: string
+      type: employeeOrgData
       description: Employee Org Data
       required: false
     assignedLicenses:

--- a/plugins/azure_ad_admin/setup.py
+++ b/plugins/azure_ad_admin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="azure_ad_admin-rapid7-plugin",
-    version="5.1.0",
+    version="6.0.0",
     description="Microsoft Entra ID Admin performs administrative tasks in Microsoft Entra ID (formerly Azure AD).It uses the [User](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) endpoint in the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview?view=graph-rest-1.0)",
     author="rapid7",
     author_email="",

--- a/plugins/azure_ad_admin/unit_test/mocks.py
+++ b/plugins/azure_ad_admin/unit_test/mocks.py
@@ -13,6 +13,7 @@ class MockRequest:
                 "@odata.type": "#microsoft.graph.user",
                 "city": None,
                 "companyName": None,
+                "employeeOrgData": {"costCenter": "111111111", "division": "Engineering"},
             },
         }
 

--- a/plugins/azure_ad_admin/unit_test/test_get_user_info.py
+++ b/plugins/azure_ad_admin/unit_test/test_get_user_info.py
@@ -38,6 +38,7 @@ class TestGetUserInfo(TestCase):
                 "accountEnabled": True,
                 "manager": {
                     "@odata.type": "#microsoft.graph.user",
+                    "employeeOrgData": {"costCenter": "111111111", "division": "Engineering"},
                 },
             }
         }


### PR DESCRIPTION
## 🎫 Ticket
https://rapid7.atlassian.net/browse/SOAR-21458

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [ ✅ ] Bug fix
- [ ] Other

## 🧠 Background & Motivation
Customer reported that `get_user_info` failed with `jsonschema.ValidationError` when the target user's manager had employeeOrgData populated:

`{'costCenter': '166561506'} is not of type 'string'`

The output schema typed `manager.employeeOrgData` as a string, but per Microsoft Graph it is a complex type with `costCenter` and `division`.

## ✨ What Changed
- plugin.spec.yaml: defined new `employeeOrgData` type (costCenter, division) and re-typed manager.employeeOrgData to use it
- Bumped version to `6.0.0`
- Unit tests: added populated employeeOrgData to the manager mock and updated expected_response so the existing test guards against regression.

## 🧪 Testing
- Unit tests
- Manual testing steps
- <img width="857" height="401" alt="image" src="https://github.com/user-attachments/assets/a3b27bad-9cca-43f3-806b-42ba45401d5e" />



From PR: https://github.com/rapid7/insightconnect-plugins/pull/3951