### PR TITLE
[SOAR-21545] Permissions fix

### DIFF
--- a/plugins/redhat_advisory/.CHECKSUM
+++ b/plugins/redhat_advisory/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "b7935ba824c95f26cd59e4346d9c888c",
+	"spec": "f597b19a7f44a52d3db4290ef53fd685",
 	"manifest": "70356d40426a7ae4f31e6de8161c4efc",
 	"setup": "5a77f34fb4954b6a9efefc40d43028a1",
 	"schemas": [

--- a/plugins/redhat_advisory/.CHECKSUM
+++ b/plugins/redhat_advisory/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "2aa890aae4c58b0d62508f48edf98ebc",
+	"spec": "b7935ba824c95f26cd59e4346d9c888c",
 	"manifest": "70356d40426a7ae4f31e6de8161c4efc",
 	"setup": "5a77f34fb4954b6a9efefc40d43028a1",
 	"schemas": [

--- a/plugins/redhat_advisory/Dockerfile
+++ b/plugins/redhat_advisory/Dockerfile
@@ -21,6 +21,8 @@ WORKDIR /workspace
 COPY --from=builder /workspace /workspace
 COPY --from=builder /plugin.spec.yaml /plugin.spec.yaml
 
+RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
+
 
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 

--- a/plugins/redhat_advisory/Dockerfile
+++ b/plugins/redhat_advisory/Dockerfile
@@ -21,14 +21,13 @@ WORKDIR /workspace
 COPY --from=builder /workspace /workspace
 COPY --from=builder /plugin.spec.yaml /plugin.spec.yaml
 
-RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
-
 
 RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 
 ENV PYTHONPATH="/workspace:${PYTHONPATH}"
 
 RUN rm -rf /root/.cache;
+RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
 RUN mkdir -p /workspace/tmp && chown -R nobody /workspace/tmp
 
 # User to run plugin code. The two supported users are: root, nobody

--- a/plugins/redhat_advisory/plugin.spec.yaml
+++ b/plugins/redhat_advisory/plugin.spec.yaml
@@ -31,6 +31,8 @@ sdk:
   type: slim
   version: 6.6.0
   user: nobody
+  custom_cmd:
+    - RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
 key_features:
 - Trigger a workflow when Red Hat publishes a new security advisory
 troubleshooting: |

--- a/plugins/redhat_advisory/plugin.spec.yaml
+++ b/plugins/redhat_advisory/plugin.spec.yaml
@@ -31,8 +31,7 @@ sdk:
   type: slim
   version: 6.6.0
   user: nobody
-  custom_cmd:
-    - RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
+enable_cache: true
 key_features:
 - Trigger a workflow when Red Hat publishes a new security advisory
 troubleshooting: |


### PR DESCRIPTION
## 🎫 Ticket
https://rapid7.atlassian.net/browse/SOAR-21545

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [ ] Bug fix
- [ ✅ ] Other

## 🧠 Background & Motivation
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/plugin.py", line 437, in handle_step
    output = self.start_step(
        input_message["body"],
    ...<5 lines>...
        connection_test_type=connection_test_type
    )
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/plugin.py", line 610, in start_step
    step.load_state()
    ~~~~~~~~~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/trigger.py", line 71, in load_state
    raise error
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/trigger.py", line 68, in load_state
    self._create_new_state_file(trigger_file)
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/trigger.py", line 89, in _create_new_state_file
    Path(CACHE_DIR).mkdir(parents=True, exist_ok=True)
    ~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/pathlib/_local.py", line 722, in mkdir
    os.mkdir(self, mode)
    ~~~~~~~~^^^^^^^^^^^^
PermissionError: [Errno 13] Permission denied: '/workspace/cache'
Traceback (most recent call last):
  File "/workspace/bin/komand_redhat_advisory", line 46, in <module>
    main()
    ~~~~^^
  File "/workspace/bin/komand_redhat_advisory", line 42, in main
    cli.run()
    ~~~~~~~^^
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/cli.py", line 294, in run
    args.func(args)
    ~~~~~~~~~^^^^^^
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/cli.py", line 188, in run_step
    return self.execute_step(is_test=False, is_debug=args.debug)
           ~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/cli.py", line 185, in execute_step
    raise exception
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/cli.py", line 176, in execute_step
    output = self.plugin.handle_step(msg, is_test=is_test, is_debug=is_debug)
  File "/usr/local/lib/python3.13/site-packages/insightconnect_plugin_runtime/plugin.py", line 525, in handle_step
    raise LoggedException(caught_exception, output)
insightconnect_plugin_runtime.exceptions.LoggedException: [Errno 13] Permission denied: '/workspace/cache'
```

## ✨ What Changed
- Added custom command

## 🧪 Testing
- Will test it on staging
