### PR TITLE
Rapid7 InsightIDR 12.0.8 Release

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "2e310d97121e6fe5a75450d8a2b7152d",
-	"manifest": "450d58255274436c4b185cee35f020e3",
-	"setup": "68d6a1bf680eeb2335a074810f907151",
+	"spec": "ff88a4f6d282203d8ffca8aab15e8ba9",
+	"manifest": "18f674c4226e8a05c7a591ce759c7cea",
+	"setup": "97c43432cc361571ff946baa5a2f7c30",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/Dockerfile
+++ b/plugins/rapid7_insightidr/Dockerfile
@@ -27,6 +27,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 ENV PYTHONPATH="/workspace:${PYTHONPATH}"
 
 RUN rm -rf /root/.cache;
+RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
 RUN mkdir -p /workspace/tmp && chown -R nobody /workspace/tmp
 
 # User to run plugin code. The two supported users are: root, nobody

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "12.0.7"
+Version = "12.0.8"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3428,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile
 * 12.0.7 - Updated dependencies | SDK bump to 6.6.0
 * 12.0.6 - Updated dependencies | SDK bump to 6.4.3
 * 12.0.5 - Removed default region in connection | Actions: `Advanced Query on Log Set` - Fixed issue with fetching logs with statistical queries | Updated SDK to latest version (6.4.2)

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 12.0.7
+version: 12.0.8
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2025-07-22."]
 vendor: rapid7
@@ -21,6 +21,7 @@ hub_tags:
   use_cases: [threat_detection_and_response]
   keywords: [siem, rapid7, cloud_enabled]
   features: []
+enable_cache: true
 key_features:
   - "System Information and Event Management"
   - "Endpoint Detection and Response"
@@ -35,6 +36,7 @@ sdk:
   version: 6.6.0
   user: nobody
 version_history:
+  - "12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile"
   - "12.0.7 - Updated dependencies | SDK bump to 6.6.0"
   - "12.0.6 - Updated dependencies | SDK bump to 6.4.3"
   - "12.0.5 - Removed default region in connection | Actions: `Advanced Query on Log Set` - Fixed issue with fetching logs with statistical queries | Updated SDK to latest version (6.4.2)"

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="12.0.7",
+    version="12.0.8",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## 🎫 Ticket
[[InsightIDR Plugin] missing enable_cache causing trigger errors](https://rapid7.atlassian.net/browse/SOAR-21657)

## 🧩 Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Other

## 🧠 Background & Motivation
The `enable_cache` setting was dropped from the plugin spec during the SDK 6.6.0 upgrade. Without it, the plugin's cache directory permissions were not configured in the Dockerfile, which resulted in trigger errors at runtime.

## ✨ What Changed
- Re-added `enable_cache: true` to `plugin.spec.yaml`, so `insight-plugin refresh` regenerates the `/workspace/cache` permission setup in the Dockerfile:
  ```
  RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
  RUN mkdir -p /workspace/tmp && chown -R nobody /workspace/tmp
  ```
- Bumped plugin version `12.0.7 → 12.0.8` and refreshed generated artifacts.
- SDK was already on the latest (`6.6.0`) — no SDK bump.

## 🧪 Testing
- Unit tests: 112 passed on SDK-matched Python 3.13.13.
- `insight-plugin refresh` regenerated artifacts cleanly; confirmed the Dockerfile now includes the cache/tmp permission lines.
- Container smoke test: image built cleanly and started in HTTP mode (gunicorn `Listening at`/`Booting worker`, no traceback).
- [x] Staging integration tests (run automatically when the release branch deploys).

## Next Steps
**Cloud plugin (`cloud_ready: true`)** — a companion **tf-komand** auto-PR was generated when this release branch was pushed. To deploy on staging, that PR must be **applied and merged** (this release PR alone does not deploy the cloud plugin).
