### PR TITLE
[SOAR-21653] Markdown replace SSRF sanitizer denylist with allowlist

### DIFF
--- a/plugins/markdown/.CHECKSUM
+++ b/plugins/markdown/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "8638bb98acac68885595cf393d388c2c",
+	"spec": "604d02b7c41c4c1cb267445e659bce83",
 	"manifest": "dfb754e0b162faa1cd6478a2d7f6d2f2",
 	"setup": "4451e2f293d22e300ca1afa21eafd728",
 	"schemas": [

--- a/plugins/markdown/help.md
+++ b/plugins/markdown/help.md
@@ -186,7 +186,7 @@ Example output:
 
 # Version History
 
-* 4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action that could allow SSRF via crafted Markdown input (CVE-2026-8661)
+* 4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action by sanitizing HTML with an allowlist of tags, attributes, and URL schemes, and fixed rendering of task lists and table column alignment (CVE-2026-8661)
 * 4.0.1 - Update SDK to version 6.6.0
 * 4.0.0 - Restricted script execution in the markdown_to_pdf PDF rendering engine to address a server-side scripting vector (partial fix for CVE-2026-8661) | Update SDK to version 6.4.3
 * 3.1.4 - `Markdown to PDF` - Fix issue which produced blank PDF files

--- a/plugins/markdown/icon_markdown/util/sanitizer.py
+++ b/plugins/markdown/icon_markdown/util/sanitizer.py
@@ -1,80 +1,125 @@
 import logging
-from typing import Set
-from html import escape
+import re
+from typing import Dict, Set
 from urllib.parse import urlparse
 from bs4 import BeautifulSoup, NavigableString
 
 logger = logging.getLogger(__name__)
 
-# HTML tags to be encoded (resource-loading, redirect, and script vectors)
-DENIED_TAGS: Set[str] = {
-    "script",
-    "iframe",
-    "object",
-    "embed",
-    "link",
-    "style",
-    "meta",
-    "base",
-    "svg",
-    "math",
-    "video",
-    "audio",
-    "source",
-    "track",
-    "picture",
-    "form",
+# Allowlist-based sanitization: only the tags/attributes/URL schemes below survive; everything
+# else is HTML-encoded (kept as visible text) before the HTML is handed to wkhtmltopdf. An
+# allowlist is used deliberately instead of a denylist so that new resource-loading vectors are
+# blocked by default rather than requiring the denylist to be patched for each one.
+
+# Tags produced by pandoc for standard Markdown (headings, emphasis, links, images, lists, task
+# lists, tables incl. grid/alignment/caption/colgroup, definition lists, footnotes, blockquotes,
+# code blocks/spans, sub/sup/del, hr). Any tag outside this set is encoded.
+ALLOWED_TAGS: Set[str] = {
+    "a",
+    "p",
+    "br",
+    "hr",
+    "div",
+    "span",
+    "pre",
+    "code",
+    "blockquote",
+    "figure",
+    "figcaption",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "strong",
+    "em",
+    "b",
+    "i",
+    "del",
+    "sub",
+    "sup",
+    "ul",
+    "ol",
+    "li",
+    "dl",
+    "dt",
+    "dd",
+    "label",
     "input",
+    "section",
+    "table",
+    "thead",
+    "tbody",
+    "tfoot",
+    "tr",
+    "th",
+    "td",
+    "caption",
+    "colgroup",
+    "col",
+    "img",
 }
 
-# HTML Attributes to be encoded (event handlers + inline CSS)
-DENIED_ATTRIBUTES: Set[str] = {
-    "onload",
-    "onerror",
-    "onabort",
-    "onunload",
-    "onbeforeunload",
-    "onclick",
-    "onmouseover",
-    "onmouseout",
-    "onmousedown",
-    "onmouseup",
-    "onfocus",
-    "onblur",
-    "onchange",
-    "onsubmit",
-    "onreset",
-    "onkeydown",
-    "onkeyup",
-    "onkeypress",
-    "oninput",
-    "onanimationstart",
-    "onanimationend",
-    "ontransitionend",
-    "style",
+# Attributes allowed on any allowed tag. These carry no resource-loading or scripting behavior.
+GLOBAL_ATTRS: Set[str] = {
+    "class",
+    "id",
+    "title",
+    "role",
+    "tabindex",
+    "aria-hidden",
+    "dir",
+    "lang",
+    "align",
 }
 
-# Attributes dereferenced by wkhtmltopdf/QtWebKit at render time (real SSRF sinks).
-# Only inline data: URIs and relative URLs are safe here.
-RESOURCE_URL_ATTRS: Set[str] = {
-    "src",
-    "poster",
-    "background",
-    "srcset",
-    "xlink:href",
-    "ping",
+# Additional attributes allowed only on specific tags. URL-bearing (href/src) and style attributes
+# are validated further below.
+TAG_ATTRS: Dict[str, Set[str]] = {
+    "a": {"href"},
+    "img": {"src", "alt"},
+    "ol": {"type"},
+    "li": {"value"},
+    "input": {"type", "checked", "disabled"},
+    "th": {"style", "colspan", "rowspan", "scope"},
+    "td": {"style", "colspan", "rowspan"},
+    "col": {"style", "span"},
+    "colgroup": {"style", "span"},
+    "table": {"style"},
+    "pre": {"class"},
+    "code": {"class"},
 }
-RESOURCE_URL_ALLOWED_SCHEMES: Set[str] = {"data"}
 
-# Attributes that produce a clickable hyperlink or form target in the final PDF;
-# they are not fetched at render time, so ordinary web schemes are safe.
-LINK_URL_ATTRS: Set[str] = {"href", "action", "formaction"}
-LINK_URL_ALLOWED_SCHEMES: Set[str] = {"http", "https", "mailto"}
+# Hyperlink attributes: not fetched at render time, so ordinary web schemes (and relative
+# URLs / pure fragments) are safe. javascript:, data:, file:, etc. are rejected.
+LINK_ATTRS: Set[str] = {"href"}
+LINK_ALLOWED_SCHEMES: Set[str] = {"http", "https", "mailto"}
+
+# Resource attributes dereferenced by wkhtmltopdf/QtWebKit during layout (real SSRF sinks).
+# Only inline data: URIs and genuinely relative paths are safe; protocol-relative (//host) is
+# rejected because the document is rendered from a file:// base and could still resolve to a host.
+RESOURCE_ATTRS: Set[str] = {"src"}
+RESOURCE_ALLOWED_SCHEMES: Set[str] = {"data"}
+
+# The style attribute is only needed for table column alignment/width that pandoc emits. Permit it
+# solely on table-layout tags and only when the whole value is text-align / width / height
+# declarations — anything containing url(), expression(), behavior:, etc. is rejected.
+STYLE_ALLOWED_TAGS: Set[str] = {"th", "td", "col", "colgroup", "table"}
+SAFE_STYLE = re.compile(
+    r"^\s*(?:(?:text-align\s*:\s*(?:left|right|center|justify)"
+    r"|(?:width|height)\s*:\s*\d+(?:\.\d+)?\s*(?:%|px|em|rem)?)\s*;?\s*)+$",
+    re.IGNORECASE,
+)
 
 
 def _encode_tag(tag) -> NavigableString:
-    """Convert a tag to an escaped NavigableString."""
-    return NavigableString(escape(str(tag), quote=False))
+    """Replace a tag with its raw string form.
+
+    The returned NavigableString is *not* pre-escaped; escaping happens exactly once when the
+    document is serialized with ``formatter="minimal"``. Pre-escaping here would double-encode.
+    """
+    return NavigableString(str(tag))
 
 
 def _url_scheme(value: str) -> str:
@@ -83,43 +128,96 @@ def _url_scheme(value: str) -> str:
     return urlparse(value.strip()).scheme.lower()
 
 
-def _is_disallowed(value: str, allowed_schemes: Set[str]) -> bool:
-    """A URL is disallowed when it has an explicit scheme outside the allowlist.
-
-    Relative URLs (no scheme) are considered safe because wkhtmltopdf without a
-    base URL cannot dereference them.
-    """
+def _is_safe_link(value: str) -> bool:
+    """A hyperlink URL is safe when it is relative/a fragment or uses an allowed web scheme."""
+    if not isinstance(value, str):
+        return False
     scheme = _url_scheme(value)
     if not scheme:
+        return True
+    return scheme in LINK_ALLOWED_SCHEMES
+
+
+def _is_safe_resource(value: str) -> bool:
+    """A resource URL is safe only if it is a data: URI or a genuinely relative path.
+
+    Protocol-relative references (//host/...) are rejected: with a file:// base URL they would not
+    be a network fetch, but they are never legitimate output from Markdown and only ever appear as
+    an attempt to reach a remote host, so they are treated as unsafe.
+    """
+    if not isinstance(value, str):
         return False
-    return scheme not in allowed_schemes
+    stripped = value.strip()
+    scheme = _url_scheme(stripped)
+    if scheme:
+        return scheme in RESOURCE_ALLOWED_SCHEMES
+    return not stripped.startswith("//")
 
 
-def _has_unsafe_url_attribute(tag) -> bool:
+def _iter_values(attr_value):
+    """bs4 exposes some attributes (e.g. class) as a list; normalize to an iterable of strings."""
+    if isinstance(attr_value, list):
+        return attr_value
+    return [attr_value]
+
+
+def _is_detached(tag, soup) -> bool:
+    """True if the tag is no longer attached to the document root.
+
+    When an outer tag is encoded it is replaced by escaped text, detaching the whole subtree. Its
+    descendants are still present in the pre-computed find_all() snapshot, so they must be skipped:
+    they are already represented (escaped once) inside the encoded ancestor, and re-encoding them
+    would double-escape.
+    """
+    node = tag
+    while node is not None:
+        if node is soup:
+            return False
+        node = node.parent
+    return True
+
+
+def _is_allowed_tag(tag) -> bool:
+    """Return True if the tag and every one of its attributes/values passes the allowlist."""
+    name = tag.name.lower()
+    if name not in ALLOWED_TAGS:
+        return False
+
+    allowed_attrs = GLOBAL_ATTRS | TAG_ATTRS.get(name, set())
     for attr_name, attr_value in tag.attrs.items():
-        name = attr_name.lower()
-        if name in RESOURCE_URL_ATTRS:
-            allowed = RESOURCE_URL_ALLOWED_SCHEMES
-        elif name in LINK_URL_ATTRS:
-            allowed = LINK_URL_ALLOWED_SCHEMES
-        else:
-            continue
-        values = attr_value if isinstance(attr_value, list) else [attr_value]
-        for value in values:
-            if isinstance(value, str) and _is_disallowed(value, allowed):
-                return True
-    return False
+        attr = attr_name.lower()
+        if attr not in allowed_attrs:
+            return False
+        if attr in LINK_ATTRS:
+            if not all(_is_safe_link(value) for value in _iter_values(attr_value)):
+                return False
+        elif attr in RESOURCE_ATTRS:
+            if not all(_is_safe_resource(value) for value in _iter_values(attr_value)):
+                return False
+        elif attr == "style":
+            if name not in STYLE_ALLOWED_TAGS:
+                return False
+            style_value = " ".join(str(value) for value in _iter_values(attr_value))
+            if not SAFE_STYLE.match(style_value):
+                return False
+    return True
 
 
 def sanitize_html(html_content: str) -> str:
     """
-    Sanitize HTML content by encoding potentially dangerous elements.
+    Sanitize HTML content by encoding anything outside the allowlist.
 
-    Denylist-based sanitization:
-    1. Encodes tags known to execute scripts, load remote resources, or redirect.
-    2. Encodes tags carrying denied attributes (event handlers, inline style).
-    3. Encodes tags whose URL-bearing attributes point to a disallowed scheme
-       (e.g. file:, javascript:, gopher:); relative URLs are preserved.
+    Allowlist-based sanitization:
+    1. Encodes any tag whose name is not in ALLOWED_TAGS.
+    2. Encodes any allowed tag that carries an attribute outside its allowlist (this removes event
+       handlers and unrecognized resource attributes such as srcset/ping/background by omission).
+    3. Encodes any allowed tag whose href/src points to a disallowed scheme, or whose style value
+       is not a safe alignment/width declaration.
+
+    The result is serialized with ``formatter="minimal"`` so every text node is HTML-escaped
+    exactly once (only &, <, > are escaped; non-ASCII text is left as-is). This prevents
+    entity-escaped markup (e.g. from a Markdown code span) from being resurrected into live tags on
+    output, while keeping the serialized HTML as close as possible to what pandoc emitted.
 
     Args:
         html_content: The HTML content to sanitize
@@ -132,18 +230,14 @@ def sanitize_html(html_content: str) -> str:
 
     soup = BeautifulSoup(html_content, "html.parser")
 
-    for tag in reversed(soup.find_all(True)):
-        if tag.name in DENIED_TAGS:
+    # Walk in document order so the outermost disallowed tag is encoded first, absorbing its whole
+    # subtree into a single escaped-once text node. Descendants of an already-encoded tag are
+    # detached from the document and skipped to avoid double-escaping.
+    for tag in soup.find_all(True):
+        if _is_detached(tag, soup):
+            continue
+        if not _is_allowed_tag(tag):
             logger.warning("Sanitizing HTML: encoded <%s> tag", tag.name)
             tag.replace_with(_encode_tag(tag))
-            continue
-        denied_attrs = [attr for attr in tag.attrs if attr.lower() in DENIED_ATTRIBUTES]
-        if denied_attrs:
-            logger.warning("Sanitizing HTML: encoded <%s> tag with attributes %s", tag.name, denied_attrs)
-            tag.replace_with(_encode_tag(tag))
-            continue
-        if _has_unsafe_url_attribute(tag):
-            logger.warning("Sanitizing HTML: encoded <%s> tag with disallowed URL scheme", tag.name)
-            tag.replace_with(_encode_tag(tag))
 
-    return soup.decode(formatter=None)
+    return soup.decode(formatter="minimal")

--- a/plugins/markdown/icon_markdown/util/sanitizer.py
+++ b/plugins/markdown/icon_markdown/util/sanitizer.py
@@ -177,30 +177,35 @@ def _is_detached(tag, soup) -> bool:
     return True
 
 
+def _is_safe_style(tag_name: str, attr_value) -> bool:
+    """Style is only allowed on table-layout tags and only for alignment/width declarations."""
+    if tag_name not in STYLE_ALLOWED_TAGS:
+        return False
+    style_value = " ".join(str(value) for value in _iter_values(attr_value))
+    return bool(SAFE_STYLE.match(style_value))
+
+
+def _is_allowed_attribute(tag_name: str, attr: str, attr_value) -> bool:
+    """Return True if a single attribute (and its value) is allowed on the given tag."""
+    if attr not in (GLOBAL_ATTRS | TAG_ATTRS.get(tag_name, set())):
+        return False
+    if attr in LINK_ATTRS:
+        return all(_is_safe_link(value) for value in _iter_values(attr_value))
+    if attr in RESOURCE_ATTRS:
+        return all(_is_safe_resource(value) for value in _iter_values(attr_value))
+    if attr == "style":
+        return _is_safe_style(tag_name, attr_value)
+    return True
+
+
 def _is_allowed_tag(tag) -> bool:
     """Return True if the tag and every one of its attributes/values passes the allowlist."""
     name = tag.name.lower()
     if name not in ALLOWED_TAGS:
         return False
-
-    allowed_attrs = GLOBAL_ATTRS | TAG_ATTRS.get(name, set())
-    for attr_name, attr_value in tag.attrs.items():
-        attr = attr_name.lower()
-        if attr not in allowed_attrs:
-            return False
-        if attr in LINK_ATTRS:
-            if not all(_is_safe_link(value) for value in _iter_values(attr_value)):
-                return False
-        elif attr in RESOURCE_ATTRS:
-            if not all(_is_safe_resource(value) for value in _iter_values(attr_value)):
-                return False
-        elif attr == "style":
-            if name not in STYLE_ALLOWED_TAGS:
-                return False
-            style_value = " ".join(str(value) for value in _iter_values(attr_value))
-            if not SAFE_STYLE.match(style_value):
-                return False
-    return True
+    return all(
+        _is_allowed_attribute(name, attr_name.lower(), attr_value) for attr_name, attr_value in tag.attrs.items()
+    )
 
 
 def sanitize_html(html_content: str) -> str:

--- a/plugins/markdown/plugin.spec.yaml
+++ b/plugins/markdown/plugin.spec.yaml
@@ -32,7 +32,7 @@ hub_tags:
   keywords: [markdown, html, pdf]
   features: []
 version_history:
-  - "4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action that could allow SSRF via crafted Markdown input (CVE-2026-8661)"
+  - "4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action by sanitizing HTML with an allowlist of tags, attributes, and URL schemes, and fixed rendering of task lists and table column alignment (CVE-2026-8661)"
   - 4.0.1 - Update SDK to version 6.6.0
   - 4.0.0 - Restricted script execution in the markdown_to_pdf PDF rendering engine to address a server-side scripting vector (partial fix for CVE-2026-8661) | Update SDK to version 6.4.3
   - 3.1.4 - `Markdown to PDF` - Fix issue which produced blank PDF files

--- a/plugins/markdown/unit_test/test_markdown_to_pdf.py
+++ b/plugins/markdown/unit_test/test_markdown_to_pdf.py
@@ -7,8 +7,11 @@ from unittest import TestCase
 from icon_markdown.actions.markdown_to_pdf import MarkdownToPdf
 from icon_markdown.actions.markdown_to_pdf.action import PDF_OPTIONS
 from icon_markdown.actions.markdown_to_pdf.schema import Input, Output
+from icon_markdown.util import utils
+from icon_markdown.util.sanitizer import sanitize_html
 from insightconnect_plugin_runtime.exceptions import PluginException
 from unittest import mock
+from bs4 import BeautifulSoup
 from mock_helpers import mock_request_markdown_to_pdf, mocked_request
 
 
@@ -65,3 +68,34 @@ class TestMarkdownToPdf(TestCase):
         self.assertIn("disable-local-file-access", PDF_OPTIONS)
         self.assertEqual(PDF_OPTIONS.get("load-error-handling"), "ignore")
         self.assertEqual(PDF_OPTIONS.get("load-media-error-handling"), "ignore")
+
+    @parameterized.expand(
+        [
+            # Markdown code span carrying raw HTML — pandoc entity-escapes it; the sanitizer must
+            # not let it become a live resource-loading tag on output.
+            ('`<img src="http://169.254.169.254/latest/meta-data/">`',),
+            ("`<style>@import url(http://evil.example/x.css);</style>`",),
+            ('`<link rel="stylesheet" href="http://evil.example/x.css">`',),
+            # Native Markdown image with a protocol-relative / external target.
+            ("![x](//evil.example/beacon.png)",),
+            ("![x](http://evil.example/beacon.png)",),
+        ]
+    )
+    def test_sanitized_markdown_has_no_live_remote_resource(self, markdown):
+        """Regression: attacker Markdown must not yield a live http(s) resource tag after sanitizing.
+
+        This mirrors the exact pipeline in action.run: utils.convert(md -> html) then sanitize_html.
+        A live <img src="http...">, <style>, or <link> would be fetched by wkhtmltopdf at render
+        time (SSRF), so the parsed output must contain no such live element. Encoded (escaped) text
+        is fine — it renders as inert characters and is never dereferenced.
+        """
+        sanitized = sanitize_html(utils.convert(markdown, "md", "html"))
+        soup = BeautifulSoup(sanitized, "html.parser")
+        # No live style/link elements at all.
+        self.assertEqual(soup.find_all(["style", "link"]), [])
+        # No live img pointing at a remote (http/https) or protocol-relative resource.
+        for img in soup.find_all("img"):
+            src = (img.get("src") or "").strip().lower()
+            self.assertFalse(src.startswith(("http://", "https://", "//")), f"live remote img: {src}")
+        # Escaping must happen exactly once (no resurrection, no double-encoding).
+        self.assertNotIn("&amp;lt;", sanitized)

--- a/plugins/markdown/unit_test/test_sanitizer.py
+++ b/plugins/markdown/unit_test/test_sanitizer.py
@@ -8,7 +8,7 @@ from icon_markdown.util.sanitizer import sanitize_html
 
 
 class TestSanitizer(TestCase):
-    """Test cases for HTML sanitization functionality."""
+    """Test cases for allowlist-based HTML sanitization."""
 
     @parameterized.expand(
         [
@@ -27,11 +27,6 @@ class TestSanitizer(TestCase):
                 '<p>Safe</p><object data="malicious.swf"></object>',
                 '<p>Safe</p>&lt;object data="malicious.swf"&gt;&lt;/object&gt;',
             ),
-            # Test embed tag encoding
-            (
-                '<p>Text</p><embed src="flash.swf">',
-                '<p>Text</p>&lt;embed src="flash.swf"/&gt;',
-            ),
             # Test link tag encoding
             (
                 '<link rel="stylesheet" href="evil.css"><p>Content</p>',
@@ -42,20 +37,15 @@ class TestSanitizer(TestCase):
                 '<style>body{background:url("javascript:alert(1)")}</style><p>Text</p>',
                 '&lt;style&gt;body{background:url("javascript:alert(1)")}&lt;/style&gt;<p>Text</p>',
             ),
-            # Test event handler encoding - onclick (now in deny list)
+            # Test event handler encoding - onclick
             (
                 "<p onclick=\"alert('xss')\">Click me</p>",
                 "&lt;p onclick=\"alert('xss')\"&gt;Click me&lt;/p&gt;",
             ),
-            # Test event handler encoding - onerror
+            # Test event handler encoding - onerror (img with disallowed attribute)
             (
                 '<img src="x" onerror="alert(\'xss\')">',
                 '&lt;img onerror="alert(\'xss\')" src="x"/&gt;',
-            ),
-            # Test event handler encoding - onload
-            (
-                '<img src="img.png" onload="malicious()">',
-                '&lt;img onload="malicious()" src="img.png"/&gt;',
             ),
             # Test that safe tags are preserved
             (
@@ -97,17 +87,38 @@ class TestSanitizer(TestCase):
                 '<img src="javascript:alert(1)"/>',
                 '&lt;img src="javascript:alert(1)"/&gt;',
             ),
+            # SSRF regression: srcset with an embedded external URL is encoded
+            # (srcset is not an allowed attribute, so the tag is encoded regardless of parsing)
+            (
+                '<img srcset="a.png, http://evil/x">',
+                '&lt;img srcset="a.png, http://evil/x"/&gt;',
+            ),
+            # SSRF regression: protocol-relative resource URL is encoded
+            (
+                '<img src="//evil.com/beacon.png">',
+                '&lt;img src="//evil.com/beacon.png"/&gt;',
+            ),
             # mailto: link is preserved
             (
                 '<a href="mailto:user@example.com">contact</a>',
                 '<a href="mailto:user@example.com">contact</a>',
             ),
-            # SSRF regression: inline style with url() is encoded (style is in DENIED_ATTRIBUTES)
+            # Fragment link (footnote reference) is preserved
+            (
+                '<a href="#fn1">note</a>',
+                '<a href="#fn1">note</a>',
+            ),
+            # javascript: hyperlink is encoded
+            (
+                '<a href="javascript:alert(1)">x</a>',
+                '&lt;a href="javascript:alert(1)"&gt;x&lt;/a&gt;',
+            ),
+            # SSRF regression: inline style with url() is encoded
             (
                 '<div style="background:url(http://attacker/)">x</div>',
                 '&lt;div style="background:url(http://attacker/)"&gt;x&lt;/div&gt;',
             ),
-            # SSRF regression: video with external src is encoded
+            # SSRF regression: video with external src is encoded (video is not allowed)
             (
                 '<video src="http://internal/"></video>',
                 '&lt;video src="http://internal/"&gt;&lt;/video&gt;',
@@ -116,6 +127,26 @@ class TestSanitizer(TestCase):
             (
                 '<meta http-equiv="refresh" content="0;url=http://internal/">',
                 '&lt;meta content="0;url=http://internal/" http-equiv="refresh"/&gt;',
+            ),
+            # Unknown/custom tags are encoded (allowlist default-deny)
+            (
+                "<custom-tag>z</custom-tag>",
+                "&lt;custom-tag&gt;z&lt;/custom-tag&gt;",
+            ),
+            # Task-list checkbox is preserved (regression: must render, not be encoded)
+            (
+                '<input type="checkbox" checked="">',
+                '<input checked="" type="checkbox"/>',
+            ),
+            # Table column alignment via style is preserved
+            (
+                '<th style="text-align: center;">C</th>',
+                '<th style="text-align: center;">C</th>',
+            ),
+            # A style value that smuggles url() alongside a safe declaration is encoded
+            (
+                '<th style="text-align:left;background:url(http://e)">C</th>',
+                '&lt;th style="text-align:left;background:url(http://e)"&gt;C&lt;/th&gt;',
             ),
             # Test table tags are preserved
             (
@@ -135,7 +166,7 @@ class TestSanitizer(TestCase):
         ]
     )
     def test_sanitize_html(self, input_html, expected_output):
-        """Test that dangerous HTML elements and attributes are properly sanitized."""
+        """Test that disallowed HTML elements and attributes are properly encoded."""
         result = sanitize_html(input_html)
         self.assertEqual(result, expected_output)
 
@@ -215,9 +246,52 @@ class TestSanitizer(TestCase):
         self.assertIn("data:image/png;base64", result)
         self.assertNotIn("&lt;img", result)
 
-    def test_style_attribute_is_encoded(self):
-        """Inline style attribute is encoded to prevent CSS-based SSRF via url()."""
+    def test_style_attribute_url_is_encoded(self):
+        """Inline style attribute carrying url() is encoded to prevent CSS-based SSRF."""
         html = '<div style="background:url(http://attacker/beacon)">x</div>'
         result = sanitize_html(html)
         self.assertIn("&lt;div", result)
         self.assertIn("style", result)
+
+    def test_entity_escaped_tag_is_not_resurrected(self):
+        """Regression for the formatter=None resurrection SSRF.
+
+        Text that merely *looks* like a tag (entity-escaped, e.g. from a Markdown code span) must
+        stay escaped on output and never be turned back into a live element.
+        """
+        html = '<p>&lt;img src="http://evil/x"&gt;</p>'
+        result = sanitize_html(html)
+        # The <img> must remain inert text, not a live tag, and must not be double-escaped.
+        self.assertNotIn('<img src="http://evil/x"', result)
+        self.assertIn('&lt;img src="http://evil/x"', result)
+        self.assertNotIn("&amp;lt;", result)
+
+    def test_entity_escaped_style_import_is_not_resurrected(self):
+        """A CSS @import smuggled as entity-escaped text must not become a live <style>."""
+        html = "<p>&lt;style&gt;@import url(http://evil/x.css);&lt;/style&gt;</p>"
+        result = sanitize_html(html)
+        self.assertNotIn("<style>", result)
+        self.assertIn("&lt;style&gt;", result)
+        self.assertNotIn("&amp;lt;", result)
+
+    def test_task_list_checkbox_is_preserved(self):
+        """Regression: task-list checkboxes must render (were encoded by the 4.0.2 denylist)."""
+        html = '<ul class="task-list"><li><label><input type="checkbox" checked="" />done</label></li></ul>'
+        result = sanitize_html(html)
+        self.assertIn("<input", result)
+        self.assertNotIn("&lt;input", result)
+
+    def test_table_alignment_style_is_preserved(self):
+        """Regression: table column alignment via style must render (was encoded by 4.0.2)."""
+        html = '<th style="text-align: right;">R</th>'
+        result = sanitize_html(html)
+        self.assertIn('<th style="text-align: right;">', result)
+        self.assertNotIn("&lt;th", result)
+
+    def test_nested_disallowed_tags_not_double_escaped(self):
+        """A disallowed tag containing another disallowed tag is escaped exactly once."""
+        html = '<svg><use xlink:href="http://evil"/></svg>'
+        result = sanitize_html(html)
+        self.assertNotIn("&amp;lt;", result)
+        self.assertIn("&lt;svg&gt;", result)
+        self.assertIn("&lt;use", result)


### PR DESCRIPTION
## 🎫 Ticket
https://rapid7.atlassian.net/browse/SOAR-21653

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [ ] Bug fix
- [✅  ] Other

## 🧠 Background & Motivation
The 4.0.2 fix for `CVE-2026-8661` closed the reported PoC (`<img src="http://…">`) but left a residual SSRF. The sanitizer ended with soup.decode(formatter=None), which un-escapes text on output, so entity-escaped markup from a Markdown code span (e.g. `<img src="http://169.254.169.254/…">`) was turned back into a live tag and fetched by wkhtmltopdf at render time. The denylist also encoded legitimate output, breaking task-list checkboxes and table column alignment. Since a denylist keeps missing new vectors, we switch to an allowlist (same approach the sed plugin took).

## ✨ What Changed
Rewrote `sanitizer.py` as an allowlist of tags, attributes, and URL schemes. Anything else gets encoded, so new resource vectors like srcset, ping and on* handlers are blocked by omission rather than by patching a list. Serialization now uses formatter="minimal" so text is escaped exactly once, which closes the resurrection SSRF.


## 🧪 Testing
- Unit tests