### PR TITLE
Bump SDK to 6.6.0 and add enable_cache entry

### DIFF
--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "58acbe926cb9e0dd23eb4c58b7b91d45",
+	"spec": "2d756ab7a2e1ba73d7339a98599ce66f",
 	"manifest": "1a2dc7e814ace4c7fccb8b8c9e1eed51",
 	"setup": "4faaaed8301154a2f0927e17639cd58a",
 	"schemas": [

--- a/plugins/microsoft_teams/.CHECKSUM
+++ b/plugins/microsoft_teams/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "2d756ab7a2e1ba73d7339a98599ce66f",
+	"spec": "a6283bb20c81b67793533f4cdffaafe7",
 	"manifest": "1a2dc7e814ace4c7fccb8b8c9e1eed51",
 	"setup": "4faaaed8301154a2f0927e17639cd58a",
 	"schemas": [

--- a/plugins/microsoft_teams/Dockerfile
+++ b/plugins/microsoft_teams/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.5.1 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.6.0 AS builder
 
 WORKDIR /workspace
 
@@ -11,7 +11,7 @@ ADD . /workspace
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.5.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.6.0
 
 LABEL organization=rapid7
 LABEL sdk=python

--- a/plugins/microsoft_teams/Dockerfile
+++ b/plugins/microsoft_teams/Dockerfile
@@ -27,6 +27,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 ENV PYTHONPATH="/workspace:${PYTHONPATH}"
 
 RUN rm -rf /root/.cache;
+RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
 RUN mkdir -p /workspace/tmp && chown -R nobody /workspace/tmp
 
 # User to run plugin code. The two supported users are: root, nobody

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -44,7 +44,7 @@ hub_tags:
     user_management]
   keywords: [microsoft_teams, office365, chat, cloud_enabled]
   features: []
-enable_cache: false
+enable_cache: true
 troubleshooting:
 - If there is more than one team with the same name in your organization, the oldest
   team between the two will be used.

--- a/plugins/microsoft_teams/plugin.spec.yaml
+++ b/plugins/microsoft_teams/plugin.spec.yaml
@@ -37,13 +37,14 @@ tags:
 - chat
 sdk:
   type: slim
-  version: 6.5.1
+  version: 6.6.0
   user: nobody
 hub_tags:
   use_cases: [alerting_and_notifications, application_management, threat_detection_and_response,
     user_management]
   keywords: [microsoft_teams, office365, chat, cloud_enabled]
   features: []
+enable_cache: false
 troubleshooting:
 - If there is more than one team with the same name in your organization, the oldest
   team between the two will be used.


### PR DESCRIPTION
## Summary - Bumped SDK from 6.5.1 to 6.6.0 - Added `enable_cache: true` to plugin.spec.yaml (required for cloud-ready plugins) - Dockerfile base image updated to 6.6.0 - Checksum regenerated ## Validation Plugin passes `insight-plugin validate` successfully.