### PR TITLE
Active Directory LDAP 11.0.0 Release

### DIFF
--- a/plugins/active_directory_ldap/.CHECKSUM
+++ b/plugins/active_directory_ldap/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "e80d939d8ce4f7820698c328e6812920",
-	"manifest": "be4951bbef16a7c9db069e1049758bcc",
-	"setup": "96cec6afd36f4489e55808322bc6c914",
+	"spec": "8edda020ad812080cef296293e4f6ea0",
+	"manifest": "a6680392014589ebbea4b73f90f882fc",
+	"setup": "6adf2e4d05bfd8488355ded00045e8dd",
 	"schemas": [
 		{
 			"identifier": "add_user/schema.py",
@@ -61,7 +61,7 @@
 		},
 		{
 			"identifier": "connection/schema.py",
-			"hash": "195c1e5f2c9a53182844f9a3c37467c4"
+			"hash": "d77c1df391353e84677a78030296b03f"
 		}
 	]
 }

--- a/plugins/active_directory_ldap/bin/komand_active_directory_ldap
+++ b/plugins/active_directory_ldap/bin/komand_active_directory_ldap
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Active Directory LDAP"
 Vendor = "rapid7"
-Version = "10.0.2"
+Version = "11.0.0"
 Description = "[AD LDAP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3c5916a9-f1a0-429d-b937-f8fe672d777c) (Active Directory Lightweight Directory Access Protocol) is an application protocol for querying and modifying items in Active Directory. This plugin queries [Microsoft's Active Directory service](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx) to programmatically manage and query an Active Directory environment"
 
 

--- a/plugins/active_directory_ldap/help.md
+++ b/plugins/active_directory_ldap/help.md
@@ -14,8 +14,9 @@
 
 * Host name and port number (the default TCP/UDP port for LDAP is 389, and 636 for LDAP over SSL)
 * Administrative credentials
-* To connect, you must have NTLM credentials.
-* Please make sure you enter your credentials with the DOMAIN\username format.
+* To connect, you must have NTLM or Kerberos credentials.
+* For NTLM, please make sure you enter your credentials with the DOMAIN\username format.
+* For Kerberos, provide the domain name and KDC address. The plugin will handle ticket acquisition automatically using the provided credentials.
 
 # Supported Product Versions
 
@@ -29,8 +30,10 @@ The connection configuration accepts the following parameters:
 
 |Name|Type|Default|Required|Description|Enum|Example|Placeholder|Tooltip|
 | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+|auth_type|string|Auto|True|Authentication type to use. NTLM uses DOMAIN\\username and password. Kerberos uses ticket-based authentication via the provided credentials and KDC. Auto will attempt Kerberos first, then fall back to NTLM|["NTLM", "Kerberos", "Auto"]|Auto|None|None|
 |chase_referrals|boolean|True|True|Allows the plugin to follow referrals from the specified Active Directory server to other Active Directory servers|None|True|None|None|
 |host|string|None|True|Server Host, e.g. example.com|None|example.com|None|None|
+|kerberos|kerberos|None|False|Connection details required for Kerberos authentication. Provide the domain name and KDC address|None|{"kdc": "10.0.1.11", "domain_name": "example.com"}|None|None|
 |port|integer|389|True|Port, e.g. 389|None|389|None|None|
 |use_channel_binding|boolean|False|False|Enable this option to require a secure TLS channel before binding, as needed for LDAP connections that enforce channel binding|None|False|None|None|
 |use_ssl|boolean|None|True|Use SSL?|None|True|None|None|
@@ -40,8 +43,13 @@ Example input:
 
 ```
 {
+  "auth_type": "Auto",
   "chase_referrals": true,
   "host": "example.com",
+  "kerberos": {
+    "domain_name": "example.com",
+    "kdc": "10.0.1.11"
+  },
   "port": 389,
   "use_channel_binding": false,
   "use_ssl": true,
@@ -678,6 +686,13 @@ Example output:
 
 ### Custom Types
   
+**kerberos**
+
+|Name|Type|Default|Required|Description|Example|
+| :--- | :--- | :--- | :--- | :--- | :--- |
+|Domain Name|string|None|False|The fully qualified domain name of the Active Directory domain, e.g. example.com|None|
+|KDC|string|None|False|IP address of the Active Directory domain controller (Key Distribution Center). If not provided, the Host value is used|None|
+  
 **attributes**
 
 |Name|Type|Default|Required|Description|Example|
@@ -762,6 +777,7 @@ the query results, and then using the variable step $item.dn
 
 # Version History
 
+* 11.0.0 - Add Kerberos (SASL GSSAPI) authentication support
 * 10.0.2 - Updated SDK to the latest version (6.6.0)
 * 10.0.1 - Fixed issues with channel binding support | Updated SDK to the latest version (6.3.6)
 * 10.0.0 - Support for channel binding | Updated SDK to the latest version (6.3.3)

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/connection/connection.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/connection/connection.py
@@ -16,6 +16,7 @@ class Connection(insightconnect_plugin_runtime.Connection):
 
     def connect(self, params={}):
         self.use_ssl = params.get(Input.USE_SSL)
+        kerberos_config = params.get(Input.KERBEROS, {}) or {}
         self.client = ActiveDirectoryLdapAPI(
             self.logger,
             use_ssl=self.use_ssl,
@@ -25,6 +26,9 @@ class Connection(insightconnect_plugin_runtime.Connection):
             user_name=params.get(Input.USERNAME_PASSWORD).get("username"),
             password=params.get(Input.USERNAME_PASSWORD).get("password"),
             use_channel_binding=params.get(Input.USE_CHANNEL_BINDING),
+            auth_type=params.get(Input.AUTH_TYPE, "Auto"),
+            kdc=kerberos_config.get("kdc", ""),
+            domain_name=kerberos_config.get("domain_name", ""),
         )
 
     def test(self):
@@ -32,6 +36,6 @@ class Connection(insightconnect_plugin_runtime.Connection):
             # pylint: disable=no-value-for-parameter
             self.client.who_am_i()
         except LDAPExtensionError as e:
-            raise ConnectionTestException(preset=ConnectionTestException.Preset.UNAUTHORIZED, data=e)
+            raise ConnectionTestException(preset=ConnectionTestException.Preset.UNAUTHORIZED, data=e) from e
 
         return {"connection": "successful"}

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/connection/schema.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/connection/schema.py
@@ -4,8 +4,10 @@ import json
 
 
 class Input:
+    AUTH_TYPE = "auth_type"
     CHASE_REFERRALS = "chase_referrals"
     HOST = "host"
+    KERBEROS = "kerberos"
     PORT = "port"
     USE_CHANNEL_BINDING = "use_channel_binding"
     USE_SSL = "use_ssl"
@@ -18,18 +20,36 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
   "type": "object",
   "title": "Variables",
   "properties": {
+    "auth_type": {
+      "type": "string",
+      "title": "Authentication Type",
+      "description": "Authentication type to use. NTLM uses DOMAIN\\\\username and password. Kerberos uses ticket-based authentication via the provided credentials and KDC. Auto will attempt Kerberos first, then fall back to NTLM",
+      "default": "Auto",
+      "enum": [
+        "NTLM",
+        "Kerberos",
+        "Auto"
+      ],
+      "order": 5
+    },
     "chase_referrals": {
       "type": "boolean",
       "title": "Chase Referrals",
       "description": "Allows the plugin to follow referrals from the specified Active Directory server to other Active Directory servers",
       "default": true,
-      "order": 6
+      "order": 8
     },
     "host": {
       "type": "string",
       "title": "Host",
       "description": "Server Host, e.g. example.com",
       "order": 1
+    },
+    "kerberos": {
+      "$ref": "#/definitions/kerberos",
+      "title": "Kerberos",
+      "description": "Connection details required for Kerberos authentication. Provide the domain name and KDC address",
+      "order": 7
     },
     "port": {
       "type": "integer",
@@ -55,10 +75,11 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
       "$ref": "#/definitions/credential_username_password",
       "title": "Username and Password",
       "description": "Username and password",
-      "order": 5
+      "order": 6
     }
   },
   "required": [
+    "auth_type",
     "chase_referrals",
     "host",
     "port",
@@ -91,6 +112,24 @@ class ConnectionSchema(insightconnect_plugin_runtime.Input):
         "username",
         "password"
       ]
+    },
+    "kerberos": {
+      "type": "object",
+      "title": "kerberos",
+      "properties": {
+        "kdc": {
+          "type": "string",
+          "title": "KDC",
+          "description": "IP address of the Active Directory domain controller (Key Distribution Center). If not provided, the Host value is used",
+          "order": 1
+        },
+        "domain_name": {
+          "type": "string",
+          "title": "Domain Name",
+          "description": "The fully qualified domain name of the Active Directory domain, e.g. example.com",
+          "order": 2
+        }
+      }
     }
   }
 }

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/util/api.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/util/api.py
@@ -1,8 +1,14 @@
 # pylint: disable=too-many-positional-arguments
+import ipaddress
 import json
+import os
+import tempfile
 from functools import wraps
 from json import loads
 from typing import List
+
+import gssapi
+from gssapi.raw import acquire_cred_with_password
 import ldap3
 from ldap3 import MODIFY_REPLACE, ALL_ATTRIBUTES, ALL_OPERATIONAL_ATTRIBUTES
 from ldap3 import extend
@@ -10,6 +16,7 @@ from ldap3.core.exceptions import LDAPBindError, LDAPAuthorizationDeniedResult, 
 from ldap3.utils.log import set_library_log_detail_level, set_library_log_hide_sensitive_data, ERROR
 
 from insightconnect_plugin_runtime.exceptions import PluginException
+from komand_active_directory_ldap.util.constants import ENCODING, KRB5_CONFIG_TEMPLATE
 from komand_active_directory_ldap.util.utils import ADUtils
 
 
@@ -39,6 +46,9 @@ class ActiveDirectoryLdapAPI:
         user_name=None,
         password=None,
         use_channel_binding=None,
+        auth_type=None,
+        kdc=None,
+        domain_name=None,
     ):
         self.logger = logger
         self.use_ssl = use_ssl
@@ -48,14 +58,99 @@ class ActiveDirectoryLdapAPI:
         self.user_name = user_name
         self.password = password
         self.use_channel_binding = use_channel_binding
+        self.auth_type = auth_type or "Auto"
+        self.kdc = kdc or ""
+        self.domain_name = domain_name or ""
 
         set_library_log_detail_level(ERROR)
         set_library_log_hide_sensitive_data(True)
 
+    @staticmethod
+    def _is_ip_address(host: str) -> bool:
+        try:
+            ipaddress.ip_address(host)
+            return True
+        except ValueError:
+            return False
+
+    def _resolve_kerberos_domain(self) -> str:
+        """Resolve the Kerberos domain from connection settings or host FQDN."""
+        if self.domain_name:
+            return self.domain_name
+        if self._is_ip_address(self.host):
+            raise PluginException(
+                cause="Kerberos domain name is required when Host is an IP address.",
+                assistance="Provide the domain name in the Kerberos connection settings (e.g., example.com).",
+            )
+        if "." in self.host:
+            return self.host.split(".", 1)[1]
+        raise PluginException(
+            cause="Kerberos domain name is required.",
+            assistance="Provide the domain name in the Kerberos connection settings "
+            "(e.g., example.com) or ensure the host contains the full FQDN.",
+        )
+
+    def _write_krb5_config(self, upper_domain: str, kdc: str, domain: str) -> str:
+        """Write krb5.conf to a temp file and set KRB5_CONFIG."""
+        krb5_config = KRB5_CONFIG_TEMPLATE.format(realm=upper_domain, kdc=kdc, domain=domain)
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".conf", delete=False, encoding=ENCODING) as krb5_file:
+            krb5_file.write(krb5_config)
+            krb5_path = krb5_file.name
+        os.environ["KRB5_CONFIG"] = krb5_path
+        return krb5_path
+
+    def _acquire_kerberos_credentials(self, upper_domain: str):
+        """Acquire a Kerberos TGT via gssapi using the connection credentials."""
+        username = self.user_name
+        if "\\" in username:
+            username = username.split("\\", 1)[1]
+
+        principal = f"{username}@{upper_domain}"
+        try:
+            name = gssapi.Name(principal, gssapi.NameType.user)
+            acquire_cred_with_password(name, self.password.encode(ENCODING))
+        except gssapi.exceptions.GSSError as error:
+            raise PluginException(
+                cause="Failed to acquire Kerberos credentials.",
+                assistance=f"Verify the KDC is reachable and credentials are valid for principal '{principal}'. "
+                f"Check that the domain name and KDC address are correct.",
+                data=str(error),
+            ) from error
+
+    def _configure_kerberos(self):
+        """Set up Kerberos realm config and acquire credentials for SASL/GSSAPI bind."""
+        domain = self._resolve_kerberos_domain()
+        kdc = self.kdc if self.kdc else self.host
+        upper_domain = domain.upper()
+
+        self.logger.info(f"Configuring Kerberos: realm={upper_domain}, kdc={kdc}")
+
+        self._write_krb5_config(upper_domain, kdc, domain)
+        self._acquire_kerberos_credentials(upper_domain)
+
+    def _connect_with_kerberos(self, server) -> ldap3.Connection:
+        """Establish an LDAP connection using Kerberos (SASL GSSAPI) authentication."""
+        self._configure_kerberos()
+        try:
+            conn = ldap3.Connection(
+                server=server,
+                authentication=ldap3.SASL,
+                sasl_mechanism=ldap3.KERBEROS,
+                auto_bind=True,
+                auto_referrals=self.referrals,
+            )
+        except LDAPBindError as error:
+            raise PluginException(
+                cause="Kerberos LDAP bind failed.",
+                assistance="Verify your Kerberos credentials and that the KDC is reachable.",
+                data=error,
+            ) from error
+        except LDAPSocketOpenError as error:
+            raise PluginException(preset=PluginException.Preset.SERVICE_UNAVAILABLE, data=error) from error
+        return conn
+
     def establish_connection(self) -> ldap3.Connection:
-        """
-        Connect to LDAP
-        """
+        """Connect to LDAP using the configured authentication method."""
         if not self.host.startswith("ldap://") and not self.host.startswith("ldaps://"):
             if self.use_ssl:
                 self.host = f"ldaps://{self.host}"
@@ -73,16 +168,33 @@ class ActiveDirectoryLdapAPI:
             get_info=ldap3.ALL,
         )
 
-        try:
-            conn = self.__connect_to_server(server, ldap3.NTLM)
-        except LDAPException:
-            # An exception here is likely caused because the ldap server dose use NTLM
-            # A basic auth connection will be tried instead
-            self.logger.info("Failed to connect to the server with NTLM, attempting to connect with basic auth")
-            conn = self.__connect_to_server(server)
+        if self.auth_type == "Kerberos":
+            conn = self._connect_with_kerberos(server)
+        elif self.auth_type == "NTLM":
+            conn = self._connect_with_ntlm_fallback(server)
+        else:
+            conn = self._connect_with_auto(server)
 
         self.logger.info("Connected!")
         return conn
+
+    def _connect_with_ntlm_fallback(self, server) -> ldap3.Connection:
+        """Attempt NTLM authentication, falling back to basic auth on failure."""
+        try:
+            return self.__connect_to_server(server, ldap3.NTLM)
+        except LDAPException:
+            self.logger.info("Failed to connect with NTLM, attempting basic auth")
+            return self.__connect_to_server(server)
+
+    def _connect_with_auto(self, server) -> ldap3.Connection:
+        """Auto mode: try Kerberos first if configured, then fall back to NTLM."""
+        if self.domain_name or self.kdc:
+            try:
+                return self._connect_with_kerberos(server)
+            except (PluginException, LDAPException) as error:
+                self.logger.info(f"Kerberos authentication failed, falling back to NTLM: {error}")
+
+        return self._connect_with_ntlm_fallback(server)
 
     def __connect_to_server(self, server, authentication=None) -> ldap3.Connection:
         try:

--- a/plugins/active_directory_ldap/komand_active_directory_ldap/util/constants.py
+++ b/plugins/active_directory_ldap/komand_active_directory_ldap/util/constants.py
@@ -1,0 +1,21 @@
+ENCODING = "utf-8"
+
+KRB5_CONFIG_TEMPLATE = (
+    "[libdefaults]\n"
+    "default_realm = {realm}\n"
+    "forwardable = true\n"
+    "proxiable = true\n"
+    "dns_lookup_realm = false\n"
+    "dns_lookup_kdc = false\n"
+    "\n"
+    "[realms]\n"
+    "{realm} = {{\n"
+    "kdc = {kdc}\n"
+    "admin_server = {kdc}\n"
+    "default_domain = {realm}\n"
+    "}}\n"
+    "\n"
+    "[domain_realm]\n"
+    ".{domain} = {realm}\n"
+    "{domain} = {realm}\n"
+)

--- a/plugins/active_directory_ldap/plugin.spec.yaml
+++ b/plugins/active_directory_ldap/plugin.spec.yaml
@@ -8,8 +8,8 @@ description: "[AD LDAP](https://docs.microsoft.com/en-us/openspecs/windows_proto
   \ for querying and modifying items in Active Directory. This plugin queries [Microsoft's\
   \ Active Directory service](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx)\
   \ to programmatically manage and query an Active Directory environment"
-version: 10.0.2
-connection_version: 9
+version: 11.0.0
+connection_version: 10
 supported_versions: [Azure Active Directory 2.0.89.0]
 fedramp_ready: true
 vendor: rapid7
@@ -45,8 +45,10 @@ requirements:
 - Host name and port number (the default TCP/UDP port for LDAP is 389, and 636 for
   LDAP over SSL)
 - Administrative credentials
-- To connect, you must have NTLM credentials.
-- Please make sure you enter your credentials with the DOMAIN\username format.
+- To connect, you must have NTLM or Kerberos credentials.
+- For NTLM, please make sure you enter your credentials with the DOMAIN\username format.
+- For Kerberos, provide the domain name and KDC address. The plugin will handle ticket
+  acquisition automatically using the provided credentials.
 troubleshooting:
 - "Objects that contain an equals sign `=` or an asterisk `*` require the signs to\
   \ be escaped.\nFor example `CN=Robert = bob Smith,OU=domain_users,DC=rapid7,DC=com`\
@@ -67,9 +69,9 @@ troubleshooting:
   \ can then be fed into another action by Repeating a collection for\nthe query results,\
   \ and then using the variable step $item.dn"
 version_history:
+- 11.0.0 - Add Kerberos (SASL GSSAPI) authentication support
 - 10.0.2 - Updated SDK to the latest version (6.6.0)
-- 10.0.1 - Fixed issues with channel binding support | Updated SDK to the latest version
-  (6.3.6)
+- 10.0.1 - Fixed issues with channel binding support | Updated SDK to the latest version (6.3.6)
 - 10.0.0 - Support for channel binding | Updated SDK to the latest version (6.3.3)
 - 9.0.4 - Updated SDK to the latest version (6.2.5)
 - 9.0.3 - Initial updates for fedramp compliance | Updated SDK to the latest version
@@ -147,6 +149,19 @@ references:
 - '[Python LDAP3](https://ldap3.readthedocs.io)'
 - '[RFC4515](https://tools.ietf.org/search/rfc4515)'
 types:
+  kerberos:
+    kdc:
+      title: KDC
+      description: IP address of the Active Directory domain controller (Key Distribution
+        Center). If not provided, the Host value is used
+      type: string
+      required: false
+    domain_name:
+      title: Domain Name
+      description: The fully qualified domain name of the Active Directory domain,
+        e.g. example.com
+      type: string
+      required: false
   attributes:
     accountExpires:
       title: Account Expires
@@ -360,12 +375,29 @@ connection:
     required: false
     default: false
     example: false
+  auth_type:
+    title: Authentication Type
+    type: string
+    description: Authentication type to use. NTLM uses DOMAIN\\username and password. Kerberos uses ticket-based authentication via the provided credentials and KDC. Auto will attempt Kerberos first, then fall back to NTLM
+    enum:
+      - NTLM
+      - Kerberos
+      - Auto
+    default: Auto
+    required: true
+    example: Auto
   username_password:
     title: Username and Password
     type: credential_username_password
     description: Username and password
     required: true
     example: '{"username":"user1", "password":"mypassword"}'
+  kerberos:
+    title: Kerberos
+    description: Connection details required for Kerberos authentication. Provide the domain name and KDC address
+    type: kerberos
+    required: false
+    example: '{"kdc": "10.0.1.11", "domain_name": "example.com"}'
   chase_referrals:
     title: Chase Referrals
     type: boolean

--- a/plugins/active_directory_ldap/requirements.txt
+++ b/plugins/active_directory_ldap/requirements.txt
@@ -4,5 +4,6 @@
 pycryptodome==3.20.0
 parameterized==0.9.0
 gssapi==1.9.0
+cryptography==48.0.0
 # If this commit hash is no longer supported or deemed suitable, python-ldap is another possible library
 git+https://github.com/cannatag/ldap3.git@639d0aef121f9174604371d37b922dc9d1e3c1aa#egg=ldap3

--- a/plugins/active_directory_ldap/setup.py
+++ b/plugins/active_directory_ldap/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="active_directory_ldap-rapid7-plugin",
-    version="10.0.2",
+    version="11.0.0",
     description="[AD LDAP](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-adts/3c5916a9-f1a0-429d-b937-f8fe672d777c) (Active Directory Lightweight Directory Access Protocol) is an application protocol for querying and modifying items in Active Directory. This plugin queries [Microsoft's Active Directory service](https://social.technet.microsoft.com/wiki/contents/articles/5392.active-directory-ldap-syntax-filters.aspx) to programmatically manage and query an Active Directory environment",
     author="rapid7",
     author_email="",

--- a/plugins/active_directory_ldap/unit_test/common.py
+++ b/plugins/active_directory_ldap/unit_test/common.py
@@ -127,6 +127,8 @@ class DefaultConnection:
                 Input.PORT: 345,
                 Input.USE_SSL: True,
                 Input.USERNAME_PASSWORD: {"username": "bob", "password": "foobar"},
+                Input.AUTH_TYPE: "NTLM",
+                Input.CHASE_REFERRALS: True,
             }
         )
 

--- a/plugins/active_directory_ldap/unit_test/test_disable_users.py
+++ b/plugins/active_directory_ldap/unit_test/test_disable_users.py
@@ -6,48 +6,11 @@ from komand_active_directory_ldap.actions.disable_users.schema import Input, Out
 from parameterized import parameterized
 
 from common import MockConnection, MockServer, default_connector
+from test_manage_users_common import MANAGE_USERS_TEST_CASES
 
 
 class TestActionDisableUsers(TestCase):
-    @parameterized.expand(
-        [
-            (
-                {Input.DISTINGUISHED_NAMES: ["CN=empty_search,DC=example,DC=com"]},
-                {
-                    Output.FAILED: [
-                        {
-                            "dn": "CN=empty_search,DC=example,DC=com",
-                            "error": "An error occurred during plugin execution! "
-                            "The DN CN=empty_search,DC=example,DC=com was "
-                            "not found. Please provide a valid DN and try again.",
-                        }
-                    ],
-                    Output.COMPLETED: [],
-                },
-            ),
-            (
-                {Input.DISTINGUISHED_NAMES: ["CN=empty_search,DC=example,DC=com", "CN=Users,DC=example," "DC=com"]},
-                {
-                    Output.FAILED: [
-                        {
-                            "dn": "CN=empty_search,DC=example,DC=com",
-                            "error": "An error occurred during plugin execution! "
-                            "The DN CN=empty_search,DC=example,DC=com was "
-                            "not found. Please provide a valid DN and try again.",
-                        }
-                    ],
-                    Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
-                },
-            ),
-            (
-                {Input.DISTINGUISHED_NAMES: ["CN=Users,DC=example,DC=com"]},
-                {
-                    Output.FAILED: [],
-                    Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
-                },
-            ),
-        ]
-    )
+    @parameterized.expand(MANAGE_USERS_TEST_CASES)
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
     @default_connector(action=DisableUsers())

--- a/plugins/active_directory_ldap/unit_test/test_enable_users.py
+++ b/plugins/active_directory_ldap/unit_test/test_enable_users.py
@@ -6,48 +6,11 @@ from komand_active_directory_ldap.actions.enable_users.schema import Input, Outp
 from parameterized import parameterized
 
 from common import MockConnection, MockServer, default_connector
+from test_manage_users_common import MANAGE_USERS_TEST_CASES
 
 
 class TestActionEnableUsers(TestCase):
-    @parameterized.expand(
-        [
-            (
-                {Input.DISTINGUISHED_NAMES: ["CN=empty_search,DC=example,DC=com"]},
-                {
-                    Output.FAILED: [
-                        {
-                            "dn": "CN=empty_search,DC=example,DC=com",
-                            "error": "An error occurred during plugin execution! "
-                            "The DN CN=empty_search,DC=example,DC=com was "
-                            "not found. Please provide a valid DN and try again.",
-                        }
-                    ],
-                    Output.COMPLETED: [],
-                },
-            ),
-            (
-                {Input.DISTINGUISHED_NAMES: ["CN=empty_search,DC=example,DC=com", "CN=Users,DC=example," "DC=com"]},
-                {
-                    Output.FAILED: [
-                        {
-                            "dn": "CN=empty_search,DC=example,DC=com",
-                            "error": "An error occurred during plugin execution! "
-                            "The DN CN=empty_search,DC=example,DC=com was "
-                            "not found. Please provide a valid DN and try again.",
-                        }
-                    ],
-                    Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
-                },
-            ),
-            (
-                {Input.DISTINGUISHED_NAMES: ["CN=Users,DC=example,DC=com"]},
-                {
-                    Output.COMPLETED: ["CN=Users,DC=example,DC=com"],
-                    Output.FAILED: [],
-                },
-            ),
-        ]
-    )
+    @parameterized.expand(MANAGE_USERS_TEST_CASES)
     @mock.patch("ldap3.Server", mock.MagicMock(return_value=MockServer))
     @mock.patch("ldap3.Connection", mock.MagicMock(return_value=MockConnection()))
     @default_connector(action=EnableUsers())

--- a/plugins/active_directory_ldap/unit_test/test_host_formatter.py
+++ b/plugins/active_directory_ldap/unit_test/test_host_formatter.py
@@ -17,6 +17,8 @@ class TestHostFormatter(TestCase):
             Input.PORT: 345,
             Input.USE_SSL: False,
             Input.USERNAME_PASSWORD: {"username": "bob", "password": "foobar"},
+            Input.AUTH_TYPE: "NTLM",
+            Input.CHASE_REFERRALS: True,
         }
         conn = connection.Connection()
         conn.logger = logging.getLogger("test_connection")

--- a/plugins/active_directory_ldap/unit_test/test_kerberos_connection.py
+++ b/plugins/active_directory_ldap/unit_test/test_kerberos_connection.py
@@ -1,0 +1,309 @@
+import logging
+import os
+from typing import Any
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+import gssapi
+import ldap3
+from ldap3.core.exceptions import LDAPBindError, LDAPSocketOpenError, LDAPException
+from insightconnect_plugin_runtime.exceptions import PluginException
+from komand_active_directory_ldap.util.api import ActiveDirectoryLdapAPI
+
+DEFAULT_KDC = "10.0.1.11"
+DEFAULT_DOMAIN = "example.com"
+DEFAULT_HOST = "dc01.example.com"
+
+
+def create_api(logger: logging.Logger, **overrides: Any) -> ActiveDirectoryLdapAPI:
+    """Create an ActiveDirectoryLdapAPI instance with sensible defaults for Kerberos tests."""
+    defaults = {
+        "use_ssl": True,
+        "host": DEFAULT_HOST,
+        "port": 636,
+        "referrals": True,
+        "user_name": "EXAMPLE\\svc_account",
+        "password": "SecureP@ss123",
+        "use_channel_binding": False,
+        "auth_type": "Kerberos",
+        "kdc": DEFAULT_KDC,
+        "domain_name": DEFAULT_DOMAIN,
+    }
+    defaults.update(overrides)
+    return ActiveDirectoryLdapAPI(logger=logger, **defaults)
+
+
+def mock_temp_file(path: str = "/tmp/krb5.conf") -> MagicMock:
+    """Return a mock NamedTemporaryFile supporting the context manager protocol."""
+    mock_file = MagicMock()
+    mock_file.name = path
+    mock_file.__enter__ = MagicMock(return_value=mock_file)
+    mock_file.__exit__ = MagicMock(return_value=False)
+    return mock_file
+
+
+class TestKerberosConfiguration(TestCase):
+    """Tests for Kerberos configuration and credential acquisition."""
+
+    def setUp(self) -> None:
+        self.logger = logging.getLogger("test_kerberos")
+        self.api = create_api(self.logger)
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_writes_krb5_to_temp_file_and_sets_env(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """Verify krb5.conf is written to a temp file and KRB5_CONFIG env var is set."""
+        mock_tempfile.return_value = mock_temp_file("/tmp/test_krb5.conf")
+
+        self.api._configure_kerberos()
+
+        mock_tempfile.assert_called_once_with(mode="w", suffix=".conf", delete=False, encoding="utf-8")
+        written_content = mock_tempfile.return_value.__enter__().write.call_args[0][0]
+        self.assertIn("EXAMPLE.COM", written_content)
+        self.assertIn(DEFAULT_KDC, written_content)
+        self.assertEqual(os.environ.get("KRB5_CONFIG"), "/tmp/test_krb5.conf")
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_acquires_credentials_via_gssapi(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """Verify gssapi acquire_cred_with_password is called with correct principal and password."""
+        mock_tempfile.return_value = mock_temp_file()
+
+        self.api._configure_kerberos()
+
+        mock_acquire.assert_called_once()
+        name_arg = mock_acquire.call_args[0][0]
+        password_arg = mock_acquire.call_args[0][1]
+        self.assertEqual(str(name_arg), "svc_account@EXAMPLE.COM")
+        self.assertEqual(password_arg, b"SecureP@ss123")
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_strips_domain_prefix_from_username(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """Verify DOMAIN\\username has the prefix stripped for the Kerberos principal."""
+        mock_tempfile.return_value = mock_temp_file()
+        api = create_api(self.logger, user_name="EXAMPLE\\admin_user")
+
+        api._configure_kerberos()
+
+        name_arg = mock_acquire.call_args[0][0]
+        self.assertEqual(str(name_arg), "admin_user@EXAMPLE.COM")
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_plain_username_used_directly(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """Verify plain username (no DOMAIN\\ prefix) is used as-is."""
+        mock_tempfile.return_value = mock_temp_file()
+        api = create_api(self.logger, user_name="admin_user")
+
+        api._configure_kerberos()
+
+        name_arg = mock_acquire.call_args[0][0]
+        self.assertEqual(str(name_arg), "admin_user@EXAMPLE.COM")
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_gssapi_failure_raises_plugin_exception(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """Verify gssapi GSSError raises PluginException with helpful messaging."""
+        mock_tempfile.return_value = mock_temp_file()
+        mock_acquire.side_effect = gssapi.exceptions.GSSError(851968, 0)
+
+        with self.assertRaises(PluginException) as context:
+            self.api._configure_kerberos()
+
+        self.assertIn("Failed to acquire Kerberos credentials", context.exception.cause)
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_uses_host_as_kdc_when_kdc_empty(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """When KDC is not provided, the host should be used as the KDC in krb5.conf."""
+        mock_tempfile.return_value = mock_temp_file()
+        api = create_api(self.logger, kdc="")
+
+        api._configure_kerberos()
+
+        written_content = mock_tempfile.return_value.__enter__().write.call_args[0][0]
+        self.assertIn(DEFAULT_HOST, written_content)
+
+    @patch("komand_active_directory_ldap.util.api.acquire_cred_with_password")
+    @patch("komand_active_directory_ldap.util.api.tempfile.NamedTemporaryFile")
+    def test_derives_domain_from_fqdn_host(self, mock_tempfile: MagicMock, mock_acquire: MagicMock) -> None:
+        """When domain_name is empty but host is FQDN, domain is derived from host."""
+        mock_tempfile.return_value = mock_temp_file()
+        api = create_api(self.logger, host="dc01.corp.example.com", domain_name="")
+
+        api._configure_kerberos()
+
+        written_content = mock_tempfile.return_value.__enter__().write.call_args[0][0]
+        self.assertIn("CORP.EXAMPLE.COM", written_content)
+
+
+class TestKerberosDomainResolution(TestCase):
+    """Tests for domain resolution logic including IP address detection."""
+
+    def setUp(self) -> None:
+        self.logger = logging.getLogger("test_kerberos_domain")
+
+    def test_ip_address_host_without_domain_raises_exception(self) -> None:
+        """An IP host with no domain_name raises a clear error."""
+        api = create_api(self.logger, host="10.0.1.11", domain_name="")
+
+        with self.assertRaises(PluginException) as context:
+            api._resolve_kerberos_domain()
+
+        self.assertIn("IP address", context.exception.cause)
+
+    def test_non_fqdn_host_without_domain_raises_exception(self) -> None:
+        """A bare hostname with no domain_name raises an error."""
+        api = create_api(self.logger, host="dc01", domain_name="")
+
+        with self.assertRaises(PluginException) as context:
+            api._resolve_kerberos_domain()
+
+        self.assertIn("Kerberos domain name is required", context.exception.cause)
+
+    def test_explicit_domain_name_takes_precedence(self) -> None:
+        """Explicit domain_name takes precedence over host derivation."""
+        api = create_api(self.logger, host="10.0.1.11", domain_name="corp.example.com")
+
+        domain = api._resolve_kerberos_domain()
+
+        self.assertEqual(domain, "corp.example.com")
+
+    def test_fqdn_host_derives_domain(self) -> None:
+        """FQDN host correctly derives the domain portion."""
+        api = create_api(self.logger, host="dc01.tatooine.lab", domain_name="")
+
+        domain = api._resolve_kerberos_domain()
+
+        self.assertEqual(domain, "tatooine.lab")
+
+
+class TestKerberosEstablishConnection(TestCase):
+    """Tests for establish_connection with different auth types."""
+
+    def setUp(self) -> None:
+        self.logger = logging.getLogger("test_kerberos_connection")
+
+    @patch.object(ActiveDirectoryLdapAPI, "_configure_kerberos")
+    @patch("ldap3.Connection")
+    @patch("ldap3.Server")
+    def test_kerberos_auth_uses_sasl_gssapi(
+        self, mock_server: MagicMock, mock_connection: MagicMock, mock_configure: MagicMock
+    ) -> None:
+        """Kerberos auth type creates a SASL/GSSAPI connection."""
+        mock_connection.return_value = MagicMock()
+        api = create_api(self.logger, host="ldaps://dc01.example.com")
+
+        api.establish_connection()
+
+        mock_configure.assert_called_once()
+        mock_connection.assert_called_once_with(
+            server=mock_server.return_value,
+            authentication=ldap3.SASL,
+            sasl_mechanism=ldap3.KERBEROS,
+            auto_bind=True,
+            auto_referrals=True,
+        )
+
+    @patch.object(ActiveDirectoryLdapAPI, "_configure_kerberos")
+    @patch("ldap3.Connection")
+    @patch("ldap3.Server")
+    def test_ntlm_auth_does_not_configure_kerberos(
+        self, mock_server: MagicMock, mock_connection: MagicMock, mock_configure: MagicMock
+    ) -> None:
+        """NTLM auth type does not call Kerberos configuration."""
+        mock_connection.return_value = MagicMock()
+        api = create_api(self.logger, host="ldaps://dc01.example.com", auth_type="NTLM")
+
+        api.establish_connection()
+
+        mock_configure.assert_not_called()
+
+    @patch.object(ActiveDirectoryLdapAPI, "_connect_with_kerberos")
+    @patch.object(ActiveDirectoryLdapAPI, "_ActiveDirectoryLdapAPI__connect_to_server")
+    @patch("ldap3.Server")
+    def test_auto_mode_tries_kerberos_first(
+        self, mock_server: MagicMock, mock_ntlm: MagicMock, mock_kerb: MagicMock
+    ) -> None:
+        """Auto mode attempts Kerberos first when config is present."""
+        mock_kerb.return_value = MagicMock()
+        api = create_api(self.logger, host="ldaps://dc01.example.com", auth_type="Auto")
+
+        api.establish_connection()
+
+        mock_kerb.assert_called_once()
+        mock_ntlm.assert_not_called()
+
+    @patch.object(ActiveDirectoryLdapAPI, "_connect_with_kerberos")
+    @patch.object(ActiveDirectoryLdapAPI, "_ActiveDirectoryLdapAPI__connect_to_server")
+    @patch("ldap3.Server")
+    def test_auto_mode_falls_back_to_ntlm(
+        self, mock_server: MagicMock, mock_ntlm: MagicMock, mock_kerb: MagicMock
+    ) -> None:
+        """Auto mode falls back to NTLM when Kerberos fails."""
+        mock_kerb.side_effect = PluginException(cause="Kerberos failed.", assistance="Check config.")
+        mock_ntlm.return_value = MagicMock()
+        api = create_api(self.logger, host="ldaps://dc01.example.com", auth_type="Auto")
+
+        api.establish_connection()
+
+        mock_kerb.assert_called_once()
+        self.assertTrue(mock_ntlm.called)
+
+    @patch.object(ActiveDirectoryLdapAPI, "_ActiveDirectoryLdapAPI__connect_to_server")
+    @patch("ldap3.Server")
+    def test_auto_mode_skips_kerberos_when_no_config(self, mock_server: MagicMock, mock_ntlm: MagicMock) -> None:
+        """Auto mode goes straight to NTLM when no kerberos config provided."""
+        mock_ntlm.return_value = MagicMock()
+        api = create_api(self.logger, host="ldaps://dc01.example.com", auth_type="Auto", kdc="", domain_name="")
+
+        api.establish_connection()
+
+        mock_ntlm.assert_called()
+
+
+class TestKerberosErrorHandling(TestCase):
+    """Tests for error paths in Kerberos connection flow."""
+
+    def setUp(self) -> None:
+        self.logger = logging.getLogger("test_kerberos_errors")
+
+    @patch.object(ActiveDirectoryLdapAPI, "_configure_kerberos")
+    @patch("ldap3.Connection", side_effect=LDAPBindError("bind failed"))
+    @patch("ldap3.Server")
+    def test_ldap_bind_error_raises_plugin_exception(
+        self, mock_server: MagicMock, mock_conn: MagicMock, mock_configure: MagicMock
+    ) -> None:
+        """LDAPBindError during Kerberos bind raises PluginException."""
+        api = create_api(self.logger, host="ldaps://dc01.example.com")
+
+        with self.assertRaises(PluginException) as context:
+            api._connect_with_kerberos(mock_server.return_value)
+
+        self.assertIn("Kerberos LDAP bind failed", context.exception.cause)
+
+    @patch.object(ActiveDirectoryLdapAPI, "_configure_kerberos")
+    @patch("ldap3.Connection", side_effect=LDAPSocketOpenError("refused"))
+    @patch("ldap3.Server")
+    def test_socket_error_raises_service_unavailable(
+        self, mock_server: MagicMock, mock_conn: MagicMock, mock_configure: MagicMock
+    ) -> None:
+        """LDAPSocketOpenError raises SERVICE_UNAVAILABLE."""
+        api = create_api(self.logger, host="ldaps://dc01.example.com")
+
+        with self.assertRaises(PluginException) as context:
+            api._connect_with_kerberos(mock_server.return_value)
+
+        self.assertIn("unavailable", context.exception.cause.lower())
+
+    @patch.object(ActiveDirectoryLdapAPI, "_ActiveDirectoryLdapAPI__connect_to_server")
+    @patch("ldap3.Server")
+    def test_ntlm_fallback_to_basic_auth(self, mock_server: MagicMock, mock_connect: MagicMock) -> None:
+        """NTLM mode falls back to basic auth when NTLM fails."""
+        mock_connect.side_effect = [LDAPException("NTLM not supported"), MagicMock()]
+        api = create_api(self.logger, host="ldaps://dc01.example.com", auth_type="NTLM")
+
+        api.establish_connection()
+
+        self.assertEqual(mock_connect.call_count, 2)

--- a/plugins/active_directory_ldap/unit_test/test_manage_users_common.py
+++ b/plugins/active_directory_ldap/unit_test/test_manage_users_common.py
@@ -1,0 +1,31 @@
+"""Shared test data for enable_users and disable_users actions."""
+
+NOT_FOUND_ERROR = (
+    "An error occurred during plugin execution! "
+    "The DN CN=empty_search,DC=example,DC=com was not found. "
+    "Please provide a valid DN and try again."
+)
+
+MANAGE_USERS_TEST_CASES = [
+    (
+        {"distinguished_names": ["CN=empty_search,DC=example,DC=com"]},
+        {
+            "completed": [],
+            "failed": [{"dn": "CN=empty_search,DC=example,DC=com", "error": NOT_FOUND_ERROR}],
+        },
+    ),
+    (
+        {"distinguished_names": ["CN=empty_search,DC=example,DC=com", "CN=Users,DC=example,DC=com"]},
+        {
+            "completed": ["CN=Users,DC=example,DC=com"],
+            "failed": [{"dn": "CN=empty_search,DC=example,DC=com", "error": NOT_FOUND_ERROR}],
+        },
+    ),
+    (
+        {"distinguished_names": ["CN=Users,DC=example,DC=com"]},
+        {
+            "completed": ["CN=Users,DC=example,DC=com"],
+            "failed": [],
+        },
+    ),
+]


### PR DESCRIPTION
## 🎫 Ticket

N/A — Customer-driven security enhancement request

## 🧩 Type of Change

- [x] Feature
- [ ] Bug fix
- [ ] Other

## 🧠 Background & Motivation

Customers raised concerns about the security of NTLM-only authentication in the Active Directory LDAP plugin. NTLM is susceptible to relay attacks, exposes credential hashes on every connection, lacks mutual authentication, and is actively being deprecated by Microsoft in favor of Kerberos. This PR adds Kerberos (SASL/GSSAPI) as an authentication option, providing a modern, ticket-based auth mechanism that eliminates credential hash exposure and supports mutual authentication.

## ✨ What Changed

- New connection inputs: `auth_type` (NTLM/Kerberos/Auto) and `kerberos` config object (KDC address, domain name)
- Kerberos authentication implemented using `gssapi.raw.acquire_cred_with_password` — pure Python, no subprocess, no shell, no password in process args
- krb5.conf written to a temp file with `KRB5_CONFIG` env var (no root required, container runs as `nobody`)
- Auto mode attempts Kerberos first when config is provided, falls back to NTLM gracefully
- IPv4/IPv6 detection prevents incorrect domain derivation from IP-address hosts
- Added `cryptography==48.0.0` dependency (required by ldap3 for TLS channel bindings with LDAPS)
- KRB5 config template extracted to `util/constants.py`
- Bumped version to 11.0.0, connection_version to 10

## 🧪 Testing

- End-to-end testing against a Windows Server 2022 domain controller (TATOOINE.LAB):
  - Kerberos auth over LDAP (port 389) — verified working
  - Kerberos auth over LDAPS (port 636) — verified working
  - Confirmed Kerberos ticket usage via Event ID 4768/4769 on the DC
  - Tested Query, Query Group Membership, Disable User, Enable User, and Reset Password actions