### PR TITLE
Rapid7 InsightIDR 12.0.9 Release

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "ff88a4f6d282203d8ffca8aab15e8ba9",
-	"manifest": "18f674c4226e8a05c7a591ce759c7cea",
-	"setup": "97c43432cc361571ff946baa5a2f7c30",
+	"spec": "a9bc853f410a5eee8745dfc03f6c6381",
+	"manifest": "0f295160c932fefef8b7d07d7d14a9b8",
+	"setup": "1bea76a942287c7f322bcf55882f16a3",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "12.0.8"
+Version = "12.0.9"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3428,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 12.0.9 - Retry requests with backoff on transient InsightIDR 5xx responses to resolve intermittent 500 errors
 * 12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile
 * 12.0.7 - Updated dependencies | SDK bump to 6.6.0
 * 12.0.6 - Updated dependencies | SDK bump to 6.4.3

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/constants.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/constants.py
@@ -10,5 +10,24 @@ THREE_MONTHS_SECONDS = 7776000
 # Constants for resource_helper.py
 DEFAULT_ERROR_MESSAGE = "Unknown error occurred. Please contact support or try again later."
 
+# Retry/backoff for transient 5xx responses from InsightIDR. A newly created record can
+# take a short time to become searchable (~1-2s indexing lag), so a follow-up request can
+# transiently return a 5xx. Retrying with backoff over a ~5s window (2s + 3s across the
+# gaps) resolves the vast majority of these.
+RETRY_MAX_ATTEMPTS = 3
+RETRY_BACKOFF_SECONDS = [2, 3]
+# Additive jitter (0 to N seconds) on top of each backoff so concurrent jobs that hit a
+# 5xx at the same moment don't retry in lockstep. Kept additive (never subtractive) so a
+# retry can't fire before the ~1-2s indexing window the backoff is sized to cover.
+RETRY_JITTER_SECONDS = 1
+# Transient/gateway 5xx worth retrying. Permanent 5xx (e.g. 501, 505) are excluded since
+# retrying cannot help.
+RETRYABLE_STATUS_CODES = {500, 502, 503, 504}
+# Only retry requests that are safe to repeat. POST is excluded (a committed-then-5xx
+# create must not be duplicated) EXCEPT for read-only search endpoints, which are the
+# primary source of the transient 5xx (e.g. investigations/_search after a just-created
+# record). All other methods the plugin issues (GET, DELETE) are idempotent.
+RETRYABLE_POST_ENDPOINT_SUFFIXES = ("_search", "/search")
+
 # Constants for Get New Alerts trigger.py
 TOTAL_SIZE = 100

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/util/resource_helper.py
@@ -1,7 +1,9 @@
 import asyncio
 import base64
 import json
+import random
 import re
+import time
 import uuid
 from typing import Any, Dict, List
 
@@ -11,7 +13,14 @@ from insightconnect_plugin_runtime.exceptions import PluginException
 from insightconnect_plugin_runtime.helper import clean
 
 from komand_rapid7_insightidr.connection import Connection
-from komand_rapid7_insightidr.util.constants import DEFAULT_ERROR_MESSAGE
+from komand_rapid7_insightidr.util.constants import (
+    DEFAULT_ERROR_MESSAGE,
+    RETRY_BACKOFF_SECONDS,
+    RETRY_JITTER_SECONDS,
+    RETRY_MAX_ATTEMPTS,
+    RETRYABLE_POST_ENDPOINT_SUFFIXES,
+    RETRYABLE_STATUS_CODES,
+)
 from komand_rapid7_insightidr.util.util import get_logging_context
 
 
@@ -100,6 +109,61 @@ class ResourceHelper(object):
         # add the request ID to the headers or make a new one if we're running on an orchestrator
         self.headers["R7-Correlation-Id"] = self.logging_context.get("R7-Correlation-Id", str(uuid.uuid4()))
 
+    @staticmethod
+    def _is_retryable_request(method: str, endpoint: str) -> bool:
+        """
+        Decides whether a request is safe to retry on a transient 5xx.
+
+        POST is the only method we guard: a create that commits server-side before
+        returning a 5xx must never be duplicated by a retry. The one exception is
+        read-only search POSTs (e.g. investigations/_search), which are the primary
+        source of the transient indexing-lag 5xx and carry no write side effect. Every
+        other method the plugin issues (GET, DELETE) is idempotent and safe to re-send.
+
+        :param method: HTTP method for the request
+        :param endpoint: The request URL (inspected for search endpoints)
+        :return: True if the request may be retried
+        """
+        if method.upper() == "POST":
+            return endpoint.endswith(RETRYABLE_POST_ENDPOINT_SUFFIXES)
+        return True
+
+    def _send_with_retry(self, request: requests.Request) -> requests.Response:
+        """
+        Sends a request, retrying on transient 5xx responses with backoff.
+
+        A newly created record can take a short time to become searchable (~1-2s indexing
+        lag), so a follow-up request can transiently return a 5xx. Retrying over a short
+        window resolves the vast majority of these. Retries are
+        restricted to requests that are safe to repeat (see `_is_retryable_request`) so
+        non-idempotent writes are never duplicated. Non-5xx responses (including 4xx) are
+        returned immediately and handled by the caller; the final 5xx response after all
+        attempts is returned so the caller raises as before.
+
+        :param request: The (unprepared) request to send
+        :return: The requests.Response from the last attempt
+        """
+        correlation_id = self.headers.get("R7-Correlation-Id", "N/A")
+        retryable = self._is_retryable_request(request.method, request.url)
+        with requests.Session() as session:
+            prepared_request = session.prepare_request(request)
+            response = session.send(prepared_request)
+            if not retryable:
+                return response
+            for attempt in range(1, RETRY_MAX_ATTEMPTS):
+                if response.status_code not in RETRYABLE_STATUS_CODES:
+                    return response
+                backoff = RETRY_BACKOFF_SECONDS[min(attempt - 1, len(RETRY_BACKOFF_SECONDS) - 1)]
+                backoff += random.uniform(0, RETRY_JITTER_SECONDS)  # nosec B311 - jitter timing, not security-sensitive
+                self.logger.warning(
+                    f"InsightIDR returned a transient status code of {response.status_code} "
+                    f"(request ID: {correlation_id}). Retrying in {backoff:.1f}s "
+                    f"(attempt {attempt + 1} of {RETRY_MAX_ATTEMPTS})."
+                )
+                time.sleep(backoff)
+                response = session.send(prepared_request)
+        return response
+
     def resource_request(self, endpoint: str, method: str = "get", params: dict = None, payload: dict = None) -> dict:
         """
         Sends a request to API with the provided endpoint and optional method/payload
@@ -119,9 +183,7 @@ class ResourceHelper(object):
             if payload:
                 _request.json = payload
 
-            with requests.Session() as session:
-                prepared_request = session.prepare_request(request=_request)
-                response = session.send(prepared_request)
+            response = self._send_with_retry(_request)
 
         except requests.RequestException as error:
             self.logger.error(error)
@@ -177,9 +239,7 @@ class ResourceHelper(object):
                 files=files,
             )
 
-            with requests.Session() as session:
-                prepared_request = session.prepare_request(request=_request)
-                response = session.send(prepared_request)
+            response = self._send_with_retry(_request)
             if response.status_code == 400:
                 raise PluginException(preset=PluginException.Preset.BAD_REQUEST, data=response.text)
             if response.status_code in [401, 403]:

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 12.0.8
+version: 12.0.9
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2025-07-22."]
 vendor: rapid7
@@ -36,6 +36,7 @@ sdk:
   version: 6.6.0
   user: nobody
 version_history:
+  - "12.0.9 - Retry requests with backoff on transient InsightIDR 5xx responses to resolve intermittent 500 errors"
   - "12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile"
   - "12.0.7 - Updated dependencies | SDK bump to 6.6.0"
   - "12.0.6 - Updated dependencies | SDK bump to 6.4.3"

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="12.0.8",
+    version="12.0.9",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",

--- a/plugins/rapid7_insightidr/unit_test/test_resource_helper.py
+++ b/plugins/rapid7_insightidr/unit_test/test_resource_helper.py
@@ -1,0 +1,95 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+import logging
+from unittest import TestCase
+from unittest.mock import patch
+
+import requests
+from insightconnect_plugin_runtime.exceptions import PluginException
+from komand_rapid7_insightidr.util.constants import RETRY_MAX_ATTEMPTS
+from komand_rapid7_insightidr.util.resource_helper import ResourceHelper
+
+
+def _make_response(status_code: int, body: str = "{}") -> requests.Response:
+    response = requests.Response()
+    response.status_code = status_code
+    response._content = body.encode("utf-8")
+    return response
+
+
+class TestResourceHelperRetry(TestCase):
+    def setUp(self) -> None:
+        self.helper = ResourceHelper({}, logging.getLogger("test"))
+        self.endpoint = "https://us.api.insight.rapid7.com/idr/v2/investigations/_search"
+
+        self.mock_sleep = patch("time.sleep", return_value=None).start()
+        self.mock_send = patch("requests.Session.send").start()
+        self.addCleanup(patch.stopall)
+
+    def test_resource_request_retries_5xx_then_succeeds(self) -> None:
+        self.mock_send.side_effect = [_make_response(500), _make_response(200, '{"data": "ok"}')]
+
+        result = self.helper.resource_request(self.endpoint, method="post")
+
+        self.assertEqual(result["status"], 200)
+        self.assertEqual(self.mock_send.call_count, 2)
+        self.mock_sleep.assert_called_once()
+
+    def test_resource_request_persistent_5xx_raises_after_max_attempts(self) -> None:
+        self.mock_send.return_value = _make_response(500, '{"message": "boom"}')
+
+        with self.assertRaises(PluginException):
+            self.helper.resource_request(self.endpoint, method="post")
+
+        self.assertEqual(self.mock_send.call_count, RETRY_MAX_ATTEMPTS)
+        self.assertEqual(self.mock_sleep.call_count, RETRY_MAX_ATTEMPTS - 1)
+
+    def test_resource_request_4xx_not_retried(self) -> None:
+        self.mock_send.return_value = _make_response(404, '{"message": "nope"}')
+
+        with self.assertRaises(PluginException):
+            self.helper.resource_request(self.endpoint, method="get")
+
+        self.assertEqual(self.mock_send.call_count, 1)
+        self.mock_sleep.assert_not_called()
+
+    def test_make_request_retries_5xx_then_succeeds(self) -> None:
+        self.mock_send.side_effect = [_make_response(503), _make_response(200, '{"data": "ok"}')]
+
+        result = self.helper.make_request(self.endpoint, method="POST")
+
+        self.assertEqual(result, {"data": "ok"})
+        self.assertEqual(self.mock_send.call_count, 2)
+        self.mock_sleep.assert_called_once()
+
+    def test_make_request_persistent_5xx_raises_after_max_attempts(self) -> None:
+        self.mock_send.return_value = _make_response(502, "gateway error")
+
+        with self.assertRaises(PluginException):
+            self.helper.make_request(self.endpoint, method="POST")
+
+        self.assertEqual(self.mock_send.call_count, RETRY_MAX_ATTEMPTS)
+        self.assertEqual(self.mock_sleep.call_count, RETRY_MAX_ATTEMPTS - 1)
+
+    def test_make_request_4xx_not_retried(self) -> None:
+        self.mock_send.return_value = _make_response(400, "bad request")
+
+        with self.assertRaises(PluginException):
+            self.helper.make_request(self.endpoint, method="POST")
+
+        self.assertEqual(self.mock_send.call_count, 1)
+        self.mock_sleep.assert_not_called()
+
+    def test_non_idempotent_post_5xx_not_retried(self) -> None:
+        # A create POST (not a search) must not be retried on 5xx to avoid duplicate writes.
+        create_endpoint = "https://us.api.insight.rapid7.com/idr/v2/investigations"
+        self.mock_send.return_value = _make_response(500, '{"message": "boom"}')
+
+        with self.assertRaises(PluginException):
+            self.helper.make_request(create_endpoint, method="POST")
+
+        self.assertEqual(self.mock_send.call_count, 1)
+        self.mock_sleep.assert_not_called()


### PR DESCRIPTION
## 🎫 Ticket
[SOAR-21651: Intermittent 500 Errors with the InsightIDR Plugin](https://rapid7.atlassian.net/browse/SOAR-21651)

## 🧩 Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Other

## 🧠 Background & Motivation
Promotes the 12.0.9 release to master. Customers intermittently received `500 Internal Server Error` responses from the InsightIDR plugin, where re-running the same job typically succeeded on the next attempt. A newly created record can take a short time to become searchable, so a follow-up request can arrive during that short window and get a transient 5xx.

## ✨ What Changed
- Centralized retry-with-backoff (plus jitter) around the shared send path used by both `resource_request()` and `make_request()`, retrying transient 5xx (500/502/503/504) up to 3 attempts over a short window. Retries are scoped to requests that are safe to repeat — idempotent methods plus read-only search POSTs — so non-idempotent writes are never duplicated.
- Bumped plugin version `12.0.8` → `12.0.9`.
- See #4025 for the reviewed change.

## 🧪 Testing
- Full unit suite passes; `insight-plugin refresh` regenerated cleanly; container smoke test boots cleanly in HTTP mode.
- Staging: manually exercised Search Investigations, Get Investigation, List Comments, and Create Comment actions plus the Get New Investigations trigger — all successful, with no spurious retries on healthy responses.
