### PR TITLE
Markdown 4.0.3 Release

### DIFF
--- a/plugins/markdown/.CHECKSUM
+++ b/plugins/markdown/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "604d02b7c41c4c1cb267445e659bce83",
-	"manifest": "dfb754e0b162faa1cd6478a2d7f6d2f2",
-	"setup": "4451e2f293d22e300ca1afa21eafd728",
+	"spec": "ea836288e3d0b580723e97f40aefb94d",
+	"manifest": "fd7b54a4a457f82862f6ad69dc4f20f0",
+	"setup": "e4817208313e8a9483b474c82521d68d",
 	"schemas": [
 		{
 			"identifier": "html_to_markdown/schema.py",

--- a/plugins/markdown/bin/icon_markdown
+++ b/plugins/markdown/bin/icon_markdown
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Markdown"
 Vendor = "rapid7"
-Version = "4.0.2"
+Version = "4.0.3"
 Description = "[Markdown](https://en.wikipedia.org/wiki/Markdown) is a lightweight markup language with plain text formatting syntax. This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.python.org/pypi/pypandoc/) to manipulate Markdown content"
 
 

--- a/plugins/markdown/help.md
+++ b/plugins/markdown/help.md
@@ -186,6 +186,7 @@ Example output:
 
 # Version History
 
+* 4.0.3 - Updated dependencies
 * 4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action by sanitizing HTML with an allowlist of tags, attributes, and URL schemes, and fixed rendering of task lists and table column alignment (CVE-2026-8661)
 * 4.0.1 - Update SDK to version 6.6.0
 * 4.0.0 - Restricted script execution in the markdown_to_pdf PDF rendering engine to address a server-side scripting vector (partial fix for CVE-2026-8661) | Update SDK to version 6.4.3

--- a/plugins/markdown/plugin.spec.yaml
+++ b/plugins/markdown/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: markdown
 title: Markdown
 description: '[Markdown](https://en.wikipedia.org/wiki/Markdown) is a lightweight markup language with plain text formatting syntax. This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.python.org/pypi/pypandoc/) to manipulate Markdown content'
-version: 4.0.2
+version: 4.0.3
 connection_version: 3
 vendor: rapid7
 support: community
@@ -32,6 +32,7 @@ hub_tags:
   keywords: [markdown, html, pdf]
   features: []
 version_history:
+  - 4.0.3 - Updated dependencies
   - "4.0.2 - Resolved a server-side request forgery issue in the markdown_to_pdf action by sanitizing HTML with an allowlist of tags, attributes, and URL schemes, and fixed rendering of task lists and table column alignment (CVE-2026-8661)"
   - 4.0.1 - Update SDK to version 6.6.0
   - 4.0.0 - Restricted script execution in the markdown_to_pdf PDF rendering engine to address a server-side scripting vector (partial fix for CVE-2026-8661) | Update SDK to version 6.4.3

--- a/plugins/markdown/requirements.txt
+++ b/plugins/markdown/requirements.txt
@@ -1,4 +1,4 @@
-pdfkit==0.6.1
+pdfkit==1.0.0
 pypandoc==1.13
 beautifulsoup4==4.9.3
 parameterized==0.8.1

--- a/plugins/markdown/setup.py
+++ b/plugins/markdown/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="markdown-rapid7-plugin",
-    version="4.0.2",
+    version="4.0.3",
     description="[Markdown](https://en.wikipedia.org/wiki/Markdown) is a lightweight markup language with plain text formatting syntax. This plugin utilizes [pandoc](https://pandoc.org/) via [pypandoc](https://pypi.python.org/pypi/pypandoc/) to manipulate Markdown content",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
https://rapid7.atlassian.net/browse/SOAR-21846

## Why
The `markdown` plugin pins `pdfkit==0.6.1`, which carries a **buffer overflow** vulnerability — DefectHub [#161801] (SOAR-21646), High severity, SLA-breached (~18 days overdue).

## What
- Bump `pdfkit` `0.6.1 → 1.0.0` in `requirements.txt`
- Plugin version `4.0.2 → 4.0.3` (`plugin.spec.yaml`, `setup.py`, `help.md` + changelog)

## Verification
`pdfkit 1.0.0` preserves the `from_file(input, output_path, options=...)` signature used by `markdown_to_pdf/action.py` — no code change needed:
```
signature: (input, output_path=None, options=None, toc=None, cover=None, css=None, configuration=None, cover_first=False, verbose=False)
```
1.0.0 primarily dropped Python 2 support; the plugin is Python 3 only.

from PR: https://github.com/rapid7/insightconnect-plugins/pull/4035

Passed staging tests