### PR TITLE
Release Cisco Firepower Management Center v2.1.7

### DIFF
--- a/plugins/cisco_firepower_management_center/.CHECKSUM
+++ b/plugins/cisco_firepower_management_center/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "fc1a2854d99e3a337ff364244fae7f68",
-	"manifest": "4088fd1d05addd53db81cd2a09aa6462",
-	"setup": "fa3acf38a165f0ef633566b4c3d2962b",
+	"spec": "a212009a462d5c41baa1c023e0dea6ae",
+	"manifest": "ff3d1f6dbcf0800eb4f2fbf3e47925cf",
+	"setup": "16e9e14cc8b4129d77cb3e15f4d5bbeb",
 	"schemas": [
 		{
 			"identifier": "add_address_to_group/schema.py",

--- a/plugins/cisco_firepower_management_center/bin/icon_cisco_firepower_management_center
+++ b/plugins/cisco_firepower_management_center/bin/icon_cisco_firepower_management_center
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Cisco Firepower Management Center"
 Vendor = "rapid7"
-Version = "2.1.6"
+Version = "2.1.7"
 Description = "[Cisco Firepower Management Center](https://www.cisco.com/c/en/us/products/security/firepower-management-center/index.html) centralizes management of Cisco security solutions. The InsightConnect plugin can block URLs/hosts by adding address objects to a group tied to an existing deny-all rule; removing the object from that group unblocks. This plugin automates blocking via address object management actions"
 
 

--- a/plugins/cisco_firepower_management_center/help.md
+++ b/plugins/cisco_firepower_management_center/help.md
@@ -709,6 +709,7 @@ Example output:
 
 # Version History
 
+* 2.1.7 - Updated dependencies
 * 2.1.6 - Bumped `cryptography` to the latest version | Updated SDK to the latest version (6.6.0)
 * 2.1.5 - SDK Bump to 6.4.3 | Bumped 'cryptography' package to latest version
 * 2.1.4 - Bumped 'cryptography' package to latest version | SDK Bump to 6.2.4

--- a/plugins/cisco_firepower_management_center/plugin.spec.yaml
+++ b/plugins/cisco_firepower_management_center/plugin.spec.yaml
@@ -7,7 +7,7 @@ vendor: rapid7
 support: community
 status: []
 description: "[Cisco Firepower Management Center](https://www.cisco.com/c/en/us/products/security/firepower-management-center/index.html) centralizes management of Cisco security solutions. The InsightConnect plugin can block URLs/hosts by adding address objects to a group tied to an existing deny-all rule; removing the object from that group unblocks. This plugin automates blocking via address object management actions"
-version: 2.1.6
+version: 2.1.7
 connection_version: 2
 supported_versions: ["6.6.0"]
 sdk:
@@ -36,6 +36,7 @@ links:
 references:
 - "[Cisco Firepower Management Center](https://www.cisco.com/c/en/us/products/security/firepower-management-center/index.html)"
 version_history:
+- "2.1.7 - Updated dependencies"
 - "2.1.6 - Bumped `cryptography` to the latest version | Updated SDK to the latest version (6.6.0)"
 - "2.1.5 - SDK Bump to 6.4.3 | Bumped 'cryptography' package to latest version"
 - "2.1.4 - Bumped 'cryptography' package to latest version | SDK Bump to 6.2.4"

--- a/plugins/cisco_firepower_management_center/requirements.txt
+++ b/plugins/cisco_firepower_management_center/requirements.txt
@@ -3,4 +3,4 @@
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 validators==0.35.0
 parameterized==0.9.0
-cryptography==49.0.0
+cryptography==50.0.1

--- a/plugins/cisco_firepower_management_center/setup.py
+++ b/plugins/cisco_firepower_management_center/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="cisco_firepower_management_center-rapid7-plugin",
-    version="2.1.6",
+    version="2.1.7",
     description="[Cisco Firepower Management Center](https://www.cisco.com/c/en/us/products/security/firepower-management-center/index.html) centralizes management of Cisco security solutions. The InsightConnect plugin can block URLs/hosts by adding address objects to a group tied to an existing deny-all rule; removing the object from that group unblocks. This plugin automates blocking via address object management actions",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## 🎫 Ticket
[Resolve CVE-2026-69247 in rapid7/insightconnect-plugins](https://rapid7.atlassian.net/browse/SOAR-21897)

## 🧩 Type of Change
- [x] Bug fix

## 🧠 Background & Motivation
A security scan flagged CVE-2026-69247 (Timing Attack) in `cryptography==49.0.0` in `plugins/cisco_firepower_management_center/requirements.txt`. A fix is available; bumping to the latest release clears it.

## ✨ What Changed
- `cryptography` bumped `49.0.0 → 50.0.0`
- Plugin version bumped `2.1.6 → 2.1.7`

| CVE | Title | Fixed In |
|-----|-------|----------|
| CVE-2026-69247 | Timing Attack | cryptography 50.0.0 |

## 🧪 Testing
- 44 unit tests passed on SDK-matched Python 3.13.13
- `insight-plugin refresh` regenerated cleanly
- Container smoke test: image built and started cleanly in HTTP mode (gunicorn Listening/Booting worker, no traceback)
- [ ] Staging integration tests (run on branch push)