### PR TITLE
Broadcom Symantec Endpoint Protection 2.0.8 Release

### DIFF
--- a/plugins/broadcom_symantec_endpoint_protection/.CHECKSUM
+++ b/plugins/broadcom_symantec_endpoint_protection/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "15b8e639a31cd28ca60e354bf5fc1b92",
-	"manifest": "db7cd43befe0a0e1e58bad608fda9233",
-	"setup": "a4fefadcc4c602f0f51ae9f5494a81e1",
+	"spec": "fd7811988dbd5d3e82c8a9c0a64b8795",
+	"manifest": "702fc55969611b646a97a2d1f46a2884",
+	"setup": "cc2223a56bd9f6c894a030e83d455f43",
 	"schemas": [
 		{
 			"identifier": "blacklist/schema.py",

--- a/plugins/broadcom_symantec_endpoint_protection/bin/icon_broadcom_symantec_endpoint_protection
+++ b/plugins/broadcom_symantec_endpoint_protection/bin/icon_broadcom_symantec_endpoint_protection
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Broadcom Symantec Endpoint Protection"
 Vendor = "rapid7"
-Version = "2.0.7"
+Version = "2.0.8"
 Description = "Broadcom Symantec Endpoint Protection delivers the most complete, integrated endpoint security platform on the planet"
 
 

--- a/plugins/broadcom_symantec_endpoint_protection/help.md
+++ b/plugins/broadcom_symantec_endpoint_protection/help.md
@@ -483,6 +483,7 @@ Example output:
 
 # Version History
 
+* 2.0.8 - Updated dependencies
 * 2.0.7 - Updated dependencies | Updated SDK to the latest version (6.6.0)
 * 2.0.6 - Updated dependencies
 * 2.0.5 - Updated dependencies | Updated SDK to the latest version (6.4.3)

--- a/plugins/broadcom_symantec_endpoint_protection/plugin.spec.yaml
+++ b/plugins/broadcom_symantec_endpoint_protection/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: ["insightconnect"]
 name: broadcom_symantec_endpoint_protection
 title: Broadcom Symantec Endpoint Protection
 description: Broadcom Symantec Endpoint Protection delivers the most complete, integrated endpoint security platform on the planet
-version: 2.0.7
+version: 2.0.8
 connection_version: 2
 vendor: rapid7
 sdk:
@@ -31,6 +31,7 @@ links:
 references:
   - "[Broadcom Symantec Endpoint Protection](https://www.broadcom.com/products/cyber-security/endpoint/end-user)"
 version_history:
+  - "2.0.8 - Updated dependencies"
   - "2.0.7 - Updated dependencies | Updated SDK to the latest version (6.6.0)"
   - "2.0.6 - Updated dependencies"
   - "2.0.5 - Updated dependencies | Updated SDK to the latest version (6.4.3)"

--- a/plugins/broadcom_symantec_endpoint_protection/requirements.txt
+++ b/plugins/broadcom_symantec_endpoint_protection/requirements.txt
@@ -2,5 +2,5 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 # Uncomment the below line for building wheels
-aiohttp==3.14.1
+aiohttp==3.14.3
 parameterized==0.9.0

--- a/plugins/broadcom_symantec_endpoint_protection/setup.py
+++ b/plugins/broadcom_symantec_endpoint_protection/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="broadcom_symantec_endpoint_protection-rapid7-plugin",
-    version="2.0.7",
+    version="2.0.8",
     description="Broadcom Symantec Endpoint Protection delivers the most complete, integrated endpoint security platform on the planet",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## 🎫 Ticket
[Resolve CVE-2026-69244 in rapid7/insightconnect-plugins](https://rapid7.atlassian.net/browse/SOAR-21898)

## 🧩 Type of Change
- [x] Bug fix

## 🧠 Background & Motivation
A security scan flagged CVE-2026-69244 (Use After Free) in `aiohttp==3.14.1` in `plugins/broadcom_symantec_endpoint_protection/requirements.txt`. A fix is available; bumping to the latest release clears it.

## ✨ What Changed
- `aiohttp` bumped `3.14.1 → 3.14.3`
- Plugin version bumped `2.0.7 → 2.0.8`

| CVE | Title | Fixed In |
|-----|-------|----------|
| CVE-2026-69244 | Use After Free | aiohttp 3.14.3 |

## 🧪 Testing
- 3 unit tests passed on SDK-matched Python 3.13.13
- `insight-plugin refresh` regenerated cleanly
- Container smoke test: image built and started cleanly in HTTP mode (gunicorn Listening/Booting worker, no traceback)
- [ ] Staging integration tests (run on branch push)