### PR TITLE
Release InsightVM v8.0.18

### DIFF
--- a/plugins/rapid7_insightvm/.CHECKSUM
+++ b/plugins/rapid7_insightvm/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "72c525ec1966b0f71bbcd13c851358e4",
-	"manifest": "1d91a44c661856470a4ee9ee6464aa24",
-	"setup": "629bcb3226696ac1b78e07c8ac4520ef",
+	"spec": "7734d58c0d26aace85f1e7225b56890a",
+	"manifest": "5dee69398510680094a2bc9f134e8c8e",
+	"setup": "a40effade8b32c4376dcd66550043c77",
 	"schemas": [
 		{
 			"identifier": "add_scan_engine_pool_engine/schema.py",

--- a/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
+++ b/plugins/rapid7_insightvm/bin/komand_rapid7_insightvm
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightVM Console"
 Vendor = "rapid7"
-Version = "8.0.17"
+Version = "8.0.18"
 Description = "InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans"
 
 

--- a/plugins/rapid7_insightvm/help.md
+++ b/plugins/rapid7_insightvm/help.md
@@ -4012,6 +4012,7 @@ Example output:
 
 # Version History
 
+* 8.0.18 - Updated dependencies
 * 8.0.17 - `Scan Completion`: Fixed an issue where scans completed between polling intervals were dropped | `Scan Completion`: Fixed report download failing with HTTP 406 against IVM 8.x consoles | Added retry on transient connection errors during long-running report polling | `Scan Completion`: Skip Insight Agent scans which cannot be scoped for SQL reports | `Download Reports`: Updated API headers to match latest API version | Updated SDK to latest version (6.6.0)
 * 8.0.16 - Updated dependencies
 * 8.0.15 - Addressed issue with sessions

--- a/plugins/rapid7_insightvm/plugin.spec.yaml
+++ b/plugins/rapid7_insightvm/plugin.spec.yaml
@@ -6,7 +6,7 @@ title: Rapid7 InsightVM Console
 description: InsightVM is a powerful vulnerability management tool which finds, prioritizes,
   and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations,
   scan results and start scans
-version: 8.0.17
+version: 8.0.18
 connection_version: 8
 supported_versions: [Rapid7 InsightVM API v3 2026-06-19]
 fedramp_ready: true
@@ -30,6 +30,7 @@ links:
 references:
 - '[InsightVM API 3](https://help.rapid7.com/insightvm/en-us/api/index.html)'
 version_history:
+- '8.0.18 - Updated dependencies'
 - '8.0.17 - `Scan Completion`: Fixed an issue where scans completed between polling
   intervals were dropped | `Scan Completion`: Fixed report download failing with HTTP
   406 against IVM 8.x consoles | Added retry on transient connection errors during

--- a/plugins/rapid7_insightvm/requirements.txt
+++ b/plugins/rapid7_insightvm/requirements.txt
@@ -1,7 +1,7 @@
 # List third-party dependencies here, separated by newlines.
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
-aiohttp==3.14.1
+aiohttp==3.14.3
 defusedxml==0.7.1
 parameterized==0.9.0
 freezegun==1.5.5

--- a/plugins/rapid7_insightvm/setup.py
+++ b/plugins/rapid7_insightvm/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightvm-rapid7-plugin",
-    version="8.0.17",
+    version="8.0.18",
     description="InsightVM is a powerful vulnerability management tool which finds, prioritizes, and remediates vulnerabilities. This plugin uses an orchestrator to get top remediations, scan results and start scans",
     author="rapid7",
     author_email="",


### PR DESCRIPTION
## 🎫 Ticket
N/A

## 🧩 Type of Change
- [x] Bug fix

## 🧠 Background & Motivation
Updated `aiohttp==3.14.1` in `plugins/rapid7_insightvm/requirements.txt`

## ✨ What Changed
- `aiohttp` bumped `3.14.1 → 3.14.3`

| CVE | Title | Fixed In |
|-----|-------|----------|
| CVE-2026-69244 | Use After Free | aiohttp 3.14.3 |

## 🧪 Testing
- 128 unit tests passed on SDK-matched Python 3.13.13 (73 pre-existing unimplemented stubs also present, unrelated to this change)
- `insight-plugin refresh` regenerated cleanly
