### PR TITLE
SOAR-21874: `get_new_investigations` allow for API indexing latency

### DIFF
--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "9e267fec142a4a81174d70fe2ad84965",
+	"spec": "959addfa2161041a2a702b6adec961cd",
 	"manifest": "ba98fadc46afa4b6ae6cf01d9bb4f09d",
 	"setup": "bc53d1d11b00c29b95768be1322a57db",
 	"schemas": [

--- a/plugins/rapid7_insightidr/.CHECKSUM
+++ b/plugins/rapid7_insightidr/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "a9bc853f410a5eee8745dfc03f6c6381",
-	"manifest": "0f295160c932fefef8b7d07d7d14a9b8",
-	"setup": "1bea76a942287c7f322bcf55882f16a3",
+	"spec": "9e267fec142a4a81174d70fe2ad84965",
+	"manifest": "ba98fadc46afa4b6ae6cf01d9bb4f09d",
+	"setup": "bc53d1d11b00c29b95768be1322a57db",
 	"schemas": [
 		{
 			"identifier": "add_indicators_to_a_threat/schema.py",

--- a/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
+++ b/plugins/rapid7_insightidr/bin/komand_rapid7_insightidr
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Rapid7 InsightIDR"
 Vendor = "rapid7"
-Version = "12.0.9"
+Version = "12.0.10"
 Description = "This plugin allows you to add indicators to a threat and see the status of investigations"
 
 

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3428,6 +3428,7 @@ Example output:
 
 # Version History
 
+* 12.0.10 - Trigger `Get New Investigations` updated for IDR API latency issues and dedupe logic added | Updated depdancies
 * 12.0.9 - Retry requests with backoff on transient InsightIDR 5xx responses to resolve intermittent 500 errors
 * 12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile
 * 12.0.7 - Updated dependencies | SDK bump to 6.6.0

--- a/plugins/rapid7_insightidr/help.md
+++ b/plugins/rapid7_insightidr/help.md
@@ -3428,7 +3428,7 @@ Example output:
 
 # Version History
 
-* 12.0.10 - Trigger `Get New Investigations` updated for IDR API latency issues and dedupe logic added | Updated depdancies
+* 12.0.10 - Trigger `Get New Investigations` updated for IDR API latency issues and dedupe logic added | Updated dependencies
 * 12.0.9 - Retry requests with backoff on transient InsightIDR 5xx responses to resolve intermittent 500 errors
 * 12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile
 * 12.0.7 - Updated dependencies | SDK bump to 6.6.0

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -12,8 +12,12 @@ from datetime import datetime, UTC, timedelta
 from typing import Dict, Any, List
 
 DEFAULT_FREQUENCY_SECONDS = 15
-INITIAL_LOOKBACK_MINUTES = 1
+INITIAL_LOOKBACK_MINUTES = 10
+# set this to be half of the INITIAL_LOOKBACK_MINUTES so the second run doesn't expand the window beyond lookback
+API_LATENCY_OVERLAP_MINUTES = 5
 MAX_NUMBER_OF_RETRIES = 20
+
+STATE_KEY = "RRNs"
 
 
 class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
@@ -26,22 +30,27 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             output=GetNewInvestigationsOutput(),
         )
 
+    @staticmethod
+    def get_current_time() -> datetime:
+        """Returns current UTC time - extracted for test mocking without adding freezegun dependency to the plugin"""
+        return datetime.now(UTC)
+
     def run(self, params={}):
         # START INPUT BINDING - DO NOT REMOVE - ANY INPUTS BELOW WILL UPDATE WITH YOUR PLUGIN SPEC AFTER REGENERATION
         search = params.get(Input.SEARCH)
         frequency = params.get(Input.FREQUENCY, DEFAULT_FREQUENCY_SECONDS)
         # END INPUT BINDING - DO NOT REMOVE
 
-        # Initialize the trigger starting point
-        retry_attempts_counter = 0
-        last_poll_time = datetime.now(UTC) - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)
+        # Initialize the trigger starting point & set to dedupe investigations RRNs
+        retry_attempts_counter, prev_investigations = 0, set(self.state.get(STATE_KEY, []))
+        last_poll_time = self.get_current_time() - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)
         self.logger.info("Get Investigations: trigger started")
         self.logger.info(f"Investigations search criteria: {search}")
         self.logger.info(f"Initial poll time set to: '{last_poll_time.isoformat()}'")
 
         while True:
-            # Calculate current time for this iteration (delay by 5 second to avoid overlap) and log search details
-            current_time = datetime.now(UTC) - timedelta(seconds=5)
+            # Calculate current time for this iteration (delay 5s to ensure time is safely in past before API indexes)
+            current_time = self.get_current_time() - timedelta(seconds=5)
             self.logger.info(
                 f"Searching for new investigations from '{last_poll_time.isoformat()}' to '{current_time.isoformat()}'"
             )
@@ -68,17 +77,20 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             # If investigations were found, log total and send them one by one
             # Otherwise, log that no new investigations were found
             if investigations:
-                self.logger.info(f"Found total of {len(investigations)} new investigations.")
-                for investigation in investigations:
-                    self.send_investigation(investigation)
+                self.logger.info(f"Retrieved total of {len(investigations)} investigations.")
+                prev_investigations = self.dedupe_and_send_investigations(investigations, prev_investigations)
             else:
                 self.logger.info("No new investigations found.")
 
             # Update last poll time and reset retry counter for next iteration
-            # Overlap by 1 second to handle IDR API's open time boundaries (exclusive start_time/end_time)
-            # This ensures investigations created at exact boundary timestamps are included in the next poll
-            last_poll_time = current_time
+            # Overlap window by 5 min to catch late-indexed investigations (IDR indexing is often slow)
+            last_poll_time = current_time - timedelta(minutes=API_LATENCY_OVERLAP_MINUTES)
+            self.logger.info(f"Checkpoint for next iteration {last_poll_time.isoformat()} to allow for API latency")
             retry_attempts_counter = 0
+
+            # save the state for fallback in case of plugin restart
+            self.state[STATE_KEY] = list(prev_investigations)
+            self._save_state()
 
             # Back off before next iteration
             self.logger.info(f"Sleeping for {frequency} seconds...")
@@ -119,8 +131,26 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
                 investigations.extend(response.get("data", []))
         return investigations
 
-    def send_investigation(self, investigation: Dict[str, Any]) -> None:
-        self.logger.info(f"Investigation found: {investigation.get('rrn', 'N/A')}")
+    def dedupe_and_send_investigations(self, investigations: List[Dict[str, Any]], previous_investigations: set) -> set:
+        latest_investigations = set()
+        for investigation in investigations:
+            rrn = investigation.get("rrn", "N/A")
+            # Track all RRNs from current poll for state management (enables deduplication across restarts)
+            latest_investigations.add(rrn)
+            if rrn not in previous_investigations:
+                self.send_investigation(investigation, rrn)
+            else:
+                self.logger.info(f"Duplicate investigation found and skipped: {rrn}")
+        # make sure we don't return an empty set if no new investigations were found, so we don't lose the previous state
+        if latest_investigations:
+            self.logger.info("Saving investigations RRNs retrieved during this execution.")
+            previous_investigations = latest_investigations
+        else:
+            self.logger.info("No new investigations were sent. Retaining existing state for next iteration.")
+        return previous_investigations
+
+    def send_investigation(self, investigation: Dict[str, Any], rrn: str) -> None:
+        self.logger.info(f"Investigation found: {rrn}")
         self.send({Output.INVESTIGATION: clean(investigation)})
 
     @staticmethod

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -18,6 +18,7 @@ API_LATENCY_OVERLAP_MINUTES = 5
 MAX_NUMBER_OF_RETRIES = 20
 
 STATE_KEY = "RRNs"
+TIME_STATE_KEY = "last_poll_time"
 
 
 class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
@@ -43,10 +44,17 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
 
         # Initialize the trigger starting point & set to dedupe investigations RRNs
         retry_attempts_counter, prev_investigations = 0, set(self.state.get(STATE_KEY, []))
-        last_poll_time = self.get_current_time() - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)
+
         self.logger.info("Get Investigations: trigger started")
         self.logger.info(f"Investigations search criteria: {search}")
-        self.logger.info(f"Initial poll time set to: '{last_poll_time.isoformat()}'")
+
+        if last_poll_time := self.state.get(TIME_STATE_KEY):
+            self.logger.info(
+                f"Detected a container restart, resumming from last poll time: {last_poll_time.isoformat()}"
+            )
+        else:
+            last_poll_time = self.get_current_time() - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)
+            self.logger.info(f"Initial poll time set to: '{last_poll_time.isoformat()}'")
 
         while True:
             # Calculate current time for this iteration (delay 5s to ensure time is safely in past before API indexes)
@@ -89,6 +97,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             retry_attempts_counter = 0
 
             # save the state for fallback in case of plugin restart
+            self.state[TIME_STATE_KEY] = last_poll_time
             self.state[STATE_KEY] = list(prev_investigations)
             self._save_state()
 
@@ -133,24 +142,22 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
 
     def dedupe_and_send_investigations(self, investigations: List[Dict[str, Any]], previous_investigations: set) -> set:
         latest_investigations = set()
-        for investigation in investigations:
-            rrn = investigation.get("rrn", "N/A")
-            # Track all RRNs from current poll for state management (enables deduplication across restarts)
-            latest_investigations.add(rrn)
-            if rrn not in previous_investigations:
-                self.send_investigation(investigation, rrn)
+        for i, investigation in enumerate(investigations):
+            if rrn := investigation.get("rrn"):
+                # Track all RRNs from current poll for state management (enables deduplication across restarts)
+                latest_investigations.add(rrn)
             else:
-                self.logger.info(f"Duplicate investigation found and skipped: {rrn}")
-        # make sure we don't return an empty set if no new investigations were found, so we don't lose the previous state
-        if latest_investigations:
-            self.logger.info("Saving investigations RRNs retrieved during this execution.")
-            previous_investigations = latest_investigations
-        else:
-            self.logger.info("No new investigations were sent. Retaining existing state for next iteration.")
-        return previous_investigations
+                self.logger.warn(f"Investigation {i}: does not have an RRN, skipping deduplication for this investigation.")
 
-    def send_investigation(self, investigation: Dict[str, Any], rrn: str) -> None:
-        self.logger.info(f"Investigation found: {rrn}")
+            if rrn not in previous_investigations:
+                self.send_investigation(investigation, rrn, i)
+            else:
+                self.logger.info(f"Investigation {i}: Duplicate found and skipped: {rrn}")
+
+        return latest_investigations
+
+    def send_investigation(self, investigation: Dict[str, Any], rrn: str, index: int) -> None:
+        self.logger.info(f"Investigation {index}: Found {rrn}")
         self.send({Output.INVESTIGATION: clean(investigation)})
 
     @staticmethod

--- a/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
+++ b/plugins/rapid7_insightidr/komand_rapid7_insightidr/triggers/get_new_investigations/trigger.py
@@ -48,25 +48,21 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
         self.logger.info("Get Investigations: trigger started")
         self.logger.info(f"Investigations search criteria: {search}")
 
-        if last_poll_time := self.state.get(TIME_STATE_KEY):
-            self.logger.info(
-                f"Detected a container restart, resumming from last poll time: {last_poll_time.isoformat()}"
-            )
+        if last_poll_iso := self.state.get(TIME_STATE_KEY):
+            self.logger.info(f"Detected a container restart, resumming from last poll time: {last_poll_iso}")
         else:
-            last_poll_time = self.get_current_time() - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)
-            self.logger.info(f"Initial poll time set to: '{last_poll_time.isoformat()}'")
+            last_poll_iso = (self.get_current_time() - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)).isoformat()
+            self.logger.info(f"Initial poll time set to: '{last_poll_iso}")
 
         while True:
             # Calculate current time for this iteration (delay 5s to ensure time is safely in past before API indexes)
             current_time = self.get_current_time() - timedelta(seconds=5)
-            self.logger.info(
-                f"Searching for new investigations from '{last_poll_time.isoformat()}' to '{current_time.isoformat()}'"
-            )
+            self.logger.info(f"Searching for new investigations from '{last_poll_iso}' to '{current_time.isoformat()}'")
 
             # Get all investigations since last poll time
             # In case of any errors, log the error, wait for the defined frequency, and retry
             try:
-                investigations = self.get_investigations(search, last_poll_time, current_time)
+                investigations = self.get_investigations(search, last_poll_iso, current_time.isoformat())
             except Exception as error:
                 # If max retries reached, raise the error
                 if retry_attempts_counter >= MAX_NUMBER_OF_RETRIES:
@@ -92,12 +88,12 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
 
             # Update last poll time and reset retry counter for next iteration
             # Overlap window by 5 min to catch late-indexed investigations (IDR indexing is often slow)
-            last_poll_time = current_time - timedelta(minutes=API_LATENCY_OVERLAP_MINUTES)
-            self.logger.info(f"Checkpoint for next iteration {last_poll_time.isoformat()} to allow for API latency")
+            last_poll_iso = (current_time - timedelta(minutes=API_LATENCY_OVERLAP_MINUTES)).isoformat()
+            self.logger.info(f"Checkpoint for next iteration {last_poll_iso} to allow for API latency")
             retry_attempts_counter = 0
 
             # save the state for fallback in case of plugin restart
-            self.state[TIME_STATE_KEY] = last_poll_time
+            self.state[TIME_STATE_KEY] = last_poll_iso  # we need to save this as a string
             self.state[STATE_KEY] = list(prev_investigations)
             self._save_state()
 
@@ -106,7 +102,7 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
             time.sleep(frequency)
 
     def get_investigations(
-        self, search_query: List[Dict[str, Any]], start_time: datetime, end_time: datetime
+        self, search_query: List[Dict[str, Any]], start_time: str, end_time: str
     ) -> List[Dict[str, Any]]:
         # Set connection headers for investigations preview and initialize request helper
         self.connection.headers["Accept-version"] = "investigations-preview"
@@ -116,8 +112,8 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
         payload = clean(
             {
                 "search": search_query,
-                "start_time": start_time.isoformat(),
-                "end_time": end_time.isoformat(),
+                "start_time": start_time,
+                "end_time": end_time,
             }
         )
 
@@ -147,7 +143,9 @@ class GetNewInvestigations(insightconnect_plugin_runtime.Trigger):
                 # Track all RRNs from current poll for state management (enables deduplication across restarts)
                 latest_investigations.add(rrn)
             else:
-                self.logger.warn(f"Investigation {i}: does not have an RRN, skipping deduplication for this investigation.")
+                self.logger.warn(
+                    f"Investigation {i}: does not have an RRN, skipping deduplication for this investigation."
+                )
 
             if rrn not in previous_investigations:
                 self.send_investigation(investigation, rrn, i)

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -36,7 +36,7 @@ sdk:
   version: 6.6.0
   user: nobody
 version_history:
-  - "12.0.10 - Trigger `Get New Investigations` updated for IDR API latency issues and dedupe logic added | Updated depdancies"
+  - "12.0.10 - Trigger `Get New Investigations` updated for IDR API latency issues and dedupe logic added | Updated dependencies"
   - "12.0.9 - Retry requests with backoff on transient InsightIDR 5xx responses to resolve intermittent 500 errors"
   - "12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile"
   - "12.0.7 - Updated dependencies | SDK bump to 6.6.0"

--- a/plugins/rapid7_insightidr/plugin.spec.yaml
+++ b/plugins/rapid7_insightidr/plugin.spec.yaml
@@ -4,7 +4,7 @@ products: [insightconnect]
 name: rapid7_insightidr
 title: "Rapid7 InsightIDR"
 description: "This plugin allows you to add indicators to a threat and see the status of investigations"
-version: 12.0.9
+version: 12.0.10
 connection_version: 5
 supported_versions: ["Latest release successfully tested on 2025-07-22."]
 vendor: rapid7
@@ -36,6 +36,7 @@ sdk:
   version: 6.6.0
   user: nobody
 version_history:
+  - "12.0.10 - Trigger `Get New Investigations` updated for IDR API latency issues and dedupe logic added | Updated depdancies"
   - "12.0.9 - Retry requests with backoff on transient InsightIDR 5xx responses to resolve intermittent 500 errors"
   - "12.0.8 - Enabled cache to configure the appropriate permissions in the Dockerfile"
   - "12.0.7 - Updated dependencies | SDK bump to 6.6.0"

--- a/plugins/rapid7_insightidr/requirements.txt
+++ b/plugins/rapid7_insightidr/requirements.txt
@@ -2,5 +2,5 @@
 # All dependencies must be version-pinned, eg. requests==1.2.0
 # See: https://pip.pypa.io/en/stable/user_guide/#requirements-files
 validators==0.35.0
-aiohttp==3.14.1
+aiohttp==3.14.3
 parameterized==0.9.0

--- a/plugins/rapid7_insightidr/setup.py
+++ b/plugins/rapid7_insightidr/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="rapid7_insightidr-rapid7-plugin",
-    version="12.0.9",
+    version="12.0.10",
     description="This plugin allows you to add indicators to a threat and see the status of investigations",
     author="rapid7",
     author_email="",

--- a/plugins/rapid7_insightidr/unit_test/test_get_new_investigations_trigger.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_new_investigations_trigger.py
@@ -1,0 +1,262 @@
+import os
+import sys
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+from datetime import datetime, UTC, timedelta
+
+sys.path.append(os.path.abspath("../"))
+
+from komand_rapid7_insightidr.triggers.get_new_investigations.trigger import (
+    GetNewInvestigations,
+    API_LATENCY_OVERLAP_MINUTES,
+    INITIAL_LOOKBACK_MINUTES,
+)
+from komand_rapid7_insightidr.triggers.get_new_investigations.schema import Output
+from parameterized import parameterized
+
+
+class StopLoop(Exception):
+    """Exception raised from mocked time.sleep to break trigger's while loop"""
+
+
+@patch(
+    "komand_rapid7_insightidr.triggers.get_new_investigations.trigger.GetNewInvestigations.get_current_time",
+    return_value=datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC),
+)
+@patch("time.sleep", side_effect=StopLoop)
+@patch("komand_rapid7_insightidr.triggers.get_new_investigations.trigger.GetNewInvestigations._call_search_api")
+class TestGetNewInvestigationsTrigger(TestCase):
+    def setUp(self) -> None:
+        self.trigger = GetNewInvestigations()
+        self.trigger.connection = MagicMock()
+        self.trigger.logger = MagicMock()
+        self.trigger.send = MagicMock()
+        self.trigger._save_state = MagicMock()
+        self.trigger.state = {}
+        self.params = {"frequency": 15, "search": []}
+
+    @parameterized.expand(
+        [
+            [
+                "all new investigations",
+                {},
+                [
+                    {"rrn": "rrn:investigation:1", "title": "Investigation 1"},
+                    {"rrn": "rrn:investigation:2", "title": "Investigation 2"},
+                ],
+                2,
+                {"rrn:investigation:1", "rrn:investigation:2"},
+            ],
+            [
+                "all duplicate investigations",
+                {"RRNs": ["rrn:investigation:1", "rrn:investigation:2"]},
+                [
+                    {"rrn": "rrn:investigation:1", "title": "Investigation 1"},
+                    {"rrn": "rrn:investigation:2", "title": "Investigation 2"},
+                ],
+                0,
+                {"rrn:investigation:1", "rrn:investigation:2"},
+            ],
+            [
+                "mixed new and duplicate only sends the new investigations",
+                {"RRNs": ["rrn:investigation:1"]},
+                [
+                    {"rrn": "rrn:investigation:1", "title": "Investigation 1"},
+                    {"rrn": "rrn:investigation:2", "title": "Investigation 2"},
+                    {"rrn": "rrn:investigation:3", "title": "Investigation 3"},
+                ],
+                2,
+                {"rrn:investigation:1", "rrn:investigation:2", "rrn:investigation:3"},
+            ],
+            [
+                "empty API response preserves state",
+                {"RRNs": ["rrn:investigation:1", "rrn:investigation:2"]},
+                [],
+                0,
+                {"rrn:investigation:1", "rrn:investigation:2"},
+            ],
+        ]
+    )
+    def test_single_poll_deduplication(
+        self,
+        mock_call_search_api,
+        _mock_sleep,
+        _mock_get_current_time,
+        _test_name,
+        initial_state,
+        api_response,
+        expected_sends,
+        expected_state,
+    ):
+        self.trigger.state = initial_state.copy()
+        mock_call_search_api.return_value = {"data": api_response, "metadata": {"total_pages": 1}}
+
+        # Compute expected RRNs: api_response - initial_state
+        existing_rrns = set(initial_state.get("RRNs", []))
+        expected_rrns = [inv["rrn"] for inv in api_response if inv["rrn"] not in existing_rrns]
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        self.assertEqual(self.trigger.send.call_count, expected_sends)
+
+        # Verify correct RRNs were sent
+        sent_rrns = [call_args[0][0][Output.INVESTIGATION]["rrn"] for call_args in self.trigger.send.call_args_list]
+        self.assertEqual(sent_rrns, expected_rrns)
+
+        actual_state = set(self.trigger.state.get("RRNs", []))
+        self.assertEqual(actual_state, expected_state)
+        self.trigger._save_state.assert_called_once()
+
+    def test_multiple_poll_overlapping_window_deduplication(
+        self, mock_call_search_api, mock_sleep, mock_get_current_time
+    ):
+        mock_sleep.side_effect = [None, None, StopLoop()]
+        # get_current_time() called once initially + once per loop iteration
+        mock_get_current_time.side_effect = [
+            datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC),  # Initial last_poll_time
+            datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC),  # Poll 1 current_time
+            datetime(2026, 8, 26, 12, 0, 15, tzinfo=UTC),  # Poll 2 current_time
+            datetime(2026, 8, 26, 12, 0, 30, tzinfo=UTC),  # Poll 3 current_time
+        ]
+        # Poll 1: API returns investigations A, B
+        # Poll 2: Overlapping window returns B (duplicate) and C (new, late-indexed)
+        # Poll 3: Overlapping window returns C (duplicate) and D (new)
+        mock_call_search_api.side_effect = [
+            {
+                "data": [
+                    {"rrn": "rrn:investigation:A", "title": "Investigation A"},
+                    {"rrn": "rrn:investigation:B", "title": "Investigation B"},
+                ],
+                "metadata": {"total_pages": 1},
+            },
+            {
+                "data": [
+                    {"rrn": "rrn:investigation:B", "title": "Investigation B"},
+                    {"rrn": "rrn:investigation:C", "title": "Investigation C"},
+                ],
+                "metadata": {"total_pages": 1},
+            },
+            {
+                "data": [
+                    {"rrn": "rrn:investigation:C", "title": "Investigation C"},
+                    {"rrn": "rrn:investigation:D", "title": "Investigation D"},
+                ],
+                "metadata": {"total_pages": 1},
+            },
+        ]
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        # Verify total sends: A, B (poll 1) + C (poll 2) + D (poll 3) = 4
+        self.assertEqual(self.trigger.send.call_count, 4)
+
+        # Verify RRNs sent in order
+        sent_rrns = [call_args[0][0][Output.INVESTIGATION]["rrn"] for call_args in self.trigger.send.call_args_list]
+        self.assertEqual(
+            sent_rrns, ["rrn:investigation:A", "rrn:investigation:B", "rrn:investigation:C", "rrn:investigation:D"]
+        )
+
+        # Verify final state contains only RRNs from last poll
+        final_state = set(self.trigger.state.get("RRNs", []))
+        self.assertEqual(final_state, {"rrn:investigation:C", "rrn:investigation:D"})
+
+    def test_state_loaded_from_persistence_on_restart(self, mock_call_search_api, mock_sleep, mock_get_current_time):
+        # Simulate persisted state from previous run
+        self.trigger.state = {"RRNs": ["rrn:investigation:1", "rrn:investigation:2"]}
+
+        # API returns investigations that were already processed
+        mock_call_search_api.return_value = {
+            "data": [
+                {"rrn": "rrn:investigation:1", "title": "Investigation 1"},
+                {"rrn": "rrn:investigation:2", "title": "Investigation 2"},
+                {"rrn": "rrn:investigation:3", "title": "Investigation 3"},
+            ],
+            "metadata": {"total_pages": 1},
+        }
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        self.trigger.send.assert_called_once()
+
+        # State should now contain the new RRN
+        actual_state = set(self.trigger.state.get("RRNs", []))
+        self.assertEqual(actual_state, {"rrn:investigation:1", "rrn:investigation:2", "rrn:investigation:3"})
+
+    def test_initial_lookback_window(self, mock_call_search_api, _mock_sleep, mock_get_current_time):
+        mock_now = mock_get_current_time.return_value
+        mock_call_search_api.return_value = {"data": [], "metadata": {"total_pages": 1}}
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        # Verify _call_search_api called with correct time window in payload
+        call_args = mock_call_search_api.call_args
+        payload = call_args[0][3]  # Fourth positional arg is payload (resource_helper, endpoint, method, payload)
+
+        # First poll: start_time should be current_time - 10 minutes (INITIAL_LOOKBACK_MINUTES)
+        expected_start = (mock_now - timedelta(minutes=10)).isoformat()
+        # end_time should be current_time - 5 seconds
+        expected_end = (mock_now - timedelta(seconds=5)).isoformat()
+
+        self.assertEqual(payload["start_time"], expected_start)
+        self.assertEqual(payload["end_time"], expected_end)
+
+    def test_subsequent_poll_applies_5_minute_overlap(self, mock_call_search_api, mock_sleep, mock_get_current_time):
+        """More in depth unit test of the dedupe logic that is being tested within the following unit test
+        `test_multiple_poll_overlapping_window_deduplication` as this inspects the time params being sent"""
+        # Define mock time progression
+        initial_time = datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC)
+        poll2_time = datetime(2026, 8, 26, 12, 0, 15, tzinfo=UTC)
+
+        mock_sleep.side_effect = [None, StopLoop()]  # 2 calls before we end the trigger loop
+        mock_get_current_time.side_effect = [
+            initial_time,  # Initial last_poll_time - we set the baseline for the first poll
+            initial_time,  # Poll 1 current_time - this is still the same time here
+            poll2_time,  # Poll 2 current_time - we've applied a time.sleep() and on a second iteration
+        ]
+        mock_call_search_api.return_value = {"data": [], "metadata": {"total_pages": 1}}
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        self.assertEqual(mock_call_search_api.call_count, 2)
+
+        # Extract payloads from both calls (4th positional arg)
+        payload1 = mock_call_search_api.call_args_list[0][0][3]
+        payload2 = mock_call_search_api.call_args_list[1][0][3]
+
+        queried_start1 = datetime.fromisoformat(payload1["start_time"])
+        queried_end1 = datetime.fromisoformat(payload1["end_time"])
+
+        queried_start2 = datetime.fromisoformat(payload2["start_time"])
+        queried_end2 = datetime.fromisoformat(payload2["end_time"])
+
+        # expected first loop we do a lookback of now - 10 minutes
+        exp_start1 = initial_time - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)
+
+        # expected end times, we take `get_current_time()` and minus 5 seconds for the API latency buffer
+        exp_end1 = initial_time - timedelta(seconds=5)
+        exp_end2 = poll2_time - timedelta(seconds=5)
+
+        # this is the real test that on the second iteration we're applying the 5 minute overlap
+        expected_start2 = exp_end1 - timedelta(minutes=API_LATENCY_OVERLAP_MINUTES)  # 5-minute overlap
+
+        # start and end times should match for the first run
+        self.assertEqual(queried_start1, exp_start1)
+        self.assertEqual(queried_end1, exp_end1)
+
+        # verify the second loop also has the correct start and end times, with the 5-minute overlap applied
+        self.assertEqual(queried_start2, expected_start2)
+        self.assertEqual(queried_end2, exp_end2)
+
+        # verify overlap exists (the regression from 12.0.2 that we didn't overlap for allow for late indexing)
+        self.assertLess(
+            queried_start2, queried_end1, "Poll 2 must start before Poll 1 ends to catch late-indexed investigations"
+        )
+
+        # Verify overlap is exactly 5 minutes
+        actual_overlap = queried_end1 - queried_start2
+        self.assertEqual(actual_overlap, timedelta(minutes=API_LATENCY_OVERLAP_MINUTES))

--- a/plugins/rapid7_insightidr/unit_test/test_get_new_investigations_trigger.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_new_investigations_trigger.py
@@ -75,6 +75,27 @@ class TestGetNewInvestigationsTrigger(TestCase):
                 0,
                 {"rrn:investigation:1", "rrn:investigation:2"},
             ],
+            [
+                "investigation without rrn key missing are still sent",
+                {},
+                [
+                    {"title": "Investigation without RRN", "status": "OPEN"},
+                    {"rrn": None, "title": "Investigation with None RRN"},
+                    {"rrn": "", "title": "Investigation with empty RRN"}
+                ],
+                3,
+                set(),  # nothing to track for these
+            ],
+            [
+                "duplicate rrn in same poll sends both - strange API quirk and we can't differentiate",
+                {},
+                [
+                    {"rrn": "rrn:investigation:A", "title": "Investigation A first"},
+                    {"rrn": "rrn:investigation:A", "title": "Investigation A second"},
+                ],
+                2,
+                {"rrn:investigation:A"},  # state is a set so we only have the RRN once
+            ],
         ]
     )
     def test_single_poll_deduplication(
@@ -93,7 +114,7 @@ class TestGetNewInvestigationsTrigger(TestCase):
 
         # Compute expected RRNs: api_response - initial_state
         existing_rrns = set(initial_state.get("RRNs", []))
-        expected_rrns = [inv["rrn"] for inv in api_response if inv["rrn"] not in existing_rrns]
+        expected_rrns = [inv.get("rrn") for inv in api_response if inv.get("rrn") and inv.get("rrn") not in existing_rrns]
 
         with self.assertRaises(StopLoop):
             self.trigger.run(self.params)
@@ -101,7 +122,11 @@ class TestGetNewInvestigationsTrigger(TestCase):
         self.assertEqual(self.trigger.send.call_count, expected_sends)
 
         # Verify correct RRNs were sent
-        sent_rrns = [call_args[0][0][Output.INVESTIGATION]["rrn"] for call_args in self.trigger.send.call_args_list]
+        sent_rrns = []
+        for call_args in self.trigger.send.call_args_list:
+            if sent_rrn := call_args[0][0][Output.INVESTIGATION].get("rrn"):  # test data does not always hold an RRN
+                sent_rrns.append(sent_rrn)
+
         self.assertEqual(sent_rrns, expected_rrns)
 
         actual_state = set(self.trigger.state.get("RRNs", []))
@@ -197,7 +222,7 @@ class TestGetNewInvestigationsTrigger(TestCase):
         payload = call_args[0][3]  # Fourth positional arg is payload (resource_helper, endpoint, method, payload)
 
         # First poll: start_time should be current_time - 10 minutes (INITIAL_LOOKBACK_MINUTES)
-        expected_start = (mock_now - timedelta(minutes=10)).isoformat()
+        expected_start = (mock_now - timedelta(minutes=INITIAL_LOOKBACK_MINUTES)).isoformat()
         # end_time should be current_time - 5 seconds
         expected_end = (mock_now - timedelta(seconds=5)).isoformat()
 
@@ -260,3 +285,80 @@ class TestGetNewInvestigationsTrigger(TestCase):
         # Verify overlap is exactly 5 minutes
         actual_overlap = queried_end1 - queried_start2
         self.assertEqual(actual_overlap, timedelta(minutes=API_LATENCY_OVERLAP_MINUTES))
+
+    def test_api_latency_overlap_does_not_exceed_initial_lookback(
+        self, _mock_call_search_api, _mock_sleep, _mock_get_current_time
+    ):
+        """Constraint check: API_LATENCY_OVERLAP_MINUTES must not exceed INITIAL_LOOKBACK_MINUTES
+        to prevent expanding the window beyond the initial lookback on subsequent polls"""
+        self.assertLessEqual(
+            API_LATENCY_OVERLAP_MINUTES,
+            INITIAL_LOOKBACK_MINUTES,
+            "API_LATENCY_OVERLAP_MINUTES must not exceed INITIAL_LOOKBACK_MINUTES to prevent "
+            "window expansion beyond initial lookback",
+        )
+
+    def test_pagination_fetches_all_pages(self, mock_call_search_api, _mock_sleep, _mock_get_current_time):
+        test_page_count = 3
+        mock_call_search_api.side_effect = [
+            {"data": [{"rrn": "rrn:investigation:A", "title": "A"}], "metadata": {"total_pages": test_page_count}},
+            {"data": [{"rrn": "rrn:investigation:B", "title": "B"}], "metadata": {"total_pages": test_page_count}},
+            {"data": [{"rrn": "rrn:investigation:C", "title": "C"}], "metadata": {"total_pages": test_page_count}},
+        ]
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        # API called 3 times
+        self.assertEqual(mock_call_search_api.call_count, 3)
+
+        # Verify index params: first call no index, subsequent calls have index
+        # _call_search_api(request, endpoint, method, payload, params) - params is 5th arg (index 4)
+        call_params = [call[0][4] for call in mock_call_search_api.call_args_list]
+        self.assertNotIn("index", call_params[0])  # First call has no index
+        self.assertEqual(call_params[1].get("index"), 1)
+        self.assertEqual(call_params[2].get("index"), 2)
+
+        # All 3 investigations sent
+        self.assertEqual(self.trigger.send.call_count, test_page_count)
+        sent_rrns = [call[0][0]["investigation"]["rrn"] for call in self.trigger.send.call_args_list]
+        self.assertEqual(sent_rrns, ["rrn:investigation:A", "rrn:investigation:B", "rrn:investigation:C"])
+
+    def test_restart_resumes_from_saved_poll_time(self, mock_call_search_api, _mock_sleep, mock_get_current_time):
+        """On restart, trigger should resume from saved TIME_STATE_KEY instead of initial lookback"""
+        saved_poll_time = datetime(2026, 8, 26, 11, 50, 0, tzinfo=UTC)
+        current_time =  datetime(2026, 8, 26, 13, 0, 0, tzinfo=UTC)
+        self.trigger.state = {
+            "last_poll_time": saved_poll_time,
+            "RRNs": ["rrn:investigation:old"],
+        }
+
+        mock_get_current_time.side_effect = [current_time]  # container restarted 1hr 10 mins since last poll
+
+        mock_call_search_api.return_value = {
+            "data": [{"rrn": "rrn:investigation:new", "title": "New Investigation"}],
+            "metadata": {"total_pages": 1},
+        }
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        # Verify restart log message
+        log_calls = [call[0][0] for call in self.trigger.logger.info.call_args_list]
+        self.assertTrue(any("Detected a container restart" in log for log in log_calls))
+        self.assertFalse(any("Initial poll time set to" in log for log in log_calls))
+
+        # Verify API call used saved time, not initial lookback
+        payload = mock_call_search_api.call_args[0][3]
+        self.assertEqual(payload["start_time"], saved_poll_time.isoformat())
+
+        # we haven't lost the last poll and pulling the trigger forward losing investigations
+        self.assertNotEquals(payload["start_time"], current_time.isoformat())
+
+        # but our end time should be based on this - 5 seconds for API latency buffer
+        self.assertEquals(payload["end_time"], (current_time - timedelta(seconds=5)).isoformat())
+
+        # New investigation sent
+        self.trigger.send.assert_called_once()
+        sent_investigation = self.trigger.send.call_args[0][0]["investigation"]
+        self.assertEqual(sent_investigation["rrn"], "rrn:investigation:new")

--- a/plugins/rapid7_insightidr/unit_test/test_get_new_investigations_trigger.py
+++ b/plugins/rapid7_insightidr/unit_test/test_get_new_investigations_trigger.py
@@ -10,20 +10,21 @@ from komand_rapid7_insightidr.triggers.get_new_investigations.trigger import (
     GetNewInvestigations,
     API_LATENCY_OVERLAP_MINUTES,
     INITIAL_LOOKBACK_MINUTES,
+    TIME_STATE_KEY,
 )
 from komand_rapid7_insightidr.triggers.get_new_investigations.schema import Output
 from parameterized import parameterized
 
 
 class StopLoop(Exception):
-    """Exception raised from mocked time.sleep to break trigger's while loop"""
+    """Exception raised from mocked _save_state to break trigger's while loop"""
 
 
 @patch(
     "komand_rapid7_insightidr.triggers.get_new_investigations.trigger.GetNewInvestigations.get_current_time",
     return_value=datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC),
 )
-@patch("time.sleep", side_effect=StopLoop)
+@patch("komand_rapid7_insightidr.triggers.get_new_investigations.trigger.time.sleep")
 @patch("komand_rapid7_insightidr.triggers.get_new_investigations.trigger.GetNewInvestigations._call_search_api")
 class TestGetNewInvestigationsTrigger(TestCase):
     def setUp(self) -> None:
@@ -31,7 +32,7 @@ class TestGetNewInvestigationsTrigger(TestCase):
         self.trigger.connection = MagicMock()
         self.trigger.logger = MagicMock()
         self.trigger.send = MagicMock()
-        self.trigger._save_state = MagicMock()
+        self.trigger._save_state = MagicMock(side_effect=StopLoop)
         self.trigger.state = {}
         self.params = {"frequency": 15, "search": []}
 
@@ -81,7 +82,7 @@ class TestGetNewInvestigationsTrigger(TestCase):
                 [
                     {"title": "Investigation without RRN", "status": "OPEN"},
                     {"rrn": None, "title": "Investigation with None RRN"},
-                    {"rrn": "", "title": "Investigation with empty RRN"}
+                    {"rrn": "", "title": "Investigation with empty RRN"},
                 ],
                 3,
                 set(),  # nothing to track for these
@@ -114,7 +115,9 @@ class TestGetNewInvestigationsTrigger(TestCase):
 
         # Compute expected RRNs: api_response - initial_state
         existing_rrns = set(initial_state.get("RRNs", []))
-        expected_rrns = [inv.get("rrn") for inv in api_response if inv.get("rrn") and inv.get("rrn") not in existing_rrns]
+        expected_rrns = [
+            inv.get("rrn") for inv in api_response if inv.get("rrn") and inv.get("rrn") not in existing_rrns
+        ]
 
         with self.assertRaises(StopLoop):
             self.trigger.run(self.params)
@@ -134,9 +137,9 @@ class TestGetNewInvestigationsTrigger(TestCase):
         self.trigger._save_state.assert_called_once()
 
     def test_multiple_poll_overlapping_window_deduplication(
-        self, mock_call_search_api, mock_sleep, mock_get_current_time
+        self, mock_call_search_api, _mock_sleep, mock_get_current_time
     ):
-        mock_sleep.side_effect = [None, None, StopLoop()]
+        self.trigger._save_state.side_effect = [None, None, StopLoop()]
         # get_current_time() called once initially + once per loop iteration
         mock_get_current_time.side_effect = [
             datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC),  # Initial last_poll_time
@@ -187,7 +190,7 @@ class TestGetNewInvestigationsTrigger(TestCase):
         final_state = set(self.trigger.state.get("RRNs", []))
         self.assertEqual(final_state, {"rrn:investigation:C", "rrn:investigation:D"})
 
-    def test_state_loaded_from_persistence_on_restart(self, mock_call_search_api, mock_sleep, mock_get_current_time):
+    def test_state_loaded_from_persistence_on_restart(self, mock_call_search_api, _mock_sleep, mock_get_current_time):
         # Simulate persisted state from previous run
         self.trigger.state = {"RRNs": ["rrn:investigation:1", "rrn:investigation:2"]}
 
@@ -229,14 +232,14 @@ class TestGetNewInvestigationsTrigger(TestCase):
         self.assertEqual(payload["start_time"], expected_start)
         self.assertEqual(payload["end_time"], expected_end)
 
-    def test_subsequent_poll_applies_5_minute_overlap(self, mock_call_search_api, mock_sleep, mock_get_current_time):
+    def test_subsequent_poll_applies_5_minute_overlap(self, mock_call_search_api, _mock_sleep, mock_get_current_time):
         """More in depth unit test of the dedupe logic that is being tested within the following unit test
         `test_multiple_poll_overlapping_window_deduplication` as this inspects the time params being sent"""
         # Define mock time progression
         initial_time = datetime(2026, 8, 26, 12, 0, 0, tzinfo=UTC)
         poll2_time = datetime(2026, 8, 26, 12, 0, 15, tzinfo=UTC)
 
-        mock_sleep.side_effect = [None, StopLoop()]  # 2 calls before we end the trigger loop
+        self.trigger._save_state.side_effect = [None, StopLoop()]  # 2 iterations before loop ends
         mock_get_current_time.side_effect = [
             initial_time,  # Initial last_poll_time - we set the baseline for the first poll
             initial_time,  # Poll 1 current_time - this is still the same time here
@@ -298,6 +301,27 @@ class TestGetNewInvestigationsTrigger(TestCase):
             "window expansion beyond initial lookback",
         )
 
+    def test_state_and_api_use_iso_strings_not_datetime_objects(
+        self, mock_call_search_api, _mock_sleep, _mock_get_current_time
+    ):
+        """Prevent a regression: state file can't serialize datetime objects - must use ISO strings throughout"""
+        mock_call_search_api.return_value = {"data": [], "metadata": {"total_pages": 1}}
+
+        with self.assertRaises(StopLoop):
+            self.trigger.run(self.params)
+
+        # Verify get_investigations called with string ISO times, not datetime objects
+        call_args = mock_call_search_api.call_args[0]
+        payload = call_args[3]
+        self.assertIsInstance(payload["start_time"], str, "start_time must be ISO string, not datetime")
+        self.assertIsInstance(payload["end_time"], str, "end_time must be ISO string, not datetime")
+
+        # Verify state saved with ISO string, not datetime
+        saved_time = self.trigger.state.get(TIME_STATE_KEY)
+        self.assertIsInstance(saved_time, str, "TIME_STATE_KEY must be ISO string for JSON serialization")
+        # Verify it's valid ISO format
+        datetime.fromisoformat(saved_time)
+
     def test_pagination_fetches_all_pages(self, mock_call_search_api, _mock_sleep, _mock_get_current_time):
         test_page_count = 3
         mock_call_search_api.side_effect = [
@@ -327,9 +351,9 @@ class TestGetNewInvestigationsTrigger(TestCase):
     def test_restart_resumes_from_saved_poll_time(self, mock_call_search_api, _mock_sleep, mock_get_current_time):
         """On restart, trigger should resume from saved TIME_STATE_KEY instead of initial lookback"""
         saved_poll_time = datetime(2026, 8, 26, 11, 50, 0, tzinfo=UTC)
-        current_time =  datetime(2026, 8, 26, 13, 0, 0, tzinfo=UTC)
+        current_time = datetime(2026, 8, 26, 13, 0, 0, tzinfo=UTC)
         self.trigger.state = {
-            "last_poll_time": saved_poll_time,
+            "last_poll_time": saved_poll_time.isoformat(),
             "RRNs": ["rrn:investigation:old"],
         }
 
@@ -353,10 +377,10 @@ class TestGetNewInvestigationsTrigger(TestCase):
         self.assertEqual(payload["start_time"], saved_poll_time.isoformat())
 
         # we haven't lost the last poll and pulling the trigger forward losing investigations
-        self.assertNotEquals(payload["start_time"], current_time.isoformat())
+        self.assertNotEqual(payload["start_time"], current_time.isoformat())
 
         # but our end time should be based on this - 5 seconds for API latency buffer
-        self.assertEquals(payload["end_time"], (current_time - timedelta(seconds=5)).isoformat())
+        self.assertEqual(payload["end_time"], (current_time - timedelta(seconds=5)).isoformat())
 
         # New investigation sent
         self.trigger.send.assert_called_once()


### PR DESCRIPTION
## 🎫 Ticket
<!-- Link to the related Jira ticket (if applicable, typically for features and bug fixes) -->
<!-- If no ticket exists, you can remove this section or write "N/A" -->
<!-- Ticket: [<insert ticket title>](<insert ticket link>) -->
[SOAR-21874](https://rapid7.atlassian.net/browse/SOAR-21874)

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [X] Bug fix
- [ ] Other

## 🧠 Background & Motivation
<!-- Why is this change needed? What problem or context led to this PR? -->
<!-- Provide a short explanation of the motivation and the problem being solved. -->
<!-- Examples: 
- "Users reported X error when doing Y"
- "New feature X was requested"
-->
Customer reported that since `12.0.2` there was a fault in our `Get New Investigations` trigger was not finding investigations on the IDR API. When looking at the trigger logger pre-12.0.1 you can see that the trigger always did a 20 minute look back and deduped the returning investigations. In 12.0.2 this approach was changed assuming that we could use a normal time sliding window of `time-a -> time-b` followed by `time-b -> time-c` but this does not account for the latency on the IDR API.


## ✨ What Changed
<!-- What was done? Summarize the key changes in this PR. -->
<!-- Describe the core implementation and high-level impact. -->
<!-- Examples:
- "Added new action 'X' to plugin Y"
- "Refactored X to improve performance"
-->
- Updated that we now overlap with a 5 minute window to allow for delayed indexing on IDR API. 20 minutes seems excessive and in other PRs (#4027) we were told this indexing should only be a matter of seconds. 
- No unit tests existed at all - I have added some basic tests to cover this new dedupe logic + time querying so that we would catch this if it's ever changed in future. 

Post initial commit from code review comments:
- State now contains a last_poll_time to correctly resume after the container restarts 
- Extended the code coverage in the unit tests to cover more dedupe / lack of in more test scenarios
- Unit tests now patch _save_state() to allow running unit tests in debug mode - mock on time.sleep() was throwing exceptions in debug mode via IDE debug mode. 

## 🧪 Testing
<!-- Describe how you verified the changes work as intended -->
<!-- Include details of your testing process, such as:
- Unit tests
- Manual testing steps
- Any relevant screenshots or logs
-->
- Unit tests
- Manual testing; more logs available on jira ticket:
  - restarting the docker container; reads from the state file and uses this cache to filter any new investigations:
```
Connect: Connecting...
Loaded state from /workspace/cache/example-trigger-id-johnny-n.json: {'RRNs': ['rrn:investigation:us:cf946362-0809-426d-987c-849bde704c16:investigation:JFWFO2ATG70X', 'rrn:investigation:us:cf946362-0809-426d-987c-849bde704c16:investigation:OIQXB1BROI5I']}
rapid7/Rapid7 InsightIDR:12.0.10. Step name: get_new_investigations
Get Investigations: trigger started
Investigations search criteria: []
Initial poll time set to: '2026-08-31T08:26:14.972726+00:00'
Searching for new investigations from '2026-08-31T08:26:14.972726+00:00' to '2026-08-31T08:36:09.973879+00:00'
Making request to https://us.api.insight.rapid7.com/idr/v2/investigations/_search with request ID: 05220345-4b62-4c04-a1f9-278d5567dcef
No new investigations found.
Checkpoint for next iteration 2026-08-31T08:31:09.973879+00:00 to allow for API latency
Sleeping for 15 seconds...
```
  - retrieving investigation + **with the 5 minute look back on next run from now** (post failure expected as no local env running to get data)
 ```
Sleeping for 15 seconds...
Searching for new investigations from '2026-08-31T08:34:52.857891+00:00' to '2026-08-31T08:40:08.817652+00:00'
Making request to https://us.api.insight.rapid7.com/idr/v2/investigations/_search with request ID: 90330996-9163-436d-8bea-c60af0aeb5bf
Retrieved total of 1 investigations.
Duplicate investigation found and skipped: rrn:investigation:us:cf946362-0809-426d-987c-849bde704c16:investigation:RFL38H4K1J7W
Saving investigations RRNs retrieved during this execution.
Checkpoint for next iteration 2026-08-31T08:35:08.817652+00:00 to allow for API latency
Sleeping for 15 seconds...

# next run now returns TWO investigations because of the overlap retrunning the same one above:
Searching for new investigations from '2026-08-31T08:35:08.817652+00:00' to '2026-08-31T08:40:24.671715+00:00'
Making request to https://us.api.insight.rapid7.com/idr/v2/investigations/_search with request ID: e61b8235-535e-4959-bece-27e84001d941
Retrieved total of 2 investigations.
```

  - subsequent runs and deduping already retrieved investigation
 ```
Saving investigations RRNs retrieved during this execution.
Checkpoint for next iteration 2026-08-31T08:35:24.671715+00:00 to allow for API latency
Sleeping for 15 seconds...
Searching for new investigations from '2026-08-31T08:35:24.671715+00:00' to '2026-08-31T08:40:40.749397+00:00'
Making request to https://us.api.insight.rapid7.com/idr/v2/investigations/_search with request ID: 7b1f242a-de42-45fc-ba81-97985ede210e
Retrieved total of 2 investigations.
Duplicate investigation found and skipped: rrn:investigation:us:cf946362-0809-426d-987c-849bde704c16:investigation:88NYN2QE6WPY
Duplicate investigation found and skipped: rrn:investigation:us:cf946362-0809-426d-987c-849bde704c16:investigation:RFL38H4K1J7W
Saving investigations RRNs retrieved during this execution.
Checkpoint for next iteration 2026-08-31T08:35:40.749397+00:00 to allow for API latency
Sleeping for 15 seconds...
```

  - container restart holds the checkpoint:
```
No new investigations found.
Checkpoint for next iteration 2026-08-31T14:41:33.417123+00:00 to allow for API latency
Sleeping for 15 seconds...

# forced restart below

[2026-08-31 14:46:41 +0000] [1] [INFO] Handling signal: term
[2026-08-31 14:46:51 +0000] [1] [INFO] Starting gunicorn 25.0.0
[2026-08-31 14:46:51 +0000] [1] [INFO] Listening at: http://0.0.0.0:10001 (1)
[2026-08-31 14:46:51 +0000] [1] [INFO] Using worker: gthread
[2026-08-31 14:46:51 +0000] [8] [INFO] Booting worker with pid: 8
Connect: Connecting...
Loaded state from /workspace/cache/example-trigger-id-johnny-n.json: {'last_poll_time': '2026-08-31T14:41:33.417123+00:00', 'RRNs': []}
rapid7/Rapid7 InsightIDR:12.0.10. Step name: get_new_investigations
Get Investigations: trigger started
Investigations search criteria: []
Detected a container restart, resumming from last poll time: 2026-08-31T14:41:33.417123+00:00
Searching for new investigations from '2026-08-31T14:41:33.417123+00:00' to '2026-08-31T14:47:10.610603+00:00'
```


[SOAR-21874]: https://rapid7.atlassian.net/browse/SOAR-21874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ