### PR TITLE
[SOAR-21944] fix(list_group_members): paginate members via @odata.nextLink

### DIFF
--- a/plugins/azure_ad_admin/.CHECKSUM
+++ b/plugins/azure_ad_admin/.CHECKSUM
@@ -1,7 +1,7 @@
 {
-	"spec": "90b467075296005c76388feae18ebdca",
-	"manifest": "5f232d4175b579a9bec53fe9af2af709",
-	"setup": "4657c80308adbb247d5024efee5e6ed6",
+	"spec": "97d4761a2e974bf8b4bf15ea62e76dda",
+	"manifest": "b947012f6449477702e7e3ede8cf3ffb",
+	"setup": "9e3bbb594d7efc73790990ff4093a068",
 	"schemas": [
 		{
 			"identifier": "add_user_to_group/schema.py",

--- a/plugins/azure_ad_admin/Dockerfile
+++ b/plugins/azure_ad_admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.5.1 AS builder
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.6.0 AS builder
 
 WORKDIR /workspace
 
@@ -11,7 +11,7 @@ ADD . /workspace
 RUN pip install .
 RUN pip uninstall -y setuptools
 
-FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.5.1
+FROM --platform=linux/amd64 rapid7/insightconnect-python-3-slim-plugin:6.6.0
 
 LABEL organization=rapid7
 LABEL sdk=python
@@ -27,6 +27,7 @@ RUN if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
 ENV PYTHONPATH="/workspace:${PYTHONPATH}"
 
 RUN rm -rf /root/.cache;
+RUN mkdir -p /workspace/cache && chown -R nobody /workspace/cache
 RUN mkdir -p /workspace/tmp && chown -R nobody /workspace/tmp
 
 # User to run plugin code. The two supported users are: root, nobody

--- a/plugins/azure_ad_admin/bin/icon_azure_ad_admin
+++ b/plugins/azure_ad_admin/bin/icon_azure_ad_admin
@@ -6,7 +6,7 @@ from sys import argv
 
 Name = "Microsoft Entra ID Admin"
 Vendor = "rapid7"
-Version = "6.0.0"
+Version = "6.0.1"
 Description = "Microsoft Entra ID Admin performs administrative tasks in Microsoft Entra ID (formerly Azure AD).It uses the [User](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) endpoint in the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview?view=graph-rest-1.0)"
 
 

--- a/plugins/azure_ad_admin/help.md
+++ b/plugins/azure_ad_admin/help.md
@@ -1167,6 +1167,7 @@ Example output:
 
 # Version History
 
+* 6.0.1 - `List Group Members`: Added pagination to return all group members | Updated SDK to the latest version (6.6.0)
 * 6.0.0 - `Get User Info`: Fixed output validation error when manager has `employeeOrgData` populated with `costCenter` or `division`
 * 5.1.0 - Renamed plugin to Microsoft Entra ID Admin | New action Get User Memberships. | Updated SDK to the latest version (6.5.1)
 * 5.0.1 - `Search Devices`: Fixed issue where devices output was limited | Updated SDK to the latest version (6.4.1)

--- a/plugins/azure_ad_admin/icon_azure_ad_admin/actions/list_group_members/action.py
+++ b/plugins/azure_ad_admin/icon_azure_ad_admin/actions/list_group_members/action.py
@@ -23,26 +23,36 @@ class ListGroupMembers(insightconnect_plugin_runtime.Action):
         group_id = params.get(Input.GROUP_ID)
         # END INPUT BINDING - DO NOT REMOVE
 
-        # Add ConsistencyLevel header for counting
+        # Add ConsistencyLevel header (required for $count, re-sent on each paged request)
         headers = self.connection.get_headers(self.connection.get_auth_token())
         headers["ConsistencyLevel"] = "eventual"
 
-        response = requests.request(
-            method="GET",
-            url=Endpoint.MEMBERS.format(self.connection.tenant, group_id=group_id),
-            headers=headers,
-        )
+        url = Endpoint.MEMBERS.format(self.connection.tenant, group_id=group_id)
 
-        raise_for_status(response)
+        # The API returns a maximum of 100 members per page. Follow @odata.nextLink to
+        # collect every page. Bounded loop mirrors the search_device action to avoid
+        # infinite loops (max 1,000 pages).
+        members, member_count = [], None
+        for _ in range(1_000):
+            response = requests.request(method="GET", url=url, headers=headers)
+            raise_for_status(response)
 
-        try:
-            result = response.json()
-            members = result.get("value", [])
-            member_count = result.get(
-                "@odata.count", len(members)
-            )  # Fallback to len(members) if @odata.count is missing
+            try:
+                result = response.json()
+            except ValueError:
+                raise PluginException(preset=PluginException.Preset.INVALID_JSON)
 
-        except ValueError:
-            raise PluginException(preset=PluginException.Preset.INVALID_JSON)
+            members.extend(result.get("value", []))
+
+            # @odata.count is only returned on the first page for directory resources
+            if member_count is None:
+                member_count = result.get("@odata.count")
+
+            # nextLink already encodes every query param; switch to it and keep paging
+            if not (url := result.get("@odata.nextLink")):
+                break
+
+        if member_count is None:  # Fallback to page count if @odata.count was missing
+            member_count = len(members)
 
         return {Output.MEMBERS: clean(members), Output.COUNT: member_count}

--- a/plugins/azure_ad_admin/plugin.spec.yaml
+++ b/plugins/azure_ad_admin/plugin.spec.yaml
@@ -4,16 +4,17 @@ products: [insightconnect]
 name: azure_ad_admin
 title: Microsoft Entra ID Admin
 description: "Microsoft Entra ID Admin performs administrative tasks in Microsoft Entra ID (formerly Azure AD).\n\nIt uses the [User](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) endpoint in the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview?view=graph-rest-1.0)"
-version: 6.0.0
+version: 6.0.1
 connection_version: 4
 vendor: rapid7
 cloud_ready: true
+enable_cache: true
 support: community
 supported_versions: ["2022-05-30"]
 status: []
 sdk:
   type: slim
-  version: 6.5.1
+  version: 6.6.0
   user: nobody
 key_features:
   - Add and remove users
@@ -37,6 +38,7 @@ requirements:
   \n\nTo assign a role, go to `Microsoft Entra ID` -> `Roles and administrators`. Select the desired role, click `Add assignments`, search for your application, and click `Add`."
 troubleshooting: "Trigger `risk_detection` needs Application permission to set as `IdentityRiskEvent.Read.All`"
 version_history:
+  - "6.0.1 - `List Group Members`: Added pagination to return all group members | Updated SDK to the latest version (6.6.0)"
   - "6.0.0 - `Get User Info`: Fixed output validation error when manager has `employeeOrgData` populated with `costCenter` or `division`"
   - "5.1.0 - Renamed plugin to Microsoft Entra ID Admin | New action Get User Memberships. | Updated SDK to the latest version (6.5.1)"
   - "5.0.1 - `Search Devices`: Fixed issue where devices output was limited | Updated SDK to the latest version (6.4.1)"

--- a/plugins/azure_ad_admin/setup.py
+++ b/plugins/azure_ad_admin/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="azure_ad_admin-rapid7-plugin",
-    version="6.0.0",
+    version="6.0.1",
     description="Microsoft Entra ID Admin performs administrative tasks in Microsoft Entra ID (formerly Azure AD).It uses the [User](https://docs.microsoft.com/en-us/graph/api/resources/user?view=graph-rest-1.0) endpoint in the [Microsoft Graph API](https://docs.microsoft.com/en-us/graph/overview?view=graph-rest-1.0)",
     author="rapid7",
     author_email="",

--- a/plugins/azure_ad_admin/unit_test/expected/list_group_members_pagination.json.exp
+++ b/plugins/azure_ad_admin/unit_test/expected/list_group_members_pagination.json.exp
@@ -1,0 +1,26 @@
+{
+  "members": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "displayName": "Alice Example",
+      "userPrincipalName": "alice@example.com",
+      "mail": "alice@example.com",
+      "accountEnabled": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "displayName": "Bob Example",
+      "userPrincipalName": "bob@example.com",
+      "mail": "bob@example.com",
+      "accountEnabled": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "displayName": "Carol Example",
+      "userPrincipalName": "carol@example.com",
+      "mail": "carol@example.com",
+      "accountEnabled": true
+    }
+  ],
+  "count": 3
+}

--- a/plugins/azure_ad_admin/unit_test/expected/list_group_members_single_page.json.exp
+++ b/plugins/azure_ad_admin/unit_test/expected/list_group_members_single_page.json.exp
@@ -1,0 +1,12 @@
+{
+  "members": [
+    {
+      "id": "00000000-0000-0000-0000-000000000009",
+      "displayName": "Solo Example",
+      "userPrincipalName": "solo@example.com",
+      "mail": "solo@example.com",
+      "accountEnabled": true
+    }
+  ],
+  "count": 1
+}

--- a/plugins/azure_ad_admin/unit_test/inputs/list_group_members_pagination.json.inp
+++ b/plugins/azure_ad_admin/unit_test/inputs/list_group_members_pagination.json.inp
@@ -1,0 +1,3 @@
+{
+  "group_id": "test-group-id"
+}

--- a/plugins/azure_ad_admin/unit_test/inputs/list_group_members_single_page.json.inp
+++ b/plugins/azure_ad_admin/unit_test/inputs/list_group_members_single_page.json.inp
@@ -1,0 +1,3 @@
+{
+  "group_id": "single-page-group"
+}

--- a/plugins/azure_ad_admin/unit_test/responses/list_group_members_page1.json.resp
+++ b/plugins/azure_ad_admin/unit_test/responses/list_group_members_page1.json.resp
@@ -1,0 +1,21 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects",
+  "@odata.count": 3,
+  "@odata.nextLink": "https://graph.microsoft.com/v1.0/azure_tenant/groups/test-group-id/members?$skiptoken=page2",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000001",
+      "displayName": "Alice Example",
+      "userPrincipalName": "alice@example.com",
+      "mail": "alice@example.com",
+      "accountEnabled": true
+    },
+    {
+      "id": "00000000-0000-0000-0000-000000000002",
+      "displayName": "Bob Example",
+      "userPrincipalName": "bob@example.com",
+      "mail": "bob@example.com",
+      "accountEnabled": true
+    }
+  ]
+}

--- a/plugins/azure_ad_admin/unit_test/responses/list_group_members_page2.json.resp
+++ b/plugins/azure_ad_admin/unit_test/responses/list_group_members_page2.json.resp
@@ -1,0 +1,12 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects",
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000003",
+      "displayName": "Carol Example",
+      "userPrincipalName": "carol@example.com",
+      "mail": "carol@example.com",
+      "accountEnabled": true
+    }
+  ]
+}

--- a/plugins/azure_ad_admin/unit_test/responses/list_group_members_single_page.json.resp
+++ b/plugins/azure_ad_admin/unit_test/responses/list_group_members_single_page.json.resp
@@ -1,0 +1,13 @@
+{
+  "@odata.context": "https://graph.microsoft.com/v1.0/$metadata#directoryObjects",
+  "@odata.count": 1,
+  "value": [
+    {
+      "id": "00000000-0000-0000-0000-000000000009",
+      "displayName": "Solo Example",
+      "userPrincipalName": "solo@example.com",
+      "mail": "solo@example.com",
+      "accountEnabled": true
+    }
+  ]
+}

--- a/plugins/azure_ad_admin/unit_test/test_list_group_members.py
+++ b/plugins/azure_ad_admin/unit_test/test_list_group_members.py
@@ -1,0 +1,45 @@
+import os
+import sys
+
+sys.path.append(os.path.abspath("../"))
+
+from typing import Any, Dict
+from unittest import TestCase
+from unittest.mock import MagicMock, patch
+
+from icon_azure_ad_admin.actions.list_group_members import ListGroupMembers
+from parameterized import parameterized
+
+from util import Util
+
+
+@patch("requests.request", side_effect=Util.mocked_requests)
+class TestListGroupMembers(TestCase):
+    @classmethod
+    @patch("requests.post", side_effect=Util.mocked_requests)
+    def setUpClass(cls, mock_request: MagicMock) -> None:
+        cls.action = Util.default_connector(ListGroupMembers())
+
+    @parameterized.expand(
+        [
+            [
+                "pagination_two_pages",
+                Util.read_file_to_dict("inputs/list_group_members_pagination.json.inp"),
+                Util.read_file_to_dict("expected/list_group_members_pagination.json.exp"),
+            ],
+            [
+                "single_page",
+                Util.read_file_to_dict("inputs/list_group_members_single_page.json.inp"),
+                Util.read_file_to_dict("expected/list_group_members_single_page.json.exp"),
+            ],
+        ]
+    )
+    def test_list_group_members(
+        self, mock_request: MagicMock, test_name: str, input_params: Dict[str, Any], expected: Dict[str, Any]
+    ) -> None:
+        # Regression coverage for SOAR-21944: the "pagination_two_pages" case exercises a
+        # group whose members span two @odata.nextLink pages, so the action must follow
+        # every page and return all members (previously it returned only the first page
+        # of 100 while still reporting the true @odata.count).
+        actual = self.action.run(input_params)
+        self.assertEqual(actual, expected)

--- a/plugins/azure_ad_admin/unit_test/util.py
+++ b/plugins/azure_ad_admin/unit_test/util.py
@@ -95,6 +95,13 @@ class Util:
             return MockResponse(200, "search_device_pagination_multipage2.json.resp")
         if url == "https://graph.microsoft.com/v1.0/azure_tenant/devices?$skiptoken=multipage3":
             return MockResponse(200, "search_device_pagination_multipage3.json.resp")
+        # Group members endpoints (list_group_members pagination)
+        if url == "https://graph.microsoft.com/v1.0/azure_tenant/groups/test-group-id/members?$count=true":
+            return MockResponse(200, "list_group_members_page1.json.resp")
+        if url == "https://graph.microsoft.com/v1.0/azure_tenant/groups/test-group-id/members?$skiptoken=page2":
+            return MockResponse(200, "list_group_members_page2.json.resp")
+        if url == "https://graph.microsoft.com/v1.0/azure_tenant/groups/single-page-group/members?$count=true":
+            return MockResponse(200, "list_group_members_single_page.json.resp")
         # User memberOf endpoints
         if url == "https://graph.microsoft.com/v1.0/azure_tenant/users/user@example.com/memberOf?$count=true":
             return MockResponse(200, "get_user_memberships.json.resp")


### PR DESCRIPTION
List Group Members issued a single GET to groups/{id}/members and returned only the first page (Microsoft Graph caps at 100 members/page) while reading count from @odata.count — the true server-side total. For groups with more than 100 members the returned members and count disagreed, and members past the first 100 were silently dropped.

Follow @odata.nextLink in a bounded loop (mirroring the search_device action) to accumulate every page, keeping count from the first page's @odata.count. Also bumps the SDK 6.5.1 -> 6.6.0 and the plugin version 6.0.0 -> 6.0.1, and adds a regression unit test covering cross-page member accumulation.

Fixes: SOAR-21944

## 🎫 Ticket
https://rapid7.atlassian.net/browse/SI-35043

## 🧩 Type of Change
<!-- Choose the type of change -->
- [ ] Feature
- [ ✅ ] Bug fix
- [ ] Other

## 🧠 Background & Motivation
<!-- Why is this change needed? What problem or context led to this PR? -->
<!-- Provide a short explanation of the motivation and the problem being solved. -->
<!-- Examples: 
- "Users reported X error when doing Y"
- "New feature X was requested"
-->

## ✨ What Changed
<!-- What was done? Summarize the key changes in this PR. -->
<!-- Describe the core implementation and high-level impact. -->
<!-- Examples:
- "Added new action 'X' to plugin Y"
- "Refactored X to improve performance"
-->

## 🧪 Testing
- Unit tests
- Manual testing steps
