### PR TITLE
fix(automox): send the report format on vuln sync upload

### DIFF
--- a/plugins/automox/.CHECKSUM
+++ b/plugins/automox/.CHECKSUM
@@ -1,5 +1,5 @@
 {
-	"spec": "4362f3cb8af34db1b363c2855a134d5f",
+	"spec": "a4666739ccc635a8cc2953c44b73b4dd",
 	"manifest": "e0b79aef43b0363605afdf8486b611f3",
 	"setup": "92b544a4c3c04178bddb6632e009b823",
 	"schemas": [

--- a/plugins/automox/help.md
+++ b/plugins/automox/help.md
@@ -1921,7 +1921,7 @@ Example output:
 
 # Version History
 
-* 3.1.1 - Action: Fixed - Upload Vulnerability Sync File now reports the response code and body returned by Automox instead of a generic server error | Updated SDK to the latest version (6.6.0) | Enabled cache
+* 3.1.1 - Action: Fixed - Upload Vulnerability Sync File | Updated SDK to the latest version (6.6.0) | Enabled cache
 * 3.1.0 - Action: Adds action for Automox Remediate API | Cloud Enabled | Updated SDK to the latest version (6.5.1)
 * 3.0.0 - Action: Fixed - Get Vulnerability Sync Action Set | Action: Fixed - List Vulnerability Sync Action Sets | Action: Updated - List Organization Users
 * 2.0.0 - Fix Vulnerability Sync API Actions | Action: Added - Delete Vulnerability Sync Action Set | Action: Added - Execute Vulnerability Sync Actions | Action: Added - List Vulnerability Sync Action Set Issues | Action: Added - List Vulnerability Sync Action Set Solutions | Action: Added - List Vulnerability Sync Action Sets | Action: Added - Get Vulnerability Sync Action Set | Action: Updated - Upload Vulnerability Sync File | Action: Updated - Get Devices | Action: Deleted - Action on Vulnerability Sync Batch | Action: Deleted - Vulnerability Sync Task | Action: Deleted - Get Vulnerability Sync Batch | Action: Deleted - List Vulnerability Sync Batches | Action: Deleted - List Vulnerability Sync Tasks

--- a/plugins/automox/icon_automox/actions/upload_vulnerability_sync_file/action.py
+++ b/plugins/automox/icon_automox/actions/upload_vulnerability_sync_file/action.py
@@ -38,16 +38,6 @@ class UploadVulnerabilitySyncFile(insightconnect_plugin_runtime.Action):
                 assistance=f"Review uploaded CSV and ensure it is a base64 encoded input. Error: {str(error)}",
             )
 
-        # Shape only, never content: an already-base64 input decodes without error but uploads a
-        # base64 blob instead of a CSV, which Automox rejects with no clue as to why. A blob is
-        # ASCII with no delimiter, where a real header row has one. Bounded slice so a 1M-row
-        # report is not copied just to log it.
-        prefix = decoded_data[:200]
-        self.logger.info(
-            f"Decoded CSV: {len(decoded_data)} bytes, delimiter in first {len(prefix)} bytes: "
-            f"{b',' in prefix}, ASCII: {prefix.isascii()}"
-        )
-
         resp = self.connection.automox_api.upload_vulnerability_sync_file(
             org_id,
             decoded_data,

--- a/plugins/automox/icon_automox/util/api_client.py
+++ b/plugins/automox/icon_automox/util/api_client.py
@@ -345,7 +345,12 @@ class ApiClient:
         self, org_id: int, file_content: bytes, filename: str, report_source: str
     ) -> Dict:
         with io.BytesIO(file_content) as file:
-            files = [("file", (filename, file, "text/csv"))]
+            # Automox needs the report schema both as the `source` query param and as a
+            # `format` multipart field.
+            files = [
+                ("file", (filename, file, "text/csv")),
+                ("format", (None, report_source)),
+            ]
 
             headers = {"Authorization": f"Bearer {self.api_key}"}
             params = self._org_param(org_id)
@@ -361,8 +366,8 @@ class ApiClient:
                     headers=headers,
                 )  # nosec B113
                 self.logger.info(
-                    f"Request URL: {url}, Method: POST, Source: {report_source}, Filename: {filename}, "
-                    f"Response code: {response.status_code}"
+                    f"Request URL: {url}, Method: POST, Source/Format: {report_source}, "
+                    f"Filename: {filename}, Response code: {response.status_code}"
                 )
 
                 if response.status_code == 201:

--- a/plugins/automox/plugin.spec.yaml
+++ b/plugins/automox/plugin.spec.yaml
@@ -18,7 +18,7 @@ sdk:
   version: 6.6.0
   user: nobody
 version_history:
-  - '3.1.1 - Action: Fixed - Upload Vulnerability Sync File now reports the response code and body returned by Automox instead of a generic server error | Updated SDK to the latest version (6.6.0) | Enabled cache'
+  - '3.1.1 - Action: Fixed - Upload Vulnerability Sync File | Updated SDK to the latest version (6.6.0) | Enabled cache'
   - '3.1.0 - Action: Adds action for Automox Remediate API | Cloud Enabled | Updated SDK to the latest version (6.5.1)'
   - '3.0.0 - Action: Fixed - Get Vulnerability Sync Action Set | Action: Fixed - List Vulnerability Sync Action Sets | Action: Updated - List Organization Users'
   - '2.0.0 - Fix Vulnerability Sync API Actions | Action: Added - Delete Vulnerability Sync Action Set | Action: Added - Execute Vulnerability Sync Actions | Action: Added - List Vulnerability Sync Action Set Issues | Action: Added - List Vulnerability Sync Action Set Solutions | Action: Added - List Vulnerability Sync Action Sets | Action: Added - Get Vulnerability Sync Action Set | Action: Updated - Upload Vulnerability Sync File | Action: Updated - Get Devices | Action: Deleted - Action on Vulnerability Sync Batch | Action: Deleted - Vulnerability Sync Task | Action: Deleted - Get Vulnerability Sync Batch | Action: Deleted - List Vulnerability Sync Batches | Action: Deleted - List Vulnerability Sync Tasks'

--- a/plugins/automox/unit_test/test_upload_vulnerability_sync_file.py
+++ b/plugins/automox/unit_test/test_upload_vulnerability_sync_file.py
@@ -6,6 +6,7 @@ sys.path.append(os.path.abspath("../"))
 from parameterized import parameterized
 from unittest.mock import patch, Mock
 from unittest import TestCase
+from jsonschema.validators import validate
 from insightconnect_plugin_runtime.exceptions import ConnectionTestException, PluginException
 
 from util import (
@@ -43,6 +44,21 @@ class TestUploadVulnerabilitySyncFile(TestCase):
         }
 
         self.assertEqual(response, expected_response)
+        validate(response, self.action.output.schema)
+
+    @parameterized.expand([("generic",), ("rapid7",), ("crowd-strike",)])
+    @patch("requests.post", side_effect=mock_request_post_201)
+    def test_upload_sends_source_query_param_and_format_form_field(self, report_source: str, mock_post: Mock) -> None:
+        params = {**self.params, Input.REPORT_SOURCE: report_source}
+
+        result = self.action.run(params)
+
+        validate(result, self.action.output.schema)
+        _, kwargs = mock_post.call_args
+        self.assertEqual(kwargs["params"]["source"], report_source)
+        form_fields = dict(kwargs["files"])
+        self.assertEqual(form_fields["format"], (None, report_source))
+        self.assertEqual(form_fields["file"][0], params[Input.CSV_FILE_NAME])
 
     @parameterized.expand(
         [


### PR DESCRIPTION
## 🎫 Ticket
SOAR-21928

## 🧩 Type of Change
- [ ] Feature
- [x] Bug fix
- [ ] Other

## 🧠 Background & Motivation
Automox's upload endpoint expects the report schema twice, as the `source` query parameter and as a `format` multipart field, so a workflow selecting `rapid7` reached Automox with `format` server-defaulted to `crowd-strike` and was rejected.

## ✨ What Changed
Send `format` alongside the file in `upload_vulnerability_sync_file`, log the request and response status, and shorten the customer-facing 3.1.1 changelog entry.

## 🧪 Testing
Unit tests in `unit_test/test_upload_vulnerability_sync_file.py` cover the multipart fields and the error path; `insight-plugin refresh` run clean.
